### PR TITLE
WP-10: Tokenizer (IRX#TOKN)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Test binaries
+test/test_*
+!test/test_*.c

--- a/docs/tokenizer-notes.md
+++ b/docs/tokenizer-notes.md
@@ -1,0 +1,271 @@
+# REXX Tokenizer Design Notes
+
+Reference material for WP-10 (TSK-113) implementation.
+
+Derived from:
+- SC28-1883-0: TSO/E V2 REXX Reference, Chapter 2 (Structure and Syntax)
+- Josep Maria Blasco: "A Tokenizer for Rexx and ooRexx", RexxLA 2024
+- Practical experience from BREXX/370 `nextsymb.c`
+
+---
+
+## 1. The fundamental REXX tokenizer trap: no reserved words
+
+REXX has **zero reserved words**. Every keyword (DO, IF, WHILE, SAY,
+CALL, SIGNAL, PARSE, etc.) is a plain symbol and can also be used
+as a variable name. This is legal REXX:
+
+```rexx
+while = 4
+do while = 1 to (while) while (while < 7)
+  say while
+end while
+```
+
+**Consequence for the tokenizer:** The tokenizer must classify `DO`,
+`WHILE`, `SAY`, `END` etc. as `TOK_SYMBOL` — the same type as any
+variable name. Keyword recognition is **entirely the parser's job**
+(WP-13), based on clause position and context. The tokenizer has no
+concept of "keyword tokens".
+
+If you create token types like `TOK_DO`, `TOK_IF`, `TOK_SAY` — you
+have made a mistake. There is only `TOK_SYMBOL`.
+
+---
+
+## 2. Whitespace is NOT a token, but it IS an operator
+
+In most languages, whitespace between tokens is insignificant filler.
+In REXX, a blank between two terms is the **concatenation operator**:
+
+```rexx
+x = 'hello' 'world'    /* Result: 'hello world'  (blank concatenation) */
+x = 'hello'||'world'   /* Result: 'helloworld'   (explicit concat)     */
+x = 'hello''world'     /* Result: 'helloworld'   (abuttal concat)      */
+```
+
+**Consequence for the tokenizer:** Do NOT emit whitespace/blank tokens.
+The parser will determine concatenation from the adjacency of terms
+in the token stream (two consecutive value-producing tokens with no
+operator between them = blank concatenation). The tokenizer simply
+skips whitespace between tokens.
+
+---
+
+## 3. Multi-character operators are a parser concern
+
+REXX allows whitespace and even comments between the characters that
+form a multi-character operator:
+
+```rexx
+a = b | /* a comment */ | c      /* This is || (concatenation)  */
+a = b * /* power */ * 2           /* This is ** (exponentiation) */
+a = b / /* integer div */ / c     /* This is // (remainder)      */
+```
+
+The IBM spec defines these composite operators: `**`, `//`, `||`,
+`>=`, `<=`, `\=`, `==`, `\==`, `>=`, `<=`, `>>`, `<<`, `>>=`,
+`<<=`, `\>>`, `\<<`, `&&`.
+
+**Consequence for the tokenizer:** Emit each operator CHARACTER as
+its own token. `||` becomes two `TOK_OPERATOR` tokens, each with
+value `|`. The parser combines adjacent operator tokens into
+composite operators. This is simpler, handles the whitespace-in-
+operator edge case automatically, and matches IBM's spec which
+defines operators at the syntactic (parser) level, not the lexical
+(tokenizer) level.
+
+The only exception: comparison operators that start with `\` or `¬`
+(the NOT character). `\=` should be emitted as `TOK_NOT` followed by
+`TOK_COMPARISON('=')`, letting the parser combine them.
+
+---
+
+## 4. Symbols are unusual
+
+A REXX "symbol" encompasses what most languages split into several
+categories:
+
+| REXX concept | Examples | Notes |
+|---|---|---|
+| Simple variable | `x`, `name`, `i` | Starts with A-Z or a-z or !?_@ |
+| Compound variable | `stem.i.j`, `a.b.c` | Contains dots |
+| Stem | `stem.` | Ends with dot |
+| Constant symbol | `25AB`, `3.14` | Starts with digit or dot |
+| Number | `42`, `1E5`, `3.14` | Subset of constant symbol |
+
+All of these are `TOK_SYMBOL` in the tokenizer. The distinction
+between variable symbols and constant symbols matters for the parser
+(variable lookup vs. literal value), but the tokenizer just sees a
+symbol.
+
+**Symbol characters** (SC28-1883-0, Chapter 2): A symbol starts with
+`A-Z a-z ! ? _ @` or `0-9 .` and continues with any of those plus
+digits. On EBCDIC, use `isalnum()` plus the special characters.
+
+**Compound symbols with dots:** `stem.i.j` is ONE symbol token. The
+tokenizer does not split at dots within a symbol. The variable pool
+(WP-12) handles the dot-delimited tail resolution.
+
+---
+
+## 5. Numbers vs. symbols
+
+Numbers in REXX are a subset of symbols: `42`, `3.14`, `1E5`,
+`1e-2`. The tokenizer can optionally classify these as `TOK_NUMBER`
+for convenience, but this is a **hint** — the parser and expression
+evaluator ultimately decide if something is a number based on the
+REXX number format rules (which depend on NUMERIC DIGITS).
+
+A pragmatic approach: if the token starts with a digit or `.digit`,
+classify as `TOK_NUMBER`. Everything else starting with alpha or
+special is `TOK_SYMBOL`. The expression evaluator will re-check
+numeric validity at runtime anyway.
+
+---
+
+## 6. String literals
+
+REXX has two quote characters: `'` and `"`. A string can use either:
+
+```rexx
+x = 'hello'
+x = "hello"
+```
+
+**Doubling for escape:** A quote inside a string of the same type is
+doubled:
+
+```rexx
+x = 'it''s'        /* Value: it's  */
+x = "say ""hi"""   /* Value: say "hi" */
+```
+
+**Hex strings:** A string immediately followed by `x` or `X`:
+
+```rexx
+x = 'FF'x          /* One byte, value X'FF' */
+x = 'C1 C2 C3'x    /* Three bytes           */
+```
+
+Only hex digits and spaces are allowed inside. Spaces are ignored.
+Must have an even number of hex digits (after removing spaces).
+
+**Binary strings:** A string immediately followed by `b` or `B`:
+
+```rexx
+x = '11110000'b    /* One byte, value X'F0' */
+x = '1111 0000'b   /* Same, spaces allowed  */
+```
+
+Only `0`, `1`, and spaces. Groups of 4 bits (after removing spaces,
+must be multiple of 4).
+
+**Tokenizer responsibility:** Recognize the suffix character (`x`/`X`
+or `b`/`B`) immediately after the closing quote (no whitespace
+between). Emit as `TOK_HEXSTRING` or `TOK_BINSTRING`. The token
+value should be the raw content between quotes (without suffix), and
+the suffix should be recorded in flags or a separate field.
+
+---
+
+## 7. Comments
+
+REXX comments are `/* ... */` and can be **nested**:
+
+```rexx
+/* This is /* a nested */ comment */
+say 'hello'
+```
+
+Track `comment_depth` as a counter. Increment on `/*`, decrement on
+`*/`. Only exit comment mode when depth reaches 0.
+
+**Line counting:** Newlines inside comments must still be counted
+for accurate line numbers in error messages, TRACE output, and
+PARSE SOURCE / SOURCELINE().
+
+**REXX identifier:** The first line of a REXX exec conventionally
+starts with `/* REXX */` or a comment containing the word `REXX`.
+The tokenizer does not need to check this — it is the Exec Load
+Routine's job (WP in Phase 4). The tokenizer just processes whatever
+source text it receives.
+
+---
+
+## 8. Clause boundaries
+
+A clause ends at:
+- A semicolon (`;`) — explicit clause end
+- End of line — implicit clause end (unless continuation)
+- End of source
+
+**Continuation:** A comma at the end of a clause (possibly followed
+by whitespace or comments, then newline) means the clause continues
+on the next line:
+
+```rexx
+say 'hello',      /* continues */
+    'world'
+```
+
+The tokenizer should:
+1. Emit `TOK_COMMA` for the comma
+2. NOT emit `TOK_EOC` for the line end
+3. Continue tokenizing the next line as part of the same clause
+
+**Semicolons in comments or strings** do not end clauses.
+
+**Label colons:** A symbol followed by `:` is a label. The colon
+is effectively a clause terminator. The tokenizer can emit the colon
+as `TOK_SEMICOLON` (it acts as one) or as a separate token type.
+Simplest: emit it as `TOK_SEMICOLON` — the parser recognizes labels
+from the pattern SYMBOL + SEMICOLON at clause start.
+
+---
+
+## 9. Operator characters
+
+Single-character operators to recognize:
+
+| Character | Token type |
+|---|---|
+| `+` `-` `*` `/` `%` | `TOK_OPERATOR` |
+| `=` `>` `<` | `TOK_COMPARISON` |
+| `&` `\|` | `TOK_LOGICAL` |
+| `\` `¬` | `TOK_NOT` |
+| `(` | `TOK_LPAREN` |
+| `)` | `TOK_RPAREN` |
+| `,` | `TOK_COMMA` |
+| `;` | `TOK_SEMICOLON` |
+
+Note: `|` is `TOK_LOGICAL`, not `TOK_CONCAT`. The parser forms `||`
+from two adjacent `TOK_LOGICAL('|')` tokens.
+
+**EBCDIC:** The NOT character has two representations: `\` (backslash,
+X'E0' in EBCDIC 037) and `¬` (logical not, X'5F' in EBCDIC 037).
+Both must be recognized. In ASCII cross-compile, `¬` may not be
+available — handle with `#ifdef` or accept only `\`.
+
+---
+
+## 10. Summary: what the tokenizer does and does NOT do
+
+**Does:**
+- Breaks source into tokens (TOK_SYMBOL, TOK_STRING, TOK_NUMBER,
+  TOK_HEXSTRING, TOK_BINSTRING, TOK_OPERATOR, TOK_COMPARISON,
+  TOK_LOGICAL, TOK_NOT, TOK_CONCAT, TOK_LPAREN, TOK_RPAREN,
+  TOK_COMMA, TOK_SEMICOLON, TOK_EOC, TOK_EOF)
+- Skips whitespace (does not emit blank tokens)
+- Strips comments (tracks nesting, preserves line count)
+- Handles continuation (comma before line end)
+- Records line/column for every token
+- Reports errors with line/column (unclosed string, unclosed comment)
+
+**Does NOT:**
+- Recognize keywords (no TOK_DO, TOK_IF, TOK_SAY — all are TOK_SYMBOL)
+- Form composite operators (no TOK_POWEROP for `**` — two TOK_OPERATOR)
+- Determine if a symbol is a variable or a label
+- Evaluate hex/binary string contents
+- Check REXX identifier in first line
+- Access or modify irx_wkblk_int (pure: source in → tokens out)

--- a/include/irxtokn.h
+++ b/include/irxtokn.h
@@ -26,11 +26,14 @@
 #define TOK_NUMBER      0x03  /* 42, 3.14, 1E5                       */
 #define TOK_HEXSTRING   0x04  /* 'FF'x                               */
 #define TOK_BINSTRING   0x05  /* '1010'b                             */
-#define TOK_OPERATOR    0x06  /* + - * / // % **                     */
-#define TOK_COMPARISON  0x07  /* = \= == \== > < >= <= >< <>         */
-#define TOK_LOGICAL     0x08  /* & | &&                              */
+/* Operator characters are emitted one per token; the parser forms   */
+/* composite operators (||, **, //, ==, >=, <=, &&, \=, etc.) from   */
+/* adjacent operator tokens. See docs/tokenizer-notes.md section 3.  */
+#define TOK_OPERATOR    0x06  /* + - * / %                           */
+#define TOK_COMPARISON  0x07  /* = > <                               */
+#define TOK_LOGICAL     0x08  /* & |                                 */
 #define TOK_NOT         0x09  /* \ or EBCDIC NOT sign                */
-#define TOK_CONCAT      0x0A  /* ||                                  */
+#define TOK_CONCAT      0x0A  /* reserved (parser may synthesize)    */
 #define TOK_LPAREN      0x0B  /* (                                   */
 #define TOK_RPAREN      0x0C  /* )                                   */
 #define TOK_COMMA       0x0D  /* ,                                   */

--- a/include/irxtokn.h
+++ b/include/irxtokn.h
@@ -1,0 +1,121 @@
+/* ------------------------------------------------------------------ */
+/*  irxtokn.h - REXX/370 Tokenizer (IRXTOKN)                          */
+/*                                                                    */
+/*  Converts REXX source text into a token stream. Single-pass,       */
+/*  reentrant. All state is in a private context on the caller's      */
+/*  stack; this header exposes only the run/free entry points and     */
+/*  the resulting token record layout.                                 */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 2 (Structure and Syntax)                */
+/*  Ref: Architecture Design v0.1.0, Section 7.2                      */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef __IRXTOKN_H__
+#define __IRXTOKN_H__
+
+#include "irx.h"
+
+/* ================================================================== */
+/*  Token types                                                       */
+/* ================================================================== */
+
+#define TOK_SYMBOL      0x01  /* FRED, A.B.C, X12, 'stem.' prefix    */
+#define TOK_STRING      0x02  /* 'hello' or "world"                  */
+#define TOK_NUMBER      0x03  /* 42, 3.14, 1E5                       */
+#define TOK_HEXSTRING   0x04  /* 'FF'x                               */
+#define TOK_BINSTRING   0x05  /* '1010'b                             */
+#define TOK_OPERATOR    0x06  /* + - * / // % **                     */
+#define TOK_COMPARISON  0x07  /* = \= == \== > < >= <= >< <>         */
+#define TOK_LOGICAL     0x08  /* & | &&                              */
+#define TOK_NOT         0x09  /* \ or EBCDIC NOT sign                */
+#define TOK_CONCAT      0x0A  /* ||                                  */
+#define TOK_LPAREN      0x0B  /* (                                   */
+#define TOK_RPAREN      0x0C  /* )                                   */
+#define TOK_COMMA       0x0D  /* ,                                   */
+#define TOK_SEMICOLON   0x0E  /* ;                                   */
+#define TOK_EOC         0x10  /* End of clause (logical newline)     */
+#define TOK_EOF         0x11  /* End of source                       */
+
+/* ================================================================== */
+/*  Token flags                                                       */
+/* ================================================================== */
+
+#define TOKF_NONE        0x00
+#define TOKF_QUOTE_DBL   0x01  /* STRING contained doubled quotes     */
+#define TOKF_COMPOUND    0x02  /* SYMBOL is a compound (has a dot)    */
+#define TOKF_CONSTANT    0x04  /* SYMBOL is a constant (starts digit  */
+                               /* or '.')                             */
+
+/* ================================================================== */
+/*  Token record (contiguous array, cache-friendly)                   */
+/* ================================================================== */
+
+struct irx_token {
+    unsigned char   tok_type;      /* TOK_*                          */
+    unsigned char   tok_flags;     /* TOKF_*                         */
+    short           tok_col;       /* 1-based column of first byte   */
+    int             tok_line;      /* 1-based line of first byte     */
+    const char     *tok_text;      /* pointer into source buffer     */
+    unsigned short  tok_length;    /* length of token text in bytes  */
+    unsigned short  tok_reserved;  /* pad / future use               */
+};
+
+/* ================================================================== */
+/*  Error reporting                                                   */
+/* ================================================================== */
+
+#define TOKERR_NONE               0
+#define TOKERR_STORAGE           20  /* irxstor failed                */
+#define TOKERR_UNTERMINATED_STR  30  /* string literal not closed     */
+#define TOKERR_UNTERMINATED_CMT  31  /* comment not closed            */
+#define TOKERR_INVALID_HEX       32  /* bad hex digit in 'xx'x        */
+#define TOKERR_INVALID_BIN       33  /* bad bit digit in 'xx'b        */
+#define TOKERR_ODD_HEX_GROUP     34  /* hex group has odd count       */
+#define TOKERR_BAD_BIN_GROUP     35  /* binary group size not 4/8     */
+#define TOKERR_BAD_CHAR          36  /* unrecognized character        */
+
+struct irx_tokn_error {
+    int  error_code;     /* TOKERR_*                                  */
+    int  error_line;     /* 1-based, where error was detected         */
+    int  error_col;      /* 1-based                                   */
+};
+
+/* ================================================================== */
+/*  Public entry points                                               */
+/* ================================================================== */
+
+/* Tokenize source text.
+ *
+ *   envblock  - owning ENVBLOCK (used to route irxstor calls).
+ *               May be NULL during bootstrap / unit tests.
+ *   src       - pointer to source text. Not copied; token records
+ *               hold pointers into this buffer, so src must outlive
+ *               the returned token array.
+ *   src_len   - length of src in bytes.
+ *   out_tokens- on success, receives a pointer to a newly allocated
+ *               array of struct irx_token ending with TOK_EOF.
+ *               Caller must release with irx_tokn_free.
+ *   out_count - on success, receives the number of tokens including
+ *               the trailing TOK_EOF entry.
+ *   out_error - optional (may be NULL). On non-zero return, receives
+ *               error code and source position.
+ *
+ *   Returns 0 on success, non-zero on error (see TOKERR_*).
+ */
+int  irx_tokn_run(struct envblock *envblock,
+                  const char *src, int src_len,
+                  struct irx_token **out_tokens, int *out_count,
+                  struct irx_tokn_error *out_error) asm("IRXTOKNR");
+
+/* Release a token array returned by irx_tokn_run.
+ *
+ *   envblock  - owning ENVBLOCK (same as passed to irx_tokn_run).
+ *   tokens    - pointer returned in out_tokens.
+ *   count     - value returned in out_count.
+ */
+void irx_tokn_free(struct envblock *envblock,
+                   struct irx_token *tokens, int count) asm("IRXTOKNF");
+
+#endif /* __IRXTOKN_H__ */

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -1,0 +1,726 @@
+/* ------------------------------------------------------------------ */
+/*  irxtokn.c - REXX/370 Tokenizer                                    */
+/*                                                                    */
+/*  Single-pass, reentrant tokenizer. All state lives in a context    */
+/*  struct allocated on the caller's stack (see struct tok_ctx).      */
+/*                                                                    */
+/*  The tokenizer is a pure source-to-tokens transformer. It does     */
+/*  not touch the internal Work Block; the caller (IRXEXEC) is        */
+/*  responsible for installing the resulting token stream into        */
+/*  wkbi_tokens when it is ready to execute.                          */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 2 (Structure and Syntax)                */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "irx.h"
+#include "irxwkblk.h"
+#include "irxfunc.h"
+#include "irxtokn.h"
+
+/* ------------------------------------------------------------------ */
+/*  Tokenizer context - private, stack-allocated per call             */
+/* ------------------------------------------------------------------ */
+
+struct tok_ctx {
+    const char        *src;          /* source buffer                */
+    int                src_len;      /* total length in bytes        */
+    int                pos;          /* byte offset into src         */
+    int                line;         /* 1-based, current position    */
+    int                col;          /* 1-based, current position    */
+
+    struct irx_token  *tokens;       /* grown array                  */
+    int                tok_count;    /* live entries                 */
+    int                tok_capacity; /* allocated slots              */
+
+    struct envblock   *envblock;     /* for irxstor                  */
+
+    int                err_code;     /* TOKERR_*                     */
+    int                err_line;
+    int                err_col;
+};
+
+/* Initial/grown token array capacity. 64 handles small execs in one  */
+/* allocation; grows by doubling thereafter.                          */
+#define TOK_INITIAL_CAPACITY 64
+
+/* ------------------------------------------------------------------ */
+/*  Character classification                                          */
+/*                                                                    */
+/*  We use <ctype.h> which crent370 provides in EBCDIC-correct form   */
+/*  on MVS and the platform libc provides for cross-compile.          */
+/*  REXX-specific classes are built on top of the standard macros.    */
+/* ------------------------------------------------------------------ */
+
+/* Characters allowed as the first character of a symbol (letter or
+ * one of the REXX special starters). */
+static int is_symbol_start(int c)
+{
+    if (isalpha(c)) return 1;
+    switch (c) {
+    case '_': case '@': case '#': case '$': case '?': case '!':
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* Characters allowed within a symbol after the first char. Dot is
+ * included; dots make a symbol compound. */
+static int is_symbol_char(int c)
+{
+    if (isalnum(c)) return 1;
+    switch (c) {
+    case '_': case '@': case '#': case '$': case '?': case '!': case '.':
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+/* The REXX "NOT" sign has two representations: backslash, and the
+ * logical-not sign. The logical-not is 0x5F in EBCDIC (CP037/CP1047)
+ * per SC28-1883-0, and is not required in cross-compile mode. */
+static int is_not_sign(int c)
+{
+    if (c == '\\') return 1;
+#ifdef __MVS__
+    if (c == 0x5F) return 1;   /* EBCDIC logical-not */
+#endif
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Position advance helper                                           */
+/* ------------------------------------------------------------------ */
+
+static void advance(struct tok_ctx *ctx, int n)
+{
+    int i;
+    for (i = 0; i < n && ctx->pos < ctx->src_len; i++) {
+        if (ctx->src[ctx->pos] == '\n') {
+            ctx->line++;
+            ctx->col = 1;
+        } else {
+            ctx->col++;
+        }
+        ctx->pos++;
+    }
+}
+
+static int peek(struct tok_ctx *ctx, int off)
+{
+    int p = ctx->pos + off;
+    if (p < 0 || p >= ctx->src_len) return -1;
+    return (unsigned char)ctx->src[p];
+}
+
+/* ------------------------------------------------------------------ */
+/*  Token array growth                                                */
+/* ------------------------------------------------------------------ */
+
+static int grow_tokens(struct tok_ctx *ctx)
+{
+    int new_cap = ctx->tok_capacity ? ctx->tok_capacity * 2
+                                    : TOK_INITIAL_CAPACITY;
+    void *new_ptr = NULL;
+    int rc = irxstor(RXSMGET,
+                     (int)(new_cap * sizeof(struct irx_token)),
+                     &new_ptr, ctx->envblock);
+    if (rc != 0) {
+        ctx->err_code = TOKERR_STORAGE;
+        return 20;
+    }
+    if (ctx->tokens != NULL) {
+        memcpy(new_ptr, ctx->tokens,
+               ctx->tok_count * sizeof(struct irx_token));
+        {
+            void *p = ctx->tokens;
+            irxstor(RXSMFRE,
+                    (int)(ctx->tok_capacity * sizeof(struct irx_token)),
+                    &p, ctx->envblock);
+        }
+    }
+    ctx->tokens = (struct irx_token *)new_ptr;
+    ctx->tok_capacity = new_cap;
+    return 0;
+}
+
+/* Append a token record. Stores text pointer and length, classifies
+ * by type/flags. Returns 0 on success, non-zero on storage error. */
+static int emit(struct tok_ctx *ctx,
+                unsigned char type, unsigned char flags,
+                const char *text, int length,
+                int start_line, int start_col)
+{
+    struct irx_token *t;
+
+    if (ctx->tok_count >= ctx->tok_capacity) {
+        if (grow_tokens(ctx) != 0) return 20;
+    }
+    t = &ctx->tokens[ctx->tok_count++];
+    t->tok_type     = type;
+    t->tok_flags    = flags;
+    t->tok_col      = (short)start_col;
+    t->tok_line     = start_line;
+    t->tok_text     = text;
+    t->tok_length   = (unsigned short)length;
+    t->tok_reserved = 0;
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Comment handling                                                  */
+/*                                                                    */
+/*  REXX block comments use slash-star and star-slash and may nest.   */
+/*  Line numbers inside a comment are still counted so SOURCELINE /   */
+/*  PARSE SOURCE / TRACE / error messages report the correct line.    */
+/* ------------------------------------------------------------------ */
+
+static int skip_comment(struct tok_ctx *ctx)
+{
+    int depth = 1;
+    /* We are positioned just past the opening '/' '*'. */
+    advance(ctx, 2);
+    while (ctx->pos < ctx->src_len) {
+        int c0 = peek(ctx, 0);
+        int c1 = peek(ctx, 1);
+        if (c0 == '/' && c1 == '*') {
+            depth++;
+            advance(ctx, 2);
+        } else if (c0 == '*' && c1 == '/') {
+            depth--;
+            advance(ctx, 2);
+            if (depth == 0) return 0;
+        } else {
+            advance(ctx, 1);
+        }
+    }
+    ctx->err_code = TOKERR_UNTERMINATED_CMT;
+    ctx->err_line = ctx->line;
+    ctx->err_col  = ctx->col;
+    return 20;
+}
+
+/* Skip whitespace (excluding newline) and comments. Does not consume
+ * newlines - the caller decides whether a newline ends a clause. */
+static int skip_inline_ws(struct tok_ctx *ctx)
+{
+    while (ctx->pos < ctx->src_len) {
+        int c0 = peek(ctx, 0);
+        int c1 = peek(ctx, 1);
+        if (c0 == ' ' || c0 == '\t' || c0 == '\r') {
+            advance(ctx, 1);
+        } else if (c0 == '/' && c1 == '*') {
+            if (skip_comment(ctx) != 0) return 20;
+        } else {
+            break;
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Clause terminator emission with continuation support              */
+/*                                                                    */
+/*  Per SC28-1883-0: a trailing comma before a line end is a          */
+/*  continuation; the comma is dropped and the newline is not a       */
+/*  clause terminator. We detect this after-the-fact: if the last     */
+/*  emitted token is TOK_COMMA and the current newline follows only   */
+/*  whitespace and comments, retract the comma and skip the EOC.      */
+/* ------------------------------------------------------------------ */
+
+static int emit_eoc(struct tok_ctx *ctx, int at_line, int at_col)
+{
+    /* Suppress EOC at the very start of the stream (leading blank
+     * lines / leading comments produce no clause). */
+    if (ctx->tok_count == 0) {
+        return 0;
+    }
+    if (ctx->tokens[ctx->tok_count - 1].tok_type == TOK_COMMA) {
+        /* Continuation: drop the trailing comma, swallow the EOC. */
+        ctx->tok_count--;
+        return 0;
+    }
+    /* Collapse multiple consecutive EOCs. */
+    if (ctx->tokens[ctx->tok_count - 1].tok_type == TOK_EOC) {
+        return 0;
+    }
+    return emit(ctx, TOK_EOC, TOKF_NONE, NULL, 0, at_line, at_col);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Scanner: string literal (and hex/bin suffixes)                    */
+/* ------------------------------------------------------------------ */
+
+static int scan_string(struct tok_ctx *ctx)
+{
+    int start_line = ctx->line;
+    int start_col  = ctx->col;
+    int text_start;
+    int quote = peek(ctx, 0);
+    int doubled = 0;
+    int suffix;
+    unsigned char type = TOK_STRING;
+    unsigned char flags = TOKF_NONE;
+
+    advance(ctx, 1);              /* consume opening quote */
+    text_start = ctx->pos;
+
+    while (ctx->pos < ctx->src_len) {
+        int c = peek(ctx, 0);
+        if (c == quote) {
+            if (peek(ctx, 1) == quote) {
+                /* Doubled quote - literal. */
+                doubled = 1;
+                advance(ctx, 2);
+                continue;
+            }
+            /* End of string. */
+            break;
+        }
+        /* REXX strings do not span lines; an embedded newline is an
+         * unterminated-string error. */
+        if (c == '\n') {
+            ctx->err_code = TOKERR_UNTERMINATED_STR;
+            ctx->err_line = start_line;
+            ctx->err_col  = start_col;
+            return 20;
+        }
+        advance(ctx, 1);
+    }
+
+    if (ctx->pos >= ctx->src_len) {
+        ctx->err_code = TOKERR_UNTERMINATED_STR;
+        ctx->err_line = start_line;
+        ctx->err_col  = start_col;
+        return 20;
+    }
+
+    /* ctx->pos is at the closing quote. */
+    {
+        int body_len = ctx->pos - text_start;
+        const char *body = ctx->src + text_start;
+
+        advance(ctx, 1);          /* consume closing quote */
+
+        /* Check for x/X or b/B suffix indicating hex/bin string. */
+        suffix = peek(ctx, 0);
+        if (suffix == 'x' || suffix == 'X') {
+            int hex_digits = 0;
+            int i;
+            for (i = 0; i < body_len; i++) {
+                int bc = (unsigned char)body[i];
+                if (bc == ' ' || bc == '\t') continue;
+                if (!isxdigit(bc)) {
+                    ctx->err_code = TOKERR_INVALID_HEX;
+                    ctx->err_line = start_line;
+                    ctx->err_col  = start_col;
+                    return 20;
+                }
+                hex_digits++;
+            }
+            if ((hex_digits & 1) != 0) {
+                ctx->err_code = TOKERR_ODD_HEX_GROUP;
+                ctx->err_line = start_line;
+                ctx->err_col  = start_col;
+                return 20;
+            }
+            type = TOK_HEXSTRING;
+            advance(ctx, 1);
+        } else if (suffix == 'b' || suffix == 'B') {
+            int bits = 0;
+            int i;
+            for (i = 0; i < body_len; i++) {
+                int bc = (unsigned char)body[i];
+                if (bc == ' ' || bc == '\t') continue;
+                if (bc != '0' && bc != '1') {
+                    ctx->err_code = TOKERR_INVALID_BIN;
+                    ctx->err_line = start_line;
+                    ctx->err_col  = start_col;
+                    return 20;
+                }
+                bits++;
+            }
+            if ((bits & 3) != 0) {
+                ctx->err_code = TOKERR_BAD_BIN_GROUP;
+                ctx->err_line = start_line;
+                ctx->err_col  = start_col;
+                return 20;
+            }
+            type = TOK_BINSTRING;
+            advance(ctx, 1);
+        }
+
+        if (doubled) flags |= TOKF_QUOTE_DBL;
+        return emit(ctx, type, flags, body, body_len,
+                    start_line, start_col);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Scanner: symbol / number                                          */
+/*                                                                    */
+/*  A run of symbol characters starting with a letter/special becomes */
+/*  a SYMBOL. A run starting with a digit or '.' is classified as     */
+/*  NUMBER if it matches REXX number syntax, otherwise as a constant  */
+/*  SYMBOL. Both are consumed by the same greedy loop; classification */
+/*  is done afterwards on the captured run.                           */
+/* ------------------------------------------------------------------ */
+
+static int looks_like_number(const char *s, int len)
+{
+    int i = 0;
+    int saw_digit = 0;
+    int saw_dot = 0;
+
+    if (len == 0) return 0;
+
+    /* Optional leading '.' handled by the digit loop. */
+    while (i < len) {
+        int c = (unsigned char)s[i];
+        if (isdigit(c)) {
+            saw_digit = 1;
+            i++;
+        } else if (c == '.' && !saw_dot) {
+            saw_dot = 1;
+            i++;
+        } else {
+            break;
+        }
+    }
+    if (!saw_digit) return 0;
+    if (i == len) return 1;
+
+    /* Exponent: E[+-]digits */
+    if (s[i] == 'E' || s[i] == 'e') {
+        i++;
+        if (i < len && (s[i] == '+' || s[i] == '-')) i++;
+        if (i == len) return 0;
+        while (i < len) {
+            if (!isdigit((unsigned char)s[i])) return 0;
+            i++;
+        }
+        return 1;
+    }
+    return 0;
+}
+
+static int scan_symbol_or_number(struct tok_ctx *ctx)
+{
+    int start_line = ctx->line;
+    int start_col  = ctx->col;
+    int start_pos  = ctx->pos;
+    int saw_dot    = 0;
+    int first      = peek(ctx, 0);
+    unsigned char flags = TOKF_NONE;
+    unsigned char type;
+    const char *text;
+    int length;
+
+    while (ctx->pos < ctx->src_len) {
+        int c = peek(ctx, 0);
+        if (!is_symbol_char(c)) break;
+        if (c == '.') saw_dot = 1;
+        advance(ctx, 1);
+    }
+
+    /* For digit/dot-started runs, extend with a signed exponent
+     * (E+nn / E-nn). The unsigned exponent (E5) is already part of
+     * the symbol_char run above. */
+    if ((isdigit(first) || first == '.') &&
+        ctx->pos > start_pos &&
+        (peek(ctx, 0) == '+' || peek(ctx, 0) == '-')) {
+        char prev = ctx->src[ctx->pos - 1];
+        if (prev == 'E' || prev == 'e') {
+            advance(ctx, 1);
+            while (ctx->pos < ctx->src_len &&
+                   isdigit(peek(ctx, 0))) {
+                advance(ctx, 1);
+            }
+        }
+    }
+
+    length = ctx->pos - start_pos;
+    text   = ctx->src + start_pos;
+
+    if (saw_dot) flags |= TOKF_COMPOUND;
+
+    /* A constant symbol starts with a digit or a dot. */
+    if (isdigit(first) || first == '.') {
+        flags |= TOKF_CONSTANT;
+        if (looks_like_number(text, length)) {
+            type = TOK_NUMBER;
+        } else {
+            type = TOK_SYMBOL;
+        }
+    } else {
+        type = TOK_SYMBOL;
+    }
+
+    return emit(ctx, type, flags, text, length, start_line, start_col);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Scanner: operators, punctuation                                   */
+/*                                                                    */
+/*  REXX has a rich operator set including multi-character variants   */
+/*  (==, \==, >=, <=, ><, <>, >>, <<, >>=, <<=, \>>, \<<, **, ||,     */
+/*   &&, //). We match the longest sequence first.                    */
+/* ------------------------------------------------------------------ */
+
+static int scan_operator(struct tok_ctx *ctx)
+{
+    int start_line = ctx->line;
+    int start_col  = ctx->col;
+    int start_pos  = ctx->pos;
+    int c0 = peek(ctx, 0);
+    int c1 = peek(ctx, 1);
+    int c2 = peek(ctx, 2);
+    unsigned char type = 0;
+    int len = 1;
+
+    /* Punctuation first. */
+    switch (c0) {
+    case '(':
+        advance(ctx, 1);
+        return emit(ctx, TOK_LPAREN, TOKF_NONE,
+                    ctx->src + start_pos, 1, start_line, start_col);
+    case ')':
+        advance(ctx, 1);
+        return emit(ctx, TOK_RPAREN, TOKF_NONE,
+                    ctx->src + start_pos, 1, start_line, start_col);
+    case ',':
+        advance(ctx, 1);
+        return emit(ctx, TOK_COMMA, TOKF_NONE,
+                    ctx->src + start_pos, 1, start_line, start_col);
+    case ';':
+        advance(ctx, 1);
+        /* Semicolon ends a clause. */
+        return emit_eoc(ctx, start_line, start_col);
+    case ':':
+        /* Colon after a symbol is a clause delimiter (label). The
+         * parser distinguishes labels from other uses by context.
+         * For the tokenizer, emit an EOC. */
+        advance(ctx, 1);
+        return emit_eoc(ctx, start_line, start_col);
+    }
+
+    /* NOT-prefixed comparison forms: \=, \==, \>, \<, \>>, \<< */
+    if (is_not_sign(c0)) {
+        if (c1 == '=' && c2 == '=') {
+            type = TOK_COMPARISON; len = 3;
+        } else if (c1 == '=' || c1 == '>' || c1 == '<') {
+            if ((c1 == '>' && c2 == '>') || (c1 == '<' && c2 == '<')) {
+                type = TOK_COMPARISON; len = 3;
+            } else {
+                type = TOK_COMPARISON; len = 2;
+            }
+        } else {
+            type = TOK_NOT; len = 1;
+        }
+        advance(ctx, len);
+        return emit(ctx, type, TOKF_NONE,
+                    ctx->src + start_pos, len, start_line, start_col);
+    }
+
+    /* Logical / concat doubled forms. */
+    if (c0 == '|' && c1 == '|') {
+        advance(ctx, 2);
+        return emit(ctx, TOK_CONCAT, TOKF_NONE,
+                    ctx->src + start_pos, 2, start_line, start_col);
+    }
+    if (c0 == '&' && c1 == '&') {
+        advance(ctx, 2);
+        return emit(ctx, TOK_LOGICAL, TOKF_NONE,
+                    ctx->src + start_pos, 2, start_line, start_col);
+    }
+    if (c0 == '|' || c0 == '&') {
+        advance(ctx, 1);
+        return emit(ctx, TOK_LOGICAL, TOKF_NONE,
+                    ctx->src + start_pos, 1, start_line, start_col);
+    }
+
+    /* Arithmetic / comparison with possible two-char forms. */
+    if (c0 == '*' && c1 == '*') {
+        advance(ctx, 2);
+        return emit(ctx, TOK_OPERATOR, TOKF_NONE,
+                    ctx->src + start_pos, 2, start_line, start_col);
+    }
+    if (c0 == '/' && c1 == '/') {
+        advance(ctx, 2);
+        return emit(ctx, TOK_OPERATOR, TOKF_NONE,
+                    ctx->src + start_pos, 2, start_line, start_col);
+    }
+    if (c0 == '+' || c0 == '-' || c0 == '*' || c0 == '/' || c0 == '%') {
+        advance(ctx, 1);
+        return emit(ctx, TOK_OPERATOR, TOKF_NONE,
+                    ctx->src + start_pos, 1, start_line, start_col);
+    }
+
+    /* Comparison operators. */
+    if (c0 == '=' && c1 == '=') {
+        advance(ctx, 2);
+        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
+                    ctx->src + start_pos, 2, start_line, start_col);
+    }
+    if (c0 == '=') {
+        advance(ctx, 1);
+        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
+                    ctx->src + start_pos, 1, start_line, start_col);
+    }
+    if (c0 == '>' && c1 == '>' && c2 == '=') {
+        advance(ctx, 3);
+        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
+                    ctx->src + start_pos, 3, start_line, start_col);
+    }
+    if (c0 == '<' && c1 == '<' && c2 == '=') {
+        advance(ctx, 3);
+        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
+                    ctx->src + start_pos, 3, start_line, start_col);
+    }
+    if (c0 == '>' && (c1 == '>' || c1 == '=' || c1 == '<')) {
+        advance(ctx, 2);
+        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
+                    ctx->src + start_pos, 2, start_line, start_col);
+    }
+    if (c0 == '<' && (c1 == '<' || c1 == '=' || c1 == '>')) {
+        advance(ctx, 2);
+        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
+                    ctx->src + start_pos, 2, start_line, start_col);
+    }
+    if (c0 == '>' || c0 == '<') {
+        advance(ctx, 1);
+        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
+                    ctx->src + start_pos, 1, start_line, start_col);
+    }
+
+    ctx->err_code = TOKERR_BAD_CHAR;
+    ctx->err_line = start_line;
+    ctx->err_col  = start_col;
+    return 20;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main loop                                                         */
+/* ------------------------------------------------------------------ */
+
+static int tokenize(struct tok_ctx *ctx)
+{
+    while (ctx->pos < ctx->src_len) {
+        int c;
+
+        if (skip_inline_ws(ctx) != 0) return 20;
+        if (ctx->pos >= ctx->src_len) break;
+
+        c = peek(ctx, 0);
+
+        if (c == '\n') {
+            int l = ctx->line;
+            int k = ctx->col;
+            advance(ctx, 1);
+            if (emit_eoc(ctx, l, k) != 0) return 20;
+            continue;
+        }
+
+        if (c == '\'' || c == '"') {
+            if (scan_string(ctx) != 0) return 20;
+            continue;
+        }
+
+        if (is_symbol_start(c) || isdigit(c) ||
+            (c == '.' && isdigit(peek(ctx, 1)))) {
+            if (scan_symbol_or_number(ctx) != 0) return 20;
+            continue;
+        }
+
+        if (scan_operator(ctx) != 0) return 20;
+    }
+
+    /* Ensure clause terminates. */
+    if (ctx->tok_count > 0 &&
+        ctx->tokens[ctx->tok_count - 1].tok_type != TOK_EOC) {
+        if (emit(ctx, TOK_EOC, TOKF_NONE, NULL, 0,
+                 ctx->line, ctx->col) != 0) return 20;
+    }
+
+    return emit(ctx, TOK_EOF, TOKF_NONE, NULL, 0,
+                ctx->line, ctx->col);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public entry points                                               */
+/* ------------------------------------------------------------------ */
+
+int irx_tokn_run(struct envblock *envblock,
+                 const char *src, int src_len,
+                 struct irx_token **out_tokens, int *out_count,
+                 struct irx_tokn_error *out_error)
+{
+    struct tok_ctx ctx;
+    int rc;
+
+    if (out_tokens == NULL || out_count == NULL ||
+        src == NULL || src_len < 0) {
+        if (out_error != NULL) {
+            out_error->error_code = TOKERR_BAD_CHAR;
+            out_error->error_line = 0;
+            out_error->error_col  = 0;
+        }
+        return 20;
+    }
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.src      = src;
+    ctx.src_len  = src_len;
+    ctx.line     = 1;
+    ctx.col      = 1;
+    ctx.envblock = envblock;
+
+    rc = tokenize(&ctx);
+
+    if (rc != 0) {
+        if (ctx.tokens != NULL) {
+            void *p = ctx.tokens;
+            irxstor(RXSMFRE,
+                    (int)(ctx.tok_capacity * sizeof(struct irx_token)),
+                    &p, envblock);
+        }
+        if (out_error != NULL) {
+            out_error->error_code = ctx.err_code;
+            out_error->error_line = ctx.err_line;
+            out_error->error_col  = ctx.err_col;
+        }
+        *out_tokens = NULL;
+        *out_count  = 0;
+        return rc;
+    }
+
+    if (out_error != NULL) {
+        out_error->error_code = TOKERR_NONE;
+        out_error->error_line = 0;
+        out_error->error_col  = 0;
+    }
+    *out_tokens = ctx.tokens;
+    *out_count  = ctx.tok_count;
+    return 0;
+}
+
+void irx_tokn_free(struct envblock *envblock,
+                   struct irx_token *tokens, int count)
+{
+    /* count is in records; the capacity-vs-count distinction is lost
+     * at this point, so we free the count-sized allocation. That is
+     * safe because irx_tokn_run shrinks the bookkeeping only, never
+     * the allocation, and irxstor ignores the length argument when
+     * backed by the crent370 heap (see irxstor implementation). */
+    void *p;
+    if (tokens == NULL) return;
+    p = tokens;
+    irxstor(RXSMFRE, (int)(count * sizeof(struct irx_token)),
+            &p, envblock);
+}

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -468,9 +468,12 @@ static int scan_symbol_or_number(struct tok_ctx *ctx)
 /* ------------------------------------------------------------------ */
 /*  Scanner: operators, punctuation                                   */
 /*                                                                    */
-/*  REXX has a rich operator set including multi-character variants   */
-/*  (==, \==, >=, <=, ><, <>, >>, <<, >>=, <<=, \>>, \<<, **, ||,     */
-/*   &&, //). We match the longest sequence first.                    */
+/*  Per design notes section 3, the tokenizer emits one token per     */
+/*  operator character. Composite operators (||, **, //, ==, >=, <=,  */
+/*  &&, \=, \==, >>, <<, >>=, <<=, \>>, \<<) are formed by the parser */
+/*  from adjacent operator tokens. This handles the awkward edge      */
+/*  case of comments or whitespace appearing inside what looks like   */
+/*  a multi-character operator (a | comment | b is still concat).     */
 /* ------------------------------------------------------------------ */
 
 static int scan_operator(struct tok_ctx *ctx)
@@ -479,130 +482,56 @@ static int scan_operator(struct tok_ctx *ctx)
     int start_col  = ctx->col;
     int start_pos  = ctx->pos;
     int c0 = peek(ctx, 0);
-    int c1 = peek(ctx, 1);
-    int c2 = peek(ctx, 2);
-    unsigned char type = 0;
-    int len = 1;
+    unsigned char type;
 
-    /* Punctuation first. */
-    switch (c0) {
-    case '(':
-        advance(ctx, 1);
-        return emit(ctx, TOK_LPAREN, TOKF_NONE,
-                    ctx->src + start_pos, 1, start_line, start_col);
-    case ')':
-        advance(ctx, 1);
-        return emit(ctx, TOK_RPAREN, TOKF_NONE,
-                    ctx->src + start_pos, 1, start_line, start_col);
-    case ',':
-        advance(ctx, 1);
-        return emit(ctx, TOK_COMMA, TOKF_NONE,
-                    ctx->src + start_pos, 1, start_line, start_col);
-    case ';':
-        advance(ctx, 1);
-        /* Semicolon ends a clause. */
-        return emit_eoc(ctx, start_line, start_col);
-    case ':':
-        /* Colon after a symbol is a clause delimiter (label). The
-         * parser distinguishes labels from other uses by context.
-         * For the tokenizer, emit an EOC. */
-        advance(ctx, 1);
-        return emit_eoc(ctx, start_line, start_col);
-    }
-
-    /* NOT-prefixed comparison forms: \=, \==, \>, \<, \>>, \<< */
+    /* NOT character (backslash, plus EBCDIC logical-not on MVS). */
     if (is_not_sign(c0)) {
-        if (c1 == '=' && c2 == '=') {
-            type = TOK_COMPARISON; len = 3;
-        } else if (c1 == '=' || c1 == '>' || c1 == '<') {
-            if ((c1 == '>' && c2 == '>') || (c1 == '<' && c2 == '<')) {
-                type = TOK_COMPARISON; len = 3;
-            } else {
-                type = TOK_COMPARISON; len = 2;
-            }
-        } else {
-            type = TOK_NOT; len = 1;
+        type = TOK_NOT;
+    } else {
+        switch (c0) {
+        case '(':
+            advance(ctx, 1);
+            return emit(ctx, TOK_LPAREN, TOKF_NONE,
+                        ctx->src + start_pos, 1, start_line, start_col);
+        case ')':
+            advance(ctx, 1);
+            return emit(ctx, TOK_RPAREN, TOKF_NONE,
+                        ctx->src + start_pos, 1, start_line, start_col);
+        case ',':
+            advance(ctx, 1);
+            return emit(ctx, TOK_COMMA, TOKF_NONE,
+                        ctx->src + start_pos, 1, start_line, start_col);
+        case ';':
+        case ':':
+            /* Both terminate a clause. The colon after a label
+             * symbol is recognised by the parser from context. */
+            advance(ctx, 1);
+            return emit(ctx, TOK_SEMICOLON, TOKF_NONE,
+                        ctx->src + start_pos, 1, start_line, start_col);
+
+        case '+': case '-': case '*': case '/': case '%':
+            type = TOK_OPERATOR;
+            break;
+
+        case '=': case '>': case '<':
+            type = TOK_COMPARISON;
+            break;
+
+        case '&': case '|':
+            type = TOK_LOGICAL;
+            break;
+
+        default:
+            ctx->err_code = TOKERR_BAD_CHAR;
+            ctx->err_line = start_line;
+            ctx->err_col  = start_col;
+            return 20;
         }
-        advance(ctx, len);
-        return emit(ctx, type, TOKF_NONE,
-                    ctx->src + start_pos, len, start_line, start_col);
     }
 
-    /* Logical / concat doubled forms. */
-    if (c0 == '|' && c1 == '|') {
-        advance(ctx, 2);
-        return emit(ctx, TOK_CONCAT, TOKF_NONE,
-                    ctx->src + start_pos, 2, start_line, start_col);
-    }
-    if (c0 == '&' && c1 == '&') {
-        advance(ctx, 2);
-        return emit(ctx, TOK_LOGICAL, TOKF_NONE,
-                    ctx->src + start_pos, 2, start_line, start_col);
-    }
-    if (c0 == '|' || c0 == '&') {
-        advance(ctx, 1);
-        return emit(ctx, TOK_LOGICAL, TOKF_NONE,
-                    ctx->src + start_pos, 1, start_line, start_col);
-    }
-
-    /* Arithmetic / comparison with possible two-char forms. */
-    if (c0 == '*' && c1 == '*') {
-        advance(ctx, 2);
-        return emit(ctx, TOK_OPERATOR, TOKF_NONE,
-                    ctx->src + start_pos, 2, start_line, start_col);
-    }
-    if (c0 == '/' && c1 == '/') {
-        advance(ctx, 2);
-        return emit(ctx, TOK_OPERATOR, TOKF_NONE,
-                    ctx->src + start_pos, 2, start_line, start_col);
-    }
-    if (c0 == '+' || c0 == '-' || c0 == '*' || c0 == '/' || c0 == '%') {
-        advance(ctx, 1);
-        return emit(ctx, TOK_OPERATOR, TOKF_NONE,
-                    ctx->src + start_pos, 1, start_line, start_col);
-    }
-
-    /* Comparison operators. */
-    if (c0 == '=' && c1 == '=') {
-        advance(ctx, 2);
-        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
-                    ctx->src + start_pos, 2, start_line, start_col);
-    }
-    if (c0 == '=') {
-        advance(ctx, 1);
-        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
-                    ctx->src + start_pos, 1, start_line, start_col);
-    }
-    if (c0 == '>' && c1 == '>' && c2 == '=') {
-        advance(ctx, 3);
-        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
-                    ctx->src + start_pos, 3, start_line, start_col);
-    }
-    if (c0 == '<' && c1 == '<' && c2 == '=') {
-        advance(ctx, 3);
-        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
-                    ctx->src + start_pos, 3, start_line, start_col);
-    }
-    if (c0 == '>' && (c1 == '>' || c1 == '=' || c1 == '<')) {
-        advance(ctx, 2);
-        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
-                    ctx->src + start_pos, 2, start_line, start_col);
-    }
-    if (c0 == '<' && (c1 == '<' || c1 == '=' || c1 == '>')) {
-        advance(ctx, 2);
-        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
-                    ctx->src + start_pos, 2, start_line, start_col);
-    }
-    if (c0 == '>' || c0 == '<') {
-        advance(ctx, 1);
-        return emit(ctx, TOK_COMPARISON, TOKF_NONE,
-                    ctx->src + start_pos, 1, start_line, start_col);
-    }
-
-    ctx->err_code = TOKERR_BAD_CHAR;
-    ctx->err_line = start_line;
-    ctx->err_col  = start_col;
-    return 20;
+    advance(ctx, 1);
+    return emit(ctx, type, TOKF_NONE,
+                ctx->src + start_pos, 1, start_line, start_col);
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -242,8 +242,11 @@ static int emit_eoc(struct tok_ctx *ctx, int at_line, int at_col)
         return 0;
     }
     if (ctx->tokens[ctx->tok_count - 1].tok_type == TOK_COMMA) {
-        /* Continuation: drop the trailing comma, swallow the EOC. */
-        ctx->tok_count--;
+        /* Continuation: keep the comma (it is also the argument
+         * separator in CALL / function-call contexts) and suppress
+         * the EOC only. Per SC28-1883-0 Chapter 2: "A clause is
+         * ended by the end of a line that is not immediately
+         * preceded by a comma." */
         return 0;
     }
     /* Collapse multiple consecutive EOCs. */

--- a/test/test_tokenizer.c
+++ b/test/test_tokenizer.c
@@ -161,40 +161,107 @@ static void test_string_doubling(void)
     irx_tokn_free(NULL, toks, n);
 }
 
-static void test_operators(void)
+static void test_operators_single_char(void)
 {
     struct irx_token *toks = NULL;
     int n = 0;
     struct irx_tokn_error err;
-    const char *src = "a + b - c * d / e // f % g ** h || i && j \\= k == l >= m <= n";
     int rc;
 
-    printf("\n--- Test: operator zoo ---\n");
+    printf("\n--- Test: single-character operator emission ---\n");
 
-    rc = run(src, &toks, &n, &err);
-    CHECK(rc == 0, "tokenizer returns 0");
-    /* 14 operands + 13 operators + EOC + EOF = 29 tokens */
-    CHECK(n == 29, "29 tokens for the operator-zoo expression");
-    if (rc == 0 && n >= 28) {
-        /* Spot-check a few operator types */
-        CHECK(toks[1].tok_type == TOK_OPERATOR && tok_text_eq(&toks[1], "+"),
-              "+ is OPERATOR");
-        CHECK(toks[9].tok_type == TOK_OPERATOR && tok_text_eq(&toks[9], "//"),
-              "// is OPERATOR");
-        CHECK(toks[13].tok_type == TOK_OPERATOR && tok_text_eq(&toks[13], "**"),
-              "** is OPERATOR");
-        CHECK(toks[15].tok_type == TOK_CONCAT && tok_text_eq(&toks[15], "||"),
-              "|| is CONCAT");
-        CHECK(toks[17].tok_type == TOK_LOGICAL && tok_text_eq(&toks[17], "&&"),
-              "&& is LOGICAL");
-        CHECK(toks[19].tok_type == TOK_COMPARISON && tok_text_eq(&toks[19], "\\="),
-              "\\= is COMPARISON");
-        CHECK(toks[21].tok_type == TOK_COMPARISON && tok_text_eq(&toks[21], "=="),
-              "== is COMPARISON");
-        CHECK(toks[23].tok_type == TOK_COMPARISON && tok_text_eq(&toks[23], ">="),
-              ">= is COMPARISON");
-        CHECK(toks[25].tok_type == TOK_COMPARISON && tok_text_eq(&toks[25], "<="),
-              "<= is COMPARISON");
+    /* Each operator character is emitted as its own token; composite
+     * forms (||, **, etc.) are the parser's job. */
+    rc = run("a||b", &toks, &n, &err);
+    CHECK(rc == 0, "'a||b' tokenizes");
+    CHECK(n == 6, "6 tokens (SYM | | SYM EOC EOF)");
+    if (n >= 6) {
+        CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "a"),
+              "[0] SYMBOL a");
+        CHECK(toks[1].tok_type == TOK_LOGICAL && tok_text_eq(&toks[1], "|"),
+              "[1] LOGICAL '|' (first of ||)");
+        CHECK(toks[2].tok_type == TOK_LOGICAL && tok_text_eq(&toks[2], "|"),
+              "[2] LOGICAL '|' (second of ||)");
+        CHECK(toks[3].tok_type == TOK_SYMBOL && tok_text_eq(&toks[3], "b"),
+              "[3] SYMBOL b");
+    }
+    irx_tokn_free(NULL, toks, n);
+
+    /* ** as two TOK_OPERATOR */
+    toks = NULL; n = 0;
+    rc = run("2**3", &toks, &n, &err);
+    CHECK(rc == 0, "'2**3' tokenizes");
+    if (n >= 4) {
+        CHECK(toks[0].tok_type == TOK_NUMBER, "[0] NUMBER 2");
+        CHECK(toks[1].tok_type == TOK_OPERATOR && tok_text_eq(&toks[1], "*"),
+              "[1] OPERATOR '*'");
+        CHECK(toks[2].tok_type == TOK_OPERATOR && tok_text_eq(&toks[2], "*"),
+              "[2] OPERATOR '*'");
+        CHECK(toks[3].tok_type == TOK_NUMBER, "[3] NUMBER 3");
+    }
+    irx_tokn_free(NULL, toks, n);
+
+    /* \= as NOT followed by COMPARISON */
+    toks = NULL; n = 0;
+    rc = run("a\\=b", &toks, &n, &err);
+    CHECK(rc == 0, "'a\\=b' tokenizes");
+    if (n >= 4) {
+        CHECK(toks[1].tok_type == TOK_NOT && tok_text_eq(&toks[1], "\\"),
+              "[1] NOT '\\'");
+        CHECK(toks[2].tok_type == TOK_COMPARISON && tok_text_eq(&toks[2], "="),
+              "[2] COMPARISON '='");
+    }
+    irx_tokn_free(NULL, toks, n);
+
+    /* >= as two COMPARISONs */
+    toks = NULL; n = 0;
+    rc = run("a>=b", &toks, &n, &err);
+    CHECK(rc == 0, "'a>=b' tokenizes");
+    if (n >= 4) {
+        CHECK(toks[1].tok_type == TOK_COMPARISON && tok_text_eq(&toks[1], ">"),
+              "[1] COMPARISON '>'");
+        CHECK(toks[2].tok_type == TOK_COMPARISON && tok_text_eq(&toks[2], "="),
+              "[2] COMPARISON '='");
+    }
+    irx_tokn_free(NULL, toks, n);
+
+    /* Comment between || characters - parser will still see two | */
+    toks = NULL; n = 0;
+    rc = run("a| /* gap */ |b", &toks, &n, &err);
+    CHECK(rc == 0, "'a| /* gap */ |b' tokenizes (comment inside ||)");
+    if (n >= 4) {
+        CHECK(toks[1].tok_type == TOK_LOGICAL && tok_text_eq(&toks[1], "|"),
+              "first | preserved");
+        CHECK(toks[2].tok_type == TOK_LOGICAL && tok_text_eq(&toks[2], "|"),
+              "second | preserved across the comment");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_punctuation(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+    int rc;
+
+    printf("\n--- Test: ; and : are TOK_SEMICOLON ---\n");
+
+    rc = run("a;b", &toks, &n, &err);
+    CHECK(rc == 0, "'a;b' tokenizes");
+    if (n >= 4) {
+        CHECK(toks[1].tok_type == TOK_SEMICOLON, "[1] ';' is SEMICOLON");
+    }
+    irx_tokn_free(NULL, toks, n);
+
+    toks = NULL; n = 0;
+    rc = run("loop:\nsay 'x'", &toks, &n, &err);
+    CHECK(rc == 0, "'loop:' label tokenizes");
+    if (n >= 2) {
+        CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "loop"),
+              "[0] SYMBOL 'loop'");
+        CHECK(toks[1].tok_type == TOK_SEMICOLON,
+              "[1] ':' is SEMICOLON");
     }
     irx_tokn_free(NULL, toks, n);
 }
@@ -347,7 +414,8 @@ int main(void)
     test_hex_string();
     test_bin_string();
     test_string_doubling();
-    test_operators();
+    test_operators_single_char();
+    test_punctuation();
     test_comments_and_lines();
     test_continuation();
     test_numbers();

--- a/test/test_tokenizer.c
+++ b/test/test_tokenizer.c
@@ -1,0 +1,363 @@
+/* ------------------------------------------------------------------ */
+/*  test_tokenizer.c - WP-10 tokenizer unit tests                     */
+/*                                                                    */
+/*  Build (Linux/gcc cross-compile):                                  */
+/*    gcc -I include -Wall -Wextra -std=gnu99 -o test/test_tokenizer  */
+/*        test/test_tokenizer.c \                                     */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \        */
+/*        'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c' \        */
+/*        'src/irx#tokn.c'                                             */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "irx.h"
+#include "irxrab.h"
+#include "irxwkblk.h"
+#include "irxfunc.h"
+#include "irxtokn.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg) \
+    do { \
+        tests_run++; \
+        if (cond) { \
+            tests_passed++; \
+            printf("  PASS: %s\n", msg); \
+        } else { \
+            tests_failed++; \
+            printf("  FAIL: %s\n", msg); \
+        } \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+static int tok_text_eq(const struct irx_token *t, const char *s)
+{
+    int n = (int)strlen(s);
+    if (t->tok_length != (unsigned short)n) return 0;
+    return memcmp(t->tok_text, s, (size_t)n) == 0;
+}
+
+static int run(const char *src, struct irx_token **out, int *count,
+               struct irx_tokn_error *err)
+{
+    return irx_tokn_run(NULL, src, (int)strlen(src), out, count, err);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_hello_world(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+    int rc;
+
+    printf("\n--- Test: say 'Hello World' ---\n");
+
+    rc = run("say 'Hello World'", &toks, &n, &err);
+    CHECK(rc == 0, "tokenizer returns 0");
+    CHECK(n == 4, "produces 4 tokens (SYMBOL STRING EOC EOF)");
+    if (n >= 4) {
+        CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "say"),
+              "[0] SYMBOL 'say'");
+        CHECK(toks[1].tok_type == TOK_STRING && tok_text_eq(&toks[1], "Hello World"),
+              "[1] STRING 'Hello World'");
+        CHECK(toks[2].tok_type == TOK_EOC,  "[2] EOC");
+        CHECK(toks[3].tok_type == TOK_EOF,  "[3] EOF");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_compound_symbol(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+
+    printf("\n--- Test: compound symbol stem.i.j ---\n");
+
+    run("stem.i.j", &toks, &n, &err);
+    CHECK(n == 3, "3 tokens (SYMBOL EOC EOF)");
+    if (n >= 1) {
+        CHECK(toks[0].tok_type == TOK_SYMBOL,
+              "[0] is SYMBOL");
+        CHECK(tok_text_eq(&toks[0], "stem.i.j"),
+              "[0] text == 'stem.i.j'");
+        CHECK((toks[0].tok_flags & TOKF_COMPOUND) != 0,
+              "[0] flagged COMPOUND");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_hex_string(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+
+    printf("\n--- Test: hex string 'FF'x ---\n");
+
+    run("'FF'x", &toks, &n, &err);
+    CHECK(n == 3, "3 tokens (HEXSTRING EOC EOF)");
+    if (n >= 1) {
+        CHECK(toks[0].tok_type == TOK_HEXSTRING, "[0] HEXSTRING");
+        CHECK(tok_text_eq(&toks[0], "FF"),       "[0] body 'FF'");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_bin_string(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+
+    printf("\n--- Test: bin string '1010'b ---\n");
+
+    run("'1010'b", &toks, &n, &err);
+    CHECK(n == 3, "3 tokens (BINSTRING EOC EOF)");
+    if (n >= 1) {
+        CHECK(toks[0].tok_type == TOK_BINSTRING, "[0] BINSTRING");
+        CHECK(tok_text_eq(&toks[0], "1010"),     "[0] body '1010'");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_string_doubling(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+
+    printf("\n--- Test: string with doubled quote 'it''s' ---\n");
+
+    run("'it''s'", &toks, &n, &err);
+    CHECK(n == 3, "3 tokens");
+    if (n >= 1) {
+        CHECK(toks[0].tok_type == TOK_STRING, "[0] STRING");
+        /* Body retains the doubling - decoding is the parser's job. */
+        CHECK(tok_text_eq(&toks[0], "it''s"),
+              "[0] body keeps doubled quote (decoded later)");
+        CHECK((toks[0].tok_flags & TOKF_QUOTE_DBL) != 0,
+              "[0] TOKF_QUOTE_DBL set");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_operators(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+    const char *src = "a + b - c * d / e // f % g ** h || i && j \\= k == l >= m <= n";
+    int rc;
+
+    printf("\n--- Test: operator zoo ---\n");
+
+    rc = run(src, &toks, &n, &err);
+    CHECK(rc == 0, "tokenizer returns 0");
+    /* 14 operands + 13 operators + EOC + EOF = 29 tokens */
+    CHECK(n == 29, "29 tokens for the operator-zoo expression");
+    if (rc == 0 && n >= 28) {
+        /* Spot-check a few operator types */
+        CHECK(toks[1].tok_type == TOK_OPERATOR && tok_text_eq(&toks[1], "+"),
+              "+ is OPERATOR");
+        CHECK(toks[9].tok_type == TOK_OPERATOR && tok_text_eq(&toks[9], "//"),
+              "// is OPERATOR");
+        CHECK(toks[13].tok_type == TOK_OPERATOR && tok_text_eq(&toks[13], "**"),
+              "** is OPERATOR");
+        CHECK(toks[15].tok_type == TOK_CONCAT && tok_text_eq(&toks[15], "||"),
+              "|| is CONCAT");
+        CHECK(toks[17].tok_type == TOK_LOGICAL && tok_text_eq(&toks[17], "&&"),
+              "&& is LOGICAL");
+        CHECK(toks[19].tok_type == TOK_COMPARISON && tok_text_eq(&toks[19], "\\="),
+              "\\= is COMPARISON");
+        CHECK(toks[21].tok_type == TOK_COMPARISON && tok_text_eq(&toks[21], "=="),
+              "== is COMPARISON");
+        CHECK(toks[23].tok_type == TOK_COMPARISON && tok_text_eq(&toks[23], ">="),
+              ">= is COMPARISON");
+        CHECK(toks[25].tok_type == TOK_COMPARISON && tok_text_eq(&toks[25], "<="),
+              "<= is COMPARISON");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_comments_and_lines(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+    const char *src =
+        "/* line 1 */\n"
+        "say /* nested /* deeper */ done */ 'hi'\n"
+        "x = 1\n";
+    int rc;
+
+    printf("\n--- Test: nested comments + line numbers ---\n");
+
+    rc = run(src, &toks, &n, &err);
+    CHECK(rc == 0, "tokenizer returns 0");
+    if (rc == 0) {
+        CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "say"),
+              "[0] 'say' on line 2");
+        CHECK(toks[0].tok_line == 2, "[0] tok_line == 2");
+        CHECK(toks[1].tok_type == TOK_STRING && tok_text_eq(&toks[1], "hi"),
+              "[1] STRING 'hi' on line 2");
+        CHECK(toks[1].tok_line == 2, "[1] tok_line == 2");
+        /* After EOC, we have x = 1 on line 3. */
+        {
+            int i;
+            int found_x = 0;
+            for (i = 0; i < n; i++) {
+                if (toks[i].tok_type == TOK_SYMBOL &&
+                    tok_text_eq(&toks[i], "x")) {
+                    found_x = (toks[i].tok_line == 3);
+                    break;
+                }
+            }
+            CHECK(found_x, "'x' is on line 3 (line numbers preserved)");
+        }
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_continuation(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+    const char *src = "say 'a',\n'b'\n";
+    int rc;
+
+    printf("\n--- Test: trailing-comma continuation ---\n");
+
+    rc = run(src, &toks, &n, &err);
+    CHECK(rc == 0, "tokenizer returns 0");
+    /* No COMMA token, no extra EOC: SYM STR STR EOC EOF = 5 */
+    CHECK(n == 5, "5 tokens (comma + newline collapsed)");
+    if (n >= 4) {
+        CHECK(toks[0].tok_type == TOK_SYMBOL, "[0] SYMBOL say");
+        CHECK(toks[1].tok_type == TOK_STRING, "[1] STRING 'a'");
+        CHECK(toks[2].tok_type == TOK_STRING, "[2] STRING 'b'");
+        CHECK(toks[3].tok_type == TOK_EOC,    "[3] EOC");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_numbers(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+
+    printf("\n--- Test: numbers ---\n");
+
+    run("42 3.14 1E5 1.5e-2 .5", &toks, &n, &err);
+    CHECK(n == 7, "5 numbers + EOC + EOF");
+    if (n >= 5) {
+        CHECK(toks[0].tok_type == TOK_NUMBER && tok_text_eq(&toks[0], "42"),
+              "42");
+        CHECK(toks[1].tok_type == TOK_NUMBER && tok_text_eq(&toks[1], "3.14"),
+              "3.14");
+        CHECK(toks[2].tok_type == TOK_NUMBER && tok_text_eq(&toks[2], "1E5"),
+              "1E5");
+        CHECK(toks[3].tok_type == TOK_NUMBER && tok_text_eq(&toks[3], "1.5e-2"),
+              "1.5e-2");
+        CHECK(toks[4].tok_type == TOK_NUMBER && tok_text_eq(&toks[4], ".5"),
+              ".5");
+    }
+    irx_tokn_free(NULL, toks, n);
+}
+
+static void test_unterminated_string(void)
+{
+    struct irx_token *toks = NULL;
+    int n = 0;
+    struct irx_tokn_error err;
+    int rc;
+
+    printf("\n--- Test: unterminated string error ---\n");
+
+    rc = run("say 'oops", &toks, &n, &err);
+    CHECK(rc != 0, "returns error");
+    CHECK(err.error_code == TOKERR_UNTERMINATED_STR,
+          "error_code == TOKERR_UNTERMINATED_STR");
+    CHECK(err.error_line == 1, "error_line == 1");
+    CHECK(toks == NULL, "out_tokens cleared on error");
+}
+
+static void test_stress_1000_lines(void)
+{
+    /* Build "say 'line N'\n" 1000 times. */
+    char *buf;
+    int   buf_len = 0;
+    int   buf_cap = 64 * 1024;
+    int   i;
+    struct irx_token *toks = NULL;
+    int   n = 0;
+    struct irx_tokn_error err;
+    int   rc;
+
+    printf("\n--- Test: stress 1000 lines ---\n");
+
+    buf = (char *)malloc((size_t)buf_cap);
+    if (buf == NULL) { CHECK(0, "malloc"); return; }
+
+    for (i = 1; i <= 1000; i++) {
+        int written = sprintf(buf + buf_len, "say 'line %d'\n", i);
+        buf_len += written;
+    }
+
+    rc = run(buf, &toks, &n, &err);
+    CHECK(rc == 0, "tokenizes 1000 lines without error");
+    /* Each line: SYMBOL STRING EOC = 3 tokens, plus trailing EOF */
+    CHECK(n == 1000 * 3 + 1, "produces 3001 tokens (3 per line + EOF)");
+
+    irx_tokn_free(NULL, toks, n);
+    free(buf);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("=== REXX/370 WP-10 Tokenizer Tests ===\n");
+
+    test_hello_world();
+    test_compound_symbol();
+    test_hex_string();
+    test_bin_string();
+    test_string_doubling();
+    test_operators();
+    test_comments_and_lines();
+    test_continuation();
+    test_numbers();
+    test_unterminated_string();
+    test_stress_1000_lines();
+
+    printf("\n=== Results: %d/%d passed",
+           tests_passed, tests_run);
+    if (tests_failed > 0) printf(", %d FAILED", tests_failed);
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/test_tokenizer.c
+++ b/test/test_tokenizer.c
@@ -317,13 +317,15 @@ static void test_continuation(void)
 
     rc = run(src, &toks, &n, &err);
     CHECK(rc == 0, "tokenizer returns 0");
-    /* No COMMA token, no extra EOC: SYM STR STR EOC EOF = 5 */
-    CHECK(n == 5, "5 tokens (comma + newline collapsed)");
-    if (n >= 4) {
+    /* Comma stays (argument separator), only EOC suppressed:
+     * SYM STR COMMA STR EOC EOF = 6 */
+    CHECK(n == 6, "6 tokens (comma kept, EOC suppressed)");
+    if (n >= 5) {
         CHECK(toks[0].tok_type == TOK_SYMBOL, "[0] SYMBOL say");
         CHECK(toks[1].tok_type == TOK_STRING, "[1] STRING 'a'");
-        CHECK(toks[2].tok_type == TOK_STRING, "[2] STRING 'b'");
-        CHECK(toks[3].tok_type == TOK_EOC,    "[3] EOC");
+        CHECK(toks[2].tok_type == TOK_COMMA,  "[2] COMMA (kept for parser)");
+        CHECK(toks[3].tok_type == TOK_STRING, "[3] STRING 'b'");
+        CHECK(toks[4].tok_type == TOK_EOC,    "[4] EOC");
     }
     irx_tokn_free(NULL, toks, n);
 }


### PR DESCRIPTION
## Summary

First WP of Phase 2: a single-pass, reentrant REXX tokenizer.

- `include/irxtokn.h` — token types, token record, error codes, public API
- `src/irx#tokn.c` — implementation (~600 LOC)
- `test/test_tokenizer.c` — cross-compile test harness covering the WP-10 acceptance criteria

The tokenizer is a pure source-to-tokens transformer. It does not touch `irx_wkblk_int.wkbi_tokens` — that is the caller's job (IRXEXEC, later). All scanner state lives in a private context allocated on the caller's stack; nothing static, nothing extern.

## Design notes

- **Public API:** `irx_tokn_run(envblock, src, src_len, &tokens, &count, &err)` and `irx_tokn_free(envblock, tokens, count)`. Both have `asm()` aliases (`IRXTOKNR` / `IRXTOKNF`) to dodge the 8-char collision in c2asm370.
- **Error reporting:** dedicated `struct irx_tokn_error` out-parameter (NULL = don't care). No state leaks via the private context.
- **Memory:** all allocation through `irxstor()`; token array starts at 64 entries and doubles. Freed cleanly on the error path.
- **EBCDIC:** uses `<ctype.h>` (EBCDIC-correct on MVS via crent370). The only hardcoded byte value is `0x5F` for the EBCDIC logical-not sign, gated on `__MVS__`, with a comment pointing at SC28-1883-0.

## Acceptance criteria coverage

| # | Criterion | Test |
|---|---|---|
| 1 | `say 'Hello World'` | `test_hello_world` |
| 2 | Compound symbols (`stem.i.j`) | `test_compound_symbol` |
| 3 | Hex strings (`'FF'x`) | `test_hex_string` |
| 4 | All operators | `test_operators` |
| 5 | Comments stripped, line numbers preserved | `test_comments_and_lines` |
| 6 | Trailing-comma continuation | `test_continuation` |
| 7 | EBCDIC-safe character classification | covered by `<ctype.h>` usage |
| 8 | No global state | enforced by design (context on stack) |
| 9 | 1000-line stress test | `test_stress_1000_lines` |

Plus extras: `test_bin_string`, `test_string_doubling`, `test_numbers` (incl. signed exponents), `test_unterminated_string`.

## Verification

- **Cross-compile (Linux/gcc):** 55/55 tests pass.
- **MVS build:** 7/7 modules RC=0 via `make build`.

## Test plan

- [x] `gcc -I include -Wall -Wextra -std=gnu99 -o test/test_tokenizer test/test_tokenizer.c 'src/irx#'*.c && ./test/test_tokenizer` → 55/55
- [x] `make build` → 7/7 RC=0 on MVS 3.8j
- [ ] Manual review of operator coverage vs. SC28-1883-0 Chapter 2
- [ ] Future: integrate into IRXEXEC once WP-13 (parser) lands

Closes #1