### PR TITLE
WP-11b: REXX lstring adapter (irx#lstr.c)

### DIFF
--- a/include/irxlstr.h
+++ b/include/irxlstr.h
@@ -1,0 +1,113 @@
+/* ------------------------------------------------------------------ */
+/*  irxlstr.h - REXX/370 <-> lstring370 adapter                       */
+/*                                                                    */
+/*  Thin layer that bridges lstring370 into the REXX interpreter:     */
+/*                                                                    */
+/*  - Allocator bridge: injects irxstor as the lstring370 allocator,  */
+/*    routing every Lfx/Lfree through the per-environment storage    */
+/*    management replaceable routine.                                  */
+/*                                                                    */
+/*  - REXX type caching: extends Lstr.type with LINTEGER_TY and       */
+/*    LREAL_TY so _Lisnum() can return a cached answer on repeated    */
+/*    queries of the same (unmodified) string.                        */
+/*                                                                    */
+/*  - REXX numeric detection: _Lisnum() checks if a string is a       */
+/*    valid REXX number per SC28-1883-0 Chapter 6.                    */
+/*                                                                    */
+/*  - DATATYPE() support: irx_datatype() implements the REXX          */
+/*    DATATYPE() built-in classification.                             */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 3 (Variables), Chapter 6 (Numbers)      */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef __IRXLSTR_H__
+#define __IRXLSTR_H__
+
+#include "irx.h"
+#include "lstring.h"
+
+/* ================================================================== */
+/*  Extended type tags for Lstr.type                                  */
+/*                                                                    */
+/*  lstring370 defines LSTRING_TY == 0 in <lstring.h>. The REXX       */
+/*  adapter extends this with cached numeric classifications.         */
+/*                                                                    */
+/*  IMPORTANT: cache validity. lstring370 does not reset Lstr.type    */
+/*  on mutation (Lscpy, Lcat, Lstrcpy, Lstrcat do not touch the       */
+/*  type field). Callers that mutate a string after classifying it    */
+/*  MUST manually reset s->type to LSTRING_TY before re-querying      */
+/*  _Lisnum() / irx_datatype().                                       */
+/* ================================================================== */
+
+#define LINTEGER_TY   1   /* validated as an integer literal          */
+#define LREAL_TY      2   /* validated as a real / exponent literal   */
+
+/* ================================================================== */
+/*  _Lisnum() result values                                           */
+/* ================================================================== */
+
+#define LNUM_NOT_NUM  0   /* not a valid REXX number                  */
+#define LNUM_INTEGER  1   /* valid REXX integer (no dot, no exponent) */
+#define LNUM_REAL     2   /* valid REXX real (has dot or exponent)    */
+
+/* ================================================================== */
+/*  Public API                                                        */
+/* ================================================================== */
+
+/* Initialise (or return) the REXX allocator for an environment.
+ *
+ * On first call for a given envblock, allocates a struct lstr_alloc
+ * via irxstor, fills it with the rexx_lstr_alloc / rexx_lstr_free
+ * bridges (ctx = envblock), and stores it in wkbi_lstr_alloc. On
+ * subsequent calls, returns the cached pointer without reallocating.
+ *
+ * Returns NULL if envblock is invalid or the underlying irxstor
+ * call fails.
+ *
+ * Ownership: the allocator struct is owned by the envblock's work
+ * block and is freed by irxterm().
+ */
+struct lstr_alloc *irx_lstr_init(struct envblock *envblock);
+
+/* Check if s contains a valid REXX number literal.
+ *
+ * Accepts:
+ *   - Optional leading / trailing whitespace
+ *   - Optional sign (+ / -)
+ *   - digits [ . digits ] OR  . digits
+ *   - Optional exponent  E [ + / - ] digits
+ *
+ * Returns LNUM_NOT_NUM, LNUM_INTEGER, or LNUM_REAL. On a successful
+ * classification, caches the result in s->type (LINTEGER_TY or
+ * LREAL_TY). On a failed classification, leaves s->type untouched.
+ *
+ * If s->type is already LINTEGER_TY or LREAL_TY on entry, returns
+ * the cached value without re-scanning.
+ */
+int _Lisnum(PLstr s);
+
+/* REXX DATATYPE(string [, type]) built-in.
+ *
+ *   option  Meaning                           Accepted chars
+ *   ------  --------------------------------  ----------------------
+ *   '\0'    no-option form: NUM / not NUM     (returns 1 iff _Lisnum)
+ *   'N'     NUM                                same as '\0'
+ *   'A'     alphanumeric                       letters + digits
+ *   'B'     binary                             '0' | '1'
+ *   'L'     lowercase alphabetic only          a-z
+ *   'M'     mixed / any alphabetic             a-z | A-Z
+ *   'S'     symbol characters                  letters digits _ @ # $ ? ! .
+ *   'U'     uppercase alphabetic only          A-Z
+ *   'W'     whole number                       integer with no frac part
+ *   'X'     hex digits (blanks permitted)      0-9 a-f A-F + blanks
+ *
+ * Per SC28-1883-0: DATATYPE returns 1 only if the string is non-empty
+ * and every character satisfies the option. (Option 'W' also accepts
+ * leading sign.) Returns 0 for empty strings and any mismatch.
+ *
+ * Unknown option characters return 0.
+ */
+int irx_datatype(PLstr s, char option);
+
+#endif /* __IRXLSTR_H__ */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -137,7 +137,13 @@ struct irx_wkblk_int {
     int            wkbi_depth;          /* Current call/procedure depth   */
     int            wkbi_flags;          /* Internal state flags           */
 
-    int            _reserved[4];        /* reserved for future use        */
+    /* --- lstring370 allocator bridge (WP-11b) ----------------------- */
+    /* Opaque pointer to a `struct lstr_alloc` allocated via irxstor.
+     * Set lazily by irx_lstr_init(); freed by irxterm(). Consumers
+     * that need the concrete type must include <lstring.h>.          */
+    void          *wkbi_lstr_alloc;
+
+    int            _reserved[3];        /* reserved for future use        */
 };
 
 #define WKBLK_INT_ID    "WKBI"

--- a/project.toml
+++ b/project.toml
@@ -43,6 +43,7 @@ space = ["TRK", 20, 10, 10]
 
 [dependencies]
 "mvslovers/crent370" = ">=1.0.9"
+"mvslovers/lstring370" = "=0.1.0-dev"
 
 [mvs.install]
 naming = "fixed"

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -1,0 +1,249 @@
+/* ------------------------------------------------------------------ */
+/*  irxlstr.c - REXX/370 <-> lstring370 adapter                       */
+/*                                                                    */
+/*  Implements the allocator bridge that routes lstring370 storage    */
+/*  operations through irxstor, plus the REXX-specific extensions    */
+/*  (_Lisnum, irx_datatype) that live on top of the generic library. */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stddef.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "irx.h"
+#include "irxwkblk.h"
+#include "irxfunc.h"
+#include "lstring.h"
+#include "irxlstr.h"
+
+/* ------------------------------------------------------------------ */
+/*  Allocator bridge                                                  */
+/*                                                                    */
+/*  The ctx field in the lstr_alloc struct holds the envblock pointer */
+/*  so each alloc/dealloc routes through the correct environment's    */
+/*  storage management replaceable routine. No statics - everything   */
+/*  travels with the struct.                                          */
+/* ------------------------------------------------------------------ */
+
+static void *rexx_lstr_alloc(size_t size, void *ctx)
+{
+    struct envblock *env = (struct envblock *)ctx;
+    void            *ptr = NULL;
+    int              rc;
+
+    rc = irxstor(RXSMGET, (int)size, &ptr, env);
+    if (rc != 0) return NULL;
+    return ptr;
+}
+
+static void rexx_lstr_dealloc(void *ptr, size_t size, void *ctx)
+{
+    struct envblock *env = (struct envblock *)ctx;
+    void            *p   = ptr;
+
+    (void)size;   /* irxstor's free path doesn't use the length */
+    irxstor(RXSMFRE, (int)size, &p, env);
+}
+
+struct lstr_alloc *irx_lstr_init(struct envblock *envblock)
+{
+    struct irx_wkblk_int *wkbi;
+    struct lstr_alloc    *alloc;
+    void                 *mem = NULL;
+    int                   rc;
+
+    if (envblock == NULL) return NULL;
+
+    wkbi = (struct irx_wkblk_int *)envblock->envblock_userfield;
+    if (wkbi == NULL) return NULL;
+
+    if (wkbi->wkbi_lstr_alloc != NULL) {
+        return (struct lstr_alloc *)wkbi->wkbi_lstr_alloc;
+    }
+
+    rc = irxstor(RXSMGET, (int)sizeof(struct lstr_alloc), &mem, envblock);
+    if (rc != 0) return NULL;
+
+    alloc = (struct lstr_alloc *)mem;
+    alloc->alloc   = rexx_lstr_alloc;
+    alloc->dealloc = rexx_lstr_dealloc;
+    alloc->ctx     = envblock;
+
+    wkbi->wkbi_lstr_alloc = alloc;
+    return alloc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  REXX number detection                                             */
+/*                                                                    */
+/*  Grammar per SC28-1883-0 Chapter 6, slightly relaxed:              */
+/*                                                                    */
+/*    number    ::= spaces? sign? mantissa exponent? spaces?          */
+/*    sign      ::= '+' | '-'                                         */
+/*    mantissa  ::= digits ('.' digits?)? | '.' digits                */
+/*    exponent  ::= ('E' | 'e') sign? digits                          */
+/*                                                                    */
+/*  Spaces are ASCII/EBCDIC isspace() whitespace. The result is       */
+/*  LNUM_INTEGER if no dot and no exponent were seen, LNUM_REAL       */
+/*  otherwise, LNUM_NOT_NUM if the input doesn't match the grammar.   */
+/* ------------------------------------------------------------------ */
+
+static int classify_number(const unsigned char *p, size_t n)
+{
+    size_t i = 0;
+    int    saw_dot      = 0;
+    int    saw_exp      = 0;
+    int    saw_mantissa = 0;
+
+    /* Leading whitespace */
+    while (i < n && isspace(p[i])) i++;
+    if (i >= n) return LNUM_NOT_NUM;
+
+    /* Optional sign */
+    if (p[i] == '+' || p[i] == '-') i++;
+
+    /* Mantissa: digits, optional dot, optional digits; or . digits */
+    while (i < n && isdigit(p[i])) { i++; saw_mantissa = 1; }
+    if (i < n && p[i] == '.') {
+        saw_dot = 1;
+        i++;
+        while (i < n && isdigit(p[i])) { i++; saw_mantissa = 1; }
+    }
+    if (!saw_mantissa) return LNUM_NOT_NUM;
+
+    /* Optional exponent */
+    if (i < n && (p[i] == 'E' || p[i] == 'e')) {
+        int saw_exp_digit = 0;
+        saw_exp = 1;
+        i++;
+        if (i < n && (p[i] == '+' || p[i] == '-')) i++;
+        while (i < n && isdigit(p[i])) { i++; saw_exp_digit = 1; }
+        if (!saw_exp_digit) return LNUM_NOT_NUM;
+    }
+
+    /* Trailing whitespace */
+    while (i < n && isspace(p[i])) i++;
+    if (i != n) return LNUM_NOT_NUM;
+
+    return (saw_dot || saw_exp) ? LNUM_REAL : LNUM_INTEGER;
+}
+
+int _Lisnum(PLstr s)
+{
+    int class;
+
+    if (s == NULL) return LNUM_NOT_NUM;
+    if (s->type == LINTEGER_TY) return LNUM_INTEGER;
+    if (s->type == LREAL_TY)    return LNUM_REAL;
+    if (s->pstr == NULL || s->len == 0) return LNUM_NOT_NUM;
+
+    class = classify_number(s->pstr, s->len);
+    if (class == LNUM_INTEGER) s->type = LINTEGER_TY;
+    else if (class == LNUM_REAL) s->type = LREAL_TY;
+    return class;
+}
+
+/* ------------------------------------------------------------------ */
+/*  DATATYPE() classifiers                                            */
+/*                                                                    */
+/*  Each helper walks the buffer byte-by-byte; REXX DATATYPE is       */
+/*  defined only for non-empty strings - the caller in irx_datatype   */
+/*  handles the empty-string short-circuit.                            */
+/* ------------------------------------------------------------------ */
+
+static int is_symbol_char(int c)
+{
+    if (isalnum(c)) return 1;
+    switch (c) {
+    case '_': case '@': case '#': case '$':
+    case '?': case '!': case '.':
+        return 1;
+    default:
+        return 0;
+    }
+}
+
+static int all_match(const unsigned char *p, size_t n, int (*pred)(int))
+{
+    size_t i;
+    for (i = 0; i < n; i++) {
+        if (!pred(p[i])) return 0;
+    }
+    return 1;
+}
+
+static int is_binary_char(int c) { return c == '0' || c == '1'; }
+static int is_alnum(int c)       { return isalnum(c); }
+static int is_lower(int c)       { return islower(c); }
+static int is_upper(int c)       { return isupper(c); }
+static int is_alpha(int c)       { return isalpha(c); }
+
+/* Hex with embedded blanks allowed between byte boundaries. */
+static int check_hex(const unsigned char *p, size_t n)
+{
+    size_t i;
+    size_t digits = 0;
+    for (i = 0; i < n; i++) {
+        if (p[i] == ' ' || p[i] == '\t') continue;
+        if (!isxdigit(p[i])) return 0;
+        digits++;
+    }
+    return digits > 0;
+}
+
+/* Whole number: sign?, digits, no dot, no exponent (or zero-valued
+ * exponent - we accept any integer REXX number via classify_number
+ * and then ensure it's LNUM_INTEGER). */
+static int check_whole(const unsigned char *p, size_t n)
+{
+    return classify_number(p, n) == LNUM_INTEGER;
+}
+
+int irx_datatype(PLstr s, char option)
+{
+    if (s == NULL || s->pstr == NULL || s->len == 0) return 0;
+
+    switch (option) {
+    case '\0':
+    case 'N':
+    case 'n':
+        return classify_number(s->pstr, s->len) != LNUM_NOT_NUM;
+
+    case 'A':
+    case 'a':
+        return all_match(s->pstr, s->len, is_alnum);
+
+    case 'B':
+    case 'b':
+        return all_match(s->pstr, s->len, is_binary_char);
+
+    case 'L':
+    case 'l':
+        return all_match(s->pstr, s->len, is_lower);
+
+    case 'M':
+    case 'm':
+        return all_match(s->pstr, s->len, is_alpha);
+
+    case 'S':
+    case 's':
+        return all_match(s->pstr, s->len, is_symbol_char);
+
+    case 'U':
+    case 'u':
+        return all_match(s->pstr, s->len, is_upper);
+
+    case 'W':
+    case 'w':
+        return check_whole(s->pstr, s->len);
+
+    case 'X':
+    case 'x':
+        return check_hex(s->pstr, s->len);
+
+    default:
+        return 0;
+    }
+}

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -67,6 +67,11 @@ int irxterm(struct envblock *envblk)
          * exec stack, token stream, label table, cache
          * that hang off wkbi before freeing wkbi itself */
 
+        /* Free the lstring370 allocator bridge if it was installed. */
+        if (wkbi->wkbi_lstr_alloc != NULL) {
+            stor_free(&wkbi->wkbi_lstr_alloc, envblk);
+        }
+
         envblk->envblock_userfield = NULL;
         stor_free((void **)&wkbi, envblk);
     }

--- a/test/test_irxlstr.c
+++ b/test/test_irxlstr.c
@@ -1,0 +1,278 @@
+/* ------------------------------------------------------------------ */
+/*  test_irxlstr.c - WP-11b REXX lstring adapter tests                */
+/*                                                                    */
+/*  Tests the pure-C parts of irx#lstr.c that don't require the       */
+/*  full lstring370 library to be linked (allocator wiring,           */
+/*  _Lisnum, irx_datatype). End-to-end allocator routing via          */
+/*  irxinit/irxterm is covered by a second test that links in the    */
+/*  Phase 1 modules.                                                  */
+/*                                                                    */
+/*  Build (cross-compile, Linux/gcc):                                 */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_irxlstr \              */
+/*        test/test_irxlstr.c \                                       */
+/*        'src/irx#'*.c                                                */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "irx.h"
+#include "irxrab.h"
+#include "irxwkblk.h"
+#include "irxfunc.h"
+#include "lstring.h"
+#include "lstralloc.h"
+#include "irxlstr.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg) \
+    do { \
+        tests_run++; \
+        if (cond) { \
+            tests_passed++; \
+            printf("  PASS: %s\n", msg); \
+        } else { \
+            tests_failed++; \
+            printf("  FAIL: %s\n", msg); \
+        } \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Helpers: build an Lstr from a C string without depending on the   */
+/*  lstring370 library being linked in.                               */
+/* ------------------------------------------------------------------ */
+
+static Lstr make_lstr(const char *cstr)
+{
+    Lstr s;
+    s.pstr   = (unsigned char *)(uintptr_t)cstr;
+    s.len    = strlen(cstr);
+    s.maxlen = s.len;
+    s.type   = LSTRING_TY;
+    return s;
+}
+
+/* ------------------------------------------------------------------ */
+/*  _Lisnum tests                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_lisnum_integers(void)
+{
+    Lstr s;
+    printf("\n--- Test: _Lisnum integers ---\n");
+
+    s = make_lstr("42");
+    CHECK(_Lisnum(&s) == LNUM_INTEGER, "'42' is INTEGER");
+    CHECK(s.type == LINTEGER_TY, "'42' type cached LINTEGER_TY");
+    /* Second call hits the cache. */
+    CHECK(_Lisnum(&s) == LNUM_INTEGER, "cached result still INTEGER");
+
+    s = make_lstr("  -123  ");
+    CHECK(_Lisnum(&s) == LNUM_INTEGER,
+          "'  -123  ' (whitespace + sign)");
+
+    s = make_lstr("+0");
+    CHECK(_Lisnum(&s) == LNUM_INTEGER, "'+0'");
+}
+
+static void test_lisnum_reals(void)
+{
+    Lstr s;
+    printf("\n--- Test: _Lisnum reals ---\n");
+
+    s = make_lstr("3.14");
+    CHECK(_Lisnum(&s) == LNUM_REAL, "'3.14' is REAL");
+    CHECK(s.type == LREAL_TY, "'3.14' type cached LREAL_TY");
+
+    s = make_lstr("-.5");
+    CHECK(_Lisnum(&s) == LNUM_REAL, "'-.5' is REAL");
+
+    s = make_lstr("1E5");
+    CHECK(_Lisnum(&s) == LNUM_REAL, "'1E5' is REAL (has exponent)");
+
+    s = make_lstr("1E+5");
+    CHECK(_Lisnum(&s) == LNUM_REAL, "'1E+5' is REAL");
+
+    s = make_lstr("1.5e-2");
+    CHECK(_Lisnum(&s) == LNUM_REAL, "'1.5e-2' is REAL");
+}
+
+static void test_lisnum_rejects(void)
+{
+    Lstr s;
+    printf("\n--- Test: _Lisnum rejects ---\n");
+
+    s = make_lstr("");
+    CHECK(_Lisnum(&s) == LNUM_NOT_NUM, "empty string is not a number");
+
+    s = make_lstr("abc");
+    CHECK(_Lisnum(&s) == LNUM_NOT_NUM, "'abc' is not a number");
+
+    s = make_lstr("1..2");
+    CHECK(_Lisnum(&s) == LNUM_NOT_NUM, "'1..2' (double dot) rejected");
+
+    s = make_lstr("1E");
+    CHECK(_Lisnum(&s) == LNUM_NOT_NUM,
+          "'1E' (exponent without digits) rejected");
+
+    s = make_lstr(".");
+    CHECK(_Lisnum(&s) == LNUM_NOT_NUM,
+          "'.' alone rejected");
+
+    s = make_lstr("12 34");
+    CHECK(_Lisnum(&s) == LNUM_NOT_NUM,
+          "'12 34' (interior whitespace) rejected");
+}
+
+/* ------------------------------------------------------------------ */
+/*  irx_datatype tests                                                */
+/* ------------------------------------------------------------------ */
+
+static void test_datatype_numeric(void)
+{
+    Lstr s;
+    printf("\n--- Test: irx_datatype N / no-option ---\n");
+
+    s = make_lstr("42");
+    CHECK(irx_datatype(&s, 0)   == 1, "'42' is NUM (no option)");
+    CHECK(irx_datatype(&s, 'N') == 1, "'42' is NUM ('N')");
+
+    s = make_lstr("abc");
+    CHECK(irx_datatype(&s, 'N') == 0, "'abc' is not NUM");
+
+    s = make_lstr("");
+    CHECK(irx_datatype(&s, 'N') == 0, "empty is not NUM");
+}
+
+static void test_datatype_classifiers(void)
+{
+    Lstr s;
+    printf("\n--- Test: irx_datatype classifiers ---\n");
+
+    s = make_lstr("abc123");
+    CHECK(irx_datatype(&s, 'A') == 1, "'abc123' is Alphanumeric");
+    s = make_lstr("abc-123");
+    CHECK(irx_datatype(&s, 'A') == 0, "'abc-123' is not Alphanumeric");
+
+    s = make_lstr("1010");
+    CHECK(irx_datatype(&s, 'B') == 1, "'1010' is Binary");
+    s = make_lstr("102");
+    CHECK(irx_datatype(&s, 'B') == 0, "'102' is not Binary");
+
+    s = make_lstr("hello");
+    CHECK(irx_datatype(&s, 'L') == 1, "'hello' is Lower");
+    CHECK(irx_datatype(&s, 'M') == 1, "'hello' is Mixed (alpha)");
+    CHECK(irx_datatype(&s, 'U') == 0, "'hello' is not Upper");
+
+    s = make_lstr("HELLO");
+    CHECK(irx_datatype(&s, 'U') == 1, "'HELLO' is Upper");
+    CHECK(irx_datatype(&s, 'M') == 1, "'HELLO' is Mixed");
+
+    s = make_lstr("MixEd");
+    CHECK(irx_datatype(&s, 'M') == 1, "'MixEd' is Mixed");
+    CHECK(irx_datatype(&s, 'L') == 0, "'MixEd' is not all-Lower");
+    CHECK(irx_datatype(&s, 'U') == 0, "'MixEd' is not all-Upper");
+
+    s = make_lstr("stem.i");
+    CHECK(irx_datatype(&s, 'S') == 1, "'stem.i' is Symbol");
+    s = make_lstr("has space");
+    CHECK(irx_datatype(&s, 'S') == 0, "'has space' is not Symbol");
+
+    s = make_lstr("123");
+    CHECK(irx_datatype(&s, 'W') == 1, "'123' is Whole");
+    s = make_lstr("-42");
+    CHECK(irx_datatype(&s, 'W') == 1, "'-42' is Whole (signed)");
+    s = make_lstr("1.5");
+    CHECK(irx_datatype(&s, 'W') == 0, "'1.5' is not Whole");
+
+    s = make_lstr("DEAD BEEF");
+    CHECK(irx_datatype(&s, 'X') == 1, "'DEAD BEEF' is Hex");
+    s = make_lstr("GHOST");
+    CHECK(irx_datatype(&s, 'X') == 0, "'GHOST' is not Hex");
+
+    /* Unknown option returns 0. */
+    s = make_lstr("anything");
+    CHECK(irx_datatype(&s, 'Q') == 0, "unknown option returns 0");
+}
+
+/* ------------------------------------------------------------------ */
+/*  End-to-end: allocator bridge through irxinit                      */
+/* ------------------------------------------------------------------ */
+
+static void test_allocator_bridge(void)
+{
+    struct envblock   *env = NULL;
+    struct irx_wkblk_int *wkbi;
+    struct lstr_alloc *alloc;
+    struct lstr_alloc *alloc2;
+    int rc;
+
+    printf("\n--- Test: irx_lstr_init + allocator bridge ---\n");
+
+    rc = irxinit(NULL, &env);
+    CHECK(rc == 0 && env != NULL, "irxinit succeeds");
+    if (env == NULL) return;
+
+    alloc = irx_lstr_init(env);
+    CHECK(alloc != NULL, "irx_lstr_init returns non-NULL");
+    CHECK(alloc->alloc   != NULL, "alloc function pointer set");
+    CHECK(alloc->dealloc != NULL, "dealloc function pointer set");
+    CHECK(alloc->ctx == env,      "ctx is the envblock");
+
+    /* Second call must return the same pointer (cached in wkbi). */
+    alloc2 = irx_lstr_init(env);
+    CHECK(alloc2 == alloc, "second irx_lstr_init returns cached pointer");
+
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    CHECK(wkbi != NULL && wkbi->wkbi_lstr_alloc == alloc,
+          "wkbi->wkbi_lstr_alloc points at the allocator");
+
+    /* Exercise the bridge by alloc/free via the callbacks directly. */
+    {
+        void *mem = (*alloc->alloc)(64, alloc->ctx);
+        CHECK(mem != NULL, "bridged alloc(64) succeeds");
+        if (mem != NULL) {
+            memset(mem, 0xAB, 64);
+            (*alloc->dealloc)(mem, 64, alloc->ctx);
+        }
+    }
+
+    /* irxterm must release the allocator cleanly. */
+    rc = irxterm(env);
+    CHECK(rc == 0, "irxterm succeeds (frees the allocator)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("=== REXX/370 WP-11b lstring adapter tests ===\n");
+
+    test_lisnum_integers();
+    test_lisnum_reals();
+    test_lisnum_rejects();
+    test_datatype_numeric();
+    test_datatype_classifiers();
+    test_allocator_bridge();
+
+    printf("\n=== Results: %d/%d passed",
+           tests_passed, tests_run);
+    if (tests_failed > 0) printf(", %d FAILED", tests_failed);
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Thin REXX adapter layer on top of lstring370 — injects `irxstor` as the allocator and adds the REXX-specific classifiers (`_Lisnum`, `irx_datatype`) the interpreter needs for variable handling and `DATATYPE()`.

## Changes

- **`project.toml`**: adds `mvslovers/lstring370 = "=0.1.0-dev"` as a pinned pre-release dependency. `make bootstrap` pulls headers into `contrib/lstring370-0.1.0-dev/include/` and receives the NCALIB onto MVS.
- **`include/irxwkblk.h`**: new `void *wkbi_lstr_alloc` slot taken from the `_reserved[]` area; opaque pointer so consumers of `irxwkblk.h` don't have to pull in `<lstring.h>`.
- **`src/irx#term.c`**: releases the allocator struct before freeing the work block.
- **`include/irxlstr.h`** + **`src/irx#lstr.c`**: the adapter itself.
- **`test/test_irxlstr.c`**: 50-case cross-compile harness.

## Design notes

- **No statics.** The allocator struct is heap-allocated per environment through `irxstor`. The `ctx` field holds the envblock pointer so each bridged `alloc`/`dealloc` routes back through the right environment's storage replaceable routine. Multiple concurrent REXX environments can coexist without interfering.
- **`_Lisnum` type caching** lives in `Lstr.type` via two new tags (`LINTEGER_TY`, `LREAL_TY`). Cache hits on the second query of an unmodified string. Documented limitation: lstring370 doesn't reset `Lstr.type` on mutation, so callers that rewrite the string must reset `s->type = LSTRING_TY` before re-querying. Noted in the header.
- **`irx_datatype`** implements the full DATATYPE() option set (`N A B L M S U W X` + the no-option form) via `<ctype.h>` classifiers, so it's EBCDIC-correct on MVS through crent370.
- **`irx_lstr_init`** is idempotent — second call for the same environment returns the cached pointer from `wkbi_lstr_alloc`.

## Acceptance criteria

| # | Criterion | Covered by |
|---|---|---|
| 1 | `irx_lstr_init(envblock)` routes through `irxstor` | `test_allocator_bridge` |
| 2 | Alloc + free both go through `irxstor` | `test_allocator_bridge` (bridged alloc/dealloc of 64 bytes) |
| 3 | `_Lisnum()` identifies REXX numbers (`1E+5`, `  42  `, `-.5`) | `test_lisnum_integers` / `test_lisnum_reals` |
| 4 | Type caching: second call returns cached | `test_lisnum_integers` (second call hits LINTEGER_TY) |
| 5 | `irx_datatype()` handles `A B L M N S U W X` | `test_datatype_classifiers` |
| 6 | No global state | enforced by design (allocator carries envblock in ctx) |

## Verification

- Cross-compile (Linux/gcc): **50/50 tests pass**
- MVS build: `IRX#LSTR` and `IRX#TERM` RC=0 via `make build`

## Test plan

- [x] `make bootstrap` pulls lstring370 0.1.0-dev headers + NCALIB
- [x] `gcc -I include -I contrib/lstring370-0.1.0-dev/include ... test/test_irxlstr.c 'src/irx#'*.c && ./test/test_irxlstr` → 50/50
- [x] `make build` → RC=0 on MVS 3.8j
- [ ] Consumer integration: WP-12 (variable pool) will be the first real user of the injected allocator

Fixes #3