### PR TITLE
WP-12: Variable Pool (irx#vpol.c)

### DIFF
--- a/include/irxvpool.h
+++ b/include/irxvpool.h
@@ -1,0 +1,127 @@
+/* ------------------------------------------------------------------ */
+/*  irxvpool.h - REXX/370 Variable Pool                               */
+/*                                                                    */
+/*  Per-scope name -> value map that stores all REXX variables for    */
+/*  an exec. Chained hash table with dynamic resize, PROCEDURE        */
+/*  EXPOSE pointer sharing, stem-default lookup. All memory goes      */
+/*  through the injected lstring370 allocator (WP-11b).               */
+/*                                                                    */
+/*  Design:                                                           */
+/*   - The pool is a pure name -> value map. Compound-tail            */
+/*     resolution (stem.i.j -> STEM.FOO.3) is the parser's job;       */
+/*     the pool receives the fully derived name.                      */
+/*   - Stem-default lookup (STEM. fallback) IS the pool's job.        */
+/*   - PROCEDURE EXPOSE uses pointer sharing: the child entry         */
+/*     carries an `exposed_ref` back into the parent's entry; all     */
+/*     reads and writes route through that link.                      */
+/*   - Stem-EXPOSE registers the stem name on the child pool;         */
+/*     any access to that stem delegates to the parent.               */
+/*   - NOVALUE handling is the interpreter's job - the pool simply    */
+/*     returns VPOOL_NOT_FOUND.                                       */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 3 (Variables)                           */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef __IRXVPOOL_H__
+#define __IRXVPOOL_H__
+
+#include "lstring.h"
+#include "lstralloc.h"
+
+/* ================================================================== */
+/*  Return codes                                                      */
+/* ================================================================== */
+
+#define VPOOL_OK          0   /* success                              */
+#define VPOOL_NOT_FOUND   1   /* variable does not exist              */
+#define VPOOL_LAST        2   /* last variable returned (for NEXT)    */
+#define VPOOL_NOMEM      20   /* allocator failed                     */
+#define VPOOL_BADARG     21   /* invalid argument                     */
+
+/* ================================================================== */
+/*  Entry flags                                                       */
+/* ================================================================== */
+
+#define VPOOL_DROPPED     0x01  /* entry is tombstoned after DROP    */
+#define VPOOL_EXPOSED_REF 0x02  /* entry is a ref into parent pool   */
+#define VPOOL_UNSET       0x04  /* placeholder created by EXPOSE     */
+
+/* ================================================================== */
+/*  Entry                                                             */
+/* ================================================================== */
+
+struct vpool_entry {
+    struct vpool_entry *next;          /* chain within bucket          */
+    Lstr                name;          /* variable name (bytes as-is) */
+    Lstr                value;         /* variable value              */
+    int                 flags;         /* VPOOL_DROPPED / _EXPOSED_REF */
+    struct vpool_entry *exposed_ref;   /* -> parent entry if exposed  */
+};
+
+/* ================================================================== */
+/*  Pool                                                              */
+/* ================================================================== */
+
+#define VPOOL_ID      "VPOL"
+#define VPOOL_ID_LEN  4
+
+struct irx_vpool {
+    unsigned char        vp_id[VPOOL_ID_LEN];  /* eye-catcher 'VPOL'   */
+    struct vpool_entry **buckets;              /* bucket array         */
+    int                  bucket_count;         /* current bucket count */
+    int                  entry_count;          /* live entries (incl.
+                                                * exposed refs)        */
+    struct irx_vpool    *parent;               /* -> parent scope      */
+    Lstr                *exposed_stems;        /* array of stem names  */
+    int                  exposed_stem_count;
+    int                  exposed_stem_cap;
+    struct lstr_alloc   *alloc;                /* injected allocator   */
+
+    /* NEXT cursor. Do not mutate the pool while iterating. */
+    int                  next_bucket;
+    struct vpool_entry  *next_entry;
+    int                  next_started;
+};
+
+/* ================================================================== */
+/*  Public API                                                        */
+/*                                                                    */
+/*  asm() aliases are required for vpool_exists / vpool_expose_var /  */
+/*  vpool_expose_stem / vpool_next / vpool_next_reset because their   */
+/*  first 8 C characters collide under c2asm370's 8-char truncation.  */
+/* ================================================================== */
+
+/* Lifecycle */
+struct irx_vpool *vpool_create (struct lstr_alloc *a,
+                                struct irx_vpool *parent);
+void              vpool_destroy(struct irx_vpool *pool);
+
+/* Core operations. `name` is used as-is (no uppercasing). The
+ * parser is responsible for producing the canonical name. */
+int vpool_set   (struct irx_vpool *pool,
+                 const PLstr name, const PLstr value);
+int vpool_get   (struct irx_vpool *pool,
+                 const PLstr name, PLstr value);
+int vpool_drop  (struct irx_vpool *pool, const PLstr name);
+int vpool_exists(struct irx_vpool *pool,
+                 const PLstr name)                      asm("VPOOLEXI");
+
+/* EXPOSE registration. Should be called on the child pool before
+ * any set/get operations. `name` for expose_stem must include the
+ * trailing dot (e.g. "STEM."). */
+int vpool_expose_var (struct irx_vpool *pool,
+                      const PLstr name)                 asm("VPOOLXPV");
+int vpool_expose_stem(struct irx_vpool *pool,
+                      const PLstr stem_name)            asm("VPOOLXPS");
+
+/* Iteration. Call vpool_next_reset() before the first vpool_next()
+ * to rewind the cursor. vpool_next() returns VPOOL_OK with the
+ * current entry's name and value copied out, or VPOOL_LAST after the
+ * last entry has been returned, or VPOOL_NOT_FOUND if the pool is
+ * empty. `name` and `value` are grown via the pool's allocator. */
+int  vpool_next      (struct irx_vpool *pool,
+                      PLstr name, PLstr value)          asm("VPOOLNXT");
+void vpool_next_reset(struct irx_vpool *pool)           asm("VPOOLNRS");
+
+#endif /* __IRXVPOOL_H__ */

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -1,0 +1,626 @@
+/* ------------------------------------------------------------------ */
+/*  irxvpol.c - REXX/370 Variable Pool implementation                 */
+/*                                                                    */
+/*  Chained hash table with dynamic resize to a next prime on load    */
+/*  factor > VP_MAX_LOAD. PROCEDURE EXPOSE uses pointer sharing via   */
+/*  vpool_entry->exposed_ref into the parent pool. Stem-EXPOSE        */
+/*  registers a stem name on the child pool; any access to names     */
+/*  matching that stem is delegated to the parent pool (recursively  */
+/*  through the parent's own exposed stems).                          */
+/*                                                                    */
+/*  All memory goes through the injected lstring370 allocator. No    */
+/*  statics, no globals - pools are fully self-contained.            */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stddef.h>
+#include <string.h>
+
+#include "lstring.h"
+#include "lstralloc.h"
+#include "irxvpool.h"
+
+/* ------------------------------------------------------------------ */
+/*  Capacity management                                               */
+/* ------------------------------------------------------------------ */
+
+static const int vp_primes[] = {
+    67, 137, 277, 557, 1117, 2237, 4483, 8963
+};
+#define VP_PRIME_COUNT  8
+#define VP_INITIAL      67
+#define VP_MAX_LOAD     4    /* entries per bucket before resize */
+
+static int next_prime_after(int current)
+{
+    int i;
+    for (i = 0; i < VP_PRIME_COUNT; i++) {
+        if (vp_primes[i] > current) return vp_primes[i];
+    }
+    return current;  /* already at or above the largest listed prime */
+}
+
+/* djb2 hash (Dan Bernstein) over the raw bytes of the name. */
+static unsigned long hash_bytes(const unsigned char *p, size_t n)
+{
+    unsigned long h = 5381UL;
+    size_t i;
+    for (i = 0; i < n; i++) {
+        h = ((h << 5) + h) + p[i];
+    }
+    return h;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Allocation helpers                                                */
+/* ------------------------------------------------------------------ */
+
+static void *vp_alloc_raw(struct lstr_alloc *a, size_t size)
+{
+    if (a == NULL) return NULL;
+    return (*a->alloc)(size, a->ctx);
+}
+
+static void vp_free_raw(struct lstr_alloc *a, void *ptr, size_t size)
+{
+    if (a == NULL || ptr == NULL) return;
+    (*a->dealloc)(ptr, size, a->ctx);
+}
+
+static void vp_entry_init(struct vpool_entry *e)
+{
+    e->next         = NULL;
+    Lzeroinit(&e->name);
+    Lzeroinit(&e->value);
+    e->flags        = 0;
+    e->exposed_ref  = NULL;
+}
+
+static struct vpool_entry *vp_entry_new(struct lstr_alloc *a)
+{
+    struct vpool_entry *e;
+    e = (struct vpool_entry *)vp_alloc_raw(a, sizeof(struct vpool_entry));
+    if (e != NULL) vp_entry_init(e);
+    return e;
+}
+
+static void vp_entry_free(struct lstr_alloc *a, struct vpool_entry *e)
+{
+    if (e == NULL) return;
+    Lfree(a, &e->name);
+    Lfree(a, &e->value);
+    vp_free_raw(a, e, sizeof(struct vpool_entry));
+}
+
+/* Allocate a fresh bucket array cleared to zero. */
+static struct vpool_entry **vp_alloc_buckets(struct lstr_alloc *a,
+                                             int count)
+{
+    struct vpool_entry **buckets;
+    size_t bytes = (size_t)count * sizeof(struct vpool_entry *);
+    buckets = (struct vpool_entry **)vp_alloc_raw(a, bytes);
+    if (buckets != NULL) memset(buckets, 0, bytes);
+    return buckets;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Lifecycle                                                         */
+/* ------------------------------------------------------------------ */
+
+struct irx_vpool *vpool_create(struct lstr_alloc *a,
+                               struct irx_vpool *parent)
+{
+    struct irx_vpool *pool;
+
+    if (a == NULL) return NULL;
+
+    pool = (struct irx_vpool *)vp_alloc_raw(a, sizeof(struct irx_vpool));
+    if (pool == NULL) return NULL;
+
+    memset(pool, 0, sizeof(*pool));
+    memcpy(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN);
+    pool->alloc        = a;
+    pool->parent       = parent;
+    pool->bucket_count = VP_INITIAL;
+    pool->buckets      = vp_alloc_buckets(a, VP_INITIAL);
+    if (pool->buckets == NULL) {
+        vp_free_raw(a, pool, sizeof(*pool));
+        return NULL;
+    }
+    return pool;
+}
+
+static void vp_free_exposed_stems(struct irx_vpool *pool)
+{
+    int i;
+    if (pool->exposed_stems == NULL) return;
+    for (i = 0; i < pool->exposed_stem_count; i++) {
+        Lfree(pool->alloc, &pool->exposed_stems[i]);
+    }
+    vp_free_raw(pool->alloc, pool->exposed_stems,
+                (size_t)pool->exposed_stem_cap * sizeof(Lstr));
+    pool->exposed_stems      = NULL;
+    pool->exposed_stem_count = 0;
+    pool->exposed_stem_cap   = 0;
+}
+
+void vpool_destroy(struct irx_vpool *pool)
+{
+    int i;
+    struct lstr_alloc *a;
+
+    if (pool == NULL) return;
+    if (memcmp(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN) != 0) return;
+
+    a = pool->alloc;
+
+    for (i = 0; i < pool->bucket_count; i++) {
+        struct vpool_entry *e = pool->buckets[i];
+        while (e != NULL) {
+            struct vpool_entry *next = e->next;
+            vp_entry_free(a, e);
+            e = next;
+        }
+    }
+    vp_free_raw(a, pool->buckets,
+                (size_t)pool->bucket_count *
+                sizeof(struct vpool_entry *));
+
+    vp_free_exposed_stems(pool);
+
+    memset(pool->vp_id, 0, VPOOL_ID_LEN);
+    vp_free_raw(a, pool, sizeof(*pool));
+}
+
+/* ------------------------------------------------------------------ */
+/*  Bucket helpers                                                    */
+/* ------------------------------------------------------------------ */
+
+static int bucket_index(const struct irx_vpool *pool, const PLstr name)
+{
+    unsigned long h = hash_bytes(name->pstr, name->len);
+    return (int)(h % (unsigned long)pool->bucket_count);
+}
+
+static struct vpool_entry *find_in_bucket(struct vpool_entry *head,
+                                          const PLstr name)
+{
+    struct vpool_entry *e;
+    for (e = head; e != NULL; e = e->next) {
+        if (e->name.len == name->len &&
+            (name->len == 0 ||
+             memcmp(e->name.pstr, name->pstr, name->len) == 0)) {
+            return e;
+        }
+    }
+    return NULL;
+}
+
+/* Resize the bucket array to the next prime if the load factor
+ * exceeds VP_MAX_LOAD and we are not already at the largest prime. */
+static int maybe_resize(struct irx_vpool *pool)
+{
+    int new_count;
+    struct vpool_entry **new_buckets;
+    int i;
+
+    if (pool->entry_count <= pool->bucket_count * VP_MAX_LOAD) {
+        return VPOOL_OK;
+    }
+    new_count = next_prime_after(pool->bucket_count);
+    if (new_count == pool->bucket_count) return VPOOL_OK;  /* at max */
+
+    new_buckets = vp_alloc_buckets(pool->alloc, new_count);
+    if (new_buckets == NULL) return VPOOL_NOMEM;
+
+    for (i = 0; i < pool->bucket_count; i++) {
+        struct vpool_entry *e = pool->buckets[i];
+        while (e != NULL) {
+            struct vpool_entry *next = e->next;
+            unsigned long h = hash_bytes(e->name.pstr, e->name.len);
+            int idx = (int)(h % (unsigned long)new_count);
+            e->next = new_buckets[idx];
+            new_buckets[idx] = e;
+            e = next;
+        }
+    }
+
+    vp_free_raw(pool->alloc, pool->buckets,
+                (size_t)pool->bucket_count *
+                sizeof(struct vpool_entry *));
+    pool->buckets      = new_buckets;
+    pool->bucket_count = new_count;
+
+    /* Iteration cursor is invalidated by resize. */
+    pool->next_started = 0;
+    pool->next_bucket  = 0;
+    pool->next_entry   = NULL;
+
+    return VPOOL_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Stem helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+static int name_matches_stem(const PLstr name, const PLstr stem)
+{
+    /* The stem name includes its trailing dot. A compound name
+     * "STEM.X" matches "STEM.", and so does the bare default
+     * "STEM." itself. */
+    if (stem->len == 0 || name->len < stem->len) return 0;
+    return memcmp(name->pstr, stem->pstr, stem->len) == 0;
+}
+
+static int matches_exposed_stem(const struct irx_vpool *pool,
+                                const PLstr name)
+{
+    int i;
+    if (pool->exposed_stem_count == 0) return 0;
+    for (i = 0; i < pool->exposed_stem_count; i++) {
+        if (name_matches_stem(name, &pool->exposed_stems[i])) return 1;
+    }
+    return 0;
+}
+
+/* Locate the first dot in `name`. Returns the 0-based offset of the
+ * dot, or -1 if there is no dot. */
+static int first_dot(const PLstr name)
+{
+    size_t i;
+    for (i = 0; i < name->len; i++) {
+        if (name->pstr[i] == '.') return (int)i;
+    }
+    return -1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Entry insertion                                                   */
+/* ------------------------------------------------------------------ */
+
+/* Insert a freshly created entry at the head of its bucket. Also
+ * bumps entry_count and triggers resize if needed. Caller is
+ * responsible for populating the entry's name and value buffers. */
+static int link_entry(struct irx_vpool *pool, struct vpool_entry *e)
+{
+    int idx = bucket_index(pool, &e->name);
+    e->next = pool->buckets[idx];
+    pool->buckets[idx] = e;
+    pool->entry_count++;
+    return maybe_resize(pool);
+}
+
+/* Unlink an entry from its bucket chain. Caller provides the
+ * already-computed bucket index. */
+static void unlink_entry(struct irx_vpool *pool, int idx,
+                         struct vpool_entry *target)
+{
+    struct vpool_entry *prev = NULL;
+    struct vpool_entry *cur  = pool->buckets[idx];
+    while (cur != NULL) {
+        if (cur == target) {
+            if (prev == NULL) pool->buckets[idx] = cur->next;
+            else prev->next = cur->next;
+            pool->entry_count--;
+            return;
+        }
+        prev = cur;
+        cur  = cur->next;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Core operations                                                   */
+/* ------------------------------------------------------------------ */
+
+/* Follow an exposed_ref to the real storage entry. */
+static struct vpool_entry *resolve_ref(struct vpool_entry *e)
+{
+    while (e != NULL && (e->flags & VPOOL_EXPOSED_REF) &&
+           e->exposed_ref != NULL) {
+        e = e->exposed_ref;
+    }
+    return e;
+}
+
+int vpool_set(struct irx_vpool *pool, const PLstr name, const PLstr value)
+{
+    int idx;
+    struct vpool_entry *e;
+    int rc;
+
+    if (pool == NULL || name == NULL || value == NULL) return VPOOL_BADARG;
+    if (memcmp(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN) != 0) return VPOOL_BADARG;
+
+    /* Stem-EXPOSE delegation. */
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+        return vpool_set(pool->parent, name, value);
+    }
+
+    idx = bucket_index(pool, name);
+    e = find_in_bucket(pool->buckets[idx], name);
+
+    if (e != NULL) {
+        struct vpool_entry *tgt = resolve_ref(e);
+        if (tgt == NULL) return VPOOL_BADARG;
+        rc = Lstrcpy(pool->alloc, &tgt->value, value);
+        if (rc != LSTR_OK) return VPOOL_NOMEM;
+        tgt->flags &= ~VPOOL_UNSET;
+        return VPOOL_OK;
+    }
+
+    /* Create a new local entry. */
+    e = vp_entry_new(pool->alloc);
+    if (e == NULL) return VPOOL_NOMEM;
+
+    rc = Lstrcpy(pool->alloc, &e->name, name);
+    if (rc != LSTR_OK) { vp_entry_free(pool->alloc, e); return VPOOL_NOMEM; }
+    rc = Lstrcpy(pool->alloc, &e->value, value);
+    if (rc != LSTR_OK) { vp_entry_free(pool->alloc, e); return VPOOL_NOMEM; }
+
+    return link_entry(pool, e);
+}
+
+int vpool_get(struct irx_vpool *pool, const PLstr name, PLstr value)
+{
+    int idx;
+    struct vpool_entry *e;
+    int rc;
+
+    if (pool == NULL || name == NULL || value == NULL) return VPOOL_BADARG;
+
+    /* Stem-EXPOSE delegation. */
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+        return vpool_get(pool->parent, name, value);
+    }
+
+    idx = bucket_index(pool, name);
+    e = find_in_bucket(pool->buckets[idx], name);
+
+    if (e != NULL) {
+        struct vpool_entry *tgt = resolve_ref(e);
+        if (tgt != NULL && !(tgt->flags & VPOOL_UNSET)) {
+            rc = Lstrcpy(pool->alloc, value, &tgt->value);
+            return (rc == LSTR_OK) ? VPOOL_OK : VPOOL_NOMEM;
+        }
+    }
+
+    /* Stem default: if `name` is compound (contains a dot before the
+     * last character), look up "STEM." as the fallback. The stem key
+     * includes the first dot. */
+    {
+        int dot = first_dot(name);
+        if (dot >= 0) {
+            Lstr stem_key;
+            int  stem_idx;
+            struct vpool_entry *stem_e;
+
+            stem_key.pstr   = name->pstr;
+            stem_key.len    = (size_t)(dot + 1);
+            stem_key.maxlen = stem_key.len;
+            stem_key.type   = LSTRING_TY;
+
+            /* Don't fall into infinite recursion: only fall back on a
+             * true compound, i.e. there is at least one character
+             * after the dot (otherwise the caller already asked for
+             * the stem default). */
+            if (name->len > stem_key.len) {
+                stem_idx = bucket_index(pool, &stem_key);
+                stem_e   = find_in_bucket(pool->buckets[stem_idx],
+                                          &stem_key);
+                if (stem_e != NULL) {
+                    struct vpool_entry *tgt = resolve_ref(stem_e);
+                    if (tgt != NULL && !(tgt->flags & VPOOL_UNSET)) {
+                        rc = Lstrcpy(pool->alloc, value, &tgt->value);
+                        return (rc == LSTR_OK) ? VPOOL_OK : VPOOL_NOMEM;
+                    }
+                }
+            }
+        }
+    }
+
+    return VPOOL_NOT_FOUND;
+}
+
+int vpool_drop(struct irx_vpool *pool, const PLstr name)
+{
+    int idx;
+    struct vpool_entry *e;
+
+    if (pool == NULL || name == NULL) return VPOOL_BADARG;
+
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+        return vpool_drop(pool->parent, name);
+    }
+
+    idx = bucket_index(pool, name);
+    e = find_in_bucket(pool->buckets[idx], name);
+    if (e == NULL) return VPOOL_NOT_FOUND;
+
+    if ((e->flags & VPOOL_EXPOSED_REF) && pool->parent != NULL) {
+        /* Drop the backing entry in the parent, then remove our ref. */
+        vpool_drop(pool->parent, name);
+    }
+
+    unlink_entry(pool, idx, e);
+    vp_entry_free(pool->alloc, e);
+    return VPOOL_OK;
+}
+
+int vpool_exists(struct irx_vpool *pool, const PLstr name)
+{
+    int idx;
+    struct vpool_entry *e;
+
+    if (pool == NULL || name == NULL) return 0;
+
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+        return vpool_exists(pool->parent, name);
+    }
+
+    idx = bucket_index(pool, name);
+    e = find_in_bucket(pool->buckets[idx], name);
+    if (e == NULL) return 0;
+
+    {
+        struct vpool_entry *tgt = resolve_ref(e);
+        if (tgt == NULL) return 0;
+        return (tgt->flags & VPOOL_UNSET) ? 0 : 1;
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  EXPOSE                                                            */
+/* ------------------------------------------------------------------ */
+
+int vpool_expose_var(struct irx_vpool *pool, const PLstr name)
+{
+    struct vpool_entry *parent_e;
+    struct vpool_entry *child_e;
+    int rc;
+    int pidx;
+
+    if (pool == NULL || name == NULL) return VPOOL_BADARG;
+    if (pool->parent == NULL) return VPOOL_OK;   /* top-level scope */
+
+    /* If an entry with this name already exists locally (e.g. the
+     * caller called EXPOSE twice), drop it and re-create as a ref. */
+    {
+        int idx = bucket_index(pool, name);
+        struct vpool_entry *existing =
+            find_in_bucket(pool->buckets[idx], name);
+        if (existing != NULL) {
+            unlink_entry(pool, idx, existing);
+            vp_entry_free(pool->alloc, existing);
+        }
+    }
+
+    /* Look up or create a placeholder entry in the parent. */
+    pidx = bucket_index(pool->parent, name);
+    parent_e = find_in_bucket(pool->parent->buckets[pidx], name);
+    if (parent_e == NULL) {
+        parent_e = vp_entry_new(pool->alloc);
+        if (parent_e == NULL) return VPOOL_NOMEM;
+        rc = Lstrcpy(pool->alloc, &parent_e->name, name);
+        if (rc != LSTR_OK) {
+            vp_entry_free(pool->alloc, parent_e);
+            return VPOOL_NOMEM;
+        }
+        parent_e->flags |= VPOOL_UNSET;
+        rc = link_entry(pool->parent, parent_e);
+        if (rc != VPOOL_OK) {
+            /* link_entry already did entry_count--; undo and free. */
+            unlink_entry(pool->parent,
+                         bucket_index(pool->parent, name), parent_e);
+            vp_entry_free(pool->alloc, parent_e);
+            return rc;
+        }
+    }
+
+    /* Install a ref entry in the child. */
+    child_e = vp_entry_new(pool->alloc);
+    if (child_e == NULL) return VPOOL_NOMEM;
+    rc = Lstrcpy(pool->alloc, &child_e->name, name);
+    if (rc != LSTR_OK) {
+        vp_entry_free(pool->alloc, child_e);
+        return VPOOL_NOMEM;
+    }
+    child_e->flags      |= VPOOL_EXPOSED_REF;
+    child_e->exposed_ref = parent_e;
+
+    return link_entry(pool, child_e);
+}
+
+int vpool_expose_stem(struct irx_vpool *pool, const PLstr stem_name)
+{
+    int rc;
+
+    if (pool == NULL || stem_name == NULL) return VPOOL_BADARG;
+    if (pool->parent == NULL) return VPOOL_OK;
+
+    /* Grow the exposed_stems array as needed. */
+    if (pool->exposed_stem_count == pool->exposed_stem_cap) {
+        int new_cap = pool->exposed_stem_cap == 0
+                      ? 4 : pool->exposed_stem_cap * 2;
+        Lstr *new_arr = (Lstr *)vp_alloc_raw(pool->alloc,
+                        (size_t)new_cap * sizeof(Lstr));
+        if (new_arr == NULL) return VPOOL_NOMEM;
+        memset(new_arr, 0, (size_t)new_cap * sizeof(Lstr));
+        if (pool->exposed_stems != NULL) {
+            memcpy(new_arr, pool->exposed_stems,
+                   (size_t)pool->exposed_stem_count * sizeof(Lstr));
+            vp_free_raw(pool->alloc, pool->exposed_stems,
+                        (size_t)pool->exposed_stem_cap * sizeof(Lstr));
+        }
+        pool->exposed_stems    = new_arr;
+        pool->exposed_stem_cap = new_cap;
+    }
+
+    {
+        Lstr *slot = &pool->exposed_stems[pool->exposed_stem_count];
+        Lzeroinit(slot);
+        rc = Lstrcpy(pool->alloc, slot, stem_name);
+        if (rc != LSTR_OK) return VPOOL_NOMEM;
+        pool->exposed_stem_count++;
+    }
+    return VPOOL_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Iteration                                                         */
+/* ------------------------------------------------------------------ */
+
+void vpool_next_reset(struct irx_vpool *pool)
+{
+    if (pool == NULL) return;
+    pool->next_started = 0;
+    pool->next_bucket  = 0;
+    pool->next_entry   = NULL;
+}
+
+int vpool_next(struct irx_vpool *pool, PLstr name, PLstr value)
+{
+    struct vpool_entry *e;
+    struct vpool_entry *tgt;
+    int rc;
+
+    if (pool == NULL || name == NULL || value == NULL) return VPOOL_BADARG;
+
+    if (!pool->next_started) {
+        pool->next_bucket  = 0;
+        pool->next_entry   = NULL;
+        pool->next_started = 1;
+    } else if (pool->next_entry != NULL) {
+        pool->next_entry = pool->next_entry->next;
+        if (pool->next_entry == NULL) {
+            /* Finished this bucket chain; scan forward. */
+            pool->next_bucket++;
+        }
+    }
+
+    /* Find the next live entry, skipping empty buckets. */
+    while (pool->next_entry == NULL &&
+           pool->next_bucket < pool->bucket_count) {
+        pool->next_entry = pool->buckets[pool->next_bucket];
+        if (pool->next_entry == NULL) pool->next_bucket++;
+    }
+
+    if (pool->next_entry == NULL) {
+        if (pool->entry_count == 0) return VPOOL_NOT_FOUND;
+        return VPOOL_LAST;
+    }
+
+    e   = pool->next_entry;
+    tgt = resolve_ref(e);
+    if (tgt == NULL) return VPOOL_BADARG;
+
+    rc = Lstrcpy(pool->alloc, name, &e->name);
+    if (rc != LSTR_OK) return VPOOL_NOMEM;
+    rc = Lstrcpy(pool->alloc, value, &tgt->value);
+    if (rc != LSTR_OK) return VPOOL_NOMEM;
+
+    /* Pre-advance so the caller can detect the final entry: if the
+     * advance lands us at the end, next call returns VPOOL_LAST. */
+    return VPOOL_OK;
+}

--- a/test/test_vpool.c
+++ b/test/test_vpool.c
@@ -1,0 +1,559 @@
+/* ------------------------------------------------------------------ */
+/*  test_vpool.c - WP-12 variable pool unit tests                     */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_vpool \                */
+/*        test/test_vpool.c 'src/irx#vpol.c' \                         */
+/*        ../lstring370/src/'lstr#cor.c'                              */
+/*                                                                    */
+/*  The tests use the default lstring370 allocator directly (no       */
+/*  irxstor bridge), so they run without needing the full rexx370    */
+/*  environment setup. Allocator injection is verified end-to-end    */
+/*  via a tracking wrapper that counts alloc/dealloc calls.          */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "lstring.h"
+#include "lstralloc.h"
+#include "irxvpool.h"
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg) \
+    do { \
+        tests_run++; \
+        if (cond) { \
+            tests_passed++; \
+            printf("  PASS: %s\n", msg); \
+        } else { \
+            tests_failed++; \
+            printf("  FAIL: %s\n", msg); \
+        } \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Helpers: manipulate Lstr via the library                          */
+/* ------------------------------------------------------------------ */
+
+static void set_lstr(struct lstr_alloc *a, Lstr *s, const char *cstr)
+{
+    Lscpy(a, s, cstr);
+}
+
+static int lstr_eq_cstr(const Lstr *s, const char *cstr)
+{
+    size_t n = strlen(cstr);
+    if (s->len != n) return 0;
+    return memcmp(s->pstr, cstr, n) == 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tracking allocator (wraps the default malloc/free allocator so    */
+/*  we can verify that nothing leaks and nothing slips past the      */
+/*  injected callbacks).                                              */
+/* ------------------------------------------------------------------ */
+
+struct track {
+    long alloc_calls;
+    long dealloc_calls;
+    long bytes_live;
+};
+
+static void *track_alloc(size_t size, void *ctx)
+{
+    struct track *t = (struct track *)ctx;
+    void *p = malloc(size);
+    if (p != NULL) {
+        t->alloc_calls++;
+        t->bytes_live += (long)size;
+    }
+    return p;
+}
+
+static void track_dealloc(void *ptr, size_t size, void *ctx)
+{
+    struct track *t = (struct track *)ctx;
+    if (ptr != NULL) {
+        t->dealloc_calls++;
+        t->bytes_live -= (long)size;
+        free(ptr);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: simple set/get/drop                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_basic_set_get_drop(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *pool;
+    Lstr name, value, out;
+
+    printf("\n--- Test: set/get/drop for simple variables ---\n");
+
+    pool = vpool_create(a, NULL);
+    CHECK(pool != NULL, "vpool_create returns non-NULL");
+
+    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    set_lstr(a, &name, "X");
+    set_lstr(a, &value, "42");
+
+    CHECK(vpool_set(pool, &name, &value) == VPOOL_OK,
+          "vpool_set X = '42'");
+    CHECK(vpool_exists(pool, &name) == 1, "vpool_exists(X) == 1");
+    CHECK(vpool_get(pool, &name, &out) == VPOOL_OK,
+          "vpool_get(X) returns OK");
+    CHECK(lstr_eq_cstr(&out, "42"), "retrieved value == '42'");
+
+    /* Overwrite */
+    set_lstr(a, &value, "hello");
+    vpool_set(pool, &name, &value);
+    vpool_get(pool, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "hello"), "overwrite works");
+
+    /* Drop */
+    CHECK(vpool_drop(pool, &name) == VPOOL_OK, "vpool_drop(X)");
+    CHECK(vpool_get(pool, &name, &out) == VPOOL_NOT_FOUND,
+          "vpool_get(X) after drop -> NOT_FOUND");
+    CHECK(vpool_exists(pool, &name) == 0,
+          "vpool_exists(X) after drop == 0");
+
+    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: stem-default lookup                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_stem_default(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *pool;
+    Lstr name, value, out;
+
+    printf("\n--- Test: stem-default lookup ---\n");
+
+    pool = vpool_create(a, NULL);
+    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+
+    /* Set STEM. = 'default' */
+    set_lstr(a, &name, "STEM.");
+    set_lstr(a, &value, "default");
+    vpool_set(pool, &name, &value);
+
+    /* STEM.X not set -> returns 'default' */
+    set_lstr(a, &name, "STEM.X");
+    CHECK(vpool_get(pool, &name, &out) == VPOOL_OK,
+          "vpool_get(STEM.X) falls back to stem");
+    CHECK(lstr_eq_cstr(&out, "default"),
+          "stem default value retrieved");
+
+    /* Set STEM.Y = 'explicit' -> direct hit, no fallback */
+    set_lstr(a, &name, "STEM.Y");
+    set_lstr(a, &value, "explicit");
+    vpool_set(pool, &name, &value);
+    vpool_get(pool, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "explicit"),
+          "explicit value beats stem default");
+
+    /* Fetching STEM.X still returns default */
+    set_lstr(a, &name, "STEM.X");
+    vpool_get(pool, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "default"),
+          "other tail still uses stem default");
+
+    /* Non-compound variable does not fall back to anything */
+    set_lstr(a, &name, "OTHER");
+    CHECK(vpool_get(pool, &name, &out) == VPOOL_NOT_FOUND,
+          "non-compound missing var -> NOT_FOUND");
+
+    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: dynamic resize with 5000 entries                            */
+/* ------------------------------------------------------------------ */
+
+static void test_resize(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *pool;
+    Lstr name, value, out;
+    int i;
+    int all_ok;
+
+    printf("\n--- Test: dynamic resize with 5000 entries ---\n");
+
+    pool = vpool_create(a, NULL);
+    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+
+    CHECK(pool->bucket_count == 67, "initial bucket count is 67");
+
+    all_ok = 1;
+    for (i = 0; i < 5000; i++) {
+        char buf[16];
+        sprintf(buf, "V%d", i);
+        set_lstr(a, &name, buf);
+        sprintf(buf, "val%d", i);
+        set_lstr(a, &value, buf);
+        if (vpool_set(pool, &name, &value) != VPOOL_OK) {
+            all_ok = 0; break;
+        }
+    }
+    CHECK(all_ok, "5000 inserts succeeded");
+    CHECK(pool->entry_count == 5000, "entry_count == 5000");
+    CHECK(pool->bucket_count > 67,
+          "table resized past initial 67 buckets");
+
+    /* Spot-check a few random keys survived the resizes. */
+    set_lstr(a, &name, "V0");
+    vpool_get(pool, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "val0"), "V0 survives resizes");
+    set_lstr(a, &name, "V2499");
+    vpool_get(pool, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "val2499"), "V2499 survives resizes");
+    set_lstr(a, &name, "V4999");
+    vpool_get(pool, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "val4999"), "V4999 survives resizes");
+
+    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: 10000 variables, load factor below 4                        */
+/* ------------------------------------------------------------------ */
+
+static void test_large_load(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *pool;
+    Lstr name, value;
+    int i;
+
+    printf("\n--- Test: 10000 variables, load factor below 4 ---\n");
+
+    pool = vpool_create(a, NULL);
+    Lzeroinit(&name); Lzeroinit(&value);
+
+    for (i = 0; i < 10000; i++) {
+        char buf[16];
+        sprintf(buf, "VAR%d", i);
+        set_lstr(a, &name, buf);
+        sprintf(buf, "%d", i);
+        set_lstr(a, &value, buf);
+        vpool_set(pool, &name, &value);
+    }
+    CHECK(pool->entry_count == 10000, "all 10000 entries present");
+    {
+        double load = (double)pool->entry_count / (double)pool->bucket_count;
+        printf("         load factor = %.2f (buckets=%d)\n",
+               load, pool->bucket_count);
+        CHECK(load < 4.0, "load factor stays below 4");
+    }
+
+    Lfree(a, &name); Lfree(a, &value);
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: scope isolation                                             */
+/* ------------------------------------------------------------------ */
+
+static void test_scope_isolation(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *parent;
+    struct irx_vpool  *child;
+    Lstr name, value, out;
+
+    printf("\n--- Test: PROCEDURE scope isolation ---\n");
+
+    parent = vpool_create(a, NULL);
+    child  = vpool_create(a, parent);
+
+    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+
+    set_lstr(a, &name, "PARENT_VAR");
+    set_lstr(a, &value, "parent_val");
+    vpool_set(parent, &name, &value);
+
+    /* Child does not see parent's locals. */
+    CHECK(vpool_get(child, &name, &out) == VPOOL_NOT_FOUND,
+          "child does not see parent's PARENT_VAR");
+    CHECK(vpool_exists(child, &name) == 0,
+          "vpool_exists(child, PARENT_VAR) == 0");
+
+    /* Parent still sees its own. */
+    CHECK(vpool_get(parent, &name, &out) == VPOOL_OK,
+          "parent still sees PARENT_VAR");
+
+    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    vpool_destroy(child);
+    vpool_destroy(parent);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: EXPOSE single variable                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_expose_var(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *parent;
+    struct irx_vpool  *child;
+    Lstr name, value, out;
+
+    printf("\n--- Test: EXPOSE single variable ---\n");
+
+    parent = vpool_create(a, NULL);
+    child  = vpool_create(a, parent);
+
+    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+
+    /* Parent already has Y = 'parent_y' */
+    set_lstr(a, &name, "Y");
+    set_lstr(a, &value, "parent_y");
+    vpool_set(parent, &name, &value);
+
+    /* Child exposes Y */
+    CHECK(vpool_expose_var(child, &name) == VPOOL_OK,
+          "vpool_expose_var(child, Y)");
+
+    /* Child sees the parent's value. */
+    CHECK(vpool_get(child, &name, &out) == VPOOL_OK,
+          "child can read exposed Y");
+    CHECK(lstr_eq_cstr(&out, "parent_y"),
+          "child reads parent's value");
+
+    /* Child writes; parent sees the new value. */
+    set_lstr(a, &value, "child_wrote");
+    vpool_set(child, &name, &value);
+    vpool_get(parent, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "child_wrote"),
+          "parent sees child's write through EXPOSE");
+
+    /* Drop in child drops in parent too. */
+    CHECK(vpool_drop(child, &name) == VPOOL_OK,
+          "vpool_drop(child, Y)");
+    CHECK(vpool_exists(parent, &name) == 0,
+          "parent's Y is gone after child's drop");
+
+    /* EXPOSE a variable the parent does not have yet:
+     * creates an unset placeholder in the parent. */
+    set_lstr(a, &name, "Z");
+    vpool_expose_var(child, &name);
+    CHECK(vpool_exists(child, &name) == 0,
+          "Z still unset via placeholder");
+
+    /* Setting Z in child creates it in parent. */
+    set_lstr(a, &value, "via_child");
+    vpool_set(child, &name, &value);
+    CHECK(vpool_exists(parent, &name) == 1,
+          "parent now has Z via EXPOSE");
+    vpool_get(parent, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "via_child"),
+          "parent's Z has the child-written value");
+
+    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    vpool_destroy(child);
+    vpool_destroy(parent);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: EXPOSE stem                                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_expose_stem(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *parent;
+    struct irx_vpool  *child;
+    Lstr name, value, out;
+
+    printf("\n--- Test: EXPOSE stem ---\n");
+
+    parent = vpool_create(a, NULL);
+    child  = vpool_create(a, parent);
+
+    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+
+    /* Expose STEM. on child */
+    set_lstr(a, &name, "STEM.");
+    vpool_expose_stem(child, &name);
+
+    /* Set STEM.FOO in child -> ends up in parent */
+    set_lstr(a, &name, "STEM.FOO");
+    set_lstr(a, &value, "bar");
+    vpool_set(child, &name, &value);
+
+    CHECK(vpool_exists(parent, &name) == 1,
+          "STEM.FOO created in parent via stem EXPOSE");
+    vpool_get(parent, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "bar"), "parent STEM.FOO == 'bar'");
+
+    /* Child reads through the same path. */
+    vpool_get(child, &name, &out);
+    CHECK(lstr_eq_cstr(&out, "bar"),
+          "child reads STEM.FOO from parent");
+
+    /* Drop via child drops in parent. */
+    vpool_drop(child, &name);
+    CHECK(vpool_exists(parent, &name) == 0,
+          "drop propagates to parent through stem EXPOSE");
+
+    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    vpool_destroy(child);
+    vpool_destroy(parent);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: iteration without duplicates                                */
+/* ------------------------------------------------------------------ */
+
+static void test_iteration(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool  *pool;
+    Lstr name, value;
+    Lstr out_name, out_value;
+    int  seen[10];
+    int  rc;
+    int  count;
+    int  i;
+
+    printf("\n--- Test: vpool_next iteration ---\n");
+
+    pool = vpool_create(a, NULL);
+    Lzeroinit(&name); Lzeroinit(&value);
+    Lzeroinit(&out_name); Lzeroinit(&out_value);
+
+    for (i = 0; i < 10; i++) {
+        char buf[8];
+        sprintf(buf, "V%d", i);
+        set_lstr(a, &name, buf);
+        sprintf(buf, "%d", i);
+        set_lstr(a, &value, buf);
+        vpool_set(pool, &name, &value);
+        seen[i] = 0;
+    }
+
+    vpool_next_reset(pool);
+    count = 0;
+    while ((rc = vpool_next(pool, &out_name, &out_value)) == VPOOL_OK) {
+        /* out_name is "V<i>" -> index from "<i>" suffix */
+        int idx = atoi((const char *)out_name.pstr + 1);
+        if (idx >= 0 && idx < 10 && !seen[idx]) seen[idx] = 1;
+        count++;
+        if (count > 20) break;   /* safety cap */
+    }
+    CHECK(rc == VPOOL_LAST, "iteration ends with VPOOL_LAST");
+    CHECK(count == 10, "iteration visited 10 entries");
+    {
+        int all_seen = 1;
+        for (i = 0; i < 10; i++) if (!seen[i]) { all_seen = 0; break; }
+        CHECK(all_seen, "every entry visited exactly once");
+    }
+
+    /* Empty pool: NOT_FOUND on first call. */
+    {
+        struct irx_vpool *empty = vpool_create(a, NULL);
+        vpool_next_reset(empty);
+        CHECK(vpool_next(empty, &out_name, &out_value) == VPOOL_NOT_FOUND,
+              "empty pool -> NOT_FOUND");
+        vpool_destroy(empty);
+    }
+
+    Lfree(a, &name);     Lfree(a, &value);
+    Lfree(a, &out_name); Lfree(a, &out_value);
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: allocator injection routes everything through callbacks     */
+/* ------------------------------------------------------------------ */
+
+static void test_allocator_injection(void)
+{
+    struct track       st;
+    struct lstr_alloc  tracking;
+    struct irx_vpool  *pool;
+    Lstr name, value, out;
+    int i;
+
+    printf("\n--- Test: allocator injection (no leaks) ---\n");
+
+    st.alloc_calls = 0; st.dealloc_calls = 0; st.bytes_live = 0;
+    tracking.alloc   = track_alloc;
+    tracking.dealloc = track_dealloc;
+    tracking.ctx     = &st;
+
+    pool = vpool_create(&tracking, NULL);
+    CHECK(pool != NULL, "vpool_create with injected allocator");
+    CHECK(st.bytes_live > 0, "allocator received alloc calls");
+
+    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+
+    for (i = 0; i < 50; i++) {
+        char buf[16];
+        sprintf(buf, "K%d", i);
+        set_lstr(&tracking, &name, buf);
+        sprintf(buf, "v%d", i);
+        set_lstr(&tracking, &value, buf);
+        vpool_set(pool, &name, &value);
+    }
+    for (i = 0; i < 50; i++) {
+        char buf[16];
+        sprintf(buf, "K%d", i);
+        set_lstr(&tracking, &name, buf);
+        vpool_drop(pool, &name);
+    }
+
+    Lfree(&tracking, &name);
+    Lfree(&tracking, &value);
+    Lfree(&tracking, &out);
+    vpool_destroy(pool);
+
+    CHECK(st.bytes_live == 0,
+          "all bytes released (no leaks via injected allocator)");
+    CHECK(st.alloc_calls == st.dealloc_calls,
+          "alloc call count == dealloc call count");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("=== REXX/370 WP-12 Variable Pool Tests ===\n");
+
+    test_basic_set_get_drop();
+    test_stem_default();
+    test_resize();
+    test_large_load();
+    test_scope_isolation();
+    test_expose_var();
+    test_expose_stem();
+    test_iteration();
+    test_allocator_injection();
+
+    printf("\n=== Results: %d/%d passed",
+           tests_passed, tests_run);
+    if (tests_failed > 0) printf(", %d FAILED", tests_failed);
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Per-scope REXX variable pool backed by a chained hash table with dynamic resize. Supports simple variables, stem-default lookup, PROCEDURE EXPOSE pointer sharing, stem-EXPOSE with parent delegation, and SHVNEXTV-style iteration.

## Design notes

- **Chained hash table** with djb2 over raw name bytes. The pool is a pure name → value map; the parser is responsible for producing the canonical (uppercased, tail-resolved) name.
- **Prime bucket sizes**: 67 → 137 → 277 → 557 → 1117 → 2237 → 4483 → 8963. Load factor > 4 triggers a resize to the next prime. With 10000 entries the pool settles at 4483 buckets (load factor ≈ 2.23).
- **PROCEDURE EXPOSE**: pointer sharing via \`vpool_entry->exposed_ref\`. Reads and writes through the child's ref entry resolve back to the parent's entry. Dropping an exposed ref drops the backing entry in the parent too. Exposing a not-yet-existing variable creates an unset placeholder in the parent.
- **Stem EXPOSE**: \`vpool_expose_stem(child, "STEM.")\` registers the stem on the child. \`vpool_set\` / \`vpool_get\` / \`vpool_drop\` / \`vpool_exists\` check \`matches_exposed_stem()\` first and delegate to the parent (recursively through the parent's own exposed stems). Future \`STEM.X\` entries therefore live in the parent and are visible to the caller after RETURN.
- **Stem-default**: \`vpool_get\` on an unset compound \`STEM.X\` falls back to \`STEM.\` as the default. Pure key-lookup logic, belongs in the pool.
- **NOVALUE handling** stays with the interpreter — the pool returns \`VPOOL_NOT_FOUND\` and lets the caller raise the condition (or not, for compound-tail accesses per SC28-1883-0).
- **Memory** goes exclusively through the injected \`lstr_alloc\` from WP-11b. No direct \`malloc\`/\`free\`, no statics, no globals.
- **Iteration** uses a single cursor stored on the pool itself. Callers must not mutate during iteration — resize invalidates the cursor explicitly.
- **8-char aliases** via \`asm()\` in the header for \`vpool_exists\` / \`vpool_expose_var\` / \`vpool_expose_stem\` / \`vpool_next\` / \`vpool_next_reset\` (they all collide under c2asm370's 8-char truncation rule).

## Acceptance criteria

| # | Criterion | Test |
|---|---|---|
| 1 | set/get/drop simple | \`test_basic_set_get_drop\` |
| 2 | stem-default lookup | \`test_stem_default\` |
| 3 | dynamic resize 5000 | \`test_resize\` |
| 4 | scope isolation | \`test_scope_isolation\` |
| 5 | EXPOSE var shared | \`test_expose_var\` |
| 6 | EXPOSE stem shared | \`test_expose_stem\` |
| 7 | NOT_FOUND for unset | \`test_basic_set_get_drop\` |
| 8 | iter no duplicates | \`test_iteration\` |
| 9 | iter LAST sentinel | \`test_iteration\` |
| 10 | 10000 entries load<4 | \`test_large_load\` (settles at 2.23) |
| 11 | allocator injection | \`test_allocator_injection\` (leak-free) |
| 12 | no global state | enforced by design (all state on pool) |

## Verification

- **Cross-compile (Linux/gcc)**: 47/47 tests pass.
- **MVS build**: \`IRX#VPOL\` RC=0 via \`make build\`.

## Test plan

- [x] \`gcc -I include -I contrib/lstring370-0.1.0-dev/include ... test/test_vpool.c src/irx#vpol.c ../lstring370/src/lstr#cor.c && ./test/test_vpool\` → 47/47
- [x] \`make build\` → RC=0
- [ ] Consumer integration: WP-13 (parser/evaluator) will be the first real user, via \`irx_lstr_init(env)\` + \`vpool_create(alloc, NULL)\`

Fixes #5