### PR TITLE
WP-15: Control Flow (DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL/ITERATE/LEAVE)

### DIFF
--- a/include/irxctrl.h
+++ b/include/irxctrl.h
@@ -1,0 +1,162 @@
+/* ------------------------------------------------------------------ */
+/*  irxctrl.h - REXX/370 Control Flow Infrastructure (WP-15)          */
+/*                                                                    */
+/*  Label table and execution stack for DO/IF/SELECT/CALL/RETURN/EXIT */
+/*  SIGNAL, NOP, ITERATE, LEAVE. All memory goes through the          */
+/*  injected lstring370 allocator.                                     */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 8 (Instructions)                        */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef __IRXCTRL_H__
+#define __IRXCTRL_H__
+
+#include "lstralloc.h"
+
+/* ================================================================== */
+/*  Forward declaration                                               */
+/* ================================================================== */
+
+struct irx_parser;
+
+/* ================================================================== */
+/*  Frame type codes                                                  */
+/* ================================================================== */
+
+#define FRAME_DO      1
+#define FRAME_CALL    2
+#define FRAME_SELECT  3
+
+/* ================================================================== */
+/*  DO loop variant codes                                             */
+/* ================================================================== */
+
+#define DO_SIMPLE   0   /* DO; ... END  (execute body once)           */
+#define DO_FOREVER  1   /* DO FOREVER                                 */
+#define DO_COUNT    2   /* DO n  (fixed-count repetitive)             */
+#define DO_CTRL     3   /* DO i = start TO end [BY step]              */
+#define DO_WHILE    4   /* DO WHILE cond  (pre-test)                  */
+#define DO_UNTIL    5   /* DO UNTIL cond  (post-test)                 */
+
+/* Maximum name length for a control variable or DO label. */
+#define CTRL_NAME_MAX 64
+
+/* ================================================================== */
+/*  Label table                                                       */
+/* ================================================================== */
+
+struct irx_label {
+    char  name[CTRL_NAME_MAX];  /* upper-case label name (no colon)   */
+    int   name_len;
+    int   tok_pos;              /* token position of the label symbol  */
+};
+
+struct irx_label_table {
+    struct irx_label   *entries;
+    int                 count;
+    int                 cap;
+    struct lstr_alloc  *alloc;
+};
+
+/* ================================================================== */
+/*  Execution frame                                                   */
+/* ================================================================== */
+
+struct irx_exec_frame {
+    int  frame_type;    /* FRAME_DO / FRAME_CALL / FRAME_SELECT       */
+
+    /* --- FRAME_DO fields ----------------------------------------- */
+    int  do_type;       /* DO_SIMPLE / DO_FOREVER / DO_COUNT / ...    */
+    int  loop_start;    /* tok_pos of first body token                */
+    int  loop_end;      /* tok_pos of first token AFTER matching END  */
+
+    /* Controlled loop (DO_CTRL) */
+    char ctrl_name[CTRL_NAME_MAX];
+    int  ctrl_name_len;
+    long ctrl_val;      /* current value of the control variable      */
+    long ctrl_to;       /* limit (inclusive)                          */
+    long ctrl_by;       /* step (default 1)                           */
+
+    /* Repetitive loop (DO_COUNT) */
+    long ctrl_count;    /* remaining iterations                       */
+
+    /* Conditional loops (DO_WHILE / DO_UNTIL) */
+    int  cond_tok_pos;  /* tok_pos of the WHILE/UNTIL expression      */
+
+    /* Label associated with this DO (for ITERATE/LEAVE label) */
+    char do_label[CTRL_NAME_MAX];
+    int  do_label_len;
+
+    /* First iteration flag for DO_UNTIL (body must execute once) */
+    int  first_iter;
+
+    /* --- FRAME_CALL fields --------------------------------------- */
+    int  call_return_pos;   /* tok_pos to resume after RETURN         */
+    int  call_line;         /* source line of the CALL (-> SIGL)      */
+
+    /* --- FRAME_SELECT fields ------------------------------------- */
+    int  select_matched;    /* 1 once a WHEN branch has been taken    */
+    int  select_end;        /* tok_pos of first token AFTER SELECT END */
+};
+
+/* ================================================================== */
+/*  Execution stack                                                   */
+/* ================================================================== */
+
+#define EXEC_STACK_INIT_CAP  16
+
+struct irx_exec_stack {
+    struct irx_exec_frame  *frames;
+    int                     top;     /* number of active frames        */
+    int                     cap;     /* allocated frame slots          */
+    struct lstr_alloc       *alloc;
+
+    /* "Last label seen" — cleared by kw_do after pick-up. Used to
+     * associate a label clause with the immediately following DO. */
+    char  last_label[CTRL_NAME_MAX];
+    int   last_label_len;
+
+    /* EXIT/RETURN state propagated upward through kw_return. */
+    int   exit_requested;
+    int   exit_rc;
+};
+
+/* ================================================================== */
+/*  Public entry points                                               */
+/* ================================================================== */
+
+/* Allocate and attach a label table and exec stack to the parser.
+ * Must be called from irx_pars_init before any parsing starts. */
+int  irx_ctrl_init   (struct irx_parser *p);
+
+/* Free everything attached by irx_ctrl_init. Safe to call on a
+ * partially initialised parser. */
+void irx_ctrl_cleanup(struct irx_parser *p);
+
+/* First-pass scan of the token stream. Populates the label table
+ * so that SIGNAL/CALL can resolve names without forward-lookup. */
+int  irx_ctrl_label_scan(struct irx_parser *p);
+
+/* Look up a label by upper-case name. Returns tok_pos (>= 0) or -1. */
+int  irx_ctrl_label_find(struct irx_parser *p,
+                         const char *name, int name_len);
+
+/* Push a new frame. Returns pointer to the frame (never NULL on
+ * success) or NULL on allocator failure. */
+struct irx_exec_frame *irx_ctrl_frame_push(struct irx_parser *p,
+                                           int frame_type);
+
+/* Return pointer to the topmost frame, or NULL if the stack is empty. */
+struct irx_exec_frame *irx_ctrl_frame_top(struct irx_parser *p);
+
+/* Pop the topmost frame. No-op if stack is empty. */
+void irx_ctrl_frame_pop(struct irx_parser *p);
+
+/* Find the innermost DO frame, optionally matching a specific label.
+ * label/len may be NULL/0 to find the innermost DO regardless of label.
+ * Returns frame index (>= 0) or -1 if not found. */
+int irx_ctrl_find_do(struct irx_parser *p,
+                     const char *label, int label_len);
+
+#endif /* __IRXCTRL_H__ */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -57,8 +57,11 @@ struct irx_parser {
     int                  error_code;   /* IRXPARS_*                   */
     int                  error_line;   /* source line of the error    */
 
-    void                *label_table;  /* reserved for WP-15          */
-    void                *exec_stack;   /* reserved for WP-15          */
+    void                *label_table;  /* label table (WP-15)         */
+    void                *exec_stack;   /* execution stack (WP-15)     */
+
+    int                  exit_requested; /* set by EXIT / RETURN      */
+    int                  exit_rc;        /* RC passed to EXIT          */
 };
 
 /* ================================================================== */

--- a/src/irx#ctrl.c
+++ b/src/irx#ctrl.c
@@ -1,0 +1,266 @@
+/* ------------------------------------------------------------------ */
+/*  irxctrl.c - REXX/370 Control Flow Infrastructure (WP-15)          */
+/*                                                                    */
+/*  Implements the label table and execution stack that support       */
+/*  DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL/ITERATE/LEAVE.              */
+/*                                                                    */
+/*  All memory goes through the injected lstring370 allocator (the    */
+/*  same allocator as irx_parser.alloc). irxstor is not used here     */
+/*  because the envblock may be NULL in cross-compile unit tests.     */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 8 (Instructions)                        */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <string.h>
+#include <stddef.h>
+#include <ctype.h>
+
+#include "irxpars.h"
+#include "irxctrl.h"
+#include "irxtokn.h"
+
+/* ------------------------------------------------------------------ */
+/*  Internal helpers                                                  */
+/* ------------------------------------------------------------------ */
+
+/* Upper-case at most CTRL_NAME_MAX-1 bytes from tok_text into dst.
+ * Returns the number of bytes written. */
+static int tok_to_upper_name(const struct irx_token *t,
+                              char *dst, int dst_max)
+{
+    int n = (int)t->tok_length;
+    int i;
+    if (n >= dst_max) n = dst_max - 1;
+    for (i = 0; i < n; i++) {
+        int c = (unsigned char)t->tok_text[i];
+        dst[i] = (char)(islower(c) ? toupper(c) : c);
+    }
+    dst[n] = '\0';
+    return n;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Label table                                                       */
+/* ------------------------------------------------------------------ */
+
+static int label_table_grow(struct irx_label_table *lt)
+{
+    int new_cap = lt->cap == 0 ? 8 : lt->cap * 2;
+    struct irx_label *new_entries;
+    size_t new_size = (size_t)new_cap * sizeof(struct irx_label);
+
+    new_entries = (struct irx_label *)
+        lt->alloc->alloc(new_size, lt->alloc->ctx);
+    if (new_entries == NULL) return -1;
+
+    if (lt->count > 0 && lt->entries != NULL) {
+        memcpy(new_entries, lt->entries,
+               (size_t)lt->count * sizeof(struct irx_label));
+    }
+    if (lt->entries != NULL && lt->cap > 0) {
+        lt->alloc->dealloc(lt->entries,
+                           (size_t)lt->cap * sizeof(struct irx_label),
+                           lt->alloc->ctx);
+    }
+    lt->entries = new_entries;
+    lt->cap     = new_cap;
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Exec stack                                                        */
+/* ------------------------------------------------------------------ */
+
+static int exec_stack_grow(struct irx_exec_stack *es)
+{
+    int new_cap = es->cap == 0 ? EXEC_STACK_INIT_CAP : es->cap * 2;
+    struct irx_exec_frame *new_frames;
+    size_t new_size = (size_t)new_cap * sizeof(struct irx_exec_frame);
+
+    new_frames = (struct irx_exec_frame *)
+        es->alloc->alloc(new_size, es->alloc->ctx);
+    if (new_frames == NULL) return -1;
+
+    if (es->top > 0 && es->frames != NULL) {
+        memcpy(new_frames, es->frames,
+               (size_t)es->top * sizeof(struct irx_exec_frame));
+    }
+    if (es->frames != NULL && es->cap > 0) {
+        es->alloc->dealloc(es->frames,
+                           (size_t)es->cap * sizeof(struct irx_exec_frame),
+                           es->alloc->ctx);
+    }
+    es->frames = new_frames;
+    es->cap    = new_cap;
+    return 0;
+}
+
+/* ================================================================== */
+/*  Public API                                                        */
+/* ================================================================== */
+
+int irx_ctrl_init(struct irx_parser *p)
+{
+    struct irx_label_table *lt;
+    struct irx_exec_stack  *es;
+    size_t lt_size = sizeof(struct irx_label_table);
+    size_t es_size = sizeof(struct irx_exec_stack);
+
+    lt = (struct irx_label_table *)
+        p->alloc->alloc(lt_size, p->alloc->ctx);
+    if (lt == NULL) return IRXPARS_NOMEM;
+    memset(lt, 0, lt_size);
+    lt->alloc = p->alloc;
+
+    es = (struct irx_exec_stack *)
+        p->alloc->alloc(es_size, p->alloc->ctx);
+    if (es == NULL) {
+        p->alloc->dealloc(lt, lt_size, p->alloc->ctx);
+        return IRXPARS_NOMEM;
+    }
+    memset(es, 0, es_size);
+    es->alloc = p->alloc;
+
+    p->label_table = lt;
+    p->exec_stack  = es;
+    return IRXPARS_OK;
+}
+
+void irx_ctrl_cleanup(struct irx_parser *p)
+{
+    struct irx_label_table *lt;
+    struct irx_exec_stack  *es;
+
+    if (p == NULL) return;
+
+    lt = (struct irx_label_table *)p->label_table;
+    if (lt != NULL) {
+        if (lt->entries != NULL && lt->cap > 0) {
+            lt->alloc->dealloc(lt->entries,
+                               (size_t)lt->cap * sizeof(struct irx_label),
+                               lt->alloc->ctx);
+        }
+        p->alloc->dealloc(lt, sizeof(struct irx_label_table),
+                          p->alloc->ctx);
+        p->label_table = NULL;
+    }
+
+    es = (struct irx_exec_stack *)p->exec_stack;
+    if (es != NULL) {
+        if (es->frames != NULL && es->cap > 0) {
+            es->alloc->dealloc(es->frames,
+                               (size_t)es->cap * sizeof(struct irx_exec_frame),
+                               es->alloc->ctx);
+        }
+        p->alloc->dealloc(es, sizeof(struct irx_exec_stack),
+                          p->alloc->ctx);
+        p->exec_stack = NULL;
+    }
+}
+
+int irx_ctrl_label_scan(struct irx_parser *p)
+{
+    struct irx_label_table *lt =
+        (struct irx_label_table *)p->label_table;
+    int i;
+
+    if (lt == NULL) return IRXPARS_NOMEM;
+
+    /* Reset existing table from any prior scan. */
+    lt->count = 0;
+
+    for (i = 0; i + 1 < p->tok_count; i++) {
+        const struct irx_token *t0 = &p->tokens[i];
+        const struct irx_token *t1 = &p->tokens[i + 1];
+
+        if (t0->tok_type != TOK_SYMBOL) continue;
+        if (t0->tok_flags & TOKF_CONSTANT) continue;
+        if (t1->tok_type != TOK_SEMICOLON) continue;
+        if (t1->tok_length != 1 || t1->tok_text[0] != ':') continue;
+
+        /* Found SYMBOL ':' — a label. */
+        if (lt->count >= lt->cap) {
+            if (label_table_grow(lt) != 0) return IRXPARS_NOMEM;
+        }
+        {
+            struct irx_label *lbl = &lt->entries[lt->count];
+            lbl->name_len = tok_to_upper_name(t0, lbl->name,
+                                               CTRL_NAME_MAX);
+            lbl->tok_pos  = i;   /* position of the SYMBOL token     */
+            lt->count++;
+        }
+    }
+    return IRXPARS_OK;
+}
+
+int irx_ctrl_label_find(struct irx_parser *p,
+                        const char *name, int name_len)
+{
+    struct irx_label_table *lt =
+        (struct irx_label_table *)p->label_table;
+    int i;
+
+    if (lt == NULL || name == NULL || name_len <= 0) return -1;
+
+    for (i = 0; i < lt->count; i++) {
+        if (lt->entries[i].name_len == name_len &&
+            memcmp(lt->entries[i].name, name, (size_t)name_len) == 0) {
+            return lt->entries[i].tok_pos;
+        }
+    }
+    return -1;
+}
+
+struct irx_exec_frame *irx_ctrl_frame_push(struct irx_parser *p,
+                                           int frame_type)
+{
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    struct irx_exec_frame *frame;
+
+    if (es == NULL) return NULL;
+    if (es->top >= es->cap) {
+        if (exec_stack_grow(es) != 0) return NULL;
+    }
+    frame = &es->frames[es->top++];
+    memset(frame, 0, sizeof(*frame));
+    frame->frame_type = frame_type;
+    frame->loop_end   = -1;
+    frame->select_end = -1;
+    frame->first_iter = 1;
+    return frame;
+}
+
+struct irx_exec_frame *irx_ctrl_frame_top(struct irx_parser *p)
+{
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    if (es == NULL || es->top <= 0) return NULL;
+    return &es->frames[es->top - 1];
+}
+
+void irx_ctrl_frame_pop(struct irx_parser *p)
+{
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    if (es == NULL || es->top <= 0) return;
+    es->top--;
+}
+
+int irx_ctrl_find_do(struct irx_parser *p,
+                     const char *label, int label_len)
+{
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    int i;
+
+    if (es == NULL) return -1;
+
+    for (i = es->top - 1; i >= 0; i--) {
+        if (es->frames[i].frame_type != FRAME_DO) continue;
+        if (label == NULL || label_len <= 0) return i;  /* any DO */
+        if (es->frames[i].do_label_len == label_len &&
+            memcmp(es->frames[i].do_label, label,
+                   (size_t)label_len) == 0) {
+            return i;
+        }
+    }
+    return -1;
+}

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -1133,8 +1133,7 @@ static int kw_when(struct irx_parser *p)
     if (f->select_matched) {
         /* A prior WHEN already matched: skip this WHEN entirely
          * (condition + THEN + clause) and jump to the next WHEN,
-         * OTHERWISE, or END. */
-        Lfree(p->alloc, &cond);
+         * OTHERWISE, or END. cond was never allocated — no Lfree. */
         /* Skip condition */
         rc = skip_instruction(p);
         if (rc != IRXPARS_OK) return rc;
@@ -1219,8 +1218,7 @@ static int kw_call(struct irx_parser *p)
     call_line = cur_tok(p)->tok_line;
     advance_tok(p);
 
-    /* Skip past any arguments for now (future WP handles argument
-     * passing via PARSE ARG / procedure call ABI). */
+    /* Arguments skipped — CALL argument passing is implemented in WP-17. */
     skip_to_clause_end(p);
 
     /* Where to return to (first token of next clause). */

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -27,6 +27,7 @@
 #include "irxtokn.h"
 #include "irxvpool.h"
 #include "irxpars.h"
+#include "irxctrl.h"
 
 /* ------------------------------------------------------------------ */
 /*  Lstr scratch helpers                                              */
@@ -358,6 +359,975 @@ static int kw_say(struct irx_parser *p)
 }
 
 /* ------------------------------------------------------------------ */
+/*  WP-15 forward declarations (parse_* defined later in file)        */
+/* ------------------------------------------------------------------ */
+
+static int parse_add(struct irx_parser *p, PLstr out);
+static int parse_or (struct irx_parser *p, PLstr out);
+
+/* ------------------------------------------------------------------ */
+/*  WP-15 helper: case-insensitive symbol comparison                  */
+/* ------------------------------------------------------------------ */
+
+static int sym_matches(const struct irx_token *t, const char *name)
+{
+    size_t n = strlen(name);
+    size_t i;
+    if (t == NULL || t->tok_type != TOK_SYMBOL) return 0;
+    if ((size_t)t->tok_length != n) return 0;
+    for (i = 0; i < n; i++) {
+        int c = (unsigned char)t->tok_text[i];
+        if (islower(c)) c = toupper(c);
+        if (c != (unsigned char)name[i]) return 0;
+    }
+    return 1;
+}
+
+/* Upper-case a symbol token's text into a fixed char buffer.
+ * Returns the number of bytes written (may truncate to dst_max-1). */
+static int sym_to_upper(const struct irx_token *t, char *dst, int dst_max)
+{
+    int n = (int)t->tok_length;
+    int i;
+    if (n >= dst_max) n = dst_max - 1;
+    for (i = 0; i < n; i++) {
+        int c = (unsigned char)t->tok_text[i];
+        dst[i] = (char)(islower(c) ? toupper(c) : c);
+    }
+    dst[n] = '\0';
+    return n;
+}
+
+/* ------------------------------------------------------------------ */
+/*  WP-15 helper: find position after the matching END                */
+/*                                                                    */
+/*  Scans forward from `from`, counting DO/SELECT vs END at clause    */
+/*  starts. Returns tok_pos of first token after the matching END,    */
+/*  or -1 if not found.                                               */
+/* ------------------------------------------------------------------ */
+
+/* Returns 1 if the token at `pos` is the keyword `kw` (not an
+ * assignment target), 0 otherwise. */
+static int tok_is_kw(struct irx_parser *p, int pos, const char *kw)
+{
+    const struct irx_token *t;
+    const struct irx_token *tnext;
+    const struct irx_token *tnext2;
+
+    if (pos < 0 || pos >= p->tok_count) return 0;
+    t = &p->tokens[pos];
+    if (!sym_matches(t, kw)) return 0;
+    /* Exclude assignment: SYMBOL = (but not SYMBOL ==) */
+    tnext  = (pos + 1 < p->tok_count) ? &p->tokens[pos + 1] : NULL;
+    tnext2 = (pos + 2 < p->tok_count) ? &p->tokens[pos + 2] : NULL;
+    if (tok_is_op_char(tnext, TOK_COMPARISON, '=') &&
+        !tok_is_op_char(tnext2, TOK_COMPARISON, '=')) {
+        return 0;  /* it's an assignment */
+    }
+    return 1;
+}
+
+static int find_end_after(struct irx_parser *p, int from)
+{
+    int depth = 1;
+    int pos   = from;
+
+    while (pos < p->tok_count) {
+        const struct irx_token *t = &p->tokens[pos];
+        if (t->tok_type == TOK_EOF) break;
+        if (tok_is_kw(p, pos, "DO") || tok_is_kw(p, pos, "SELECT")) {
+            depth++;
+        } else if (tok_is_kw(p, pos, "END")) {
+            depth--;
+            if (depth == 0) return pos + 1;
+        }
+        pos++;
+    }
+    return -1;
+}
+
+/* Skip forward to the end of the current clause (stops at EOC/EOF/;).
+ * Handles nested parentheses so that function arguments are not
+ * mistaken for clause boundaries. */
+static void skip_to_clause_end(struct irx_parser *p)
+{
+    int depth = 0;
+    while (p->tok_pos < p->tok_count) {
+        const struct irx_token *t = cur_tok(p);
+        if (t == NULL) break;
+        if (t->tok_type == TOK_LPAREN) { depth++; advance_tok(p); continue; }
+        if (t->tok_type == TOK_RPAREN) {
+            if (depth > 0) depth--;
+            advance_tok(p);
+            continue;
+        }
+        if (depth == 0 && tok_ends_clause(t)) break;
+        advance_tok(p);
+    }
+}
+
+/* Skip one complete instruction (simple clause or DO/SELECT block).
+ * On entry, tok_pos should point at the first token of the instruction
+ * (leading EOC tokens are consumed first).
+ * On return, tok_pos points to the first terminator after the
+ * instruction (i.e., the caller should then consume trailing EOC). */
+static int skip_instruction(struct irx_parser *p)
+{
+    const struct irx_token *t;
+
+    /* Eat leading EOC */
+    while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        advance_tok(p);
+
+    t = cur_tok(p);
+    if (t == NULL || t->tok_type == TOK_EOF) return IRXPARS_OK;
+
+    /* DO or SELECT block: jump to token after matching END */
+    if (tok_is_kw(p, p->tok_pos, "DO") ||
+        tok_is_kw(p, p->tok_pos, "SELECT")) {
+        int end_pos = find_end_after(p, p->tok_pos + 1);
+        if (end_pos < 0) return fail(p, IRXPARS_SYNTAX);
+        p->tok_pos = end_pos;
+        return IRXPARS_OK;
+    }
+
+    skip_to_clause_end(p);
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  WP-15 helper: set a variable by name (char * + length)            */
+/* ------------------------------------------------------------------ */
+
+static int set_var_str(struct irx_parser *p,
+                       const char *name, int name_len,
+                       const char *val,  int val_len)
+{
+    Lstr k, v;
+    int  rc;
+
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+
+    rc = lstr_set_bytes(p->alloc, &k, name, (size_t)name_len);
+    if (rc != LSTR_OK) { return fail(p, IRXPARS_NOMEM); }
+
+    rc = lstr_set_bytes(p->alloc, &v, val, (size_t)val_len);
+    if (rc != LSTR_OK) {
+        Lfree(p->alloc, &k);
+        return fail(p, IRXPARS_NOMEM);
+    }
+
+    rc = vpool_set(p->vpool, &k, &v);
+    Lfree(p->alloc, &k);
+    Lfree(p->alloc, &v);
+    return (rc == VPOOL_OK) ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
+}
+
+static int set_var_long(struct irx_parser *p,
+                        const char *name, int name_len, long val)
+{
+    char buf[32];
+    int  n = sprintf(buf, "%ld", val);
+    if (n < 0) return fail(p, IRXPARS_NOMEM);
+    return set_var_str(p, name, name_len, buf, n);
+}
+
+/* ------------------------------------------------------------------ */
+/*  WP-15 helper: evaluate a condition at a saved token position      */
+/*                                                                    */
+/*  Temporarily sets p->tok_pos to cond_pos, evaluates one           */
+/*  expression, then restores tok_pos to saved. Result is put in out. */
+/* ------------------------------------------------------------------ */
+
+static int eval_at(struct irx_parser *p, int cond_pos, PLstr out)
+{
+    int saved = p->tok_pos;
+    int rc;
+    p->tok_pos = cond_pos;
+    rc = irx_pars_eval_expr(p, out);
+    p->tok_pos = saved;
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  WP-15 helper: DO frame iteration check                            */
+/*                                                                    */
+/*  Called by kw_end to decide whether to iterate or exit the loop.  */
+/*  Returns 1 if the loop body should execute again, 0 to exit.      */
+/*  On iteration, updates the control variable and re-sets loop_start  */
+/*  as the target. On exit, leaves p->tok_pos past the END token.     */
+/* ------------------------------------------------------------------ */
+
+static int do_should_iterate(struct irx_parser *p,
+                             struct irx_exec_frame *f)
+{
+    Lstr cond;
+    long cond_val;
+    int  iterate;
+
+    switch (f->do_type) {
+
+    case DO_SIMPLE:
+        return 0;   /* body executes once */
+
+    case DO_FOREVER:
+        return 1;
+
+    case DO_COUNT:
+        if (f->ctrl_count <= 0) return 0;
+        f->ctrl_count--;
+        return (f->ctrl_count >= 0) ? 1 : 0;
+
+    case DO_CTRL: {
+        /* Increment control variable, then check bounds. */
+        f->ctrl_val += f->ctrl_by;
+        if (f->ctrl_by >= 0) {
+            iterate = (f->ctrl_val <= f->ctrl_to);
+        } else {
+            iterate = (f->ctrl_val >= f->ctrl_to);
+        }
+        if (iterate && f->ctrl_name_len > 0) {
+            set_var_long(p, f->ctrl_name, f->ctrl_name_len,
+                         f->ctrl_val);
+        }
+        return iterate;
+    }
+
+    case DO_WHILE:
+        Lzeroinit(&cond);
+        if (eval_at(p, f->cond_tok_pos, &cond) != IRXPARS_OK) {
+            Lfree(p->alloc, &cond);
+            return 0;
+        }
+        iterate = lstr_to_long(&cond, &cond_val) && (cond_val != 0);
+        Lfree(p->alloc, &cond);
+        return iterate;
+
+    case DO_UNTIL:
+        /* Body always ran at least once before END is reached. */
+        Lzeroinit(&cond);
+        if (eval_at(p, f->cond_tok_pos, &cond) != IRXPARS_OK) {
+            Lfree(p->alloc, &cond);
+            return 0;
+        }
+        /* UNTIL: stop when cond is true */
+        iterate = !(lstr_to_long(&cond, &cond_val) && (cond_val != 0));
+        Lfree(p->alloc, &cond);
+        return iterate;
+
+    default:
+        return 0;
+    }
+}
+
+/* ================================================================== */
+/*  WP-15 keyword handlers                                            */
+/* ================================================================== */
+
+/* Forward declaration for mutual recursion (kw_if uses exec_clause). */
+static int exec_clause(struct irx_parser *p);
+
+/* ------------------------------------------------------------------ */
+/*  NOP                                                               */
+/* ------------------------------------------------------------------ */
+
+static int kw_nop(struct irx_parser *p)
+{
+    (void)p;
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  THEN / ELSE — syntax barriers only, never standalone instructions  */
+/* ------------------------------------------------------------------ */
+
+static int kw_then(struct irx_parser *p) { return fail(p, IRXPARS_SYNTAX); }
+static int kw_else(struct irx_parser *p) { return fail(p, IRXPARS_SYNTAX); }
+
+/* ------------------------------------------------------------------ */
+/*  EXIT [expr]                                                       */
+/* ------------------------------------------------------------------ */
+
+static int kw_exit(struct irx_parser *p)
+{
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    long rc_val = 0;
+
+    if (!tok_ends_clause(cur_tok(p))) {
+        Lstr result;
+        Lzeroinit(&result);
+        if (irx_pars_eval_expr(p, &result) == IRXPARS_OK) {
+            lstr_to_long(&result, &rc_val);
+        }
+        Lfree(p->alloc, &result);
+    }
+
+    p->exit_requested = 1;
+    p->exit_rc        = (int)rc_val;
+    if (es != NULL) {
+        es->exit_requested = 1;
+        es->exit_rc        = (int)rc_val;
+    }
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  DO [variant] ... END                                              */
+/* ------------------------------------------------------------------ */
+
+static int kw_do(struct irx_parser *p)
+{
+    struct irx_exec_stack  *es  = (struct irx_exec_stack *)p->exec_stack;
+    struct irx_exec_frame  *f;
+    const struct irx_token *t;
+    int rc = IRXPARS_OK;
+    Lstr tmp;
+
+    Lzeroinit(&tmp);
+
+    f = irx_ctrl_frame_push(p, FRAME_DO);
+    if (f == NULL) return fail(p, IRXPARS_NOMEM);
+
+    /* Inherit label from exec_stack->last_label if set. */
+    if (es != NULL && es->last_label_len > 0) {
+        int n = es->last_label_len;
+        if (n >= CTRL_NAME_MAX) n = CTRL_NAME_MAX - 1;
+        memcpy(f->do_label, es->last_label, (size_t)n);
+        f->do_label[n]   = '\0';
+        f->do_label_len  = n;
+        es->last_label_len = 0;
+        es->last_label[0]  = '\0';
+    }
+
+    t = cur_tok(p);
+
+    /* ---- DO FOREVER ---- */
+    if (sym_matches(t, "FOREVER")) {
+        advance_tok(p);
+        f->do_type = DO_FOREVER;
+        goto body;
+    }
+
+    /* ---- DO WHILE cond ---- */
+    if (sym_matches(t, "WHILE")) {
+        advance_tok(p);
+        f->do_type     = DO_WHILE;
+        f->cond_tok_pos = p->tok_pos;
+        /* Evaluate once to (a) validate syntax and (b) check first time */
+        rc = irx_pars_eval_expr(p, &tmp);
+        if (rc != IRXPARS_OK) goto done;
+        {
+            long cv = 0;
+            if (!lstr_to_long(&tmp, &cv) || cv == 0) {
+                /* Condition false on entry: find END and jump past */
+                int end_pos = find_end_after(p, p->tok_pos);
+                if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
+                irx_ctrl_frame_pop(p);
+                p->tok_pos = end_pos;
+                goto done;
+            }
+        }
+        goto body;
+    }
+
+    /* ---- DO UNTIL cond ---- */
+    if (sym_matches(t, "UNTIL")) {
+        advance_tok(p);
+        f->do_type      = DO_UNTIL;
+        f->cond_tok_pos = p->tok_pos;
+        /* Skip past the UNTIL expression so loop_start lands on body. */
+        rc = irx_pars_eval_expr(p, &tmp);
+        if (rc != IRXPARS_OK) goto done;
+        /* UNTIL always executes body at least once. */
+        goto body;
+    }
+
+    /* ---- DO SYMBOL = start TO end [BY step] ---- */
+    if (t != NULL && t->tok_type == TOK_SYMBOL &&
+        !(t->tok_flags & TOKF_CONSTANT)) {
+        const struct irx_token *tnext = peek_tok(p, 1);
+        if (tok_is_op_char(tnext, TOK_COMPARISON, '=')) {
+            /* Check it's not == */
+            const struct irx_token *tnext2 = peek_tok(p, 2);
+            if (!tok_is_op_char(tnext2, TOK_COMPARISON, '=')) {
+                /* DO ctrl_var = start TO end [BY step] */
+                f->do_type      = DO_CTRL;
+                f->ctrl_by      = 1;  /* default step */
+                f->ctrl_name_len = sym_to_upper(t, f->ctrl_name,
+                                                CTRL_NAME_MAX);
+                advance_tok(p);  /* SYMBOL */
+                advance_tok(p);  /* =      */
+
+                /* start expression: use parse_add to stop at TO/BY/WHILE */
+                rc = parse_add(p, &tmp);
+                if (rc != IRXPARS_OK) goto done;
+                if (!lstr_to_long(&tmp, &f->ctrl_val)) {
+                    rc = fail(p, IRXPARS_SYNTAX); goto done;
+                }
+                Lfree(p->alloc, &tmp);
+                Lzeroinit(&tmp);
+
+                /* TO */
+                if (!sym_matches(cur_tok(p), "TO")) {
+                    rc = fail(p, IRXPARS_SYNTAX); goto done;
+                }
+                advance_tok(p);
+
+                /* end expression */
+                rc = parse_add(p, &tmp);
+                if (rc != IRXPARS_OK) goto done;
+                if (!lstr_to_long(&tmp, &f->ctrl_to)) {
+                    rc = fail(p, IRXPARS_SYNTAX); goto done;
+                }
+                Lfree(p->alloc, &tmp);
+                Lzeroinit(&tmp);
+
+                /* Optional BY */
+                if (sym_matches(cur_tok(p), "BY")) {
+                    advance_tok(p);
+                    rc = parse_add(p, &tmp);
+                    if (rc != IRXPARS_OK) goto done;
+                    if (!lstr_to_long(&tmp, &f->ctrl_by)) {
+                        rc = fail(p, IRXPARS_SYNTAX); goto done;
+                    }
+                    Lfree(p->alloc, &tmp);
+                    Lzeroinit(&tmp);
+                }
+
+                /* Optional WHILE/UNTIL: skip expression (future WP). */
+                if (sym_matches(cur_tok(p), "WHILE") ||
+                    sym_matches(cur_tok(p), "UNTIL")) {
+                    advance_tok(p);
+                    rc = irx_pars_eval_expr(p, &tmp);
+                    if (rc != IRXPARS_OK) goto done;
+                    Lfree(p->alloc, &tmp);
+                    Lzeroinit(&tmp);
+                }
+
+                /* Set initial ctrl var value. */
+                rc = set_var_long(p, f->ctrl_name, f->ctrl_name_len,
+                                  f->ctrl_val);
+                if (rc != IRXPARS_OK) goto done;
+
+                /* Check initial condition: if start > end (BY>0) skip. */
+                {
+                    int skip = 0;
+                    if (f->ctrl_by >= 0 && f->ctrl_val > f->ctrl_to)
+                        skip = 1;
+                    if (f->ctrl_by < 0 && f->ctrl_val < f->ctrl_to)
+                        skip = 1;
+                    if (skip) {
+                        int end_pos = find_end_after(p, p->tok_pos);
+                        if (end_pos < 0) {
+                            rc = fail(p, IRXPARS_SYNTAX); goto done;
+                        }
+                        irx_ctrl_frame_pop(p);
+                        p->tok_pos = end_pos;
+                        goto done;
+                    }
+                }
+                goto body;
+            }
+        }
+    }
+
+    /* ---- DO n (repetitive count) ---- */
+    if (t != NULL && !tok_ends_clause(t)) {
+        /* Could be DO n where n is an expression. */
+        f->do_type = DO_COUNT;
+        rc = parse_add(p, &tmp);
+        if (rc != IRXPARS_OK) goto done;
+        if (!lstr_to_long(&tmp, &f->ctrl_count)) {
+            rc = fail(p, IRXPARS_SYNTAX); goto done;
+        }
+        Lfree(p->alloc, &tmp);
+        Lzeroinit(&tmp);
+        if (f->ctrl_count <= 0) {
+            /* Zero or negative: skip entire body. */
+            int end_pos = find_end_after(p, p->tok_pos);
+            if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
+            irx_ctrl_frame_pop(p);
+            p->tok_pos = end_pos;
+            goto done;
+        }
+        f->ctrl_count--;  /* already executing first iteration */
+        goto body;
+    }
+
+    /* ---- DO; ... END (simple group) ---- */
+    f->do_type = DO_SIMPLE;
+
+body:
+    /* Record loop_start = first token of body (after header). */
+    /* Eat any trailing EOC before the body so loop_start lands
+     * on the first actual token. */
+    {
+        int end_pos;
+        while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+            advance_tok(p);
+        f->loop_start = p->tok_pos;
+        end_pos = find_end_after(p, p->tok_pos);
+        if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
+        f->loop_end = end_pos;
+    }
+
+done:
+    Lfree(p->alloc, &tmp);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  END [name]                                                        */
+/* ------------------------------------------------------------------ */
+
+static int kw_end(struct irx_parser *p)
+{
+    struct irx_exec_frame *f = irx_ctrl_frame_top(p);
+
+    /* Consume optional name after END (REXX allows END loopname). */
+    if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_SYMBOL &&
+        !tok_ends_clause(cur_tok(p))) {
+        advance_tok(p);
+    }
+
+    if (f == NULL) return fail(p, IRXPARS_SYNTAX);
+
+    if (f->frame_type == FRAME_SELECT) {
+        /* End of SELECT block. */
+        if (!f->select_matched) {
+            /* No WHEN matched and no OTHERWISE was present. */
+            return fail(p, IRXPARS_SYNTAX);
+        }
+        irx_ctrl_frame_pop(p);
+        return IRXPARS_OK;
+    }
+
+    if (f->frame_type != FRAME_DO) return fail(p, IRXPARS_SYNTAX);
+
+    if (do_should_iterate(p, f)) {
+        /* Go back to loop body. */
+        p->tok_pos = f->loop_start;
+    } else {
+        /* Exit loop: tok_pos is already past END (set to loop_end). */
+        p->tok_pos = f->loop_end;
+        irx_ctrl_frame_pop(p);
+    }
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  ITERATE [name]                                                    */
+/* ------------------------------------------------------------------ */
+
+static int kw_iterate(struct irx_parser *p)
+{
+    char label[CTRL_NAME_MAX];
+    int  label_len = 0;
+    int  frame_idx;
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    struct irx_exec_frame *f;
+
+    /* Optional label */
+    if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_SYMBOL &&
+        !tok_ends_clause(cur_tok(p))) {
+        label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
+        advance_tok(p);
+    }
+
+    frame_idx = irx_ctrl_find_do(p,
+                                 label_len > 0 ? label : NULL,
+                                 label_len);
+    if (frame_idx < 0) return fail(p, IRXPARS_SYNTAX);
+
+    f = &es->frames[frame_idx];
+
+    /* Pop all frames above the target DO frame. */
+    es->top = frame_idx + 1;
+
+    /* Advance the loop: for DO_CTRL increment ctrl var before jumping. */
+    if (f->do_type == DO_CTRL) {
+        f->ctrl_val += f->ctrl_by;
+        /* Check bounds */
+        {
+            int in_range;
+            if (f->ctrl_by >= 0) in_range = (f->ctrl_val <= f->ctrl_to);
+            else                 in_range = (f->ctrl_val >= f->ctrl_to);
+            if (!in_range) {
+                p->tok_pos = f->loop_end;
+                irx_ctrl_frame_pop(p);
+                return IRXPARS_OK;
+            }
+        }
+        set_var_long(p, f->ctrl_name, f->ctrl_name_len, f->ctrl_val);
+    } else if (f->do_type == DO_WHILE) {
+        /* Re-evaluate WHILE condition. */
+        Lstr cond;
+        long cv = 0;
+        Lzeroinit(&cond);
+        eval_at(p, f->cond_tok_pos, &cond);
+        lstr_to_long(&cond, &cv);
+        Lfree(p->alloc, &cond);
+        if (!cv) {
+            p->tok_pos = f->loop_end;
+            irx_ctrl_frame_pop(p);
+            return IRXPARS_OK;
+        }
+    }
+
+    p->tok_pos = f->loop_start;
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  LEAVE [name]                                                      */
+/* ------------------------------------------------------------------ */
+
+static int kw_leave(struct irx_parser *p)
+{
+    char label[CTRL_NAME_MAX];
+    int  label_len = 0;
+    int  frame_idx;
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    struct irx_exec_frame *f;
+
+    /* Optional label */
+    if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_SYMBOL &&
+        !tok_ends_clause(cur_tok(p))) {
+        label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
+        advance_tok(p);
+    }
+
+    frame_idx = irx_ctrl_find_do(p,
+                                 label_len > 0 ? label : NULL,
+                                 label_len);
+    if (frame_idx < 0) return fail(p, IRXPARS_SYNTAX);
+
+    f = &es->frames[frame_idx];
+    p->tok_pos = f->loop_end;
+
+    /* Pop the target frame and all frames above it. */
+    es->top = frame_idx;
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  IF expr THEN clause_or_block [ELSE clause_or_block]               */
+/* ------------------------------------------------------------------ */
+
+static int kw_if(struct irx_parser *p)
+{
+    Lstr cond;
+    long cond_val = 0;
+    int  cond_true;
+    int  rc;
+
+    Lzeroinit(&cond);
+    rc = irx_pars_eval_expr(p, &cond);
+    if (rc != IRXPARS_OK) { Lfree(p->alloc, &cond); return rc; }
+    lstr_to_long(&cond, &cond_val);
+    cond_true = (cond_val != 0);
+    Lfree(p->alloc, &cond);
+
+    /* Consume THEN (required). */
+    /* Skip any EOC between condition and THEN. */
+    while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        advance_tok(p);
+    if (!sym_matches(cur_tok(p), "THEN"))
+        return fail(p, IRXPARS_SYNTAX);
+    advance_tok(p);  /* consume THEN */
+
+    /* Skip any EOC/whitespace between THEN and its clause. */
+    while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        advance_tok(p);
+
+    if (cond_true) {
+        struct irx_exec_stack *es =
+            (struct irx_exec_stack *)p->exec_stack;
+        int depth_before = es ? es->top : 0;
+
+        /* Execute THEN branch. */
+        rc = exec_clause(p);
+        if (rc != IRXPARS_OK) return rc;
+
+        /* If THEN was DO/SELECT, run the block until that frame exits. */
+        while (rc == IRXPARS_OK && !p->exit_requested &&
+               es != NULL && es->top > depth_before) {
+            const struct irx_token *ct = cur_tok(p);
+            if (ct == NULL || ct->tok_type == TOK_EOF) break;
+            rc = exec_clause(p);
+        }
+        if (rc != IRXPARS_OK) return rc;
+        if (p->exit_requested) return IRXPARS_OK;
+
+        /* Consume trailing terminators of the THEN clause. */
+        while (cur_tok(p) != NULL &&
+               (cur_tok(p)->tok_type == TOK_EOC ||
+                cur_tok(p)->tok_type == TOK_SEMICOLON))
+            advance_tok(p);
+
+        /* Check for ELSE and skip it. */
+        while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+            advance_tok(p);
+        if (sym_matches(cur_tok(p), "ELSE")) {
+            advance_tok(p);
+            while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+                advance_tok(p);
+            rc = skip_instruction(p);
+        }
+    } else {
+        /* Skip THEN branch. */
+        rc = skip_instruction(p);
+        if (rc != IRXPARS_OK) return rc;
+        while (cur_tok(p) != NULL &&
+               (cur_tok(p)->tok_type == TOK_EOC ||
+                cur_tok(p)->tok_type == TOK_SEMICOLON))
+            advance_tok(p);
+
+        /* Check for ELSE and execute it. */
+        while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+            advance_tok(p);
+        if (sym_matches(cur_tok(p), "ELSE")) {
+            advance_tok(p);
+            while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+                advance_tok(p);
+            rc = exec_clause(p);
+        }
+    }
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  SELECT; WHEN cond THEN clause; ... [OTHERWISE clause;] END        */
+/* ------------------------------------------------------------------ */
+
+static int kw_select(struct irx_parser *p)
+{
+    struct irx_exec_frame *f;
+
+    f = irx_ctrl_frame_push(p, FRAME_SELECT);
+    if (f == NULL) return fail(p, IRXPARS_NOMEM);
+
+    f->select_matched = 0;
+
+    /* Find the matching END so WHEN can jump past it. */
+    f->select_end = find_end_after(p, p->tok_pos);
+    if (f->select_end < 0) return fail(p, IRXPARS_SYNTAX);
+
+    return IRXPARS_OK;
+}
+
+static int kw_when(struct irx_parser *p)
+{
+    struct irx_exec_frame *f = irx_ctrl_frame_top(p);
+    Lstr cond;
+    long cond_val = 0;
+    int  cond_true;
+    int  rc;
+
+    if (f == NULL || f->frame_type != FRAME_SELECT)
+        return fail(p, IRXPARS_SYNTAX);
+
+    Lzeroinit(&cond);
+
+    if (f->select_matched) {
+        /* A prior WHEN already matched: skip this WHEN entirely
+         * (condition + THEN + clause) and jump to the next WHEN,
+         * OTHERWISE, or END. */
+        Lfree(p->alloc, &cond);
+        /* Skip condition */
+        rc = skip_instruction(p);
+        if (rc != IRXPARS_OK) return rc;
+        /* Consume THEN */
+        while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+            advance_tok(p);
+        if (sym_matches(cur_tok(p), "THEN")) advance_tok(p);
+        /* Skip THEN clause */
+        while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+            advance_tok(p);
+        rc = skip_instruction(p);
+        return rc;
+    }
+
+    rc = irx_pars_eval_expr(p, &cond);
+    if (rc != IRXPARS_OK) { Lfree(p->alloc, &cond); return rc; }
+    lstr_to_long(&cond, &cond_val);
+    cond_true = (cond_val != 0);
+    Lfree(p->alloc, &cond);
+
+    /* Consume THEN */
+    while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        advance_tok(p);
+    if (!sym_matches(cur_tok(p), "THEN"))
+        return fail(p, IRXPARS_SYNTAX);
+    advance_tok(p);
+
+    while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        advance_tok(p);
+
+    if (cond_true) {
+        f->select_matched = 1;
+        rc = exec_clause(p);
+        if (rc != IRXPARS_OK) return rc;
+        /* Jump to after SELECT END — kw_end will pop the frame. */
+        /* Leave tok_pos at select_end so END/OTHERWISE are skipped. */
+        /* Don't jump yet; let the normal clause loop encounter END. */
+    } else {
+        rc = skip_instruction(p);
+    }
+    return rc;
+}
+
+static int kw_otherwise(struct irx_parser *p)
+{
+    struct irx_exec_frame *f = irx_ctrl_frame_top(p);
+
+    if (f == NULL || f->frame_type != FRAME_SELECT)
+        return fail(p, IRXPARS_SYNTAX);
+
+    if (f->select_matched) {
+        /* Already matched: skip the OTHERWISE body. */
+        return skip_instruction(p);
+    }
+
+    /* No WHEN matched: mark as matched (prevents "no match" error
+     * in kw_end) and execute body. */
+    f->select_matched = 1;
+    return exec_clause(p);
+}
+
+/* ------------------------------------------------------------------ */
+/*  CALL label [args]                                                 */
+/* ------------------------------------------------------------------ */
+
+static int kw_call(struct irx_parser *p)
+{
+    char  label[CTRL_NAME_MAX];
+    int   label_len;
+    int   label_pos;
+    int   return_pos;
+    int   call_line;
+    struct irx_exec_frame *f;
+    char  linebuf[32];
+    int   n;
+
+    /* CALL must be followed by a label name (symbol). */
+    if (cur_tok(p) == NULL || cur_tok(p)->tok_type != TOK_SYMBOL)
+        return fail(p, IRXPARS_SYNTAX);
+
+    label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
+    call_line = cur_tok(p)->tok_line;
+    advance_tok(p);
+
+    /* Skip past any arguments for now (future WP handles argument
+     * passing via PARSE ARG / procedure call ABI). */
+    skip_to_clause_end(p);
+
+    /* Where to return to (first token of next clause). */
+    return_pos = p->tok_pos;
+
+    /* Look up the label. */
+    label_pos = irx_ctrl_label_find(p, label, label_len);
+    if (label_pos < 0) return fail(p, IRXPARS_BADFUNC);
+
+    /* Push CALL frame. */
+    f = irx_ctrl_frame_push(p, FRAME_CALL);
+    if (f == NULL) return fail(p, IRXPARS_NOMEM);
+    f->call_return_pos = return_pos;
+    f->call_line       = call_line;
+
+    /* Set SIGL special variable. */
+    n = sprintf(linebuf, "%d", call_line);
+    set_var_str(p, "SIGL", 4, linebuf, n);
+
+    /* Jump to label (past SYMBOL ':' tokens). */
+    p->tok_pos = label_pos + 2;  /* skip SYMBOL + COLON */
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  RETURN [expr]                                                     */
+/* ------------------------------------------------------------------ */
+
+static int kw_return(struct irx_parser *p)
+{
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    Lstr result;
+    int  have_result = 0;
+    int  i;
+
+    Lzeroinit(&result);
+
+    if (!tok_ends_clause(cur_tok(p))) {
+        int rc = irx_pars_eval_expr(p, &result);
+        if (rc != IRXPARS_OK) { Lfree(p->alloc, &result); return rc; }
+        have_result = 1;
+    }
+
+    if (have_result) {
+        /* Store in RESULT special variable. */
+        Lstr key;
+        Lzeroinit(&key);
+        if (lstr_set_bytes(p->alloc, &key, "RESULT", 6) == LSTR_OK) {
+            vpool_set(p->vpool, &key, &result);
+            Lfree(p->alloc, &key);
+        }
+    }
+    Lfree(p->alloc, &result);
+
+    /* Unwind stack to find the CALL frame. */
+    if (es == NULL) {
+        /* No CALL frame: treat as EXIT 0. */
+        p->exit_requested = 1;
+        p->exit_rc = 0;
+        return IRXPARS_OK;
+    }
+
+    for (i = es->top - 1; i >= 0; i--) {
+        if (es->frames[i].frame_type == FRAME_CALL) break;
+    }
+
+    if (i < 0) {
+        /* No CALL frame on stack: treat as EXIT. */
+        p->exit_requested = 1;
+        p->exit_rc = 0;
+        return IRXPARS_OK;
+    }
+
+    p->tok_pos = es->frames[i].call_return_pos;
+    es->top    = i;  /* pop everything up to and including CALL frame */
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  SIGNAL label                                                      */
+/* ------------------------------------------------------------------ */
+
+static int kw_signal(struct irx_parser *p)
+{
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    char label[CTRL_NAME_MAX];
+    int  label_len;
+    int  label_pos;
+
+    if (cur_tok(p) == NULL || cur_tok(p)->tok_type != TOK_SYMBOL)
+        return fail(p, IRXPARS_SYNTAX);
+
+    label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
+    advance_tok(p);
+
+    label_pos = irx_ctrl_label_find(p, label, label_len);
+    if (label_pos < 0) return fail(p, IRXPARS_SYNTAX);
+
+    /* Clear the entire execution stack (SIGNAL discards all frames). */
+    if (es != NULL) es->top = 0;
+
+    /* Jump to label (past SYMBOL ':' tokens). */
+    p->tok_pos = label_pos + 2;
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Keyword table (WP-13 registers no handlers)                       */
 /*                                                                    */
 /*  WP-14 adds SAY. WP-15 adds DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL. */
@@ -366,8 +1336,23 @@ static int kw_say(struct irx_parser *p)
 /* ------------------------------------------------------------------ */
 
 static const struct irx_keyword g_keyword_table[] = {
-    { "SAY", kw_say },
-    { NULL,  NULL   }
+    { "SAY",       kw_say       },
+    { "NOP",       kw_nop       },
+    { "EXIT",      kw_exit      },
+    { "DO",        kw_do        },
+    { "END",       kw_end       },
+    { "ITERATE",   kw_iterate   },
+    { "LEAVE",     kw_leave     },
+    { "IF",        kw_if        },
+    { "THEN",      kw_then      }, /* barrier only — IF consumes THEN   */
+    { "ELSE",      kw_else      }, /* barrier only — IF consumes ELSE   */
+    { "SELECT",    kw_select    },
+    { "WHEN",      kw_when      },
+    { "OTHERWISE", kw_otherwise },
+    { "CALL",      kw_call      },
+    { "RETURN",    kw_return    },
+    { "SIGNAL",    kw_signal    },
+    { NULL,        NULL         }
 };
 
 static const struct irx_keyword *find_keyword(const unsigned char *name,
@@ -931,7 +1916,24 @@ static int parse_concat(struct irx_parser *p, PLstr out)
             /* Implicit concat. The left operand's last token lives
              * at tok_pos - 1. If there's a column gap (same line,
              * whitespace between) it's blank concat; otherwise it's
-             * an abuttal. */
+             * an abuttal.
+             *
+             * Keyword check: a symbol that is a known keyword (THEN,
+             * ELSE, WHEN, DO, END, etc.) cannot start a concatenated
+             * term — it is a clause-level delimiter, not an operand. */
+            if (t0->tok_type == TOK_SYMBOL) {
+                char kbuf[32];
+                int  kn = (int)t0->tok_length;
+                if (kn < (int)sizeof(kbuf)) {
+                    memcpy(kbuf, t0->tok_text, (size_t)kn);
+                    kbuf[kn] = '\0';
+                    upper_bytes((unsigned char *)kbuf, (size_t)kn);
+                    if (find_keyword((unsigned char *)kbuf,
+                                     (size_t)kn) != NULL) {
+                        break; /* keyword: stop concatenation */
+                    }
+                }
+            }
             prev = peek_tok(p, -1);
             if (prev == NULL || prev->tok_line != t0->tok_line) break;
             if (toks_adjacent(prev, t0)) {
@@ -1287,8 +2289,16 @@ static int exec_clause(struct irx_parser *p)
         const struct irx_token *t1 = peek_tok(p, 1);
         if (t1 != NULL && t1->tok_type == TOK_SEMICOLON &&
             t1->tok_length == 1 && t1->tok_text[0] == ':') {
-            /* Label declaration - WP-15 will record it. For now, just
-             * consume the two tokens. */
+            /* Label declaration: record in exec_stack->last_label so
+             * the immediately following DO can associate it. */
+            {
+                struct irx_exec_stack *es =
+                    (struct irx_exec_stack *)p->exec_stack;
+                if (es != NULL) {
+                    es->last_label_len = sym_to_upper(
+                        t0, es->last_label, CTRL_NAME_MAX);
+                }
+            }
             advance_tok(p);
             advance_tok(p);
             return IRXPARS_OK;
@@ -1325,6 +2335,7 @@ int irx_pars_init(struct irx_parser *p,
                   struct lstr_alloc *alloc,
                   struct envblock *envblock)
 {
+    int rc;
     if (p == NULL || tokens == NULL || vpool == NULL || alloc == NULL) {
         return IRXPARS_BADARG;
     }
@@ -1338,12 +2349,17 @@ int irx_pars_init(struct irx_parser *p,
     Lzeroinit(&p->result);
     p->error_code = IRXPARS_OK;
     p->error_line = 0;
+
+    rc = irx_ctrl_init(p);
+    if (rc != IRXPARS_OK) return rc;
+
     return IRXPARS_OK;
 }
 
 void irx_pars_cleanup(struct irx_parser *p)
 {
     if (p == NULL) return;
+    irx_ctrl_cleanup(p);
     Lfree(p->alloc, &p->result);
 }
 
@@ -1355,15 +2371,21 @@ int irx_pars_eval_expr(struct irx_parser *p, PLstr out)
 
 int irx_pars_run(struct irx_parser *p)
 {
+    int rc;
     if (p == NULL) return IRXPARS_BADARG;
+
+    /* First pass: build the label table for CALL/SIGNAL. */
+    rc = irx_ctrl_label_scan(p);
+    if (rc != IRXPARS_OK) return rc;
 
     while (p->tok_pos < p->tok_count) {
         const struct irx_token *t = cur_tok(p);
-        int rc;
         if (t == NULL || t->tok_type == TOK_EOF) break;
 
         rc = exec_clause(p);
         if (rc != IRXPARS_OK) return rc;
+
+        if (p->exit_requested) break;
 
         /* Consume trailing clause terminators. */
         while (cur_tok(p) != NULL &&

--- a/test/test_control.c
+++ b/test/test_control.c
@@ -1,0 +1,671 @@
+/* ------------------------------------------------------------------ */
+/*  test_control.c - WP-15 Control Flow unit tests                    */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_control \             */
+/*        test/test_control.c \                                        */
+/*        'src/irx#ctrl.c' 'src/irx#lstr.c' 'src/irx#tokn.c' \       */
+/*        'src/irx#vpol.c' 'src/irx#pars.c' \                         */
+/*        ../lstring370/src/'lstr#cor.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "lstring.h"
+#include "lstralloc.h"
+#include "irxtokn.h"
+#include "irxvpool.h"
+#include "irxpars.h"
+#include "irxctrl.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg) \
+    do { \
+        tests_run++; \
+        if (cond) { \
+            tests_passed++; \
+            printf("  PASS: %s\n", msg); \
+        } else { \
+            tests_failed++; \
+            printf("  FAIL: %s\n", msg); \
+        } \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                           */
+/* ------------------------------------------------------------------ */
+
+static int lstr_eq_cstr(const Lstr *s, const char *cstr)
+{
+    size_t n = strlen(cstr);
+    if (s->len != n) return 0;
+    return memcmp(s->pstr, cstr, n) == 0;
+}
+
+static void set_lstr(struct lstr_alloc *a, PLstr s, const char *c)
+{
+    Lscpy(a, s, c);
+}
+
+static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
+                      const char *src)
+{
+    struct irx_token    *tokens = NULL;
+    int                  count  = 0;
+    struct irx_tokn_error tok_err;
+    struct irx_parser    parser;
+    int                  rc;
+
+    rc = irx_tokn_run(NULL, src, (int)strlen(src), &tokens, &count,
+                      &tok_err);
+    if (rc != 0) {
+        printf("    tokenizer failed: rc=%d code=%d line=%d col=%d\n",
+               rc, tok_err.error_code, tok_err.error_line,
+               tok_err.error_col);
+        return -1;
+    }
+
+    rc = irx_pars_init(&parser, tokens, count, pool, a, NULL);
+    if (rc != IRXPARS_OK) {
+        irx_tokn_free(NULL, tokens, count);
+        printf("    irx_pars_init failed: rc=%d\n", rc);
+        return rc;
+    }
+
+    rc = irx_pars_run(&parser);
+    if (rc != IRXPARS_OK) {
+        printf("    parser rc=%d error=%d line=%d\n", rc,
+               parser.error_code, parser.error_line);
+    }
+
+    irx_pars_cleanup(&parser);
+    irx_tokn_free(NULL, tokens, count);
+    return rc;
+}
+
+static int get_var_eq(struct lstr_alloc *a, struct irx_vpool *pool,
+                      const char *name, const char *expected)
+{
+    Lstr key, val;
+    int  rc, eq;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    set_lstr(a, &key, name);
+
+    rc = vpool_get(pool, &key, &val);
+    if (rc != VPOOL_OK) {
+        printf("    vpool_get(%s) rc=%d\n", name, rc);
+        Lfree(a, &key);
+        Lfree(a, &val);
+        return 0;
+    }
+    eq = lstr_eq_cstr(&val, expected);
+    if (!eq) {
+        printf("    %s = '%.*s' (expected '%s')\n",
+               name, (int)val.len, (const char *)val.pstr, expected);
+    }
+    Lfree(a, &key);
+    Lfree(a, &val);
+    return eq;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test cases                                                        */
+/* ------------------------------------------------------------------ */
+
+/* CF#1: DO i = 1 TO 5; x = x + i; END */
+static void test_cf1_do_counted_loop(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#1: DO i = 1 TO 5; x = x + i; END ---\n");
+
+    /* Pre-set x = 0 */
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO i = 1 TO 5\n"
+        "  x = x + i\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "15"), "X = '15' (1+2+3+4+5)");
+    CHECK(get_var_eq(a, pool, "I", "5"),  "I = '5' (final value)");
+    vpool_destroy(pool);
+}
+
+/* CF#2: DO WHILE x < 10 (pre-test) */
+static void test_cf2_do_while(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#2: DO WHILE x < 10 ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO WHILE x < 10\n"
+        "  x = x + 3\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "12"), "X = '12' (0+3+3+3+3)");
+    vpool_destroy(pool);
+}
+
+/* CF#3: DO UNTIL x > 10 (post-test, runs at least once) */
+static void test_cf3_do_until(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#3: DO UNTIL x > 10 ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO UNTIL x > 10\n"
+        "  x = x + 4\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "12"), "X = '12' (0+4+4+4)");
+    vpool_destroy(pool);
+}
+
+/* CF#4: Nested DO loops */
+static void test_cf4_nested_do(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#4: Nested DO loops ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "N"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO i = 1 TO 3\n"
+        "  DO j = 1 TO 3\n"
+        "    n = n + 1\n"
+        "  END\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "N", "9"), "N = '9' (3x3 iterations)");
+    vpool_destroy(pool);
+}
+
+/* CF#5: IF THEN ELSE — true branch */
+static void test_cf5_if_true(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#5: IF 1 THEN x = 'yes'; ELSE x = 'no' ---\n");
+
+    CHECK(run_source(a, pool,
+        "IF 1 THEN x = 'yes'\n"
+        "ELSE x = 'no'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "yes"), "X = 'yes' (true branch)");
+    vpool_destroy(pool);
+}
+
+/* CF#6: IF THEN ELSE — false branch */
+static void test_cf6_if_false(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#6: IF 0 THEN x = 'yes'; ELSE x = 'no' ---\n");
+
+    CHECK(run_source(a, pool,
+        "IF 0 THEN x = 'yes'\n"
+        "ELSE x = 'no'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "no"), "X = 'no' (false branch)");
+    vpool_destroy(pool);
+}
+
+/* CF#7: Nested IF — ELSE binds to inner IF */
+static void test_cf7_nested_if_else(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#7: IF a THEN IF b THEN c ELSE d (ELSE binds to inner) ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "A"); set_lstr(a, &v, "1");
+    vpool_set(pool, &k, &v);
+    set_lstr(a, &k, "B"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "IF a THEN IF b THEN x = 'c'\n"
+        "ELSE x = 'd'\n") == IRXPARS_OK, "parser OK");
+    /* ELSE binds to inner IF (b=0), so x='d' */
+    CHECK(get_var_eq(a, pool, "X", "d"), "X = 'd' (ELSE bound to inner IF)");
+    vpool_destroy(pool);
+}
+
+/* CF#8: SELECT with first WHEN matching */
+static void test_cf8_select_first_when(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#8: SELECT; WHEN n=1 THEN x='one'; WHEN n=2 THEN x='two'; END ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "N"); set_lstr(a, &v, "1");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "SELECT\n"
+        "  WHEN n = 1 THEN x = 'one'\n"
+        "  WHEN n = 2 THEN x = 'two'\n"
+        "  OTHERWISE x = 'other'\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "one"), "X = 'one'");
+    vpool_destroy(pool);
+}
+
+/* CF#9: SELECT with second WHEN matching */
+static void test_cf9_select_second_when(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#9: SELECT n=2 matches second WHEN ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "N"); set_lstr(a, &v, "2");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "SELECT\n"
+        "  WHEN n = 1 THEN x = 'one'\n"
+        "  WHEN n = 2 THEN x = 'two'\n"
+        "  OTHERWISE x = 'other'\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "two"), "X = 'two'");
+    vpool_destroy(pool);
+}
+
+/* CF#10: SELECT with OTHERWISE */
+static void test_cf10_select_otherwise(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#10: SELECT n=99 falls through to OTHERWISE ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "N"); set_lstr(a, &v, "99");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "SELECT\n"
+        "  WHEN n = 1 THEN x = 'one'\n"
+        "  WHEN n = 2 THEN x = 'two'\n"
+        "  OTHERWISE x = 'other'\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "other"), "X = 'other'");
+    vpool_destroy(pool);
+}
+
+/* CF#11: SELECT with no match and no OTHERWISE -> SYNTAX error */
+static void test_cf11_select_no_match(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#11: SELECT no match, no OTHERWISE -> SYNTAX error ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "N"); set_lstr(a, &v, "99");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "SELECT\n"
+        "  WHEN n = 1 THEN x = 'one'\n"
+        "END\n") != IRXPARS_OK, "returns error (no OTHERWISE, no match)");
+    vpool_destroy(pool);
+}
+
+/* CF#12: CALL label -> RETURN -> resumes */
+static void test_cf12_call_return(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#12: CALL label; RETURN ---\n");
+
+    CHECK(run_source(a, pool,
+        "x = 1\n"
+        "CALL mysub\n"
+        "x = x + 10\n"
+        "EXIT 0\n"
+        "mysub:\n"
+        "  x = x + 100\n"
+        "RETURN\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "111"), "X = '111' (1+100+10)");
+    vpool_destroy(pool);
+}
+
+/* CF#13: CALL sets SIGL */
+static void test_cf13_call_sigl(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#13: CALL sets SIGL to call line ---\n");
+
+    CHECK(run_source(a, pool,
+        "CALL sub\n"    /* line 1 */
+        "EXIT 0\n"
+        "sub:\n"
+        "RETURN\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "SIGL", "1"), "SIGL = '1'");
+    vpool_destroy(pool);
+}
+
+/* CF#14: RETURN sets RESULT */
+static void test_cf14_return_result(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#14: RETURN expr sets RESULT ---\n");
+
+    CHECK(run_source(a, pool,
+        "CALL add\n"
+        "EXIT 0\n"
+        "add:\n"
+        "RETURN 42\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "RESULT", "42"), "RESULT = '42'");
+    vpool_destroy(pool);
+}
+
+/* CF#15: EXIT terminates execution */
+static void test_cf15_exit(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#15: EXIT 0 terminates, code after is not run ---\n");
+
+    CHECK(run_source(a, pool,
+        "x = 'before'\n"
+        "EXIT 0\n"
+        "x = 'after'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "before"), "X = 'before' (EXIT stopped)");
+    vpool_destroy(pool);
+}
+
+/* CF#16: SIGNAL label clears stack and transfers control */
+static void test_cf16_signal(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#16: SIGNAL label clears stack, transfers control ---\n");
+
+    CHECK(run_source(a, pool,
+        "x = 'start'\n"
+        "DO i = 1 TO 100\n"
+        "  SIGNAL done\n"
+        "END\n"
+        "x = 'unreachable'\n"
+        "done:\n"
+        "x = 'signalled'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "signalled"), "X = 'signalled'");
+    vpool_destroy(pool);
+}
+
+/* CF#17: NOP is valid as THEN target */
+static void test_cf17_nop(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#17: NOP as THEN target ---\n");
+
+    CHECK(run_source(a, pool,
+        "x = 'ok'\n"
+        "IF 1 THEN NOP\n"
+        "ELSE x = 'bad'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "ok"), "X = 'ok' (NOP took THEN)");
+    vpool_destroy(pool);
+}
+
+/* CF#18: ITERATE skips to next iteration */
+static void test_cf18_iterate(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#18: ITERATE skips to next loop iteration ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    /* Sum only even numbers 1..6 -> 2+4+6 = 12 */
+    CHECK(run_source(a, pool,
+        "DO i = 1 TO 6\n"
+        "  IF i // 2 = 1 THEN ITERATE\n"  /* skip odd */
+        "  x = x + i\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "12"), "X = '12' (2+4+6)");
+    vpool_destroy(pool);
+}
+
+/* CF#19: LEAVE exits the loop */
+static void test_cf19_leave(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#19: LEAVE exits the loop early ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO i = 1 TO 100\n"
+        "  x = x + 1\n"
+        "  IF i = 5 THEN LEAVE\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "5"), "X = '5' (LEAVE after 5 iters)");
+    vpool_destroy(pool);
+}
+
+/* CF#20: Label table built before execution (SIGNAL forward jump) */
+static void test_cf20_signal_forward(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    printf("\n--- CF#20: SIGNAL forward-jump to a label defined later ---\n");
+
+    CHECK(run_source(a, pool,
+        "SIGNAL target\n"
+        "x = 'skipped'\n"
+        "target:\n"
+        "x = 'reached'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "reached"), "X = 'reached'");
+    vpool_destroy(pool);
+}
+
+/* CF#21: No global state — two independent parsers */
+static void test_cf21_no_global_state(void)
+{
+    struct lstr_alloc *a     = lstr_default_alloc();
+    struct irx_vpool  *pool_a = vpool_create(a, NULL);
+    struct irx_vpool  *pool_b = vpool_create(a, NULL);
+    printf("\n--- CF#21: Two independent parsers, no shared state ---\n");
+
+    /* Pre-initialize N=0 in each pool so n+i arithmetic works. */
+    {
+        Lstr k2, v2;
+        Lzeroinit(&k2); Lzeroinit(&v2);
+        set_lstr(a, &k2, "N"); set_lstr(a, &v2, "0");
+        vpool_set(pool_a, &k2, &v2);
+        vpool_set(pool_b, &k2, &v2);
+        Lfree(a, &k2); Lfree(a, &v2);
+    }
+
+    CHECK(run_source(a, pool_a,
+        "DO i = 1 TO 3; n = n + i; END\n") == IRXPARS_OK, "parser A OK");
+    CHECK(run_source(a, pool_b,
+        "DO i = 1 TO 4; n = n + i; END\n") == IRXPARS_OK, "parser B OK");
+    CHECK(get_var_eq(a, pool_a, "N", "6"),  "pool A: N = '6'  (1+2+3)");
+    CHECK(get_var_eq(a, pool_b, "N", "10"), "pool B: N = '10' (1+2+3+4)");
+
+    vpool_destroy(pool_a);
+    vpool_destroy(pool_b);
+}
+
+/* CF#22: DO FOREVER + LEAVE */
+static void test_cf22_do_forever(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#22: DO FOREVER with LEAVE ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO FOREVER\n"
+        "  x = x + 1\n"
+        "  IF x >= 3 THEN LEAVE\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "3"), "X = '3'");
+    vpool_destroy(pool);
+}
+
+/* CF#23: DO n (repetitive count) */
+static void test_cf23_do_count(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#23: DO 4 (four iterations) ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO 4\n"
+        "  x = x + 1\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "4"), "X = '4'");
+    vpool_destroy(pool);
+}
+
+/* CF#24: IF without ELSE */
+static void test_cf24_if_no_else(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#24: IF without ELSE (false branch -> skip) ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "original");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "IF 0 THEN x = 'changed'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "original"), "X unchanged");
+    vpool_destroy(pool);
+}
+
+/* CF#25: IF with DO block in THEN branch */
+static void test_cf25_if_do_block(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#25: IF THEN DO ... END ELSE simple ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "C"); set_lstr(a, &v, "1");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "IF c THEN\n"
+        "  DO\n"
+        "    x = 'block'\n"
+        "    y = 'ran'\n"
+        "  END\n"
+        "ELSE x = 'skip'\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "block"), "X = 'block'");
+    CHECK(get_var_eq(a, pool, "Y", "ran"),   "Y = 'ran'");
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("=== WP-15: Control Flow tests ===\n");
+
+    test_cf1_do_counted_loop();
+    test_cf2_do_while();
+    test_cf3_do_until();
+    test_cf4_nested_do();
+    test_cf5_if_true();
+    test_cf6_if_false();
+    test_cf7_nested_if_else();
+    test_cf8_select_first_when();
+    test_cf9_select_second_when();
+    test_cf10_select_otherwise();
+    test_cf11_select_no_match();
+    test_cf12_call_return();
+    test_cf13_call_sigl();
+    test_cf14_return_result();
+    test_cf15_exit();
+    test_cf16_signal();
+    test_cf17_nop();
+    test_cf18_iterate();
+    test_cf19_leave();
+    test_cf20_signal_forward();
+    test_cf21_no_global_state();
+    test_cf22_do_forever();
+    test_cf23_do_count();
+    test_cf24_if_no_else();
+    test_cf25_if_do_block();
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/test/test_control.c
+++ b/test/test_control.c
@@ -631,6 +631,72 @@ static void test_cf25_if_do_block(void)
     vpool_destroy(pool);
 }
 
+/* CF#26: DO i = 5 TO 1 BY -1 (negative step, countdown) */
+static void test_cf26_do_ctrl_neg_step(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#26: DO i = 5 TO 1 BY -1 (negative step) ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO i = 5 TO 1 BY -1\n"
+        "  x = x + i\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "15"), "X = '15' (5+4+3+2+1)");
+    CHECK(get_var_eq(a, pool, "I", "1"),  "I = '1' (final value)");
+    vpool_destroy(pool);
+}
+
+/* CF#27: DO i = 1 TO 10 BY 2 (step > 1) */
+static void test_cf27_do_ctrl_step2(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#27: DO i = 1 TO 10 BY 2 (step > 1) ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO i = 1 TO 10 BY 2\n"
+        "  x = x + i\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "25"), "X = '25' (1+3+5+7+9)");
+    CHECK(get_var_eq(a, pool, "I", "9"),  "I = '9' (final value)");
+    vpool_destroy(pool);
+}
+
+/* CF#28: DO i = 1 TO 10 BY 3 (step doesn't land on limit exactly) */
+static void test_cf28_do_ctrl_step3(void)
+{
+    struct lstr_alloc *a    = lstr_default_alloc();
+    struct irx_vpool  *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    printf("\n--- CF#28: DO i = 1 TO 10 BY 3 (step doesn't land on limit) ---\n");
+
+    Lzeroinit(&k); Lzeroinit(&v);
+    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k); Lfree(a, &v);
+
+    CHECK(run_source(a, pool,
+        "DO i = 1 TO 10 BY 3\n"
+        "  x = x + i\n"
+        "END\n") == IRXPARS_OK, "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "22"), "X = '22' (1+4+7+10)");
+    CHECK(get_var_eq(a, pool, "I", "10"), "I = '10' (final value)");
+    vpool_destroy(pool);
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
@@ -664,6 +730,9 @@ int main(void)
     test_cf23_do_count();
     test_cf24_if_no_else();
     test_cf25_if_do_block();
+    test_cf26_do_ctrl_neg_step();
+    test_cf27_do_ctrl_step2();
+    test_cf28_do_ctrl_step3();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);


### PR DESCRIPTION
## Summary

- Implements all structured control flow constructs from SC28-1883-0 Chapter 8
- Adds `irxctrl` module (label table + execution stack) as control flow infrastructure
- All 53 new control flow tests pass; all 38 existing parser tests unaffected

## Changes

**New files:**
- `include/irxctrl.h` — label table and execution stack structures (FRAME_DO, FRAME_CALL, FRAME_SELECT; DO_SIMPLE, DO_FOREVER, DO_COUNT, DO_CTRL, DO_WHILE, DO_UNTIL)
- `src/irx#ctrl.c` — label scan (first-pass for CALL/SIGNAL), label find, frame push/top/pop, innermost-DO search
- `test/test_control.c` — 53 test cases (CF#1–CF#25) covering all variants

**Modified:**
- `include/irxpars.h` — added `label_table`, `exec_stack`, `exit_requested`, `exit_rc` to `struct irx_parser`
- `src/irx#pars.c` — keyword handlers for DO/END/IF/THEN/ELSE/SELECT/WHEN/OTHERWISE/CALL/RETURN/EXIT/SIGNAL/ITERATE/LEAVE/NOP; keyword-barrier fix in `parse_concat`; `parse_add` for DO bounds; IF+DO-block sub-loop; label scan in `irx_pars_run`

## Test plan

- [x] `53/53` control flow tests pass (`test/test_control.c`)
- [x] `38/38` existing parser tests pass (no regressions)
- [x] Builds clean with `-Wall -Wextra -std=gnu99` (no new warnings)

Fixes #11