### PR TITLE
WP-18: Hello World end-to-end execution (irx_exec_run)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Tests: `test/test_name.c`
 | `src/irx#pars.c` | IRX#PARS | Parser + expression evaluator (WP-13) |
 | `src/irx#io.c`   | IRX#IO   | Default I/O routine IRXINOUT (WP-14) |
 | `src/irx#ctrl.c` | IRX#CTRL | Control flow: DO/IF/SELECT/CALL/SIGNAL (WP-15) |
+| `src/irx#exec.c` | IRX#EXEC | End-to-end execution pipeline irx_exec_run() (WP-18) |
 
 New source files follow the same pattern: `src/irx#xxxx.c` where
 `xxxx` is a 4-character identifier. Member names must be ≤ 8 chars.
@@ -251,6 +252,12 @@ gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     -o test/test_control test/test_control.c \
     $PHASE1_SRC $PHASE2_SRC $LSTRING_SRC
 ./test/test_control
+
+# Hello World end-to-end (WP-18) — 16/16
+gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
+    -o test/test_hello test/test_hello.c \
+    $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' $LSTRING_SRC
+./test/test_hello
 ```
 
 ## Work packages
@@ -261,7 +268,7 @@ and acceptance criteria.
 
 Current status:
 - Phase 1 (WP-01 through WP-05): complete
-- Phase 2 (WP-10 through WP-15): complete
+- Phase 2 (WP-10 through WP-15, WP-18): complete
 - Next: WP-16 (PARSE instruction)
 
 ## Knowledge sources

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -24,7 +24,7 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-15 | DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL | 2 | DONE (62/62) — PR #12 |
 | WP-16 | PARSE instruction | 2 | OPEN |
 | WP-17 | PROCEDURE EXPOSE | 2 | OPEN |
-| WP-18 | Hello World end-to-end | 2 | OPEN |
+| WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | OPEN |
 | WP-21 | Built-in string functions | 3 | OPEN |
 | WP-22 | Built-in misc functions | 3 | OPEN |

--- a/include/irxexec.h
+++ b/include/irxexec.h
@@ -1,0 +1,40 @@
+/* ------------------------------------------------------------------ */
+/*  irxexec.h - REXX/370 End-to-End Execution (WP-18)                 */
+/*                                                                    */
+/*  irx_exec_run() is the top-level entry point that ties all Phase 2  */
+/*  components together: environment, tokenizer, variable pool,        */
+/*  parser, control flow, and I/O.                                     */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 1 (Introduction), Chapter 8              */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef __IRXEXEC_H__
+#define __IRXEXEC_H__
+
+#include "irx.h"
+
+/* Execute a REXX program from source text.
+ *
+ *   source     - REXX source text (need not be NUL-terminated)
+ *   source_len - length of source in bytes
+ *   rc_out     - receives the EXIT return code (0 if no EXIT clause)
+ *                May be NULL if the caller does not need the RC.
+ *   envblock   - pre-existing Language Processor Environment, or NULL
+ *                to have irx_exec_run create (and destroy) one.
+ *
+ * Pipeline:
+ *   irxinit -> irx_lstr_init -> irx_tokn_run -> vpool_create
+ *   -> irx_pars_init -> irx_ctrl_init -> irx_ctrl_label_scan
+ *   -> irx_pars_run -> cleanup -> irxterm (if own_env)
+ *
+ * Returns:
+ *   0        success (exit_rc in *rc_out)
+ *   20       IRXINIT or allocator failure
+ *   TOKERR_* tokenizer error (30-36)
+ *   IRXPARS_* parser / runtime error (20-25)
+ */
+int irx_exec_run(const char *source, int source_len,
+                 int *rc_out, struct envblock *envblock);
+
+#endif /* __IRXEXEC_H__ */

--- a/project.toml
+++ b/project.toml
@@ -67,6 +67,12 @@ include = [
   "IRX#UID",
   "IRX#MSID",
   "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
 ]
 
 # ---------------------------------------------------------------

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -1,0 +1,83 @@
+/* ------------------------------------------------------------------ */
+/*  irx#exec.c - REXX/370 End-to-End Execution (WP-18)                */
+/*                                                                    */
+/*  irx_exec_run() wires all Phase 2 components together:             */
+/*  environment -> tokenizer -> variable pool -> parser -> cleanup.   */
+/*                                                                    */
+/*  This is pure glue — no new logic. Each step uses the public API   */
+/*  of the component it calls.                                         */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <string.h>
+
+#include "irx.h"
+#include "irxfunc.h"
+#include "irxexec.h"
+#include "irxlstr.h"
+#include "irxtokn.h"
+#include "irxvpool.h"
+#include "irxpars.h"
+#include "irxctrl.h"
+
+int irx_exec_run(const char *source, int source_len,
+                 int *rc_out, struct envblock *envblock)
+{
+    int                   own_env   = 0;
+    struct irx_token     *tokens    = NULL;
+    int                   tok_count = 0;
+    struct irx_tokn_error tok_err;
+    struct lstr_alloc    *alloc     = NULL;
+    struct irx_vpool     *vpool     = NULL;
+    struct irx_parser     parser;
+    int                   rc;
+
+    memset(&parser,  0, sizeof(parser));
+    memset(&tok_err, 0, sizeof(tok_err));
+
+    /* 1. Environment ------------------------------------------------ */
+    if (envblock == NULL) {
+        rc = irxinit(NULL, &envblock);
+        if (rc != 0) return rc;
+        own_env = 1;
+    }
+
+    /* 2. Allocator bridge (WP-11b) ---------------------------------- */
+    alloc = irx_lstr_init(envblock);
+    if (alloc == NULL) { rc = 20; goto cleanup; }
+
+    /* 3. Tokenize --------------------------------------------------- */
+    rc = irx_tokn_run(envblock, source, source_len,
+                      &tokens, &tok_count, &tok_err);
+    if (rc != 0) goto cleanup;
+
+    /* 4. Variable pool ---------------------------------------------- */
+    vpool = vpool_create(alloc, NULL);
+    if (vpool == NULL) { rc = 20; goto cleanup; }
+
+    /* 5. Parser init ------------------------------------------------- */
+    rc = irx_pars_init(&parser, tokens, tok_count, vpool, alloc, envblock);
+    if (rc != 0) goto cleanup;
+
+    /* 6. Control flow init + label scan (WP-15) --------------------- */
+    rc = irx_ctrl_init(&parser);
+    if (rc != 0) goto cleanup;
+
+    rc = irx_ctrl_label_scan(&parser);
+    if (rc != 0) goto cleanup;
+
+    /* 7. Execute ----------------------------------------------------- */
+    rc = irx_pars_run(&parser);
+
+    if (rc_out != NULL)
+        *rc_out = parser.exit_rc;
+
+cleanup:
+    irx_ctrl_cleanup(&parser);
+    irx_pars_cleanup(&parser);
+    if (vpool  != NULL) vpool_destroy(vpool);
+    if (tokens != NULL) irx_tokn_free(envblock, tokens, tok_count);
+    if (own_env)        irxterm(envblock);
+    return rc;
+}

--- a/test/test_hello.c
+++ b/test/test_hello.c
@@ -1,0 +1,280 @@
+/* ------------------------------------------------------------------ */
+/*  test_hello.c - WP-18 Hello World End-to-End integration tests     */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_hello \               */
+/*        test/test_hello.c \                                          */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \       */
+/*        'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c' \       */
+/*        'src/irx#io.c'   'src/irx#lstr.c' 'src/irx#tokn.c' \       */
+/*        'src/irx#vpol.c' 'src/irx#pars.c' 'src/irx#ctrl.c' \       */
+/*        'src/irx#exec.c' \                                           */
+/*        ../lstring370/src/'lstr#cor.c'                              */
+/*                                                                    */
+/*  Each test calls irx_exec_run() with REXX source and checks        */
+/*  output and return codes via a mock I/O routine installed into     */
+/*  IRXEXTE before execution.                                          */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxwkblk.h"
+#include "irxfunc.h"
+#include "irxexec.h"
+#include "irxwkblk.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg) \
+    do { \
+        tests_run++; \
+        if (cond) { \
+            tests_passed++; \
+            printf("  PASS: %s\n", msg); \
+        } else { \
+            tests_failed++; \
+            printf("  FAIL: %s\n", msg); \
+        } \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Mock I/O — accumulates all SAY lines separated by '\n'            */
+/* ------------------------------------------------------------------ */
+
+#define OUT_BUF_SIZE 4096
+
+static char g_out[OUT_BUF_SIZE];
+static int  g_out_len = 0;
+
+static void reset_output(void)
+{
+    g_out_len = 0;
+    g_out[0]  = '\0';
+}
+
+/* Returns 1 if the accumulated output contains the given line. */
+static int output_contains(const char *line)
+{
+    int line_len = (int)strlen(line);
+    int i;
+
+    for (i = 0; i <= g_out_len - line_len; i++) {
+        if (memcmp(g_out + i, line, (size_t)line_len) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+static int mock_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL
+            && data->pstr != NULL && data->len > 0) {
+        int n = (int)data->len;
+        if (g_out_len + n + 1 < OUT_BUF_SIZE) {
+            memcpy(g_out + g_out_len, data->pstr, (size_t)n);
+            g_out_len          += n;
+            g_out[g_out_len++]  = '\n';
+            g_out[g_out_len]    = '\0';
+        }
+    }
+    return 0;
+}
+
+static void install_mock(struct envblock *env)
+{
+    struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+        exte->io_routine = (void *)mock_io;
+}
+
+/* Run source through irx_exec_run, installing mock I/O first. */
+static int run_with_mock(const char *src, int *exit_rc_out)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0) return rc;
+
+    install_mock(env);
+    reset_output();
+
+    rc = irx_exec_run(src, (int)strlen(src), exit_rc_out, env);
+
+    irxterm(env);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test cases                                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_hw1_hello_world(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- HW#1: Hello World exec ---\n");
+
+    rc = run_with_mock(
+        "/* REXX */\n"
+        "say 'Hello World from REXX/370!'\n"
+        "x = 2 + 3\n"
+        "say 'The answer is' x\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "EXIT return code is 0");
+    CHECK(output_contains("Hello World from REXX/370!"),
+          "first SAY: 'Hello World from REXX/370!'");
+    CHECK(output_contains("The answer is 5"),
+          "second SAY: 'The answer is 5'");
+}
+
+static void test_hw2_do_loop_sum(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- HW#2: DO loop sum 1..10 ---\n");
+
+    rc = run_with_mock(
+        "/* REXX */\n"
+        "sum = 0\n"
+        "do i = 1 to 10\n"
+        "  sum = sum + i\n"
+        "end\n"
+        "say 'Sum 1..10 =' sum\n"
+        "exit sum\n",
+        &exit_rc);
+
+    CHECK(rc == 0,       "irx_exec_run returns 0");
+    CHECK(exit_rc == 55, "EXIT return code is 55");
+    CHECK(output_contains("Sum 1..10 = 55"),
+          "SAY: 'Sum 1..10 = 55'");
+}
+
+static void test_hw3_null_envblock(void)
+{
+    /* irx_exec_run with envblock=NULL must create its own environment. */
+    struct irxexte *exte;
+    int exit_rc = -1;
+    int rc;
+
+    /* We cannot install a mock without an env, so we just verify that
+     * the call succeeds and the exit code is correct. */
+    printf("\n--- HW#3: envblock=NULL (auto-create environment) ---\n");
+
+    /* Redirect irxinout output to /dev/null by hijacking the real
+     * irxinout (it uses printf); just verify rc is correct. */
+    {
+        const char *src = "x = 6 * 7\n" "exit x\n";
+        rc = irx_exec_run(src, (int)strlen(src), &exit_rc, NULL);
+    }
+
+    CHECK(rc == 0,       "irx_exec_run returns 0");
+    CHECK(exit_rc == 42, "EXIT return code is 42");
+
+    (void)exte; /* suppress unused warning */
+}
+
+static void test_hw4_syntax_error(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- HW#4: syntax error returns non-zero ---\n");
+
+    rc = run_with_mock(
+        "say 'unterminated\n",
+        &exit_rc);
+
+    CHECK(rc != 0, "irx_exec_run returns non-zero on error");
+}
+
+static void test_hw5_exit_nonzero(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- HW#5: EXIT with non-zero code ---\n");
+
+    rc = run_with_mock(
+        "exit 7\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 7, "EXIT return code is 7");
+}
+
+static void test_hw6_no_exit_clause(void)
+{
+    /* When a program has no EXIT, exit_rc must be 0. */
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- HW#6: no EXIT clause -> rc_out = 0 ---\n");
+
+    rc = run_with_mock(
+        "x = 1\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit_rc is 0 (no EXIT in source)");
+}
+
+static void test_hw7_if_then_else(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- HW#7: IF/THEN/ELSE end-to-end ---\n");
+
+    rc = run_with_mock(
+        "x = 10\n"
+        "if x > 5 then\n"
+        "  say 'big'\n"
+        "else\n"
+        "  say 'small'\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(output_contains("big"), "SAY: 'big' (true branch taken)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("=== WP-18: Hello World End-to-End tests ===\n");
+
+    test_hw1_hello_world();
+    test_hw2_do_loop_sum();
+    test_hw3_null_envblock();
+    test_hw4_syntax_error();
+    test_hw5_exit_nonzero();
+    test_hw6_no_exit_clause();
+    test_hw7_if_then_else();
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #13

## Summary

- `irx_exec_run()` wires all Phase 2 components together in ~60 lines of glue code
- New `include/irxexec.h` and `src/irx#exec.c`
- 7 integration tests in `test/test_hello.c` — **16/16 passing**
- `project.toml`: all Phase 2 modules added to IRXJCL link include list

## Tests

```
HW#1: Hello World exec            — SAY, assignment, blank concat, EXIT 0
HW#2: DO loop sum 1..10           — exit RC = 55
HW#3: envblock=NULL               — auto-creates environment, EXIT 42
HW#4: syntax error                — returns non-zero without crash
HW#5: EXIT with non-zero code     — exit RC = 7
HW#6: no EXIT clause              — rc_out = 0
HW#7: IF/THEN/ELSE end-to-end     — correct branch taken
```

All prior tests still pass: 70+47+38+27+50+62 = 294/294.