### PR TITLE
WP-17: PROCEDURE EXPOSE, CALL arguments, ARG instruction and BIF

### DIFF
--- a/include/irxctrl.h
+++ b/include/irxctrl.h
@@ -12,13 +12,15 @@
 #ifndef __IRXCTRL_H__
 #define __IRXCTRL_H__
 
+#include "lstring.h"
 #include "lstralloc.h"
 
 /* ================================================================== */
-/*  Forward declaration                                               */
+/*  Forward declarations                                              */
 /* ================================================================== */
 
 struct irx_parser;
+struct irx_vpool;   /* used by FRAME_CALL for PROCEDURE EXPOSE (WP-17) */
 
 /* ================================================================== */
 /*  Frame type codes                                                  */
@@ -94,6 +96,14 @@ struct irx_exec_frame {
     /* --- FRAME_CALL fields --------------------------------------- */
     int  call_return_pos;   /* tok_pos to resume after RETURN         */
     int  call_line;         /* source line of the CALL (-> SIGL)      */
+
+    /* WP-17: PROCEDURE EXPOSE */
+    struct irx_vpool *saved_vpool;     /* caller's vpool before PROCEDURE   */
+    Lstr             *saved_args;      /* caller's call_args array           */
+    int              *saved_arg_exists;/* caller's call_arg_exists array     */
+    int               saved_argc;      /* caller's call_argc                 */
+    int               procedure_allowed; /* 1 = PROCEDURE may follow next    */
+    int               has_procedure;   /* 1 = PROCEDURE was executed         */
 
     /* --- FRAME_SELECT fields ------------------------------------- */
     int  select_matched;    /* 1 once a WHEN branch has been taken    */

--- a/include/irxexec.h
+++ b/include/irxexec.h
@@ -18,6 +18,9 @@
  *
  *   source     - REXX source text (need not be NUL-terminated)
  *   source_len - length of source in bytes
+ *   args       - argument string for the program (ARG / PARSE ARG),
+ *                or NULL if no argument is provided
+ *   args_len   - length of args in bytes (0 if args is NULL)
  *   rc_out     - receives the EXIT return code (0 if no EXIT clause)
  *                May be NULL if the caller does not need the RC.
  *   envblock   - pre-existing Language Processor Environment, or NULL
@@ -25,7 +28,7 @@
  *
  * Pipeline:
  *   irxinit -> irx_lstr_init -> irx_tokn_run -> vpool_create
- *   -> irx_pars_init -> irx_ctrl_init -> irx_ctrl_label_scan
+ *   -> irx_pars_init -> irx_ctrl_label_scan
  *   -> irx_pars_run -> cleanup -> irxterm (if own_env)
  *
  * Returns:
@@ -35,6 +38,7 @@
  *   IRXPARS_* parser / runtime error (20-25)
  */
 int irx_exec_run(const char *source, int source_len,
+                 const char *args, int args_len,
                  int *rc_out, struct envblock *envblock);
 
 #endif /* __IRXEXEC_H__ */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -28,6 +28,13 @@
 #include "lstralloc.h"
 
 /* ================================================================== */
+/*  Constants                                                         */
+/* ================================================================== */
+
+/* Maximum number of arguments in a CALL or function call. */
+#define IRX_MAX_ARGS 16
+
+/* ================================================================== */
 /*  Return codes                                                      */
 /* ================================================================== */
 
@@ -62,6 +69,15 @@ struct irx_parser {
 
     int                  exit_requested; /* set by EXIT / RETURN      */
     int                  exit_rc;        /* RC passed to EXIT          */
+
+    /* WP-17: PROCEDURE EXPOSE — current subroutine argument context.
+     * call_args[0..call_argc-1] are the argument values; call_arg_exists
+     * is a parallel array where 1 = argument was passed, 0 = omitted.
+     * Both arrays are heap-allocated (IRX_MAX_ARGS elements each).
+     * NULL when no CALL is active (top-level or no args passed). */
+    Lstr  *call_args;       /* current subroutine argument values      */
+    int   *call_arg_exists; /* 1=passed, 0=omitted (per argument)      */
+    int    call_argc;       /* number of argument positions            */
 };
 
 /* ================================================================== */

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -81,11 +81,17 @@ int irx_exec_run(const char *source, int source_len,
         }
         memset(la, 0, (size_t)IRX_MAX_ARGS * sizeof(Lstr));
         memset(le, 0, (size_t)IRX_MAX_ARGS * sizeof(int));
-        if (Lfx(alloc, &la[0], (size_t)args_len) == LSTR_OK) {
-            memcpy(la[0].pstr, args, (size_t)args_len);
-            la[0].len  = (size_t)args_len;
-            la[0].type = LSTRING_TY;
+        if (Lfx(alloc, &la[0], (size_t)args_len) != LSTR_OK) {
+            alloc->dealloc(la, (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                           alloc->ctx);
+            alloc->dealloc(le, (size_t)IRX_MAX_ARGS * sizeof(int),
+                           alloc->ctx);
+            rc = 20;
+            goto cleanup;
         }
+        memcpy(la[0].pstr, args, (size_t)args_len);
+        la[0].len  = (size_t)args_len;
+        la[0].type = LSTRING_TY;
         le[0]                = 1;
         parser.call_args       = la;
         parser.call_arg_exists = le;

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -22,6 +22,7 @@
 #include "irxctrl.h"
 
 int irx_exec_run(const char *source, int source_len,
+                 const char *args, int args_len,
                  int *rc_out, struct envblock *envblock)
 {
     int                   own_env   = 0;
@@ -60,10 +61,38 @@ int irx_exec_run(const char *source, int source_len,
     rc = irx_pars_init(&parser, tokens, tok_count, vpool, alloc, envblock);
     if (rc != 0) goto cleanup;
 
-    /* 6. Control flow init + label scan (WP-15) --------------------- */
-    rc = irx_ctrl_init(&parser);
-    if (rc != 0) goto cleanup;
+    /* 5b. Top-level argument setup (WP-17) -------------------------- */
+    if (args != NULL && args_len > 0) {
+        Lstr *la;
+        int  *le;
+        la = (Lstr *)alloc->alloc(
+            (size_t)IRX_MAX_ARGS * sizeof(Lstr), alloc->ctx);
+        le = (int  *)alloc->alloc(
+            (size_t)IRX_MAX_ARGS * sizeof(int),  alloc->ctx);
+        if (la == NULL || le == NULL) {
+            if (la != NULL)
+                alloc->dealloc(la, (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                               alloc->ctx);
+            if (le != NULL)
+                alloc->dealloc(le, (size_t)IRX_MAX_ARGS * sizeof(int),
+                               alloc->ctx);
+            rc = 20;
+            goto cleanup;
+        }
+        memset(la, 0, (size_t)IRX_MAX_ARGS * sizeof(Lstr));
+        memset(le, 0, (size_t)IRX_MAX_ARGS * sizeof(int));
+        if (Lfx(alloc, &la[0], (size_t)args_len) == LSTR_OK) {
+            memcpy(la[0].pstr, args, (size_t)args_len);
+            la[0].len  = (size_t)args_len;
+            la[0].type = LSTRING_TY;
+        }
+        le[0]                = 1;
+        parser.call_args       = la;
+        parser.call_arg_exists = le;
+        parser.call_argc       = 1;
+    }
 
+    /* 6. Label scan ------------------------------------------------- */
     rc = irx_ctrl_label_scan(&parser);
     if (rc != 0) goto cleanup;
 

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -295,8 +295,70 @@ static int bif_length(struct irx_parser *p, int argc, PLstr *argv,
     return long_to_lstr(p->alloc, result, (long)argv[0]->len);
 }
 
+/* ------------------------------------------------------------------ */
+/*  ARG([n[,option]]) - argument count / value / existence (WP-17)   */
+/* ------------------------------------------------------------------ */
+
+static int bif_arg(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
+{
+    int n;
+    char nbuf[16];
+    int  nlen;
+
+    /* ARG() -> number of arguments. */
+    if (argc == 0) {
+        return long_to_lstr(p->alloc, result, (long)p->call_argc);
+    }
+
+    /* Get positional index n (1-based). */
+    nlen = (argv[0]->len < (int)sizeof(nbuf) - 1)
+           ? (int)argv[0]->len : (int)(sizeof(nbuf) - 1);
+    memcpy(nbuf, argv[0]->pstr, (size_t)nlen);
+    nbuf[nlen] = '\0';
+    n = atoi(nbuf);
+    if (n < 1) return fail(p, IRXPARS_SYNTAX);
+
+    if (argc == 1) {
+        /* ARG(n) -> value of argument n or "". */
+        if (n <= p->call_argc && p->call_arg_exists != NULL &&
+            p->call_arg_exists[n - 1] &&
+            p->call_args != NULL) {
+            int rc = Lstrcpy(p->alloc, result, &p->call_args[n - 1]);
+            return (rc == LSTR_OK) ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
+        }
+        return (lstr_set_bytes(p->alloc, result, "", 0) == LSTR_OK)
+               ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
+    }
+
+    /* argc == 2: 'E' (exists) or 'O' (omitted) option. */
+    if (argv[1]->len != 1) return fail(p, IRXPARS_SYNTAX);
+    {
+        int   flag;
+        int   exists;
+        unsigned char opt = argv[1]->pstr[0];
+        char  answer;
+
+        if (islower(opt)) opt = (unsigned char)toupper(opt);
+        exists = (n <= p->call_argc && p->call_arg_exists != NULL &&
+                  p->call_arg_exists[n - 1]) ? 1 : 0;
+
+        if (opt == 'E') {
+            flag = exists;
+        } else if (opt == 'O') {
+            flag = !exists;
+        } else {
+            return fail(p, IRXPARS_SYNTAX);
+        }
+
+        answer = flag ? '1' : '0';
+        return (lstr_set_bytes(p->alloc, result, &answer, 1) == LSTR_OK)
+               ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
+    }
+}
+
 static const struct irx_bif g_bif_table[] = {
-    { "LENGTH", 1, 1, bif_length }
+    { "LENGTH", 1, 1, bif_length },
+    { "ARG",    0, 2, bif_arg    }
 };
 static const int g_bif_count = (int)(sizeof(g_bif_table) /
                                      sizeof(g_bif_table[0]));
@@ -1201,14 +1263,20 @@ static int kw_otherwise(struct irx_parser *p)
 
 static int kw_call(struct irx_parser *p)
 {
-    char  label[CTRL_NAME_MAX];
-    int   label_len;
-    int   label_pos;
-    int   return_pos;
-    int   call_line;
+    char   label[CTRL_NAME_MAX];
+    int    label_len;
+    int    label_pos;
+    int    return_pos;
+    int    call_line;
     struct irx_exec_frame *f;
-    char  linebuf[32];
-    int   n;
+    char   linebuf[32];
+    int    n;
+    Lstr  *new_args   = NULL;
+    int   *new_exists = NULL;
+    int    argc       = 0;
+    int    after_comma = 0;
+    int    rc;
+    int    i;
 
     /* CALL must be followed by a label name (symbol). */
     if (cur_tok(p) == NULL || cur_tok(p)->tok_type != TOK_SYMBOL)
@@ -1218,7 +1286,66 @@ static int kw_call(struct irx_parser *p)
     call_line = cur_tok(p)->tok_line;
     advance_tok(p);
 
-    /* Arguments skipped — CALL argument passing is implemented in WP-17. */
+    /* Allocate argument arrays. */
+    new_args = (Lstr *)p->alloc->alloc(
+        (size_t)IRX_MAX_ARGS * sizeof(Lstr), p->alloc->ctx);
+    new_exists = (int *)p->alloc->alloc(
+        (size_t)IRX_MAX_ARGS * sizeof(int),  p->alloc->ctx);
+    if (new_args == NULL || new_exists == NULL) {
+        rc = fail(p, IRXPARS_NOMEM);
+        goto err;
+    }
+    memset(new_args,   0, (size_t)IRX_MAX_ARGS * sizeof(Lstr));
+    memset(new_exists, 0, (size_t)IRX_MAX_ARGS * sizeof(int));
+
+    /* Parse comma-separated arguments until clause end.
+     * An omitted argument is an empty slot between commas, or
+     * before the first comma, or after the last comma. */
+    if (!tok_ends_clause(cur_tok(p))) {
+        for (;;) {
+            if (argc >= IRX_MAX_ARGS) {
+                rc = fail(p, IRXPARS_SYNTAX);
+                goto err;
+            }
+            if (cur_tok(p) != NULL &&
+                cur_tok(p)->tok_type == TOK_COMMA) {
+                /* Omitted argument at this position. */
+                Lzeroinit(&new_args[argc]);
+                new_exists[argc] = 0;
+                argc++;
+                advance_tok(p);
+                after_comma = 1;
+                continue;
+            }
+            if (tok_ends_clause(cur_tok(p))) {
+                /* Trailing comma means one more omitted argument. */
+                if (after_comma) {
+                    if (argc >= IRX_MAX_ARGS) {
+                        rc = fail(p, IRXPARS_SYNTAX);
+                        goto err;
+                    }
+                    Lzeroinit(&new_args[argc]);
+                    new_exists[argc] = 0;
+                    argc++;
+                }
+                break;
+            }
+            /* Evaluate the expression for this argument position. */
+            Lzeroinit(&new_args[argc]);
+            rc = irx_pars_eval_expr(p, &new_args[argc]);
+            if (rc != IRXPARS_OK) goto err;
+            new_exists[argc] = 1;
+            argc++;
+            after_comma = 0;
+            if (cur_tok(p) != NULL &&
+                cur_tok(p)->tok_type == TOK_COMMA) {
+                advance_tok(p);
+                after_comma = 1;
+                continue;
+            }
+            break;
+        }
+    }
     skip_to_clause_end(p);
 
     /* Where to return to (first token of next clause). */
@@ -1226,21 +1353,52 @@ static int kw_call(struct irx_parser *p)
 
     /* Look up the label. */
     label_pos = irx_ctrl_label_find(p, label, label_len);
-    if (label_pos < 0) return fail(p, IRXPARS_BADFUNC);
+    if (label_pos < 0) {
+        rc = fail(p, IRXPARS_BADFUNC);
+        goto err;
+    }
 
-    /* Push CALL frame. */
+    /* Push CALL frame, saving the current argument context. */
     f = irx_ctrl_frame_push(p, FRAME_CALL);
-    if (f == NULL) return fail(p, IRXPARS_NOMEM);
-    f->call_return_pos = return_pos;
-    f->call_line       = call_line;
+    if (f == NULL) {
+        rc = fail(p, IRXPARS_NOMEM);
+        goto err;
+    }
+    f->call_return_pos   = return_pos;
+    f->call_line         = call_line;
+    f->saved_vpool       = NULL;
+    f->saved_args        = p->call_args;
+    f->saved_arg_exists  = p->call_arg_exists;
+    f->saved_argc        = p->call_argc;
+    f->procedure_allowed = 1;
+    f->has_procedure     = 0;
+
+    /* Install the new argument context. */
+    p->call_args       = new_args;
+    p->call_arg_exists = new_exists;
+    p->call_argc       = argc;
 
     /* Set SIGL special variable. */
     n = sprintf(linebuf, "%d", call_line);
     set_var_str(p, "SIGL", 4, linebuf, n);
 
     /* Jump to label (past SYMBOL ':' tokens). */
-    p->tok_pos = label_pos + 2;  /* skip SYMBOL + COLON */
+    p->tok_pos = label_pos + 2;
     return IRXPARS_OK;
+
+err:
+    if (new_args != NULL) {
+        for (i = 0; i < argc; i++) Lfree(p->alloc, &new_args[i]);
+        p->alloc->dealloc(new_args,
+                          (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                          p->alloc->ctx);
+    }
+    if (new_exists != NULL) {
+        p->alloc->dealloc(new_exists,
+                          (size_t)IRX_MAX_ARGS * sizeof(int),
+                          p->alloc->ctx);
+    }
+    return rc;
 }
 
 /* ------------------------------------------------------------------ */
@@ -1250,9 +1408,10 @@ static int kw_call(struct irx_parser *p)
 static int kw_return(struct irx_parser *p)
 {
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
-    Lstr result;
-    int  have_result = 0;
-    int  i;
+    struct irx_exec_frame *f;
+    Lstr   result;
+    int    have_result = 0;
+    int    i, j;
 
     Lzeroinit(&result);
 
@@ -1262,8 +1421,24 @@ static int kw_return(struct irx_parser *p)
         have_result = 1;
     }
 
+    /* Locate the nearest enclosing CALL frame. */
+    if (es == NULL) goto no_call_frame;
+
+    for (i = es->top - 1; i >= 0; i--) {
+        if (es->frames[i].frame_type == FRAME_CALL) break;
+    }
+    if (i < 0) goto no_call_frame;
+
+    f = &es->frames[i];
+
+    /* Restore the caller's variable pool if PROCEDURE was executed. */
+    if (f->has_procedure) {
+        vpool_destroy(p->vpool);   /* destroy child pool */
+        p->vpool = f->saved_vpool; /* restore caller's pool */
+    }
+
+    /* Set RESULT in the caller's variable pool (now restored). */
     if (have_result) {
-        /* Store in RESULT special variable. */
         Lstr key;
         Lzeroinit(&key);
         if (lstr_set_bytes(p->alloc, &key, "RESULT", 6) == LSTR_OK) {
@@ -1273,27 +1448,250 @@ static int kw_return(struct irx_parser *p)
     }
     Lfree(p->alloc, &result);
 
-    /* Unwind stack to find the CALL frame. */
-    if (es == NULL) {
-        /* No CALL frame: treat as EXIT 0. */
-        p->exit_requested = 1;
-        p->exit_rc = 0;
-        return IRXPARS_OK;
+    /* Restore the caller's argument context. */
+    if (p->call_args != NULL) {
+        for (j = 0; j < p->call_argc; j++)
+            Lfree(p->alloc, &p->call_args[j]);
+        p->alloc->dealloc(p->call_args,
+                          (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                          p->alloc->ctx);
     }
+    if (p->call_arg_exists != NULL) {
+        p->alloc->dealloc(p->call_arg_exists,
+                          (size_t)IRX_MAX_ARGS * sizeof(int),
+                          p->alloc->ctx);
+    }
+    p->call_args       = f->saved_args;
+    p->call_arg_exists = f->saved_arg_exists;
+    p->call_argc       = f->saved_argc;
 
+    p->tok_pos = f->call_return_pos;
+    es->top    = i;   /* pop everything up to and including CALL frame */
+    return IRXPARS_OK;
+
+no_call_frame:
+    /* No CALL frame on stack: set RESULT at top level, treat as EXIT 0. */
+    if (have_result) {
+        Lstr key;
+        Lzeroinit(&key);
+        if (lstr_set_bytes(p->alloc, &key, "RESULT", 6) == LSTR_OK) {
+            vpool_set(p->vpool, &key, &result);
+            Lfree(p->alloc, &key);
+        }
+    }
+    Lfree(p->alloc, &result);
+    p->exit_requested = 1;
+    p->exit_rc = 0;
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  PROCEDURE [EXPOSE var ...]  (WP-17)                               */
+/* ------------------------------------------------------------------ */
+
+static int kw_procedure(struct irx_parser *p)
+{
+    struct irx_exec_stack  *es = (struct irx_exec_stack *)p->exec_stack;
+    struct irx_exec_frame  *f;
+    struct irx_vpool       *child;
+    const struct irx_token *t;
+    char   kw[8];
+    int    kw_len;
+    int    i;
+
+    /* Find the nearest enclosing CALL frame. */
+    if (es == NULL) return fail(p, IRXPARS_SYNTAX);
     for (i = es->top - 1; i >= 0; i--) {
         if (es->frames[i].frame_type == FRAME_CALL) break;
     }
+    if (i < 0) return fail(p, IRXPARS_SYNTAX);
 
-    if (i < 0) {
-        /* No CALL frame on stack: treat as EXIT. */
-        p->exit_requested = 1;
-        p->exit_rc = 0;
-        return IRXPARS_OK;
+    f = &es->frames[i];
+    if (!f->procedure_allowed) return fail(p, IRXPARS_SYNTAX);
+
+    /* Mark PROCEDURE as executed for this CALL frame. */
+    f->procedure_allowed = 0;
+    f->has_procedure     = 1;
+
+    /* Create an isolated child variable pool. */
+    child = vpool_create(p->alloc, p->vpool);
+    if (child == NULL) return fail(p, IRXPARS_NOMEM);
+
+    /* Save caller's pool and switch to child pool. */
+    f->saved_vpool = p->vpool;
+    p->vpool       = child;
+
+    /* Parse optional EXPOSE keyword and variable list. */
+    t = cur_tok(p);
+    if (t != NULL && !tok_ends_clause(t) && t->tok_type == TOK_SYMBOL) {
+        kw_len = sym_to_upper(t, kw, (int)sizeof(kw));
+        if (kw_len == 6 && memcmp(kw, "EXPOSE", 6) == 0) {
+            advance_tok(p);   /* consume EXPOSE */
+
+            /* Parse each name in the expose list. */
+            while (!tok_ends_clause(cur_tok(p))) {
+                Lstr   ename;
+                int    rc;
+                size_t el;
+
+                t = cur_tok(p);
+                if (t == NULL || t->tok_type != TOK_SYMBOL) break;
+
+                Lzeroinit(&ename);
+                rc = set_upper_from_tok(p->alloc, &ename, t);
+                if (rc != LSTR_OK) {
+                    Lfree(p->alloc, &ename);
+                    return fail(p, IRXPARS_NOMEM);
+                }
+                advance_tok(p);
+
+                /* Names ending with '.' are stem names. */
+                el = ename.len;
+                if (el > 0 && ename.pstr[el - 1] == '.') {
+                    vpool_expose_stem(child, &ename);
+                } else {
+                    vpool_expose_var(child, &ename);
+                }
+                Lfree(p->alloc, &ename);
+            }
+        }
     }
 
-    p->tok_pos = es->frames[i].call_return_pos;
-    es->top    = i;  /* pop everything up to and including CALL frame */
+    skip_to_clause_end(p);
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  ARG [var ...]  (WP-17)                                            */
+/*                                                                    */
+/*  Simplified PARSE UPPER ARG: splits call_args[0] by words and     */
+/*  assigns (uppercased) to the listed variables. The last variable   */
+/*  receives the remaining words joined with single spaces.           */
+/* ------------------------------------------------------------------ */
+
+/* Assign words from src[0..srclen-1] (starting at *pos_inout) to
+ * vars[0..nvar-1], uppercased. The last variable gets the remaining text
+ * trailing-stripped. Updates *pos_inout to reflect consumed input. */
+static int arg_assign_words(struct irx_parser *p,
+                             const unsigned char *src, size_t srclen,
+                             size_t *pos_inout,
+                             char vars[][CTRL_NAME_MAX], int *var_lens,
+                             int nvar)
+{
+    int    i;
+    size_t pos = *pos_inout;
+
+    for (i = 0; i < nvar; i++) {
+        Lstr   val;
+        Lstr   key;
+        size_t wstart;
+        size_t wend;
+        int    rc;
+
+        Lzeroinit(&val);
+        Lzeroinit(&key);
+
+        /* Skip leading whitespace. */
+        while (pos < srclen && isspace((unsigned char)src[pos])) pos++;
+        wstart = pos;
+
+        if (i == nvar - 1) {
+            /* Last var: rest of string, trailing-stripped. */
+            wend = srclen;
+            while (wend > wstart && isspace((unsigned char)src[wend - 1]))
+                wend--;
+        } else {
+            /* Non-last var: next non-space run. */
+            while (pos < srclen && !isspace((unsigned char)src[pos])) pos++;
+            wend = pos;
+        }
+
+        if (wend > wstart) {
+            size_t vlen = wend - wstart;
+            if (Lfx(p->alloc, &val, vlen) != LSTR_OK)
+                return fail(p, IRXPARS_NOMEM);
+            memcpy(val.pstr, src + wstart, vlen);
+            val.len  = vlen;
+            val.type = LSTRING_TY;
+            upper_bytes(val.pstr, vlen);
+        }
+
+        rc = lstr_set_bytes(p->alloc, &key, vars[i], (size_t)var_lens[i]);
+        if (rc != LSTR_OK) {
+            Lfree(p->alloc, &val);
+            return fail(p, IRXPARS_NOMEM);
+        }
+        vpool_set(p->vpool, &key, &val);
+        Lfree(p->alloc, &key);
+        Lfree(p->alloc, &val);
+    }
+
+    *pos_inout = pos;
+    return IRXPARS_OK;
+}
+
+static int kw_arg(struct irx_parser *p)
+{
+    /* ARG [template [, template ...]]
+     * Each comma advances to the next argument position.
+     * Each template assigns words from that argument to variables. */
+    char   vars[IRX_MAX_ARGS][CTRL_NAME_MAX];
+    int    var_lens[IRX_MAX_ARGS];
+    int    nvar;
+    int    arg_idx = 0;
+    int    hit_comma;
+    int    rc;
+    size_t pos;
+    const unsigned char *src;
+    size_t srclen;
+
+    while (!tok_ends_clause(cur_tok(p))) {
+        const struct irx_token *t;
+
+        /* Collect variable names until comma or clause end. */
+        nvar = 0;
+        hit_comma = 0;
+        while (!tok_ends_clause(cur_tok(p))) {
+            t = cur_tok(p);
+            if (t == NULL) break;
+            if (t->tok_type == TOK_COMMA) {
+                advance_tok(p);
+                hit_comma = 1;
+                break;
+            }
+            if (t->tok_type != TOK_SYMBOL) {
+                skip_to_clause_end(p);
+                return IRXPARS_OK;
+            }
+            if (nvar < IRX_MAX_ARGS) {
+                var_lens[nvar] = sym_to_upper(t, vars[nvar], CTRL_NAME_MAX);
+                nvar++;
+            }
+            advance_tok(p);
+        }
+
+        /* Assign words from the current argument to the collected vars. */
+        src    = NULL;
+        srclen = 0;
+        pos    = 0;
+        if (arg_idx < p->call_argc && p->call_arg_exists != NULL &&
+            p->call_arg_exists[arg_idx] && p->call_args != NULL &&
+            p->call_args[arg_idx].pstr != NULL) {
+            src    = p->call_args[arg_idx].pstr;
+            srclen = p->call_args[arg_idx].len;
+        }
+
+        if (nvar > 0) {
+            rc = arg_assign_words(p, src, srclen, &pos,
+                                  vars, var_lens, nvar);
+            if (rc != IRXPARS_OK) return rc;
+        }
+
+        arg_idx++;
+
+        if (!hit_comma) break;   /* no comma: done */
+    }
+
     return IRXPARS_OK;
 }
 
@@ -1350,6 +1748,8 @@ static const struct irx_keyword g_keyword_table[] = {
     { "CALL",      kw_call      },
     { "RETURN",    kw_return    },
     { "SIGNAL",    kw_signal    },
+    { "PROCEDURE", kw_procedure },
+    { "ARG",       kw_arg       },
     { NULL,        NULL         }
 };
 
@@ -1521,8 +1921,6 @@ static int lookup_variable(struct irx_parser *p,
 /*  parser has already consumed the SYMBOL; it is the caller's job    */
 /*  to detect the pattern. Arguments are comma-separated expressions. */
 /* ------------------------------------------------------------------ */
-
-#define IRX_MAX_ARGS 16
 
 static int parse_function_call(struct irx_parser *p,
                                const struct irx_token *name_tok,
@@ -1920,15 +2318,23 @@ static int parse_concat(struct irx_parser *p, PLstr out)
              * ELSE, WHEN, DO, END, etc.) cannot start a concatenated
              * term — it is a clause-level delimiter, not an operand. */
             if (t0->tok_type == TOK_SYMBOL) {
-                char kbuf[32];
-                int  kn = (int)t0->tok_length;
-                if (kn < (int)sizeof(kbuf)) {
-                    memcpy(kbuf, t0->tok_text, (size_t)kn);
-                    kbuf[kn] = '\0';
-                    upper_bytes((unsigned char *)kbuf, (size_t)kn);
-                    if (find_keyword((unsigned char *)kbuf,
-                                     (size_t)kn) != NULL) {
-                        break; /* keyword: stop concatenation */
+                /* If the symbol is immediately followed by '(' it is a
+                 * function call, not a keyword instruction — do not stop. */
+                const struct irx_token *tnxt = peek_tok(p, 1);
+                int is_func = (tnxt != NULL &&
+                               tnxt->tok_type == TOK_LPAREN &&
+                               toks_adjacent(t0, tnxt));
+                if (!is_func) {
+                    char kbuf[32];
+                    int  kn = (int)t0->tok_length;
+                    if (kn < (int)sizeof(kbuf)) {
+                        memcpy(kbuf, t0->tok_text, (size_t)kn);
+                        kbuf[kn] = '\0';
+                        upper_bytes((unsigned char *)kbuf, (size_t)kn);
+                        if (find_keyword((unsigned char *)kbuf,
+                                         (size_t)kn) != NULL) {
+                            break; /* keyword: stop concatenation */
+                        }
                     }
                 }
             }
@@ -2245,6 +2651,15 @@ static int exec_command(struct irx_parser *p)
 /*  Clause classification                                             */
 /* ------------------------------------------------------------------ */
 
+/* Clear the procedure_allowed flag on the topmost CALL frame.
+ * Called before any executable clause other than PROCEDURE. */
+static void proc_allowed_clear(struct irx_parser *p)
+{
+    struct irx_exec_frame *f = irx_ctrl_frame_top(p);
+    if (f != NULL && f->frame_type == FRAME_CALL)
+        f->procedure_allowed = 0;
+}
+
 static int is_assignment_here(struct irx_parser *p)
 {
     const struct irx_token *t0 = peek_tok(p, 0);
@@ -2279,6 +2694,7 @@ static int exec_clause(struct irx_parser *p)
 
     /* Rule 1: assignment. */
     if (is_assignment_here(p)) {
+        proc_allowed_clear(p);
         return exec_assignment(p);
     }
 
@@ -2288,7 +2704,8 @@ static int exec_clause(struct irx_parser *p)
         if (t1 != NULL && t1->tok_type == TOK_SEMICOLON &&
             t1->tok_length == 1 && t1->tok_text[0] == ':') {
             /* Label declaration: record in exec_stack->last_label so
-             * the immediately following DO can associate it. */
+             * the immediately following DO can associate it.
+             * Labels do NOT clear procedure_allowed. */
             {
                 struct irx_exec_stack *es =
                     (struct irx_exec_stack *)p->exec_stack;
@@ -2313,6 +2730,11 @@ static int exec_clause(struct irx_parser *p)
             kw = find_keyword(upname.pstr, upname.len);
             Lfree(p->alloc, &upname);
             if (kw != NULL) {
+                /* PROCEDURE is allowed only as first executable clause
+                 * in a subroutine; it checks procedure_allowed itself.
+                 * All other keywords clear the flag before executing. */
+                if (kw->kw_handler != kw_procedure)
+                    proc_allowed_clear(p);
                 advance_tok(p);
                 return kw->kw_handler(p);
             }
@@ -2320,6 +2742,7 @@ static int exec_clause(struct irx_parser *p)
     }
 
     /* Rule 4: command. */
+    proc_allowed_clear(p);
     return exec_command(p);
 }
 
@@ -2359,6 +2782,23 @@ void irx_pars_cleanup(struct irx_parser *p)
     if (p == NULL) return;
     irx_ctrl_cleanup(p);
     Lfree(p->alloc, &p->result);
+
+    /* Free call_args if any remain (WP-17). */
+    if (p->alloc != NULL && p->call_args != NULL) {
+        int i;
+        for (i = 0; i < p->call_argc; i++)
+            Lfree(p->alloc, &p->call_args[i]);
+        p->alloc->dealloc(p->call_args,
+                          (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                          p->alloc->ctx);
+        p->call_args = NULL;
+    }
+    if (p->alloc != NULL && p->call_arg_exists != NULL) {
+        p->alloc->dealloc(p->call_arg_exists,
+                          (size_t)IRX_MAX_ARGS * sizeof(int),
+                          p->alloc->ctx);
+        p->call_arg_exists = NULL;
+    }
 }
 
 int irx_pars_eval_expr(struct irx_parser *p, PLstr out)

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -310,6 +310,9 @@ static int bif_arg(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
         return long_to_lstr(p->alloc, result, (long)p->call_argc);
     }
 
+    /* Empty index string is a syntax error. */
+    if (argv[0]->len == 0) return fail(p, IRXPARS_SYNTAX);
+
     /* Get positional index n (1-based). */
     nlen = (argv[0]->len < (int)sizeof(nbuf) - 1)
            ? (int)argv[0]->len : (int)(sizeof(nbuf) - 1);
@@ -1333,7 +1336,11 @@ static int kw_call(struct irx_parser *p)
             /* Evaluate the expression for this argument position. */
             Lzeroinit(&new_args[argc]);
             rc = irx_pars_eval_expr(p, &new_args[argc]);
-            if (rc != IRXPARS_OK) goto err;
+            if (rc != IRXPARS_OK) {
+                /* eval may have partially allocated into new_args[argc]. */
+                Lfree(p->alloc, &new_args[argc]);
+                goto err;
+            }
             new_exists[argc] = 1;
             argc++;
             after_comma = 0;
@@ -1523,7 +1530,8 @@ static int kw_procedure(struct irx_parser *p)
 
     /* Parse optional EXPOSE keyword and variable list. */
     t = cur_tok(p);
-    if (t != NULL && !tok_ends_clause(t) && t->tok_type == TOK_SYMBOL) {
+    if (t != NULL && !tok_ends_clause(t) && t->tok_type == TOK_SYMBOL &&
+        t->tok_length == 6) {
         kw_len = sym_to_upper(t, kw, (int)sizeof(kw));
         if (kw_len == 6 && memcmp(kw, "EXPOSE", 6) == 0) {
             advance_tok(p);   /* consume EXPOSE */
@@ -1535,7 +1543,82 @@ static int kw_procedure(struct irx_parser *p)
                 size_t el;
 
                 t = cur_tok(p);
-                if (t == NULL || t->tok_type != TOK_SYMBOL) break;
+                if (t == NULL) break;
+
+                /* Indirect expose: (varname) — look up varname in the
+                 * caller's pool, split its value by whitespace, expose
+                 * each resulting name (or stem if it ends with '.'). */
+                if (t->tok_type == TOK_LPAREN) {
+                    Lstr   iname;
+                    Lstr   ival;
+                    size_t ipos;
+                    size_t ilen;
+
+                    advance_tok(p);               /* consume ( */
+                    t = cur_tok(p);
+                    if (t == NULL || t->tok_type != TOK_SYMBOL)
+                        return fail(p, IRXPARS_SYNTAX);
+
+                    Lzeroinit(&iname);
+                    if (set_upper_from_tok(p->alloc, &iname, t) != LSTR_OK) {
+                        Lfree(p->alloc, &iname);
+                        return fail(p, IRXPARS_NOMEM);
+                    }
+                    advance_tok(p);               /* consume varname */
+
+                    t = cur_tok(p);
+                    if (t == NULL || t->tok_type != TOK_RPAREN) {
+                        Lfree(p->alloc, &iname);
+                        return fail(p, IRXPARS_SYNTAX);
+                    }
+                    advance_tok(p);               /* consume ) */
+
+                    /* Look up in the caller's pool (f->saved_vpool). */
+                    Lzeroinit(&ival);
+                    vpool_get(f->saved_vpool, &iname, &ival);
+                    Lfree(p->alloc, &iname);
+
+                    /* Split ival by whitespace and expose each word. */
+                    ilen = ival.len;
+                    ipos = 0;
+                    while (ipos < ilen) {
+                        size_t wstart;
+                        size_t wend;
+
+                        while (ipos < ilen &&
+                               isspace((unsigned char)ival.pstr[ipos]))
+                            ipos++;
+                        wstart = ipos;
+                        while (ipos < ilen &&
+                               !isspace((unsigned char)ival.pstr[ipos]))
+                            ipos++;
+                        wend = ipos;
+                        if (wend == wstart) break;
+
+                        Lzeroinit(&ename);
+                        if (Lfx(p->alloc, &ename,
+                                wend - wstart) != LSTR_OK) {
+                            Lfree(p->alloc, &ival);
+                            return fail(p, IRXPARS_NOMEM);
+                        }
+                        memcpy(ename.pstr, ival.pstr + wstart,
+                               wend - wstart);
+                        ename.len  = wend - wstart;
+                        ename.type = LSTRING_TY;
+                        upper_bytes(ename.pstr, ename.len);
+
+                        el = ename.len;
+                        if (el > 0 && ename.pstr[el - 1] == '.')
+                            vpool_expose_stem(child, &ename);
+                        else
+                            vpool_expose_var(child, &ename);
+                        Lfree(p->alloc, &ename);
+                    }
+                    Lfree(p->alloc, &ival);
+                    continue;
+                }
+
+                if (t->tok_type != TOK_SYMBOL) break;
 
                 Lzeroinit(&ename);
                 rc = set_upper_from_tok(p->alloc, &ename, t);
@@ -1572,10 +1655,13 @@ static int kw_procedure(struct irx_parser *p)
 /* Assign words from src[0..srclen-1] (starting at *pos_inout) to
  * vars[0..nvar-1], uppercased. The last variable gets the remaining text
  * trailing-stripped. Updates *pos_inout to reflect consumed input. */
+/* Get pointer to the i-th variable name slot in the flat heap buffer. */
+#define ARG_VAR(vars, i) ((vars) + (i) * CTRL_NAME_MAX)
+
 static int arg_assign_words(struct irx_parser *p,
                              const unsigned char *src, size_t srclen,
                              size_t *pos_inout,
-                             char vars[][CTRL_NAME_MAX], int *var_lens,
+                             char *vars, int *var_lens,
                              int nvar)
 {
     int    i;
@@ -1616,7 +1702,8 @@ static int arg_assign_words(struct irx_parser *p,
             upper_bytes(val.pstr, vlen);
         }
 
-        rc = lstr_set_bytes(p->alloc, &key, vars[i], (size_t)var_lens[i]);
+        rc = lstr_set_bytes(p->alloc, &key, ARG_VAR(vars, i),
+                            (size_t)var_lens[i]);
         if (rc != LSTR_OK) {
             Lfree(p->alloc, &val);
             return fail(p, IRXPARS_NOMEM);
@@ -1634,16 +1721,32 @@ static int kw_arg(struct irx_parser *p)
 {
     /* ARG [template [, template ...]]
      * Each comma advances to the next argument position.
-     * Each template assigns words from that argument to variables. */
-    char   vars[IRX_MAX_ARGS][CTRL_NAME_MAX];
-    int    var_lens[IRX_MAX_ARGS];
+     * Each template assigns words from that argument to variables.
+     *
+     * Variable name storage is heap-allocated (IRX_MAX_ARGS *
+     * CTRL_NAME_MAX bytes) to keep the parser stack frame small
+     * on MVS 24-bit targets. */
+    char   *vars;
+    int    *var_lens;
     int    nvar;
     int    arg_idx = 0;
     int    hit_comma;
-    int    rc;
+    int    rc     = IRXPARS_OK;
     size_t pos;
     const unsigned char *src;
     size_t srclen;
+    size_t vars_size     = (size_t)IRX_MAX_ARGS * CTRL_NAME_MAX;
+    size_t var_lens_size = (size_t)IRX_MAX_ARGS * sizeof(int);
+
+    vars     = (char *)p->alloc->alloc(vars_size, p->alloc->ctx);
+    var_lens = (int  *)p->alloc->alloc(var_lens_size, p->alloc->ctx);
+    if (vars == NULL || var_lens == NULL) {
+        if (vars != NULL)
+            p->alloc->dealloc(vars, vars_size, p->alloc->ctx);
+        if (var_lens != NULL)
+            p->alloc->dealloc(var_lens, var_lens_size, p->alloc->ctx);
+        return fail(p, IRXPARS_NOMEM);
+    }
 
     while (!tok_ends_clause(cur_tok(p))) {
         const struct irx_token *t;
@@ -1661,10 +1764,11 @@ static int kw_arg(struct irx_parser *p)
             }
             if (t->tok_type != TOK_SYMBOL) {
                 skip_to_clause_end(p);
-                return IRXPARS_OK;
+                goto done;
             }
             if (nvar < IRX_MAX_ARGS) {
-                var_lens[nvar] = sym_to_upper(t, vars[nvar], CTRL_NAME_MAX);
+                var_lens[nvar] = sym_to_upper(t, ARG_VAR(vars, nvar),
+                                              CTRL_NAME_MAX);
                 nvar++;
             }
             advance_tok(p);
@@ -1684,7 +1788,7 @@ static int kw_arg(struct irx_parser *p)
         if (nvar > 0) {
             rc = arg_assign_words(p, src, srclen, &pos,
                                   vars, var_lens, nvar);
-            if (rc != IRXPARS_OK) return rc;
+            if (rc != IRXPARS_OK) goto done;
         }
 
         arg_idx++;
@@ -1692,7 +1796,10 @@ static int kw_arg(struct irx_parser *p)
         if (!hit_comma) break;   /* no comma: done */
     }
 
-    return IRXPARS_OK;
+done:
+    p->alloc->dealloc(vars,     vars_size,     p->alloc->ctx);
+    p->alloc->dealloc(var_lens, var_lens_size, p->alloc->ctx);
+    return rc;
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/test_hello.c
+++ b/test/test_hello.c
@@ -113,7 +113,7 @@ static int run_with_mock(const char *src, int *exit_rc_out)
     install_mock(env);
     reset_output();
 
-    rc = irx_exec_run(src, (int)strlen(src), exit_rc_out, env);
+    rc = irx_exec_run(src, (int)strlen(src), NULL, 0, exit_rc_out, env);
 
     irxterm(env);
     return rc;
@@ -184,7 +184,7 @@ static void test_hw3_null_envblock(void)
      * irxinout (it uses printf); just verify rc is correct. */
     {
         const char *src = "x = 6 * 7\n" "exit x\n";
-        rc = irx_exec_run(src, (int)strlen(src), &exit_rc, NULL);
+        rc = irx_exec_run(src, (int)strlen(src), NULL, 0, &exit_rc, NULL);
     }
 
     CHECK(rc == 0,       "irx_exec_run returns 0");

--- a/test/test_procedure.c
+++ b/test/test_procedure.c
@@ -1,0 +1,599 @@
+/* ------------------------------------------------------------------ */
+/*  test_procedure.c - WP-17 PROCEDURE EXPOSE acceptance tests        */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_procedure \           */
+/*        test/test_procedure.c \                                      */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \       */
+/*        'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c' \       */
+/*        'src/irx#io.c'   'src/irx#lstr.c' 'src/irx#tokn.c' \       */
+/*        'src/irx#vpol.c' 'src/irx#pars.c' 'src/irx#ctrl.c' \       */
+/*        'src/irx#exec.c' \                                           */
+/*        ../lstring370/src/'lstr#cor.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxwkblk.h"
+#include "irxfunc.h"
+#include "irxexec.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg) \
+    do { \
+        tests_run++; \
+        if (cond) { \
+            tests_passed++; \
+            printf("  PASS: %s\n", msg); \
+        } else { \
+            tests_failed++; \
+            printf("  FAIL: %s\n", msg); \
+        } \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Mock I/O                                                          */
+/* ------------------------------------------------------------------ */
+
+#define OUT_BUF_SIZE 4096
+
+static char g_out[OUT_BUF_SIZE];
+static int  g_out_len = 0;
+
+static void reset_output(void)
+{
+    g_out_len = 0;
+    g_out[0]  = '\0';
+}
+
+static int output_contains(const char *line)
+{
+    int line_len = (int)strlen(line);
+    int i;
+    for (i = 0; i <= g_out_len - line_len; i++) {
+        if (memcmp(g_out + i, line, (size_t)line_len) == 0) return 1;
+    }
+    return 0;
+}
+
+static int mock_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL
+            && data->pstr != NULL && data->len > 0) {
+        int n = (int)data->len;
+        if (g_out_len + n + 1 < OUT_BUF_SIZE) {
+            memcpy(g_out + g_out_len, data->pstr, (size_t)n);
+            g_out_len          += n;
+            g_out[g_out_len++]  = '\n';
+            g_out[g_out_len]    = '\0';
+        }
+    }
+    return 0;
+}
+
+static void install_mock(struct envblock *env)
+{
+    struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+        exte->io_routine = (void *)mock_io;
+}
+
+static int run_src(const char *src, int *exit_rc_out)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0) return rc;
+
+    install_mock(env);
+    reset_output();
+
+    rc = irx_exec_run(src, (int)strlen(src), NULL, 0, exit_rc_out, env);
+
+    irxterm(env);
+    return rc;
+}
+
+static int run_src_with_args(const char *src, const char *args,
+                              int *exit_rc_out)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0) return rc;
+
+    install_mock(env);
+    reset_output();
+
+    rc = irx_exec_run(src, (int)strlen(src),
+                      args, (int)strlen(args),
+                      exit_rc_out, env);
+
+    irxterm(env);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: CALL without PROCEDURE - caller variable is visible         */
+/* ------------------------------------------------------------------ */
+
+static void test_pr01_call_no_procedure(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#01: CALL without PROCEDURE (shared scope) ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 42\n"
+        "call mysub\n"
+        "say 'x =' x\n"
+        "exit 0\n"
+        "mysub:\n"
+        "  x = 99\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,     "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("x = 99"),
+          "SAY shows x=99 (sub modified caller's var)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: PROCEDURE isolates scope                                    */
+/* ------------------------------------------------------------------ */
+
+static void test_pr02_procedure_isolates(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#02: PROCEDURE isolates caller scope ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 42\n"
+        "call mysub\n"
+        "say 'x =' x\n"
+        "exit 0\n"
+        "mysub:\n"
+        "  procedure\n"
+        "  x = 99\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("x = 42"),
+          "SAY shows x=42 (PROCEDURE kept sub's x private)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: PROCEDURE EXPOSE shares named variable                      */
+/* ------------------------------------------------------------------ */
+
+static void test_pr03_expose_var(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#03: PROCEDURE EXPOSE shares named variable ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 10\n"
+        "y = 20\n"
+        "call mysub\n"
+        "say 'x =' x\n"
+        "say 'y =' y\n"
+        "exit 0\n"
+        "mysub:\n"
+        "  procedure expose x\n"
+        "  x = 99\n"
+        "  y = 77\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("x = 99"),
+          "SAY shows x=99 (exposed var modified)");
+    CHECK(output_contains("y = 20"),
+          "SAY shows y=20 (non-exposed var unchanged)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: RETURN value stored in RESULT                               */
+/* ------------------------------------------------------------------ */
+
+static void test_pr04_return_value(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#04: RETURN value stored in RESULT ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call double 21\n"
+        "say 'result =' result\n"
+        "exit 0\n"
+        "double:\n"
+        "  procedure\n"
+        "  arg n\n"
+        "  return n + n\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("result = 42"),
+          "SAY shows result=42 (RETURN value)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: CALL passes multiple arguments                              */
+/* ------------------------------------------------------------------ */
+
+static void test_pr05_call_multiple_args(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#05: CALL passes multiple arguments ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call add 3, 7\n"
+        "say 'sum =' result\n"
+        "exit 0\n"
+        "add:\n"
+        "  procedure\n"
+        "  arg a, b\n"
+        "  return a + b\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("sum = 10"),
+          "SAY shows sum=10 (3+7)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: ARG() BIF returns argument count                            */
+/* ------------------------------------------------------------------ */
+
+static void test_pr06_arg_bif_count(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#06: ARG() BIF returns argument count ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call check 'a', 'b', 'c'\n"
+        "say 'count =' result\n"
+        "exit 0\n"
+        "check:\n"
+        "  procedure\n"
+        "  return arg()\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("count = 3"),
+          "ARG() returns 3");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: ARG(n) BIF returns nth argument                             */
+/* ------------------------------------------------------------------ */
+
+static void test_pr07_arg_bif_nth(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#07: ARG(n) BIF returns nth argument ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call check 'hello', 'world'\n"
+        "say result\n"
+        "exit 0\n"
+        "check:\n"
+        "  procedure\n"
+        "  return arg(2)\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("world"),
+          "ARG(2) returns 'world'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: ARG(n,'E') and ARG(n,'O')                                   */
+/* ------------------------------------------------------------------ */
+
+static void test_pr08_arg_bif_exists_omitted(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#08: ARG(n,'E') / ARG(n,'O') ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call check 'x', , 'z'\n"
+        "exit 0\n"
+        "check:\n"
+        "  procedure\n"
+        "  say arg(1,'E') arg(2,'E') arg(3,'E')\n"
+        "  say arg(1,'O') arg(2,'O') arg(3,'O')\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("1 0 1"),
+          "exists: arg1=1, arg2=0 (omitted), arg3=1");
+    CHECK(output_contains("0 1 0"),
+          "omitted: arg1=0, arg2=1, arg3=0");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: Nested CALL with PROCEDURE                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_pr09_nested_calls(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#09: nested CALL with PROCEDURE ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 1\n"
+        "call outer\n"
+        "say 'x =' x\n"
+        "exit 0\n"
+        "outer:\n"
+        "  procedure\n"
+        "  x = 2\n"
+        "  call inner\n"
+        "  return\n"
+        "inner:\n"
+        "  procedure\n"
+        "  x = 3\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("x = 1"),
+          "x stays 1 in caller after nested PROCEDURE calls");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: ARG instruction uppercases value                            */
+/* ------------------------------------------------------------------ */
+
+static void test_pr10_arg_uppercase(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#10: ARG instruction uppercases value ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call greet 'hello world'\n"
+        "exit 0\n"
+        "greet:\n"
+        "  procedure\n"
+        "  arg msg\n"
+        "  say msg\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("HELLO WORLD"),
+          "ARG uppercases 'hello world' to 'HELLO WORLD'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: ARG with multiple variables splits by words                 */
+/* ------------------------------------------------------------------ */
+
+static void test_pr11_arg_word_split(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#11: ARG splits by words ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call split 'alpha beta gamma'\n"
+        "exit 0\n"
+        "split:\n"
+        "  procedure\n"
+        "  arg a b rest\n"
+        "  say a\n"
+        "  say b\n"
+        "  say rest\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("ALPHA"),  "first word: ALPHA");
+    CHECK(output_contains("BETA"),   "second word: BETA");
+    CHECK(output_contains("GAMMA"),  "rest: GAMMA");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: top-level ARG() BIF with no args                            */
+/* ------------------------------------------------------------------ */
+
+static void test_pr12_toplevel_arg_bif_no_args(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#12: top-level ARG() with no args passed ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "say arg()\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("0"),
+          "ARG() at top level with no args returns 0");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: top-level ARG with passed argument string                   */
+/* ------------------------------------------------------------------ */
+
+static void test_pr13_toplevel_arg_with_args(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#13: top-level ARG with argument string ---\n");
+
+    rc = run_src_with_args(
+        "/* REXX */\n"
+        "arg first rest\n"
+        "say first\n"
+        "say arg()\n"
+        "exit 0\n",
+        "hello world",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("HELLO"),  "ARG first word = HELLO");
+    CHECK(output_contains("1"),      "ARG() = 1 (one arg string passed)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: PROCEDURE without EXPOSE (all vars private)                 */
+/* ------------------------------------------------------------------ */
+
+static void test_pr14_procedure_all_private(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#14: PROCEDURE without EXPOSE (all vars private) ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "a = 1\n"
+        "b = 2\n"
+        "c = 3\n"
+        "call mysub\n"
+        "say a b c\n"
+        "exit 0\n"
+        "mysub:\n"
+        "  procedure\n"
+        "  a = 10\n"
+        "  b = 20\n"
+        "  c = 30\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("1 2 3"),
+          "a b c unchanged (all private via PROCEDURE)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test: PROCEDURE EXPOSE multiple variables                         */
+/* ------------------------------------------------------------------ */
+
+static void test_pr15_expose_multiple(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#15: PROCEDURE EXPOSE multiple variables ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "a = 1\n"
+        "b = 2\n"
+        "c = 3\n"
+        "call mysub\n"
+        "say a b c\n"
+        "exit 0\n"
+        "mysub:\n"
+        "  procedure expose a c\n"
+        "  a = 10\n"
+        "  b = 20\n"
+        "  c = 30\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("10 2 30"),
+          "a=10 (exposed), b=2 (private), c=30 (exposed)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("=== WP-17: PROCEDURE EXPOSE tests ===\n");
+
+    test_pr01_call_no_procedure();
+    test_pr02_procedure_isolates();
+    test_pr03_expose_var();
+    test_pr04_return_value();
+    test_pr05_call_multiple_args();
+    test_pr06_arg_bif_count();
+    test_pr07_arg_bif_nth();
+    test_pr08_arg_bif_exists_omitted();
+    test_pr09_nested_calls();
+    test_pr10_arg_uppercase();
+    test_pr11_arg_word_split();
+    test_pr12_toplevel_arg_bif_no_args();
+    test_pr13_toplevel_arg_with_args();
+    test_pr14_procedure_all_private();
+    test_pr15_expose_multiple();
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/test/test_procedure.c
+++ b/test/test_procedure.c
@@ -570,6 +570,45 @@ static void test_pr15_expose_multiple(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Test: PROCEDURE EXPOSE (indirect)                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_pr16_expose_indirect(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PR#16: PROCEDURE EXPOSE (indirect) ---\n");
+
+    /* NAMES holds 'A B STEM.' — parenthesized indirection in
+     * EXPOSE should look up NAMES in the caller's pool, split
+     * its value by whitespace, and expose A, B, and STEM. (stem). */
+    rc = run_src(
+        "/* REXX */\n"
+        "a = 1\n"
+        "b = 2\n"
+        "stem.1 = 'one'\n"
+        "stem.2 = 'two'\n"
+        "names = 'A B STEM.'\n"
+        "call mysub\n"
+        "say a b stem.1 stem.2\n"
+        "exit 0\n"
+        "mysub:\n"
+        "  procedure expose (names)\n"
+        "  a = 11\n"
+        "  b = 22\n"
+        "  stem.1 = 'ONE'\n"
+        "  stem.2 = 'TWO'\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("11 22 ONE TWO"),
+          "a, b, stem.* all exposed via (names) indirect");
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -592,6 +631,7 @@ int main(void)
     test_pr13_toplevel_arg_with_args();
     test_pr14_procedure_all_private();
     test_pr15_expose_multiple();
+    test_pr16_expose_indirect();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);


### PR DESCRIPTION
## Summary

- CALL instruction now parses comma-separated argument expressions and saves them in a per-frame call context (up to `IRX_MAX_ARGS = 16`)
- PROCEDURE creates a child variable pool, fully isolating callee variables from the caller
- PROCEDURE EXPOSE shares individual named variables and stems from the parent pool
- RETURN restores the caller's vpool, then writes the return value into RESULT in the caller's scope
- ARG instruction (PARSE UPPER ARG semantics): splits argument string by words, uppercases values, assigns to named variables; comma separators advance to the next argument slot
- ARG() BIF: `ARG()` returns count, `ARG(n)` returns the nth argument, `ARG(n,'E')` / `ARG(n,'O')` test existence or omission
- `irx_exec_run()` signature extended with `args` / `args_len` for passing a top-level argument string
- Fixed `parse_concat`: a symbol immediately followed by adjacent `(` is a function call — not a keyword stop
- Fixed double `irx_ctrl_init` call (was already called inside `irx_pars_init`)

## Test plan

- [ ] 50/50 WP-17 acceptance tests pass (`test/test_procedure.c`)
- [ ] 16/16 WP-18 hello-world end-to-end tests pass (`test/test_hello.c`)
- [ ] 62/62 WP-15 control flow tests pass (`test/test_control.c`)
- [ ] 38/38 WP-13 parser tests pass (`test/test_parser.c`)

Fixes #15