### PR TITLE
chore: flatten unnecessary C89-style scope blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,51 @@ Key points:
   interpreter runtime state (variables, stack, trace, numeric settings)
 - All state is per-environment. Zero globals. This is non-negotiable.
 
+## C Language Standard
+
+**We target C99 / gnu99, not C89.** `project.toml` sets
+`cflags = ["-std=gnu99"]` and the cross-compile tests use `-std=gnu99`.
+c2asm370 (GCC 3.2.3) accepts gnu99 features.
+
+**Allowed and encouraged:**
+- Variable declarations anywhere in a block — not just at the top.
+- Mixed declarations and code: declare each variable at its point of
+  first use. This shortens live ranges and improves readability.
+- `for (int i = 0; ...)` loop-initializer declarations.
+- `//` single-line comments.
+
+**Do NOT** wrap code in bare `{}` blocks purely to introduce a new
+variable scope. That is a C89 workaround and is no longer needed.
+
+```c
+/* BAD — bare block exists only to declare idx and existing */
+if (some_condition) {
+    {
+        int idx = bucket_index(pool, name);
+        struct vpool_entry *existing =
+            find_in_bucket(pool->buckets[idx], name);
+        /* ... */
+    }
+}
+
+/* GOOD — declare where first used */
+if (some_condition) {
+    int idx = bucket_index(pool, name);
+    struct vpool_entry *existing =
+        find_in_bucket(pool->buckets[idx], name);
+    /* ... */
+}
+```
+
+A bare `{}` block is legitimate only when you genuinely need a
+narrower scope for resource lifetime (e.g. a temporary `Lstr` that
+must be freed before the surrounding control flow continues). If the
+block exists because "C89 requires declarations at top" — remove it.
+
+**Note on headers:** public headers in `include/` may still prefer
+C89-compatible declarations if they are consumed by external projects
+that pin to `-std=c89`. Inside `src/`, use C99 freely.
+
 ## Build system
 
 - **Compiler:** c2asm370 (C → HLASM cross-compiler for MVS 3.8j)

--- a/src/irx#ctrl.c
+++ b/src/irx#ctrl.c
@@ -183,13 +183,11 @@ int irx_ctrl_label_scan(struct irx_parser *p)
         if (lt->count >= lt->cap) {
             if (label_table_grow(lt) != 0) return IRXPARS_NOMEM;
         }
-        {
-            struct irx_label *lbl = &lt->entries[lt->count];
-            lbl->name_len = tok_to_upper_name(t0, lbl->name,
-                                               CTRL_NAME_MAX);
-            lbl->tok_pos  = i;   /* position of the SYMBOL token     */
-            lt->count++;
-        }
+        struct irx_label *lbl = &lt->entries[lt->count];
+        lbl->name_len = tok_to_upper_name(t0, lbl->name,
+                                           CTRL_NAME_MAX);
+        lbl->tok_pos  = i;   /* position of the SYMBOL token     */
+        lt->count++;
     }
     return IRXPARS_OK;
 }

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -335,28 +335,26 @@ static int bif_arg(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
 
     /* argc == 2: 'E' (exists) or 'O' (omitted) option. */
     if (argv[1]->len != 1) return fail(p, IRXPARS_SYNTAX);
-    {
-        int   flag;
-        int   exists;
-        unsigned char opt = argv[1]->pstr[0];
-        char  answer;
+    int   flag;
+    int   exists;
+    unsigned char opt = argv[1]->pstr[0];
+    char  answer;
 
-        if (islower(opt)) opt = (unsigned char)toupper(opt);
-        exists = (n <= p->call_argc && p->call_arg_exists != NULL &&
-                  p->call_arg_exists[n - 1]) ? 1 : 0;
+    if (islower(opt)) opt = (unsigned char)toupper(opt);
+    exists = (n <= p->call_argc && p->call_arg_exists != NULL &&
+              p->call_arg_exists[n - 1]) ? 1 : 0;
 
-        if (opt == 'E') {
-            flag = exists;
-        } else if (opt == 'O') {
-            flag = !exists;
-        } else {
-            return fail(p, IRXPARS_SYNTAX);
-        }
-
-        answer = flag ? '1' : '0';
-        return (lstr_set_bytes(p->alloc, result, &answer, 1) == LSTR_OK)
-               ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
+    if (opt == 'E') {
+        flag = exists;
+    } else if (opt == 'O') {
+        flag = !exists;
+    } else {
+        return fail(p, IRXPARS_SYNTAX);
     }
+
+    answer = flag ? '1' : '0';
+    return (lstr_set_bytes(p->alloc, result, &answer, 1) == LSTR_OK)
+           ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
 }
 
 static const struct irx_bif g_bif_table[] = {
@@ -782,16 +780,14 @@ static int kw_do(struct irx_parser *p)
         /* Evaluate once to (a) validate syntax and (b) check first time */
         rc = irx_pars_eval_expr(p, &tmp);
         if (rc != IRXPARS_OK) goto done;
-        {
-            long cv = 0;
-            if (!lstr_to_long(&tmp, &cv) || cv == 0) {
-                /* Condition false on entry: find END and jump past */
-                int end_pos = find_end_after(p, p->tok_pos);
-                if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
-                irx_ctrl_frame_pop(p);
-                p->tok_pos = end_pos;
-                goto done;
-            }
+        long cv = 0;
+        if (!lstr_to_long(&tmp, &cv) || cv == 0) {
+            /* Condition false on entry: find END and jump past */
+            int end_pos = find_end_after(p, p->tok_pos);
+            if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
+            irx_ctrl_frame_pop(p);
+            p->tok_pos = end_pos;
+            goto done;
         }
         goto body;
     }
@@ -876,21 +872,19 @@ static int kw_do(struct irx_parser *p)
                 if (rc != IRXPARS_OK) goto done;
 
                 /* Check initial condition: if start > end (BY>0) skip. */
-                {
-                    int skip = 0;
-                    if (f->ctrl_by >= 0 && f->ctrl_val > f->ctrl_to)
-                        skip = 1;
-                    if (f->ctrl_by < 0 && f->ctrl_val < f->ctrl_to)
-                        skip = 1;
-                    if (skip) {
-                        int end_pos = find_end_after(p, p->tok_pos);
-                        if (end_pos < 0) {
-                            rc = fail(p, IRXPARS_SYNTAX); goto done;
-                        }
-                        irx_ctrl_frame_pop(p);
-                        p->tok_pos = end_pos;
-                        goto done;
+                int skip = 0;
+                if (f->ctrl_by >= 0 && f->ctrl_val > f->ctrl_to)
+                    skip = 1;
+                if (f->ctrl_by < 0 && f->ctrl_val < f->ctrl_to)
+                    skip = 1;
+                if (skip) {
+                    int end_pos = find_end_after(p, p->tok_pos);
+                    if (end_pos < 0) {
+                        rc = fail(p, IRXPARS_SYNTAX); goto done;
                     }
+                    irx_ctrl_frame_pop(p);
+                    p->tok_pos = end_pos;
+                    goto done;
                 }
                 goto body;
             }
@@ -1014,15 +1008,13 @@ static int kw_iterate(struct irx_parser *p)
     if (f->do_type == DO_CTRL) {
         f->ctrl_val += f->ctrl_by;
         /* Check bounds */
-        {
-            int in_range;
-            if (f->ctrl_by >= 0) in_range = (f->ctrl_val <= f->ctrl_to);
-            else                 in_range = (f->ctrl_val >= f->ctrl_to);
-            if (!in_range) {
-                p->tok_pos = f->loop_end;
-                irx_ctrl_frame_pop(p);
-                return IRXPARS_OK;
-            }
+        int in_range;
+        if (f->ctrl_by >= 0) in_range = (f->ctrl_val <= f->ctrl_to);
+        else                 in_range = (f->ctrl_val >= f->ctrl_to);
+        if (!in_range) {
+            p->tok_pos = f->loop_end;
+            irx_ctrl_frame_pop(p);
+            return IRXPARS_OK;
         }
         set_var_long(p, f->ctrl_name, f->ctrl_name_len, f->ctrl_val);
     } else if (f->do_type == DO_WHILE) {
@@ -2158,14 +2150,12 @@ static int parse_primary(struct irx_parser *p, PLstr out)
         }
 
         /* Function call: SYMBOL immediately followed by '('. */
-        {
-            const struct irx_token *nxt = peek_tok(p, 1);
-            if (nxt != NULL && nxt->tok_type == TOK_LPAREN &&
-                toks_adjacent(t, nxt)) {
-                const struct irx_token *name_tok = t;
-                advance_tok(p);   /* consume SYMBOL */
-                return parse_function_call(p, name_tok, out);
-            }
+        const struct irx_token *nxt = peek_tok(p, 1);
+        if (nxt != NULL && nxt->tok_type == TOK_LPAREN &&
+            toks_adjacent(t, nxt)) {
+            const struct irx_token *name_tok = t;
+            advance_tok(p);   /* consume SYMBOL */
+            return parse_function_call(p, name_tok, out);
         }
 
         /* Plain variable reference. */
@@ -2203,24 +2193,22 @@ static int parse_prefix(struct irx_parser *p, PLstr out)
         t = cur_tok(p);
     }
 
-    {
-        int rc = parse_primary(p, out);
-        if (rc != IRXPARS_OK) return rc;
+    int rc = parse_primary(p, out);
+    if (rc != IRXPARS_OK) return rc;
 
-        if (negate) {
-            long v;
-            if (!lstr_to_long(out, &v)) return fail(p, IRXPARS_SYNTAX);
-            if (long_to_lstr(p->alloc, out, -v) != LSTR_OK) {
-                return fail(p, IRXPARS_NOMEM);
-            }
+    if (negate) {
+        long v;
+        if (!lstr_to_long(out, &v)) return fail(p, IRXPARS_SYNTAX);
+        if (long_to_lstr(p->alloc, out, -v) != LSTR_OK) {
+            return fail(p, IRXPARS_NOMEM);
         }
-        if (logical_not) {
-            long v;
-            if (!lstr_to_long(out, &v)) return fail(p, IRXPARS_SYNTAX);
-            if (v != 0 && v != 1) return fail(p, IRXPARS_SYNTAX);
-            if (long_to_lstr(p->alloc, out, v ? 0 : 1) != LSTR_OK) {
-                return fail(p, IRXPARS_NOMEM);
-            }
+    }
+    if (logical_not) {
+        long v;
+        if (!lstr_to_long(out, &v)) return fail(p, IRXPARS_SYNTAX);
+        if (v != 0 && v != 1) return fail(p, IRXPARS_SYNTAX);
+        if (long_to_lstr(p->alloc, out, v ? 0 : 1) != LSTR_OK) {
+            return fail(p, IRXPARS_NOMEM);
         }
     }
     return IRXPARS_OK;
@@ -2557,39 +2545,37 @@ static int parse_comparison(struct irx_parser *p, PLstr out)
     int rc = parse_concat(p, out);
     if (rc != IRXPARS_OK) return rc;
 
-    {
-        int op;
-        Lstr rhs;
-        int c, result;
+    int op;
+    Lstr rhs;
+    int c, result;
 
-        if (!match_comparison(p, &op)) return IRXPARS_OK;
+    if (!match_comparison(p, &op)) return IRXPARS_OK;
 
-        Lzeroinit(&rhs);
-        rc = parse_concat(p, &rhs);
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+    Lzeroinit(&rhs);
+    rc = parse_concat(p, &rhs);
+    if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
 
-        if (op == CMP_EQS || op == CMP_NES) {
-            c = compare_strict(out, &rhs);
-        } else {
-            c = compare_normal(out, &rhs);
-        }
-        Lfree(p->alloc, &rhs);
+    if (op == CMP_EQS || op == CMP_NES) {
+        c = compare_strict(out, &rhs);
+    } else {
+        c = compare_normal(out, &rhs);
+    }
+    Lfree(p->alloc, &rhs);
 
-        switch (op) {
-        case CMP_EQ:  result = (c == 0); break;
-        case CMP_NE:  result = (c != 0); break;
-        case CMP_EQS: result = (c == 0); break;
-        case CMP_NES: result = (c != 0); break;
-        case CMP_GT:  result = (c >  0); break;
-        case CMP_LT:  result = (c <  0); break;
-        case CMP_GE:  result = (c >= 0); break;
-        case CMP_LE:  result = (c <= 0); break;
-        default:      result = 0; break;
-        }
+    switch (op) {
+    case CMP_EQ:  result = (c == 0); break;
+    case CMP_NE:  result = (c != 0); break;
+    case CMP_EQS: result = (c == 0); break;
+    case CMP_NES: result = (c != 0); break;
+    case CMP_GT:  result = (c >  0); break;
+    case CMP_LT:  result = (c <  0); break;
+    case CMP_GE:  result = (c >= 0); break;
+    case CMP_LE:  result = (c <= 0); break;
+    default:      result = 0; break;
+    }
 
-        if (long_to_lstr(p->alloc, out, (long)result) != LSTR_OK) {
-            return fail(p, IRXPARS_NOMEM);
-        }
+    if (long_to_lstr(p->alloc, out, (long)result) != LSTR_OK) {
+        return fail(p, IRXPARS_NOMEM);
     }
     return IRXPARS_OK;
 }
@@ -2813,13 +2799,11 @@ static int exec_clause(struct irx_parser *p)
             /* Label declaration: record in exec_stack->last_label so
              * the immediately following DO can associate it.
              * Labels do NOT clear procedure_allowed. */
-            {
-                struct irx_exec_stack *es =
-                    (struct irx_exec_stack *)p->exec_stack;
-                if (es != NULL) {
-                    es->last_label_len = sym_to_upper(
-                        t0, es->last_label, CTRL_NAME_MAX);
-                }
+            struct irx_exec_stack *es =
+                (struct irx_exec_stack *)p->exec_stack;
+            if (es != NULL) {
+                es->last_label_len = sym_to_upper(
+                    t0, es->last_label, CTRL_NAME_MAX);
             }
             advance_tok(p);
             advance_tok(p);
@@ -2827,24 +2811,22 @@ static int exec_clause(struct irx_parser *p)
         }
 
         /* Rule 3: keyword instruction. */
-        {
-            Lstr upname;
-            const struct irx_keyword *kw;
-            Lzeroinit(&upname);
-            if (set_upper_from_tok(p->alloc, &upname, t0) != LSTR_OK) {
-                return fail(p, IRXPARS_NOMEM);
-            }
-            kw = find_keyword(upname.pstr, upname.len);
-            Lfree(p->alloc, &upname);
-            if (kw != NULL) {
-                /* PROCEDURE is allowed only as first executable clause
-                 * in a subroutine; it checks procedure_allowed itself.
-                 * All other keywords clear the flag before executing. */
-                if (kw->kw_handler != kw_procedure)
-                    proc_allowed_clear(p);
-                advance_tok(p);
-                return kw->kw_handler(p);
-            }
+        Lstr upname;
+        const struct irx_keyword *kw;
+        Lzeroinit(&upname);
+        if (set_upper_from_tok(p->alloc, &upname, t0) != LSTR_OK) {
+            return fail(p, IRXPARS_NOMEM);
+        }
+        kw = find_keyword(upname.pstr, upname.len);
+        Lfree(p->alloc, &upname);
+        if (kw != NULL) {
+            /* PROCEDURE is allowed only as first executable clause
+             * in a subroutine; it checks procedure_allowed itself.
+             * All other keywords clear the flag before executing. */
+            if (kw->kw_handler != kw_procedure)
+                proc_allowed_clear(p);
+            advance_tok(p);
+            return kw->kw_handler(p);
         }
     }
 

--- a/src/irx#rab.c
+++ b/src/irx#rab.c
@@ -72,15 +72,13 @@ int irx_rab_obtain(struct irx_rab **rab_ptr)
     }
 
     /* Allocate new RAB */
-    {
-        void *storage = NULL;
-        int rc = irxstor(RXSMGET, (int)sizeof(struct irx_rab),
-                         &storage, NULL);
-        if (rc != 0) {
-            return 20;
-        }
-        rab = (struct irx_rab *)storage;
+    void *storage = NULL;
+    int rc = irxstor(RXSMGET, (int)sizeof(struct irx_rab),
+                     &storage, NULL);
+    if (rc != 0) {
+        return 20;
     }
+    rab = (struct irx_rab *)storage;
 
     /* Initialize RAB */
     memcpy(rab->rab_id, RAB_ID, 4);
@@ -126,10 +124,8 @@ int irx_rab_release(struct irx_rab *rab)
     *tcbuser_ptr = rab->rab_prev_tcbuser;
 
     /* Free RAB storage */
-    {
-        void *ptr = rab;
-        irxstor(RXSMFRE, (int)sizeof(struct irx_rab), &ptr, NULL);
-    }
+    void *ptr = rab;
+    irxstor(RXSMFRE, (int)sizeof(struct irx_rab), &ptr, NULL);
 
     return 0;
 }

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -98,44 +98,38 @@ int irxterm(struct envblock *envblk)
 
     /* 8+9. Remove from RAB and free env_node */
     rab = NULL;
-    {
-        /* Walk RAB chain to find our node */
-        void **tcbuser_ptr;
-        struct irx_env_node *cur;
+    /* Walk RAB chain to find our node */
+    void **tcbuser_ptr;
+    struct irx_env_node *cur;
 
 #ifdef __MVS__
-        {
-            void **psa_tcb = (void **)(*(int *)0x218);
-            tcbuser_ptr = (void **)((char *)psa_tcb + 0x0A8);
-        }
+    void **psa_tcb = (void **)(*(int *)0x218);
+    tcbuser_ptr = (void **)((char *)psa_tcb + 0x0A8);
 #else
-        extern void *_simulated_tcbuser;
-        tcbuser_ptr = &_simulated_tcbuser;
+    extern void *_simulated_tcbuser;
+    tcbuser_ptr = &_simulated_tcbuser;
 #endif
 
-        if (*tcbuser_ptr != NULL) {
-            rab = (struct irx_rab *)(*tcbuser_ptr);
-            if (memcmp(rab->rab_id, RAB_ID, 4) == 0) {
-                /* Find node for this envblock */
-                cur = (struct irx_env_node *)rab->rab_first;
-                while (cur != NULL) {
-                    if (cur->node_envblock == envblk) {
-                        node = cur;
-                        irx_rab_remove_env(rab, node);
-                        stor_free((void **)&node, envblk);
-                        break;
-                    }
-                    cur = cur->node_next;
+    if (*tcbuser_ptr != NULL) {
+        rab = (struct irx_rab *)(*tcbuser_ptr);
+        if (memcmp(rab->rab_id, RAB_ID, 4) == 0) {
+            /* Find node for this envblock */
+            cur = (struct irx_env_node *)rab->rab_first;
+            while (cur != NULL) {
+                if (cur->node_envblock == envblk) {
+                    node = cur;
+                    irx_rab_remove_env(rab, node);
+                    stor_free((void **)&node, envblk);
+                    break;
                 }
+                cur = cur->node_next;
             }
         }
     }
 
     /* 10. Free ENVBLOCK itself (no envblock context for this free) */
-    {
-        void *p = envblk;
-        irxstor(RXSMFRE, 0, &p, NULL);
-    }
+    void *p = envblk;
+    irxstor(RXSMFRE, 0, &p, NULL);
 
     /* 11. Release RAB if empty */
     if (rab != NULL && rab->rab_env_count == 0) {

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -138,12 +138,10 @@ static int grow_tokens(struct tok_ctx *ctx)
     if (ctx->tokens != NULL) {
         memcpy(new_ptr, ctx->tokens,
                ctx->tok_count * sizeof(struct irx_token));
-        {
-            void *p = ctx->tokens;
-            irxstor(RXSMFRE,
-                    (int)(ctx->tok_capacity * sizeof(struct irx_token)),
-                    &p, ctx->envblock);
-        }
+        void *p = ctx->tokens;
+        irxstor(RXSMFRE,
+                (int)(ctx->tok_capacity * sizeof(struct irx_token)),
+                &p, ctx->envblock);
     }
     ctx->tokens = (struct irx_token *)new_ptr;
     ctx->tok_capacity = new_cap;
@@ -305,64 +303,62 @@ static int scan_string(struct tok_ctx *ctx)
     }
 
     /* ctx->pos is at the closing quote. */
-    {
-        int body_len = ctx->pos - text_start;
-        const char *body = ctx->src + text_start;
+    int body_len = ctx->pos - text_start;
+    const char *body = ctx->src + text_start;
 
-        advance(ctx, 1);          /* consume closing quote */
+    advance(ctx, 1);          /* consume closing quote */
 
-        /* Check for x/X or b/B suffix indicating hex/bin string. */
-        suffix = peek(ctx, 0);
-        if (suffix == 'x' || suffix == 'X') {
-            int hex_digits = 0;
-            int i;
-            for (i = 0; i < body_len; i++) {
-                int bc = (unsigned char)body[i];
-                if (bc == ' ' || bc == '\t') continue;
-                if (!isxdigit(bc)) {
-                    ctx->err_code = TOKERR_INVALID_HEX;
-                    ctx->err_line = start_line;
-                    ctx->err_col  = start_col;
-                    return 20;
-                }
-                hex_digits++;
-            }
-            if ((hex_digits & 1) != 0) {
-                ctx->err_code = TOKERR_ODD_HEX_GROUP;
+    /* Check for x/X or b/B suffix indicating hex/bin string. */
+    suffix = peek(ctx, 0);
+    if (suffix == 'x' || suffix == 'X') {
+        int hex_digits = 0;
+        int i;
+        for (i = 0; i < body_len; i++) {
+            int bc = (unsigned char)body[i];
+            if (bc == ' ' || bc == '\t') continue;
+            if (!isxdigit(bc)) {
+                ctx->err_code = TOKERR_INVALID_HEX;
                 ctx->err_line = start_line;
                 ctx->err_col  = start_col;
                 return 20;
             }
-            type = TOK_HEXSTRING;
-            advance(ctx, 1);
-        } else if (suffix == 'b' || suffix == 'B') {
-            int bits = 0;
-            int i;
-            for (i = 0; i < body_len; i++) {
-                int bc = (unsigned char)body[i];
-                if (bc == ' ' || bc == '\t') continue;
-                if (bc != '0' && bc != '1') {
-                    ctx->err_code = TOKERR_INVALID_BIN;
-                    ctx->err_line = start_line;
-                    ctx->err_col  = start_col;
-                    return 20;
-                }
-                bits++;
-            }
-            if ((bits & 3) != 0) {
-                ctx->err_code = TOKERR_BAD_BIN_GROUP;
-                ctx->err_line = start_line;
-                ctx->err_col  = start_col;
-                return 20;
-            }
-            type = TOK_BINSTRING;
-            advance(ctx, 1);
+            hex_digits++;
         }
-
-        if (doubled) flags |= TOKF_QUOTE_DBL;
-        return emit(ctx, type, flags, body, body_len,
-                    start_line, start_col);
+        if ((hex_digits & 1) != 0) {
+            ctx->err_code = TOKERR_ODD_HEX_GROUP;
+            ctx->err_line = start_line;
+            ctx->err_col  = start_col;
+            return 20;
+        }
+        type = TOK_HEXSTRING;
+        advance(ctx, 1);
+    } else if (suffix == 'b' || suffix == 'B') {
+        int bits = 0;
+        int i;
+        for (i = 0; i < body_len; i++) {
+            int bc = (unsigned char)body[i];
+            if (bc == ' ' || bc == '\t') continue;
+            if (bc != '0' && bc != '1') {
+                ctx->err_code = TOKERR_INVALID_BIN;
+                ctx->err_line = start_line;
+                ctx->err_col  = start_col;
+                return 20;
+            }
+            bits++;
+        }
+        if ((bits & 3) != 0) {
+            ctx->err_code = TOKERR_BAD_BIN_GROUP;
+            ctx->err_line = start_line;
+            ctx->err_col  = start_col;
+            return 20;
+        }
+        type = TOK_BINSTRING;
+        advance(ctx, 1);
     }
+
+    if (doubled) flags |= TOKF_QUOTE_DBL;
+    return emit(ctx, type, flags, body, body_len,
+                start_line, start_col);
 }
 
 /* ------------------------------------------------------------------ */

--- a/src/irx#uid.c
+++ b/src/irx#uid.c
@@ -25,45 +25,41 @@ int irxuid(char *userid, struct envblock *envblock)
     memset(userid, ' ', 8);
 
 #ifdef __MVS__
-    {
-        /* MVS 3.8j: Navigate PSA -> ASCB -> ASXB -> LWA -> PSCB
-         * PSCB+X'00' = PSCBUSER (7 bytes, blank-padded)
-         *
-         * Fallback: ASCB -> ASXB -> ACEE -> ACEEUNAM (if RACF active)
-         * Fallback: JCT jobname
-         */
+    /* MVS 3.8j: Navigate PSA -> ASCB -> ASXB -> LWA -> PSCB
+     * PSCB+X'00' = PSCBUSER (7 bytes, blank-padded)
+     *
+     * Fallback: ASCB -> ASXB -> ACEE -> ACEEUNAM (if RACF active)
+     * Fallback: JCT jobname
+     */
 
-        /* PSA+X'224' -> current ASCB */
-        void *ascb = *(void **)0x224;
-        if (ascb != NULL) {
-            /* ASCB+X'6C' -> ASXB */
-            void *asxb = *(void **)((char *)ascb + 0x6C);
-            if (asxb != NULL) {
-                /* ASXB+X'14' -> LWA (Logon Work Area) */
-                void *lwa = *(void **)((char *)asxb + 0x14);
-                if (lwa != NULL) {
-                    /* LWA+X'18' -> PSCB */
-                    void *pscb = *(void **)((char *)lwa + 0x18);
-                    if (pscb != NULL) {
-                        /* PSCB+X'00' = PSCBUSER (7 bytes) */
-                        memcpy(userid, (char *)pscb, 7);
-                        return 0;
-                    }
+    /* PSA+X'224' -> current ASCB */
+    void *ascb = *(void **)0x224;
+    if (ascb != NULL) {
+        /* ASCB+X'6C' -> ASXB */
+        void *asxb = *(void **)((char *)ascb + 0x6C);
+        if (asxb != NULL) {
+            /* ASXB+X'14' -> LWA (Logon Work Area) */
+            void *lwa = *(void **)((char *)asxb + 0x14);
+            if (lwa != NULL) {
+                /* LWA+X'18' -> PSCB */
+                void *pscb = *(void **)((char *)lwa + 0x18);
+                if (pscb != NULL) {
+                    /* PSCB+X'00' = PSCBUSER (7 bytes) */
+                    memcpy(userid, (char *)pscb, 7);
+                    return 0;
                 }
             }
         }
+    }
 
-        /* Fallback: return blanks (non-TSO batch) */
-        /* TODO: try ACEE/JCT extraction */
-    }
+    /* Fallback: return blanks (non-TSO batch) */
+    /* TODO: try ACEE/JCT extraction */
 #else
-    {
-        /* Cross-compile: use getlogin() or environment */
-        const char *user = "TESTUSER";
-        int len = (int)strlen(user);
-        if (len > 8) len = 8;
-        memcpy(userid, user, len);
-    }
+    /* Cross-compile: use getlogin() or environment */
+    const char *user = "TESTUSER";
+    int len = (int)strlen(user);
+    if (len > 8) len = 8;
+    memcpy(userid, user, len);
 #endif
 
     return 0;

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -389,32 +389,30 @@ int vpool_get(struct irx_vpool *pool, const PLstr name, PLstr value)
     /* Stem default: if `name` is compound (contains a dot before the
      * last character), look up "STEM." as the fallback. The stem key
      * includes the first dot. */
-    {
-        int dot = first_dot(name);
-        if (dot >= 0) {
-            Lstr stem_key;
-            int  stem_idx;
-            struct vpool_entry *stem_e;
+    int dot = first_dot(name);
+    if (dot >= 0) {
+        Lstr stem_key;
+        int  stem_idx;
+        struct vpool_entry *stem_e;
 
-            stem_key.pstr   = name->pstr;
-            stem_key.len    = (size_t)(dot + 1);
-            stem_key.maxlen = stem_key.len;
-            stem_key.type   = LSTRING_TY;
+        stem_key.pstr   = name->pstr;
+        stem_key.len    = (size_t)(dot + 1);
+        stem_key.maxlen = stem_key.len;
+        stem_key.type   = LSTRING_TY;
 
-            /* Don't fall into infinite recursion: only fall back on a
-             * true compound, i.e. there is at least one character
-             * after the dot (otherwise the caller already asked for
-             * the stem default). */
-            if (name->len > stem_key.len) {
-                stem_idx = bucket_index(pool, &stem_key);
-                stem_e   = find_in_bucket(pool->buckets[stem_idx],
-                                          &stem_key);
-                if (stem_e != NULL) {
-                    struct vpool_entry *tgt = resolve_ref(stem_e);
-                    if (tgt != NULL && !(tgt->flags & VPOOL_UNSET)) {
-                        rc = Lstrcpy(pool->alloc, value, &tgt->value);
-                        return (rc == LSTR_OK) ? VPOOL_OK : VPOOL_NOMEM;
-                    }
+        /* Don't fall into infinite recursion: only fall back on a
+         * true compound, i.e. there is at least one character
+         * after the dot (otherwise the caller already asked for
+         * the stem default). */
+        if (name->len > stem_key.len) {
+            stem_idx = bucket_index(pool, &stem_key);
+            stem_e   = find_in_bucket(pool->buckets[stem_idx],
+                                      &stem_key);
+            if (stem_e != NULL) {
+                struct vpool_entry *tgt = resolve_ref(stem_e);
+                if (tgt != NULL && !(tgt->flags & VPOOL_UNSET)) {
+                    rc = Lstrcpy(pool->alloc, value, &tgt->value);
+                    return (rc == LSTR_OK) ? VPOOL_OK : VPOOL_NOMEM;
                 }
             }
         }
@@ -463,11 +461,9 @@ int vpool_exists(struct irx_vpool *pool, const PLstr name)
     e = find_in_bucket(pool->buckets[idx], name);
     if (e == NULL) return 0;
 
-    {
-        struct vpool_entry *tgt = resolve_ref(e);
-        if (tgt == NULL) return 0;
-        return (tgt->flags & VPOOL_UNSET) ? 0 : 1;
-    }
+    struct vpool_entry *tgt = resolve_ref(e);
+    if (tgt == NULL) return 0;
+    return (tgt->flags & VPOOL_UNSET) ? 0 : 1;
 }
 
 /* ------------------------------------------------------------------ */
@@ -486,14 +482,12 @@ int vpool_expose_var(struct irx_vpool *pool, const PLstr name)
 
     /* If an entry with this name already exists locally (e.g. the
      * caller called EXPOSE twice), drop it and re-create as a ref. */
-    {
-        int idx = bucket_index(pool, name);
-        struct vpool_entry *existing =
-            find_in_bucket(pool->buckets[idx], name);
-        if (existing != NULL) {
-            unlink_entry(pool, idx, existing);
-            vp_entry_free(pool->alloc, existing);
-        }
+    int idx = bucket_index(pool, name);
+    struct vpool_entry *existing =
+        find_in_bucket(pool->buckets[idx], name);
+    if (existing != NULL) {
+        unlink_entry(pool, idx, existing);
+        vp_entry_free(pool->alloc, existing);
     }
 
     /* Look up or create a placeholder entry in the parent. */
@@ -557,13 +551,11 @@ int vpool_expose_stem(struct irx_vpool *pool, const PLstr stem_name)
         pool->exposed_stem_cap = new_cap;
     }
 
-    {
-        Lstr *slot = &pool->exposed_stems[pool->exposed_stem_count];
-        Lzeroinit(slot);
-        rc = Lstrcpy(pool->alloc, slot, stem_name);
-        if (rc != LSTR_OK) return VPOOL_NOMEM;
-        pool->exposed_stem_count++;
-    }
+    Lstr *slot = &pool->exposed_stems[pool->exposed_stem_count];
+    Lzeroinit(slot);
+    rc = Lstrcpy(pool->alloc, slot, stem_name);
+    if (rc != LSTR_OK) return VPOOL_NOMEM;
+    pool->exposed_stem_count++;
     return VPOOL_OK;
 }
 

--- a/test/test_control.c
+++ b/test/test_control.c
@@ -524,14 +524,12 @@ static void test_cf21_no_global_state(void)
     printf("\n--- CF#21: Two independent parsers, no shared state ---\n");
 
     /* Pre-initialize N=0 in each pool so n+i arithmetic works. */
-    {
-        Lstr k2, v2;
-        Lzeroinit(&k2); Lzeroinit(&v2);
-        set_lstr(a, &k2, "N"); set_lstr(a, &v2, "0");
-        vpool_set(pool_a, &k2, &v2);
-        vpool_set(pool_b, &k2, &v2);
-        Lfree(a, &k2); Lfree(a, &v2);
-    }
+    Lstr k2, v2;
+    Lzeroinit(&k2); Lzeroinit(&v2);
+    set_lstr(a, &k2, "N"); set_lstr(a, &v2, "0");
+    vpool_set(pool_a, &k2, &v2);
+    vpool_set(pool_b, &k2, &v2);
+    Lfree(a, &k2); Lfree(a, &v2);
 
     CHECK(run_source(a, pool_a,
         "DO i = 1 TO 3; n = n + i; END\n") == IRXPARS_OK, "parser A OK");

--- a/test/test_hello.c
+++ b/test/test_hello.c
@@ -182,10 +182,8 @@ static void test_hw3_null_envblock(void)
 
     /* Redirect irxinout output to /dev/null by hijacking the real
      * irxinout (it uses printf); just verify rc is correct. */
-    {
-        const char *src = "x = 6 * 7\n" "exit x\n";
-        rc = irx_exec_run(src, (int)strlen(src), NULL, 0, &exit_rc, NULL);
-    }
+    const char *src = "x = 6 * 7\n" "exit x\n";
+    rc = irx_exec_run(src, (int)strlen(src), NULL, 0, &exit_rc, NULL);
 
     CHECK(rc == 0,       "irx_exec_run returns 0");
     CHECK(exit_rc == 42, "EXIT return code is 42");

--- a/test/test_irxlstr.c
+++ b/test/test_irxlstr.c
@@ -240,13 +240,11 @@ static void test_allocator_bridge(void)
           "wkbi->wkbi_lstr_alloc points at the allocator");
 
     /* Exercise the bridge by alloc/free via the callbacks directly. */
-    {
-        void *mem = (*alloc->alloc)(64, alloc->ctx);
-        CHECK(mem != NULL, "bridged alloc(64) succeeds");
-        if (mem != NULL) {
-            memset(mem, 0xAB, 64);
-            (*alloc->dealloc)(mem, 64, alloc->ctx);
-        }
+    void *mem = (*alloc->alloc)(64, alloc->ctx);
+    CHECK(mem != NULL, "bridged alloc(64) succeeds");
+    if (mem != NULL) {
+        memset(mem, 0xAB, 64);
+        (*alloc->dealloc)(mem, 64, alloc->ctx);
     }
 
     /* irxterm must release the allocator cleanly. */

--- a/test/test_phase1.c
+++ b/test/test_phase1.c
@@ -108,20 +108,16 @@ static void test_single_env(void)
     }
 
     /* Validate RAB chain */
-    {
-        struct envblock *found = irx_find_env();
-        CHECK(found == envblk, "irx_find_env returns our envblock");
-    }
+    struct envblock *found = irx_find_env();
+    CHECK(found == envblk, "irx_find_env returns our envblock");
 
     /* IRXTERM */
     rc = irxterm(envblk);
     CHECK(rc == 0, "irxterm returns 0");
 
     /* Verify cleanup */
-    {
-        struct envblock *found = irx_find_env();
-        CHECK(found == NULL, "irx_find_env returns NULL after term");
-    }
+    found = irx_find_env();
+    CHECK(found == NULL, "irx_find_env returns NULL after term");
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/test_tokenizer.c
+++ b/test/test_tokenizer.c
@@ -289,18 +289,16 @@ static void test_comments_and_lines(void)
               "[1] STRING 'hi' on line 2");
         CHECK(toks[1].tok_line == 2, "[1] tok_line == 2");
         /* After EOC, we have x = 1 on line 3. */
-        {
-            int i;
-            int found_x = 0;
-            for (i = 0; i < n; i++) {
-                if (toks[i].tok_type == TOK_SYMBOL &&
-                    tok_text_eq(&toks[i], "x")) {
-                    found_x = (toks[i].tok_line == 3);
-                    break;
-                }
+        int i;
+        int found_x = 0;
+        for (i = 0; i < n; i++) {
+            if (toks[i].tok_type == TOK_SYMBOL &&
+                tok_text_eq(&toks[i], "x")) {
+                found_x = (toks[i].tok_line == 3);
+                break;
             }
-            CHECK(found_x, "'x' is on line 3 (line numbers preserved)");
         }
+        CHECK(found_x, "'x' is on line 3 (line numbers preserved)");
     }
     irx_tokn_free(NULL, toks, n);
 }

--- a/test/test_vpool.c
+++ b/test/test_vpool.c
@@ -24,6 +24,10 @@
 #include "lstralloc.h"
 #include "irxvpool.h"
 
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
 static int tests_run    = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
@@ -257,12 +261,10 @@ static void test_large_load(void)
         vpool_set(pool, &name, &value);
     }
     CHECK(pool->entry_count == 10000, "all 10000 entries present");
-    {
-        double load = (double)pool->entry_count / (double)pool->bucket_count;
-        printf("         load factor = %.2f (buckets=%d)\n",
-               load, pool->bucket_count);
-        CHECK(load < 4.0, "load factor stays below 4");
-    }
+    double load = (double)pool->entry_count / (double)pool->bucket_count;
+    printf("         load factor = %.2f (buckets=%d)\n",
+           load, pool->bucket_count);
+    CHECK(load < 4.0, "load factor stays below 4");
 
     Lfree(a, &name); Lfree(a, &value);
     vpool_destroy(pool);
@@ -461,20 +463,16 @@ static void test_iteration(void)
     }
     CHECK(rc == VPOOL_LAST, "iteration ends with VPOOL_LAST");
     CHECK(count == 10, "iteration visited 10 entries");
-    {
-        int all_seen = 1;
-        for (i = 0; i < 10; i++) if (!seen[i]) { all_seen = 0; break; }
-        CHECK(all_seen, "every entry visited exactly once");
-    }
+    int all_seen = 1;
+    for (i = 0; i < 10; i++) if (!seen[i]) { all_seen = 0; break; }
+    CHECK(all_seen, "every entry visited exactly once");
 
     /* Empty pool: NOT_FOUND on first call. */
-    {
-        struct irx_vpool *empty = vpool_create(a, NULL);
-        vpool_next_reset(empty);
-        CHECK(vpool_next(empty, &out_name, &out_value) == VPOOL_NOT_FOUND,
-              "empty pool -> NOT_FOUND");
-        vpool_destroy(empty);
-    }
+    struct irx_vpool *empty = vpool_create(a, NULL);
+    vpool_next_reset(empty);
+    CHECK(vpool_next(empty, &out_name, &out_value) == VPOOL_NOT_FOUND,
+          "empty pool -> NOT_FOUND");
+    vpool_destroy(empty);
 
     Lfree(a, &name);     Lfree(a, &value);
     Lfree(a, &out_name); Lfree(a, &out_value);


### PR DESCRIPTION
## Summary

The project targets `-std=gnu99`; variable declarations may appear anywhere in a block. This PR removes bare `{}` scope blocks whose only purpose was to allow mid-function declarations under C89 rules.

- **CLAUDE.md**: new "C Language Standard" section documenting the gnu99 target, allowed C99 features (mid-block decls, `for (int i = ...)`, `//` comments), and the bare-block policy with BAD/GOOD example
- Flattened ~32 bare blocks across 7 source files and 6 test files
- Preserved blocks that narrow resource lifetime or follow a label (C99 forbids declarations directly after a label)
- `test_vpool.c`: added missing `_simulated_tcbuser` stub (pre-existing build breakage uncovered during verification — matches pattern in all other test files)

No logic changes.

## Test plan

All suites green:

| Suite      | Result  |
|------------|---------|
| tokenizer  | 70/70   |
| phase1     | 38/38   |
| vpool      | 47/47   |
| parser     | 38/38   |
| say        | 27/27   |
| control    | 62/62   |
| hello      | 16/16   |
| procedure  | 53/53   |
| irxlstr    | 50/50   |
| **total**  | **401/401** |