### PR TITLE
fix: add asm() aliases to irx_ctrl_* and irx_pars_* prototypes

### DIFF
--- a/include/irxctrl.h
+++ b/include/irxctrl.h
@@ -134,39 +134,48 @@ struct irx_exec_stack {
 
 /* ================================================================== */
 /*  Public entry points                                               */
+/*                                                                    */
+/*  asm() aliases are required because all irx_ctrl_* functions share */
+/*  the same first 8 characters ("irx_ctrl") and would collide under  */
+/*  c2asm370's 8-character identifier truncation, leaving only the    */
+/*  first non-static function visible as the module entry point.      */
 /* ================================================================== */
 
 /* Allocate and attach a label table and exec stack to the parser.
  * Must be called from irx_pars_init before any parsing starts. */
-int  irx_ctrl_init   (struct irx_parser *p);
+int  irx_ctrl_init   (struct irx_parser *p)            asm("IRXCTLIN");
 
 /* Free everything attached by irx_ctrl_init. Safe to call on a
  * partially initialised parser. */
-void irx_ctrl_cleanup(struct irx_parser *p);
+void irx_ctrl_cleanup(struct irx_parser *p)            asm("IRXCTLCL");
 
 /* First-pass scan of the token stream. Populates the label table
  * so that SIGNAL/CALL can resolve names without forward-lookup. */
-int  irx_ctrl_label_scan(struct irx_parser *p);
+int  irx_ctrl_label_scan(struct irx_parser *p)         asm("IRXCTLLS");
 
 /* Look up a label by upper-case name. Returns tok_pos (>= 0) or -1. */
 int  irx_ctrl_label_find(struct irx_parser *p,
-                         const char *name, int name_len);
+                         const char *name,
+                         int name_len)                 asm("IRXCTLLF");
 
 /* Push a new frame. Returns pointer to the frame (never NULL on
  * success) or NULL on allocator failure. */
-struct irx_exec_frame *irx_ctrl_frame_push(struct irx_parser *p,
-                                           int frame_type);
+struct irx_exec_frame *irx_ctrl_frame_push(
+                         struct irx_parser *p,
+                         int frame_type)               asm("IRXCTLFP");
 
 /* Return pointer to the topmost frame, or NULL if the stack is empty. */
-struct irx_exec_frame *irx_ctrl_frame_top(struct irx_parser *p);
+struct irx_exec_frame *irx_ctrl_frame_top(
+                         struct irx_parser *p)         asm("IRXCTLFT");
 
 /* Pop the topmost frame. No-op if stack is empty. */
-void irx_ctrl_frame_pop(struct irx_parser *p);
+void irx_ctrl_frame_pop(struct irx_parser *p)          asm("IRXCTLFO");
 
 /* Find the innermost DO frame, optionally matching a specific label.
  * label/len may be NULL/0 to find the innermost DO regardless of label.
  * Returns frame index (>= 0) or -1 if not found. */
 int irx_ctrl_find_do(struct irx_parser *p,
-                     const char *label, int label_len);
+                     const char *label,
+                     int label_len)                    asm("IRXCTLFD");
 
 #endif /* __IRXCTRL_H__ */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -114,6 +114,10 @@ struct irx_bif {
 /*  Public entry points                                               */
 /* ================================================================== */
 
+/* asm() aliases: every irx_pars_* function shares the same first 8
+ * characters ("irx_pars") and would collide under c2asm370's
+ * 8-character identifier truncation without explicit aliases. */
+
 /* Initialise a parser context. Does NOT take ownership of tokens or
  * vpool; the caller is responsible for their lifetime. The result
  * Lstr inside the context is zero-initialised and grown on demand. */
@@ -121,20 +125,21 @@ int  irx_pars_init(struct irx_parser *p,
                    struct irx_token *tokens, int tok_count,
                    struct irx_vpool *vpool,
                    struct lstr_alloc *alloc,
-                   struct envblock *envblock);
+                   struct envblock *envblock)          asm("IRXPARIN");
 
 /* Release allocator-backed memory owned by the context (the result
  * Lstr). Safe to call on a zero-initialised context. */
-void irx_pars_cleanup(struct irx_parser *p);
+void irx_pars_cleanup(struct irx_parser *p)            asm("IRXPARCL");
 
 /* Top-level clause loop. Processes every clause in the token stream
  * until TOK_EOF or an error. Returns IRXPARS_OK or an IRXPARS_* code. */
-int  irx_pars_run(struct irx_parser *p);
+int  irx_pars_run(struct irx_parser *p)                asm("IRXPARRN");
 
 /* Evaluate the expression starting at the current token position
  * into out. Stops at a clause terminator or a right parenthesis at
  * depth 0. Used both internally and by higher-level instructions
  * (SAY, IF, WHILE, etc.) in later work packages. */
-int  irx_pars_eval_expr(struct irx_parser *p, PLstr out);
+int  irx_pars_eval_expr(struct irx_parser *p,
+                        PLstr out)                     asm("IRXPAREV");
 
 #endif /* __IRXPARS_H__ */


### PR DESCRIPTION
## Summary

**MVS build was broken for IRX#CTRL and IRX#PARS** — IFOX00 reports IFO189 (INVALID ENTRY OPERAND) and IFO196 (previously defined) for every function after the first in these two modules:

\`\`\`
527 IRX@CTRL PDPPRLG CINDEX=4,FRAME=104,BASER=12,ENTRY=YES
IFO196 IRX@CTRL HAS BEEN PREVIOUSLY DEFINED
\`\`\`

## Root cause

c2asm370 truncates C identifiers to 8 characters for HLASM output. Every function in \`irx#ctrl.c\` starts with \`irx_ctrl\` and every function in \`irx#pars.c\` starts with \`irx_pars\` — so after truncation they all collapse to the same name and collide with the module entry label.

This is a **pre-existing** issue (present since WP-15 landed) that went unnoticed because MVS builds had not been run since then. It is not related to PR #16 or PR #17.

\`irxtokn.h\` and \`irxvpool.h\` already handle this with explicit \`asm()\` aliases. This PR applies the same pattern to \`irxctrl.h\` and \`irxpars.h\`.

## Changes

Added 8-character \`asm()\` aliases to 12 prototypes:

| C name | HLASM alias |
|---|---|
| \`irx_ctrl_init\` | \`IRXCTLIN\` |
| \`irx_ctrl_cleanup\` | \`IRXCTLCL\` |
| \`irx_ctrl_label_scan\` | \`IRXCTLLS\` |
| \`irx_ctrl_label_find\` | \`IRXCTLLF\` |
| \`irx_ctrl_frame_push\` | \`IRXCTLFP\` |
| \`irx_ctrl_frame_top\` | \`IRXCTLFT\` |
| \`irx_ctrl_frame_pop\` | \`IRXCTLFO\` |
| \`irx_ctrl_find_do\` | \`IRXCTLFD\` |
| \`irx_pars_init\` | \`IRXPARIN\` |
| \`irx_pars_cleanup\` | \`IRXPARCL\` |
| \`irx_pars_run\` | \`IRXPARRN\` |
| \`irx_pars_eval_expr\` | \`IRXPAREV\` |

## Test plan

- [x] 401/401 Linux cross-compile tests pass (tokenizer 70, phase1 38, vpool 47, parser 38, say 27, control 62, hello 16, procedure 53, irxlstr 50)
- [x] \`make build\` on MVS: all 13 modules RC=0