### PR TITLE
chore: add code style infrastructure, fix header guards

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,78 @@
+---
+# REXX/370 — Code formatting rules
+# Run: clang-format -i src/*.c include/*.h test/*.c
+
+Language: Cpp
+Standard: c++03    # closest to C99 formatting; clang-format has no 'C99' option
+
+# Indentation: 4 spaces, no tabs
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+IndentCaseLabels: true
+IndentCaseBlocks: false
+
+# Braces: Allman / BSD style
+BreakBeforeBraces: Allman
+BraceWrapping:
+  AfterFunction: true
+  AfterControlStatement: Always
+  AfterStruct: true
+  AfterUnion: true
+  AfterEnum: true
+  AfterExternBlock: true
+  BeforeElse: true
+  BeforeCatch: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+
+# Line length: disabled (let humans decide line breaks)
+ColumnLimit: 0
+
+# Pointer alignment: * attached to name
+PointerAlignment: Right
+ReferenceAlignment: Right
+DerivePointerAlignment: false
+
+# Includes: system first, then project
+SortIncludes: true
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<'
+    Priority: 1
+  - Regex: '^"'
+    Priority: 2
+
+# Spaces
+SpaceBeforeParens: ControlStatements
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceInEmptyBlock: false
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: Consecutive
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: true
+
+# Single-line control: never (always use braces)
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortFunctionsOnASingleLine: None
+
+# Function declarations: return type on same line
+AlwaysBreakAfterReturnType: None
+
+# Other
+InsertBraces: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 2
+SeparateDefinitionBlocks: Always
+...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,88 @@
+---
+# REXX/370 — Static analysis rules
+# Run: clang-tidy src/*.c -- -I./include -I../lstring370/include -std=gnu99
+#
+# NOTE: Some checks are disabled because crent370 / MVS headers
+# are not available during cross-compile analysis. The tool will
+# report warnings from our code only, not from system headers.
+
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-reserved-identifier,
+  -bugprone-assignment-in-if-condition,
+  cert-*,
+  -cert-dcl37-c,
+  -cert-dcl51-cpp,
+  clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  misc-*,
+  -misc-unused-parameters,
+  -misc-no-recursion,
+  performance-*,
+  readability-braces-around-statements,
+  readability-else-after-return,
+  readability-function-cognitive-complexity,
+  readability-identifier-naming,
+  readability-isolate-declaration,
+  readability-magic-numbers,
+  readability-misleading-indentation,
+  readability-redundant-declaration,
+
+# Naming conventions: snake_case everywhere, ALL_CAPS for macros
+CheckOptions:
+  # Functions
+  - key: readability-identifier-naming.FunctionCase
+    value: lower_case
+
+  # Variables (local + global)
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.LocalVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.GlobalVariableCase
+    value: lower_case
+
+  # Parameters
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+
+  # Struct/Union/Enum members
+  - key: readability-identifier-naming.MemberCase
+    value: lower_case
+
+  # Struct/Union/Enum type names
+  - key: readability-identifier-naming.TypedefCase
+    value: lower_case
+  - key: readability-identifier-naming.TypedefSuffix
+    value: '_t'
+  - key: readability-identifier-naming.StructCase
+    value: lower_case
+  - key: readability-identifier-naming.UnionCase
+    value: lower_case
+  - key: readability-identifier-naming.EnumCase
+    value: lower_case
+
+  # Enum constants: ALL_CAPS (same as macros)
+  - key: readability-identifier-naming.EnumConstantCase
+    value: UPPER_CASE
+
+  # Macros: ALL_CAPS
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+
+  # Magic numbers: allow 0 and 1 (they're ubiquitous)
+  - key: readability-magic-numbers.IgnoredIntegerValues
+    value: '0;1;2;-1'
+
+  # Cognitive complexity threshold
+  - key: readability-function-cognitive-complexity.Threshold
+    value: '40'
+
+# Treat warnings as non-fatal during build (advisory)
+WarningsAsErrors: ''
+
+# Only analyze our source, not system headers
+HeaderFilterRegex: '(irx|lstr|vpool).*\.h$'
+...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,21 +26,28 @@ Key points:
   interpreter runtime state (variables, stack, trace, numeric settings)
 - All state is per-environment. Zero globals. This is non-negotiable.
 
-## C Language Standard
+## Code Style
 
-**We target C99 / gnu99, not C89.** `project.toml` sets
+**We target C99 / gnu99.** `project.toml` sets
 `cflags = ["-std=gnu99"]` and the cross-compile tests use `-std=gnu99`.
-c2asm370 (GCC 3.2.3) accepts gnu99 features.
+c2asm370 (GCC 3.2.3) accepts gnu99 features. C99 idioms are expected
+throughout `src/`, `include/`, and `test/`.
 
-**Allowed and encouraged:**
-- Variable declarations anywhere in a block — not just at the top.
-- Mixed declarations and code: declare each variable at its point of
-  first use. This shortens live ranges and improves readability.
-- `for (int i = 0; ...)` loop-initializer declarations.
-- `//` single-line comments.
+The full style guide lives in [`docs/code-style.md`](docs/code-style.md).
+`.clang-format` and `.clang-tidy` at the repo root encode the
+mechanically enforceable parts. **Run `clang-format -i src/*.c
+include/*.h test/*.c` before every commit.**
 
-**Do NOT** wrap code in bare `{}` blocks purely to introduce a new
-variable scope. That is a C89 workaround and is no longer needed.
+### Language rules
+
+- Declare variables where they are first used, not at block top.
+  Shortens live ranges and improves readability.
+- `for (int i = 0; i < n; i++)` loop-initializer declarations are fine.
+- `//` single-line comments are fine.
+- **Do NOT** wrap code in bare `{}` blocks just to declare variables
+  mid-function. Bare blocks are legitimate only to narrow a resource
+  lifetime (e.g. a temporary `Lstr` that must be freed before the
+  surrounding control flow continues).
 
 ```c
 /* BAD — bare block exists only to declare idx and existing */
@@ -62,14 +69,47 @@ if (some_condition) {
 }
 ```
 
-A bare `{}` block is legitimate only when you genuinely need a
-narrower scope for resource lifetime (e.g. a temporary `Lstr` that
-must be freed before the surrounding control flow continues). If the
-block exists because "C89 requires declarations at top" — remove it.
+### Formatting
 
-**Note on headers:** public headers in `include/` may still prefer
-C89-compatible declarations if they are consumed by external projects
-that pin to `-std=c89`. Inside `src/`, use C99 freely.
+- **Allman / BSD braces**: opening brace on its own line for functions,
+  control flow, and compound statements.
+- 4-space indent, no tabs.
+- **Braces are required** even on single-line `if`/`for`/`while`
+  bodies. `clang-format`'s `InsertBraces` enforces this automatically.
+- `switch`/`case`: indent `case` one level from `switch`; wrap each
+  non-trivial case body in its own `{ ... }`. clang-format cannot
+  enforce case-body braces — apply them by hand.
+- Pointer style: `char *ptr` (star attached to the name).
+
+### Naming
+
+- `snake_case` for variables, functions, types, and struct members.
+- `ALL_CAPS` for macros and enum values.
+- Typedefs end with `_t` (e.g. `irx_parser_t`).
+- Header guards use the `FILENAME_H` form — **no** leading double
+  underscores (those are reserved by the C standard). Example:
+  `#ifndef IRXVPOOL_H` / `#define IRXVPOOL_H` / `#endif /* IRXVPOOL_H */`.
+
+### Constants
+
+- Prefer enums over `#define` chains for related constants.
+- No magic numbers in code — hoist them to a `#define` or an enum with
+  a meaningful name.
+
+### Includes
+
+- System headers first, then project headers, with a blank line
+  between the two groups.
+- Inside each group, keep entries alphabetized where practical.
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irxpars.h"
+#include "irxvpool.h"
+```
 
 ## Build system
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -1,0 +1,232 @@
+## Code style
+
+This project uses **C99 / gnu99** (see `project.toml`: `cflags = ["-std=gnu99"]`).
+We do **NOT** target C89. Do not write C89-compatible code.
+
+Formatting is enforced by `.clang-format`. Static analysis by `.clang-tidy`.
+Run before every commit:
+
+```bash
+clang-format -i src/*.c include/*.h test/*.c
+clang-tidy src/*.c -- -I./include -std=gnu99
+```
+
+### C99 rules we use
+
+- Declare variables where they are first used, not at the top of the block
+- `for (int i = 0; ...)` is fine
+- `//` single-line comments are fine
+- Do NOT create bare `{}` blocks just to introduce a declaration scope.
+  If a block exists only because "C89 requires declarations at top" — remove it.
+  The only legitimate bare `{}` is when you genuinely need a narrower scope
+  for resource cleanup.
+
+### Indentation
+
+4 spaces. No tabs. Tabs in source files are a bug.
+
+### Braces: Allman / BSD style
+
+Opening brace on its own line. Always. Even for single-line bodies.
+
+```c
+int irxstor(int function, int length, void **addr_ptr, struct envblock *envblock)
+{
+    if (length <= 0)
+    {
+        return 20;
+    }
+    return 0;
+}
+```
+
+### Braces on single-line bodies: required
+
+Always use braces, even for one-line if/for/while/do bodies:
+
+```c
+/* WRONG */
+if (rc != 0) return 20;
+for (i = 0; i < n; i++) count++;
+
+/* RIGHT */
+if (rc != 0)
+{
+    return 20;
+}
+for (i = 0; i < n; i++)
+{
+    count++;
+}
+```
+
+### Switch/case
+
+Case labels indented one level inside switch. Braces around case bodies.
+
+**Note:** `clang-format` cannot auto-insert braces around case bodies
+(known limitation). It will preserve them if present. This is a manual
+convention — always add `{}` around case bodies when writing new code.
+
+```c
+switch (function)
+{
+    case RXSMGET:
+    {
+        void *ptr = calloc(1, (size_t)length);
+        if (ptr == NULL)
+        {
+            return 20;
+        }
+        *addr_ptr = ptr;
+        return 0;
+    }
+    case RXSMFRE:
+    {
+        free(*addr_ptr);
+        *addr_ptr = NULL;
+        return 0;
+    }
+    default:
+    {
+        return 20;
+    }
+}
+```
+
+### Naming conventions
+
+| Element | Style | Example |
+|---|---|---|
+| Variables | snake_case | `max_value`, `tok_count`, `bucket_count` |
+| Functions | snake_case | `vpool_create`, `irx_tokn_run` |
+| Types (typedef) | snake_case with `_t` suffix | `user_t`, `lstr_alloc_t` |
+| Structs | snake_case (no suffix) | `struct irx_vpool`, `struct irx_token` |
+| Enums | snake_case | `enum tok_type` |
+| Enum values | ALL_CAPS | `TOK_SYMBOL`, `VPOOL_OK` |
+| Macros / constants | ALL_CAPS | `MAX_BUFFER_SIZE`, `ENVBLOCK_ID` |
+| Library prefix | yes, always | `irx_`, `vpool_`, `lstr_`, `Lstr` |
+
+Short/terse names are OK for system-level code:
+
+```c
+int i, j, k;       /* loop counters */
+char *p;            /* pointer */
+int rc;             /* return code */
+int len, n;         /* lengths, counts */
+char *buf, *tmp;    /* buffers */
+```
+
+### Pointer style
+
+`*` attached to the name, not the type:
+
+```c
+char *ptr;
+int *values;
+struct envblock *envblock;
+void **addr_ptr;
+```
+
+### Types: prefer typedef over raw struct
+
+```c
+/* Definition */
+typedef struct irx_token_s
+{
+    unsigned char tok_type;
+    unsigned char tok_flags;
+    short         tok_col;
+    int           tok_line;
+} irx_token_t;
+
+/* Usage: prefer the typedef */
+irx_token_t *tokens;          /* good */
+struct irx_token_s *tokens;   /* acceptable but verbose */
+```
+
+Exception: the IBM-compatible control blocks in `irx.h` keep their existing
+`struct` names for compatibility. Don't rename those.
+
+### Enums over #define chains
+
+Prefer C99 enums for related constants:
+
+```c
+/* Prefer this */
+enum tok_type
+{
+    TOK_SYMBOL     = 0x01,
+    TOK_STRING     = 0x02,
+    TOK_NUMBER     = 0x03,
+};
+
+/* Over this */
+#define TOK_SYMBOL   0x01
+#define TOK_STRING   0x02
+#define TOK_NUMBER   0x03
+```
+
+Exception: values that must be usable in `#if` preprocessor conditions
+stay as `#define`.
+
+### No magic numbers
+
+```c
+/* WRONG */
+if (bucket_count > 4 * entry_count) resize();
+buf = malloc(1024);
+
+/* RIGHT */
+#define VP_MAX_LOAD  4
+#define IO_BUF_SIZE  1024
+
+if (bucket_count > VP_MAX_LOAD * entry_count) resize();
+buf = malloc(IO_BUF_SIZE);
+```
+
+### Header guards
+
+Use `#ifndef` / `#define` / `#endif`, not `#pragma once`:
+
+```c
+#ifndef IRXTOKN_H
+#define IRXTOKN_H
+
+/* ... */
+
+#endif /* IRXTOKN_H */
+```
+
+Guard name: header filename in ALL_CAPS, dots replaced by underscores.
+No leading double underscores (reserved by C standard).
+
+### Include order
+
+System headers first (angle brackets), then project headers (quotes).
+Blank line between groups:
+
+```c
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "irx.h"
+#include "irxwkblk.h"
+#include "irxfunc.h"
+```
+
+### Return type on same line as function name
+
+```c
+int irx_tokn_run(struct envblock *envblock, const char *src, int src_len)
+{
+    ...
+}
+```
+
+### Line length
+
+No hard limit. Let the code breathe. Don't wrap lines just to hit 80 columns.
+If a function signature or expression is naturally long, let it be long.
+Clang-format is configured with `ColumnLimit: 0`.

--- a/include/irx.h
+++ b/include/irx.h
@@ -11,8 +11,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRX_H__
-#define __IRX_H__
+#ifndef IRX_H
+#define IRX_H
 
 /* ================================================================== */
 /*  Argument Table (ARGTABLE)                                         */
@@ -642,4 +642,4 @@ struct irxexec_plist {
 #define IRXEXEC_BADPLIST    32
 #define IRXEXEC_NOHOSTCMD   (-3)
 
-#endif /* __IRX_H__ */
+#endif /* IRX_H */

--- a/include/irxctrl.h
+++ b/include/irxctrl.h
@@ -9,8 +9,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXCTRL_H__
-#define __IRXCTRL_H__
+#ifndef IRXCTRL_H
+#define IRXCTRL_H
 
 #include "lstring.h"
 #include "lstralloc.h"
@@ -178,4 +178,4 @@ int irx_ctrl_find_do(struct irx_parser *p,
                      const char *label,
                      int label_len)                    asm("IRXCTLFD");
 
-#endif /* __IRXCTRL_H__ */
+#endif /* IRXCTRL_H */

--- a/include/irxexec.h
+++ b/include/irxexec.h
@@ -9,8 +9,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXEXEC_H__
-#define __IRXEXEC_H__
+#ifndef IRXEXEC_H
+#define IRXEXEC_H
 
 #include "irx.h"
 
@@ -41,4 +41,4 @@ int irx_exec_run(const char *source, int source_len,
                  const char *args, int args_len,
                  int *rc_out, struct envblock *envblock);
 
-#endif /* __IRXEXEC_H__ */
+#endif /* IRXEXEC_H */

--- a/include/irxfunc.h
+++ b/include/irxfunc.h
@@ -7,8 +7,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXFUNC_H__
-#define __IRXFUNC_H__
+#ifndef IRXFUNC_H
+#define IRXFUNC_H
 
 #include "irx.h"
 #include "irxrab.h"
@@ -159,4 +159,4 @@ struct envblock *irx_find_env_by_name(const char *name);
 /* Validate an ENVBLOCK (check eye-catcher, pointers) */
 int  irx_validate_envblock(struct envblock *envblock);
 
-#endif /* __IRXFUNC_H__ */
+#endif /* IRXFUNC_H */

--- a/include/irxio.h
+++ b/include/irxio.h
@@ -12,8 +12,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXIO_H__
-#define __IRXIO_H__
+#ifndef IRXIO_H
+#define IRXIO_H
 
 #include "irx.h"
 #include "lstring.h"
@@ -34,4 +34,4 @@
  */
 int irxinout(int function, PLstr data, struct envblock *envblock);
 
-#endif /* __IRXIO_H__ */
+#endif /* IRXIO_H */

--- a/include/irxlstr.h
+++ b/include/irxlstr.h
@@ -21,8 +21,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXLSTR_H__
-#define __IRXLSTR_H__
+#ifndef IRXLSTR_H
+#define IRXLSTR_H
 
 #include "irx.h"
 #include "lstring.h"
@@ -110,4 +110,4 @@ int _Lisnum(PLstr s);
  */
 int irx_datatype(PLstr s, char option);
 
-#endif /* __IRXLSTR_H__ */
+#endif /* IRXLSTR_H */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -18,8 +18,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXPARS_H__
-#define __IRXPARS_H__
+#ifndef IRXPARS_H
+#define IRXPARS_H
 
 #include "irx.h"
 #include "irxtokn.h"
@@ -142,4 +142,4 @@ int  irx_pars_run(struct irx_parser *p)                asm("IRXPARRN");
 int  irx_pars_eval_expr(struct irx_parser *p,
                         PLstr out)                     asm("IRXPAREV");
 
-#endif /* __IRXPARS_H__ */
+#endif /* IRXPARS_H */

--- a/include/irxrab.h
+++ b/include/irxrab.h
@@ -23,8 +23,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXRAB_H__
-#define __IRXRAB_H__
+#ifndef IRXRAB_H
+#define IRXRAB_H
 
 #include "irx.h"
 
@@ -73,4 +73,4 @@ struct irx_env_node {
 #define ENVNODE_ACTIVE  0x80000000  /* Environment is active             */
 #define ENVNODE_TERM    0x40000000  /* Being terminated                  */
 
-#endif /* __IRXRAB_H__ */
+#endif /* IRXRAB_H */

--- a/include/irxtokn.h
+++ b/include/irxtokn.h
@@ -12,8 +12,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXTOKN_H__
-#define __IRXTOKN_H__
+#ifndef IRXTOKN_H
+#define IRXTOKN_H
 
 #include "irx.h"
 
@@ -121,4 +121,4 @@ int  irx_tokn_run(struct envblock *envblock,
 void irx_tokn_free(struct envblock *envblock,
                    struct irx_token *tokens, int count) asm("IRXTOKNF");
 
-#endif /* __IRXTOKN_H__ */
+#endif /* IRXTOKN_H */

--- a/include/irxvpool.h
+++ b/include/irxvpool.h
@@ -23,8 +23,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXVPOOL_H__
-#define __IRXVPOOL_H__
+#ifndef IRXVPOOL_H
+#define IRXVPOOL_H
 
 #include "lstring.h"
 #include "lstralloc.h"
@@ -124,4 +124,4 @@ int  vpool_next      (struct irx_vpool *pool,
                       PLstr name, PLstr value)          asm("VPOOLNXT");
 void vpool_next_reset(struct irx_vpool *pool)           asm("VPOOLNRS");
 
-#endif /* __IRXVPOOL_H__ */
+#endif /* IRXVPOOL_H */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -14,8 +14,8 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#ifndef __IRXWKBLK_H__
-#define __IRXWKBLK_H__
+#ifndef IRXWKBLK_H
+#define IRXWKBLK_H
 
 #include "irx.h"
 
@@ -158,4 +158,4 @@ struct irx_wkblk_int {
 #define NUMERIC_FUZZ_DEFAULT    0
 #define NUMERIC_DIGITS_MAX      50  /* MVS 3.8j practical limit          */
 
-#endif /* __IRXWKBLK_H__ */
+#endif /* IRXWKBLK_H */


### PR DESCRIPTION
## Summary

- Adds `.clang-format` and `.clang-tidy` at the repo root encoding the mechanically enforceable style rules (Allman braces, 4-space indent, `InsertBraces`, snake_case, no magic numbers, etc.)
- Adds `docs/code-style.md` with the full style guide
- Expands CLAUDE.md's old "C Language Standard" section into a full **Code Style** section summarising the rules inline, referencing `docs/code-style.md`, and instructing `clang-format -i src/*.c include/*.h test/*.c` before every commit
- Drops the stale "headers may stay C89-compatible" caveat — the whole project targets C99/gnu99
- Renames header guards from reserved-name `__IRXFOO_H__` form to `IRXFOO_H` across all 11 `include/*.h` files (double leading underscores are reserved by the C standard)

## Test plan

- [x] 401/401 cross-compile tests pass (tokenizer, phase1, vpool, parser, say, control, hello, procedure, irxlstr)
- [ ] Run `clang-format -i` in a follow-up pass to normalise existing sources (deliberately out of scope here to keep the diff reviewable)