### PR TITLE
chore: apply clang-format across src, include, test

### DIFF
--- a/include/irx.h
+++ b/include/irx.h
@@ -19,17 +19,19 @@
 /*  Used by IRXEXEC to pass arguments to a REXX exec                  */
 /* ================================================================== */
 
-struct argtable_entry {
-    void          *argstring_ptr;       /* Address of the argument string */
-    int            argstring_length;    /* Length of the argument string  */
+struct argtable_entry
+{
+    void *argstring_ptr;  /* Address of the argument string */
+    int argstring_length; /* Length of the argument string  */
 };
 
 /* End-of-table marker: 8 bytes of 0xFF */
-struct argstring {
-    unsigned char  argtable_end[8];     /* End of ARGTABLE marker         */
+struct argstring
+{
+    unsigned char argtable_end[8]; /* End of ARGTABLE marker         */
 };
 
-#define ARGTABLE_END  "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
+#define ARGTABLE_END "\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
 
 /* ================================================================== */
 /*  Environment Block (ENVBLOCK)                                      */
@@ -37,55 +39,62 @@ struct argstring {
 /*  Ref: SC28-1883-0, Chapter 14, Page 323                           */
 /* ================================================================== */
 
-struct envblock {
-    unsigned char  envblock_id[8];      /* Eye-catcher: 'ENVBLOCK'        */
-    unsigned char  envblock_version[4]; /* Version number in EBCDIC       */
-    int            envblock_length;     /* Length of ENVBLOCK              */
-    void          *envblock_parmblock;  /* -> PARMBLOCK                   */
-    void          *envblock_userfield;  /* User field (available to exits)*/
-    void          *envblock_workblok_ext; /* -> Work Block Extension      */
-    void          *envblock_irxexte;    /* -> IRXEXTE (Entry Point Vector)*/
+struct envblock
+{
+    unsigned char envblock_id[8];      /* Eye-catcher: 'ENVBLOCK'        */
+    unsigned char envblock_version[4]; /* Version number in EBCDIC       */
+    int envblock_length;               /* Length of ENVBLOCK              */
+    void *envblock_parmblock;          /* -> PARMBLOCK                   */
+    void *envblock_userfield;          /* User field (available to exits)*/
+    void *envblock_workblok_ext;       /* -> Work Block Extension      */
+    void *envblock_irxexte;            /* -> IRXEXTE (Entry Point Vector)*/
 
     /* Error information area */
-    union {
-        unsigned char  _envblock_error[256];
-        struct {
-            void          *_error_call_;              /* -> routine in error    */
-            int            _filler1;                  /* reserved               */
-            unsigned char  _error_msgid[8];           /* Message ID of error    */
-            unsigned char  _primary_error_message[80];/* Primary error message  */
-            unsigned char  _alternate_error_msg[160]; /* Extended error message */
+    union
+    {
+        unsigned char _envblock_error[256];
+
+        struct
+        {
+            void *_error_call_;                       /* -> routine in error    */
+            int _filler1;                             /* reserved               */
+            unsigned char _error_msgid[8];            /* Message ID of error    */
+            unsigned char _primary_error_message[80]; /* Primary error message  */
+            unsigned char _alternate_error_msg[160];  /* Extended error message */
         } _envblock_struct1;
     } _envblock_union1;
 
-    void          *envblock_compgmtb;   /* -> Compiler Programming Table  */
-    void          *envblock_attnrout_parmptr; /* -> Attention routine parms*/
-    void          *envblock_ectptr;     /* -> ECT (TSO environments)      */
+    void *envblock_compgmtb;         /* -> Compiler Programming Table  */
+    void *envblock_attnrout_parmptr; /* -> Attention routine parms*/
+    void *envblock_ectptr;           /* -> ECT (TSO environments)      */
 
     /* Information flags */
-    union {
-        unsigned char  _envblock_info_flags[4];
-        struct {
-            int            _envblock_terma_cleanup : 1, /* IRXTERMA active */
-                           : 7;
-            unsigned char  _filler2[3];
+    union
+    {
+        unsigned char _envblock_info_flags[4];
+
+        struct
+        {
+            int _envblock_terma_cleanup : 1, /* IRXTERMA active */
+                : 7;
+            unsigned char _filler2[3];
         } _envblock_struct2;
     } _envblock_union2;
 
-    int            _filler3[4];         /* reserved                       */
+    int _filler3[4]; /* reserved                       */
 };
 
-#define ENVBLOCK_ID             "ENVBLOCK"
-#define ENVBLOCK_VERSION_0100   "0100"
+#define ENVBLOCK_ID           "ENVBLOCK"
+#define ENVBLOCK_VERSION_0100 "0100"
 
 /* Accessor macros */
-#define envblock_error          _envblock_union1._envblock_error
-#define error_call_             _envblock_union1._envblock_struct1._error_call_
-#define error_msgid             _envblock_union1._envblock_struct1._error_msgid
-#define primary_error_message   _envblock_union1._envblock_struct1._primary_error_message
-#define alternate_error_msg     _envblock_union1._envblock_struct1._alternate_error_msg
-#define envblock_info_flags     _envblock_union2._envblock_info_flags
-#define envblock_terma_cleanup  _envblock_union2._envblock_struct2._envblock_terma_cleanup
+#define envblock_error         _envblock_union1._envblock_error
+#define error_call_            _envblock_union1._envblock_struct1._error_call_
+#define error_msgid            _envblock_union1._envblock_struct1._error_msgid
+#define primary_error_message  _envblock_union1._envblock_struct1._primary_error_message
+#define alternate_error_msg    _envblock_union1._envblock_struct1._alternate_error_msg
+#define envblock_info_flags    _envblock_union2._envblock_info_flags
+#define envblock_terma_cleanup _envblock_union2._envblock_struct2._envblock_terma_cleanup
 
 /* ================================================================== */
 /*  Evaluation Block (EVALBLOCK)                                      */
@@ -93,17 +102,18 @@ struct envblock {
 /*  Ref: SC28-1883-0, Chapter 12, Page 225                           */
 /* ================================================================== */
 
-struct evalblock {
-    int            evalblock_evpad1;    /* reserved - set to binary zero  */
-    int            evalblock_evsize;    /* Size in double words           */
-    int            evalblock_evlen;     /* Length of data in EVDATA       */
-    int            evalblock_evpad2;    /* reserved - set to binary zero  */
-    unsigned char  evalblock_evdata[1]; /* Result data (variable length)  */
+struct evalblock
+{
+    int evalblock_evpad1;              /* reserved - set to binary zero  */
+    int evalblock_evsize;              /* Size in double words           */
+    int evalblock_evlen;               /* Length of data in EVDATA       */
+    int evalblock_evpad2;              /* reserved - set to binary zero  */
+    unsigned char evalblock_evdata[1]; /* Result data (variable length)  */
 };
 
-#define EVALBLOCK_NORESULT      ((int)0x80000000)
-#define EVALBLOCK_HEADER_LEN    16
-#define EVALBLOCK_DATA_LEN      256
+#define EVALBLOCK_NORESULT   ((int)0x80000000)
+#define EVALBLOCK_HEADER_LEN 16
+#define EVALBLOCK_DATA_LEN   256
 
 /* ================================================================== */
 /*  Exec Block (EXECBLK)                                              */
@@ -111,25 +121,26 @@ struct evalblock {
 /*  Ref: SC28-1883-0, Chapter 12, Page 220                           */
 /* ================================================================== */
 
-struct execblk {
-    unsigned char  exec_blk_acryn[8];   /* Acronym: 'IRXEXECB'           */
-    int            exec_blk_length;     /* Length of EXECBLK in bytes     */
-    int            _filler1;            /* reserved                       */
-    unsigned char  exec_member[8];      /* Member name (blank-padded)     */
-    unsigned char  exec_ddname[8];      /* DD name (blank-padded)         */
-    unsigned char  exec_subcom[8];      /* Initial subcommand environment */
-    void          *exec_dsnptr;         /* -> data set name (optional)    */
-    int            exec_dsnlen;         /* Length of DSN                  */
+struct execblk
+{
+    unsigned char exec_blk_acryn[8]; /* Acronym: 'IRXEXECB'           */
+    int exec_blk_length;             /* Length of EXECBLK in bytes     */
+    int _filler1;                    /* reserved                       */
+    unsigned char exec_member[8];    /* Member name (blank-padded)     */
+    unsigned char exec_ddname[8];    /* DD name (blank-padded)         */
+    unsigned char exec_subcom[8];    /* Initial subcommand environment */
+    void *exec_dsnptr;               /* -> data set name (optional)    */
+    int exec_dsnlen;                 /* Length of DSN                  */
     /* --- V1 ends here (0x30) --- */
-    void          *exec_extname_ptr;    /* -> extended exec name          */
-    int            exec_extname_len;    /* Length of extended name         */
-    int            _filler2[2];         /* reserved                       */
+    void *exec_extname_ptr; /* -> extended exec name          */
+    int exec_extname_len;   /* Length of extended name         */
+    int _filler2[2];        /* reserved                       */
     /* --- V2 ends here (0x40) --- */
 };
 
-#define EXECBLK_ID          "IRXEXECB"
-#define EXECBLK_V1_LEN      0x30
-#define EXECBLK_V2_LEN      0x40
+#define EXECBLK_ID     "IRXEXECB"
+#define EXECBLK_V1_LEN 0x30
+#define EXECBLK_V2_LEN 0x40
 
 /* ================================================================== */
 /*  In-Storage Control Block (INSTBLK)                                */
@@ -137,33 +148,35 @@ struct execblk {
 /*  Ref: SC28-1883-0, Chapter 12, Page 222                           */
 /* ================================================================== */
 
-struct instblk_entry {
-    void          *instblk_stmt_;       /* Address of REXX statement      */
-    int            instblk_stmtlen;     /* Length of the REXX statement   */
+struct instblk_entry
+{
+    void *instblk_stmt_; /* Address of REXX statement      */
+    int instblk_stmtlen; /* Length of the REXX statement   */
 };
 
-struct instblk {
+struct instblk
+{
     /* 128-byte fixed header */
-    unsigned char  instblk_acronym[8];  /* Eye-catcher: 'IRXINSTB'        */
-    int            instblk_hdrlen;      /* Length of header (128)          */
-    int            _filler1;            /* reserved                        */
-    void          *instblk_address;     /* -> first INSTBLK_ENTRY          */
-    int            instblk_usedlen;     /* Total used length of entries    */
-    unsigned char  instblk_member[8];   /* Member name (for PARSE SOURCE)  */
-    unsigned char  instblk_ddname[8];   /* DD name (for PARSE SOURCE)      */
-    unsigned char  instblk_subcom[8];   /* Initial subcommand environment  */
-    int            _filler2;            /* reserved                        */
-    int            instblk_dsnlen;      /* Length of data set name          */
-    unsigned char  instblk_dsname[54];  /* Data set name                   */
-    short int      _filler3;            /* reserved                        */
-    void          *instblk_extname_ptr; /* -> extended exec name           */
-    int            instblk_extname_len; /* Length of extended name          */
-    int            _filler4[2];         /* reserved                        */
+    unsigned char instblk_acronym[8]; /* Eye-catcher: 'IRXINSTB'        */
+    int instblk_hdrlen;               /* Length of header (128)          */
+    int _filler1;                     /* reserved                        */
+    void *instblk_address;            /* -> first INSTBLK_ENTRY          */
+    int instblk_usedlen;              /* Total used length of entries    */
+    unsigned char instblk_member[8];  /* Member name (for PARSE SOURCE)  */
+    unsigned char instblk_ddname[8];  /* DD name (for PARSE SOURCE)      */
+    unsigned char instblk_subcom[8];  /* Initial subcommand environment  */
+    int _filler2;                     /* reserved                        */
+    int instblk_dsnlen;               /* Length of data set name          */
+    unsigned char instblk_dsname[54]; /* Data set name                   */
+    short int _filler3;               /* reserved                        */
+    void *instblk_extname_ptr;        /* -> extended exec name           */
+    int instblk_extname_len;          /* Length of extended name          */
+    int _filler4[2];                  /* reserved                        */
     /* Entries follow at offset 128 */
 };
 
-#define INSTBLK_ID          "IRXINSTB"
-#define INSTBLK_HDRLEN      128
+#define INSTBLK_ID     "IRXINSTB"
+#define INSTBLK_HDRLEN 128
 
 /* ================================================================== */
 /*  REXX Vector of External Entry Points (IRXEXTE)                    */
@@ -171,37 +184,38 @@ struct instblk {
 /*  Ref: SC28-1883-0, Chapter 14, Page 328                           */
 /* ================================================================== */
 
-struct irxexte {
-    int            irxexte_entry_count; /* Number of entry points         */
-    void          *irxinit;             /* IRXINIT - Env Initialize       */
-    void          *load_routine;        /* Active Exec Load Routine       */
-    void          *irxload;             /* IRXLOAD - Default Exec Load    */
-    void          *irxexcom;            /* IRXEXCOM - Variable Access     */
-    void          *irxexec;             /* IRXEXEC - Run Exec             */
-    void          *io_routine;          /* Active I/O Routine             */
-    void          *irxinout;            /* IRXINOUT - Default I/O         */
-    void          *irxjcl;              /* IRXJCL - JCL Entry Point       */
-    void          *irxrlt;              /* IRXRLT - Get Result            */
-    void          *stack_routine;       /* Active Data Stack Routine      */
-    void          *irxstk;              /* IRXSTK - Default Data Stack    */
-    void          *irxsubcm;            /* IRXSUBCM - Subcommand Table    */
-    void          *irxterm;             /* IRXTERM - Env Terminate        */
-    void          *irxic;               /* IRXIC - Immediate Commands     */
-    void          *msgid_routine;       /* Active Message ID Routine      */
-    void          *irxmsgid;            /* IRXMSGID - Default Msg ID      */
-    void          *userid_routine;      /* Active User ID Routine         */
-    void          *irxuid;              /* IRXUID - Default User ID       */
-    void          *irxterma;            /* IRXTERMA - Abnormal Term       */
-    void          *irxsay;              /* IRXSAY - SAY Routine           */
-    void          *irxers;              /* IRXERS - External Routine Srch */
-    void          *irxhst;              /* IRXHST - Host Command          */
-    void          *irxhlt;              /* IRXHLT - Halt Condition        */
-    void          *irxtxt;              /* IRXTXT - Trace Text            */
-    void          *irxlin;              /* IRXLIN - LINESIZE              */
-    void          *irxrte;              /* IRXRTE - IRXEXEC Exit          */
+struct irxexte
+{
+    int irxexte_entry_count; /* Number of entry points         */
+    void *irxinit;           /* IRXINIT - Env Initialize       */
+    void *load_routine;      /* Active Exec Load Routine       */
+    void *irxload;           /* IRXLOAD - Default Exec Load    */
+    void *irxexcom;          /* IRXEXCOM - Variable Access     */
+    void *irxexec;           /* IRXEXEC - Run Exec             */
+    void *io_routine;        /* Active I/O Routine             */
+    void *irxinout;          /* IRXINOUT - Default I/O         */
+    void *irxjcl;            /* IRXJCL - JCL Entry Point       */
+    void *irxrlt;            /* IRXRLT - Get Result            */
+    void *stack_routine;     /* Active Data Stack Routine      */
+    void *irxstk;            /* IRXSTK - Default Data Stack    */
+    void *irxsubcm;          /* IRXSUBCM - Subcommand Table    */
+    void *irxterm;           /* IRXTERM - Env Terminate        */
+    void *irxic;             /* IRXIC - Immediate Commands     */
+    void *msgid_routine;     /* Active Message ID Routine      */
+    void *irxmsgid;          /* IRXMSGID - Default Msg ID      */
+    void *userid_routine;    /* Active User ID Routine         */
+    void *irxuid;            /* IRXUID - Default User ID       */
+    void *irxterma;          /* IRXTERMA - Abnormal Term       */
+    void *irxsay;            /* IRXSAY - SAY Routine           */
+    void *irxers;            /* IRXERS - External Routine Srch */
+    void *irxhst;            /* IRXHST - Host Command          */
+    void *irxhlt;            /* IRXHLT - Halt Condition        */
+    void *irxtxt;            /* IRXTXT - Trace Text            */
+    void *irxlin;            /* IRXLIN - LINESIZE              */
+    void *irxrte;            /* IRXRTE - IRXEXEC Exit          */
 };
 
-#define IRXEXTE_ENTRY_COUNT  26
+#define IRXEXTE_ENTRY_COUNT 26
 
 /* ================================================================== */
 /*  Shared Variable Block (SHVBLOCK)                                  */
@@ -209,46 +223,47 @@ struct irxexte {
 /*  Ref: SC28-1883-0, Chapter 12, Page 241                           */
 /* ================================================================== */
 
-struct shvblock {
-    void          *shvnext;             /* -> next SHVBLOCK (or NULL)     */
-    int            shvuser;             /* User field (FETCH NEXT cursor) */
-    unsigned char  shvcode;             /* Function code                  */
-    unsigned char  shvret;              /* Return code flags              */
-    short int      _shvpad;             /* reserved (should be 0)         */
-    int            shvbufl;             /* Length of fetch value buffer    */
-    void          *shvnama;             /* -> variable name               */
-    int            shvnaml;             /* Length of variable name buffer  */
-    void          *shvvala;             /* -> value buffer                */
-    int            shvvall;             /* Length of value buffer          */
-    int            shvnamelen;          /* Actual length of var name       */
-    int            shvvalelen;          /* Actual length of value          */
+struct shvblock
+{
+    void *shvnext;         /* -> next SHVBLOCK (or NULL)     */
+    int shvuser;           /* User field (FETCH NEXT cursor) */
+    unsigned char shvcode; /* Function code                  */
+    unsigned char shvret;  /* Return code flags              */
+    short int _shvpad;     /* reserved (should be 0)         */
+    int shvbufl;           /* Length of fetch value buffer    */
+    void *shvnama;         /* -> variable name               */
+    int shvnaml;           /* Length of variable name buffer  */
+    void *shvvala;         /* -> value buffer                */
+    int shvvall;           /* Length of value buffer          */
+    int shvnamelen;        /* Actual length of var name       */
+    int shvvalelen;        /* Actual length of value          */
 };
 
 /* Function codes (SHVCODE) */
-#define SHVSTORE    'S'
-#define SHVFETCH    'F'
-#define SHVDROPV    'D'
-#define SHVSYSET    's'
-#define SHVSYFET    'f'
-#define SHVSYDRO    'd'
-#define SHVNEXTV    'N'
-#define SHVPRIV     'P'
+#define SHVSTORE 'S'
+#define SHVFETCH 'F'
+#define SHVDROPV 'D'
+#define SHVSYSET 's'
+#define SHVSYFET 'f'
+#define SHVSYDRO 'd'
+#define SHVNEXTV 'N'
+#define SHVPRIV  'P'
 
 /* Return code flags (SHVRET) - can be ORed */
-#define SHVCLEAN    0x00
-#define SHVNEWV     0x01
-#define SHVLVAR     0x02
-#define SHVTRUNC    0x04
-#define SHVBADN     0x08
-#define SHVBADV     0x10
-#define SHVBADF     0x80
+#define SHVCLEAN 0x00
+#define SHVNEWV  0x01
+#define SHVLVAR  0x02
+#define SHVTRUNC 0x04
+#define SHVBADN  0x08
+#define SHVBADV  0x10
+#define SHVBADF  0x80
 
 /* IRXEXCOM return codes */
-#define SHVRCOK     0
-#define SHVRCINV    (-1)
-#define SHVRCIST    (-2)
+#define SHVRCOK  0
+#define SHVRCINV (-1)
+#define SHVRCIST (-2)
 
-#define SHVBLEN     0x28    /* 40 bytes */
+#define SHVBLEN 0x28 /* 40 bytes */
 
 /* ================================================================== */
 /*  Parameter Block (PARMBLOCK)                                       */
@@ -256,88 +271,95 @@ struct shvblock {
 /*  Ref: SC28-1883-0, Chapter 14, Page 324                           */
 /* ================================================================== */
 
-struct parmblock {
-    unsigned char  parmblock_id[8];       /* Eye-catcher: 'IRXPARMS'    */
-    unsigned char  parmblock_version[4];  /* Version in EBCDIC          */
-    unsigned char  parmblock_language[3]; /* Language identifier         */
-    unsigned char  _filler1;
+struct parmblock
+{
+    unsigned char parmblock_id[8];       /* Eye-catcher: 'IRXPARMS'    */
+    unsigned char parmblock_version[4];  /* Version in EBCDIC          */
+    unsigned char parmblock_language[3]; /* Language identifier         */
+    unsigned char _filler1;
 
-    void          *parmblock_modnamet;    /* -> MODNAMET                */
-    void          *parmblock_subcomtb;    /* -> SUBCOMTB header         */
-    void          *parmblock_packtb;      /* -> PACKTB header           */
-    unsigned char  parmblock_parsetok[8]; /* Parse source token         */
+    void *parmblock_modnamet;            /* -> MODNAMET                */
+    void *parmblock_subcomtb;            /* -> SUBCOMTB header         */
+    void *parmblock_packtb;              /* -> PACKTB header           */
+    unsigned char parmblock_parsetok[8]; /* Parse source token         */
 
     /* Flags */
-    union {
-        unsigned char  _parmblock_flags[4];
-        struct {
-            int            _tsofl     : 1,
-                           : 1,
-                           _cmdsofl   : 1,
-                           _funcsofl  : 1,
-                           _nostkfl   : 1,
-                           _noreadfl  : 1,
-                           _nowrtfl   : 1,
-                           _newstkfl  : 1;
-            int            _userpkfl  : 1,
-                           _locpkfl   : 1,
-                           _syspkfl   : 1,
-                           _newscfl   : 1,
-                           _closexfl  : 1,
-                           _noestae   : 1,
-                           _rentrant  : 1,
-                           _nopmsgs   : 1;
-            int            _altmsgs   : 1,
-                           _spshare   : 1,
-                           _storfl    : 1,
-                           _noloaddd  : 1,
-                           _nomsgwto  : 1,
-                           _nomsgio   : 1,
-                           _rostorfl  : 1,
-                           : 1;
-            unsigned char  _filler2;
+    union
+    {
+        unsigned char _parmblock_flags[4];
+
+        struct
+        {
+            int _tsofl : 1,
+                : 1,
+                _cmdsofl : 1,
+                _funcsofl : 1,
+                _nostkfl : 1,
+                _noreadfl : 1,
+                _nowrtfl : 1,
+                _newstkfl : 1;
+            int _userpkfl : 1,
+                _locpkfl : 1,
+                _syspkfl : 1,
+                _newscfl : 1,
+                _closexfl : 1,
+                _noestae : 1,
+                _rentrant : 1,
+                _nopmsgs : 1;
+            int _altmsgs : 1,
+                _spshare : 1,
+                _storfl : 1,
+                _noloaddd : 1,
+                _nomsgwto : 1,
+                _nomsgio : 1,
+                _rostorfl : 1,
+                : 1;
+            unsigned char _filler2;
         } _parmblock_struct1;
     } _parmblock_union1;
 
     /* Masks (correspond 1:1 to flags) */
-    union {
-        unsigned char  _parmblock_masks[4];
-        struct {
-            int            _tsofl_mask     : 1,
-                           : 1,
-                           _cmdsofl_mask   : 1,
-                           _funcsofl_mask  : 1,
-                           _nostkfl_mask   : 1,
-                           _noreadfl_mask  : 1,
-                           _nowrtfl_mask   : 1,
-                           _newstkfl_mask  : 1;
-            int            _userpkfl_mask  : 1,
-                           _locpkfl_mask   : 1,
-                           _syspkfl_mask   : 1,
-                           _newscfl_mask   : 1,
-                           _closexfl_mask  : 1,
-                           _noestae_mask   : 1,
-                           _rentrant_mask  : 1,
-                           _nopmsgs_mask   : 1;
-            int            _altmsgs_mask   : 1,
-                           _spshare_mask   : 1,
-                           _storfl_mask    : 1,
-                           _noloaddd_mask  : 1,
-                           _nomsgwto_mask  : 1,
-                           _nomsgio_mask   : 1,
-                           _rostorfl_mask  : 1,
-                           : 1;
-            unsigned char  _filler3;
+    union
+    {
+        unsigned char _parmblock_masks[4];
+
+        struct
+        {
+            int _tsofl_mask : 1,
+                : 1,
+                _cmdsofl_mask : 1,
+                _funcsofl_mask : 1,
+                _nostkfl_mask : 1,
+                _noreadfl_mask : 1,
+                _nowrtfl_mask : 1,
+                _newstkfl_mask : 1;
+            int _userpkfl_mask : 1,
+                _locpkfl_mask : 1,
+                _syspkfl_mask : 1,
+                _newscfl_mask : 1,
+                _closexfl_mask : 1,
+                _noestae_mask : 1,
+                _rentrant_mask : 1,
+                _nopmsgs_mask : 1;
+            int _altmsgs_mask : 1,
+                _spshare_mask : 1,
+                _storfl_mask : 1,
+                _noloaddd_mask : 1,
+                _nomsgwto_mask : 1,
+                _nomsgio_mask : 1,
+                _rostorfl_mask : 1,
+                : 1;
+            unsigned char _filler3;
         } _parmblock_struct2;
     } _parmblock_union2;
 
-    int            parmblock_subpool;     /* Subpool number             */
-    unsigned char  parmblock_addrspn[8];  /* Address space name         */
-    unsigned char  parmblock_ffff[8];     /* End marker (hex FF)        */
+    int parmblock_subpool;              /* Subpool number             */
+    unsigned char parmblock_addrspn[8]; /* Address space name         */
+    unsigned char parmblock_ffff[8];    /* End marker (hex FF)        */
 };
 
-#define PARMBLOCK_ID            "IRXPARMS"
-#define PARMBLOCK_VERSION_0200  "0200"
+#define PARMBLOCK_ID           "IRXPARMS"
+#define PARMBLOCK_VERSION_0200 "0200"
 
 /* Flag accessor macros */
 #define parmblock_flags _parmblock_union1._parmblock_flags
@@ -394,21 +416,22 @@ struct parmblock {
 /*  Ref: SC28-1883-0, Chapter 14, Page 330                           */
 /* ================================================================== */
 
-struct modnamet {
-    unsigned char  modnamet_indd[8];    /* Input DD (SYSTSIN)             */
-    unsigned char  modnamet_outdd[8];   /* Output DD (SYSTSPRT)           */
-    unsigned char  modnamet_loaddd[8];  /* Load exec DD (SYSEXEC)         */
-    unsigned char  modnamet_iorout[8];  /* I/O routine                    */
-    unsigned char  modnamet_exrout[8];  /* Exec load routine              */
-    unsigned char  modnamet_getfreer[8];/* Storage management routine     */
-    unsigned char  modnamet_execinit[8];/* Exec initialization exit       */
-    unsigned char  modnamet_attnrout[8];/* Attention handling routine     */
-    unsigned char  modnamet_stackrt[8]; /* Data stack routine             */
-    unsigned char  modnamet_irxexecx[8];/* IRXEXEC exit routine           */
-    unsigned char  modnamet_idrout[8];  /* User ID routine                */
-    unsigned char  modnamet_msgidrt[8]; /* Message ID routine             */
-    unsigned char  modnamet_execterm[8];/* Exec termination exit          */
-    unsigned char  modnamet_ffff[8];    /* End marker (hex FF)            */
+struct modnamet
+{
+    unsigned char modnamet_indd[8];     /* Input DD (SYSTSIN)             */
+    unsigned char modnamet_outdd[8];    /* Output DD (SYSTSPRT)           */
+    unsigned char modnamet_loaddd[8];   /* Load exec DD (SYSEXEC)         */
+    unsigned char modnamet_iorout[8];   /* I/O routine                    */
+    unsigned char modnamet_exrout[8];   /* Exec load routine              */
+    unsigned char modnamet_getfreer[8]; /* Storage management routine     */
+    unsigned char modnamet_execinit[8]; /* Exec initialization exit       */
+    unsigned char modnamet_attnrout[8]; /* Attention handling routine     */
+    unsigned char modnamet_stackrt[8];  /* Data stack routine             */
+    unsigned char modnamet_irxexecx[8]; /* IRXEXEC exit routine           */
+    unsigned char modnamet_idrout[8];   /* User ID routine                */
+    unsigned char modnamet_msgidrt[8];  /* Message ID routine             */
+    unsigned char modnamet_execterm[8]; /* Exec termination exit          */
+    unsigned char modnamet_ffff[8];     /* End marker (hex FF)            */
 };
 
 /* ================================================================== */
@@ -416,79 +439,86 @@ struct modnamet {
 /*  Ref: SC28-1883-0, Chapter 14                                     */
 /* ================================================================== */
 
-struct subcomtb_header {
-    void          *subcomtb_first;      /* -> first SUBCOMTB entry        */
-    int            subcomtb_total;      /* Total entries                  */
-    int            subcomtb_used;       /* Used entries                   */
-    int            subcomtb_length;     /* Length of each entry           */
-    unsigned char  subcomtb_initial[8]; /* Initial subcommand env name    */
-    unsigned char  _filler1[8];         /* reserved                       */
-    unsigned char  subcomtb_ffff[8];    /* End marker (hex FF)            */
+struct subcomtb_header
+{
+    void *subcomtb_first;              /* -> first SUBCOMTB entry        */
+    int subcomtb_total;                /* Total entries                  */
+    int subcomtb_used;                 /* Used entries                   */
+    int subcomtb_length;               /* Length of each entry           */
+    unsigned char subcomtb_initial[8]; /* Initial subcommand env name    */
+    unsigned char _filler1[8];         /* reserved                       */
+    unsigned char subcomtb_ffff[8];    /* End marker (hex FF)            */
 };
 
-struct subcomtb_entry {
-    unsigned char  subcomtb_name[8];    /* Subcommand environment name    */
-    unsigned char  subcomtb_routine[8]; /* Handler routine name           */
-    unsigned char  subcomtb_token[16];  /* User token                     */
+struct subcomtb_entry
+{
+    unsigned char subcomtb_name[8];    /* Subcommand environment name    */
+    unsigned char subcomtb_routine[8]; /* Handler routine name           */
+    unsigned char subcomtb_token[16];  /* User token                     */
 };
 
-#define SUBCOMTB_ENTRY_LEN  32
+#define SUBCOMTB_ENTRY_LEN 32
 
 /* ================================================================== */
 /*  Function Package Table (PACKTB)                                   */
 /* ================================================================== */
 
-struct packtb_header {
-    void          *packtb_user_first;   /* -> first user entry            */
-    int            packtb_user_total;
-    int            packtb_user_used;
-    void          *packtb_local_first;  /* -> first local entry           */
-    int            packtb_local_total;
-    int            packtb_local_used;
-    void          *packtb_system_first; /* -> first system entry          */
-    int            packtb_system_total;
-    int            packtb_system_used;
-    int            packtb_length;       /* Length of each entry           */
-    unsigned char  packtb_ffff[8];      /* End marker                     */
+struct packtb_header
+{
+    void *packtb_user_first; /* -> first user entry            */
+    int packtb_user_total;
+    int packtb_user_used;
+    void *packtb_local_first; /* -> first local entry           */
+    int packtb_local_total;
+    int packtb_local_used;
+    void *packtb_system_first; /* -> first system entry          */
+    int packtb_system_total;
+    int packtb_system_used;
+    int packtb_length;            /* Length of each entry           */
+    unsigned char packtb_ffff[8]; /* End marker                     */
 };
 
-struct packtb_entry {
-    unsigned char  packtb_name[8];      /* Package name                   */
-    unsigned char  _filler1[8];         /* reserved / next                */
-    unsigned char  valid_parmblock_version[4];
+struct packtb_entry
+{
+    unsigned char packtb_name[8]; /* Package name                   */
+    unsigned char _filler1[8];    /* reserved / next                */
+    unsigned char valid_parmblock_version[4];
 };
 
 /* ================================================================== */
 /*  Function Package Directory (FPCKDIR)                              */
 /* ================================================================== */
 
-struct fpckdir_header {
-    unsigned char  fpckdir_id[8];
-    int            fpckdir_header_length;
-    int            fpckdir_functions;
-    int            _filler1;
-    int            fpckdir_entry_length;
+struct fpckdir_header
+{
+    unsigned char fpckdir_id[8];
+    int fpckdir_header_length;
+    int fpckdir_functions;
+    int _filler1;
+    int fpckdir_entry_length;
 };
 
-struct fpckdir_entry {
-    unsigned char  fpckdir_funcname[8];
-    void          *fpckdir_funcaddr;
-    int            _filler1;
-    unsigned char  fpckdir_sysname[8];
-    unsigned char  fpckdir_sysdd[8];
+struct fpckdir_entry
+{
+    unsigned char fpckdir_funcname[8];
+    void *fpckdir_funcaddr;
+    int _filler1;
+    unsigned char fpckdir_sysname[8];
+    unsigned char fpckdir_sysdd[8];
 };
 
 /* ================================================================== */
 /*  External Function Parameter List (EFPL)                           */
 /* ================================================================== */
 
-struct efpl {
-    void          *efplcom;             /* reserved                       */
-    void          *efplbarg;            /* reserved                       */
-    void          *efplearg;            /* reserved                       */
-    void          *efplfb;              /* reserved                       */
-    void          *efplarg;             /* -> argument table              */
-    void          *efpleval;            /* -> address of EVALBLOCK        */
+struct efpl
+{
+    void *efplcom;  /* reserved                       */
+    void *efplbarg; /* reserved                       */
+    void *efplearg; /* reserved                       */
+    void *efplfb;   /* reserved                       */
+    void *efplarg;  /* -> argument table              */
+    void *efpleval; /* -> address of EVALBLOCK        */
 };
 
 /* ================================================================== */
@@ -496,28 +526,34 @@ struct efpl {
 /*  Ref: SC28-1883-0, Chapter 14, Page 326                           */
 /* ================================================================== */
 
-struct workblok_ext {
-    void          *workext_execblk;     /* -> EXECBLK                     */
-    void          *workext_argtable;    /* -> first ARGTABLE entry        */
-    union {
-        unsigned char  _workext_flags[4];
-        struct {
-            int            _workext_command    : 1,
-                           _workext_function   : 1,
-                           _workext_subroutine : 1,
-                           : 5;
-            unsigned char  _filler1[3];
+struct workblok_ext
+{
+    void *workext_execblk;  /* -> EXECBLK                     */
+    void *workext_argtable; /* -> first ARGTABLE entry        */
+
+    union
+    {
+        unsigned char _workext_flags[4];
+
+        struct
+        {
+            int _workext_command : 1,
+                _workext_function : 1,
+                _workext_subroutine : 1,
+                : 5;
+            unsigned char _filler1[3];
         } _workext_struct1;
     } _workext_union1;
-    void          *workext_instblk;     /* -> INSTBLK header              */
-    void          *workext_cpplptr;     /* -> CPPL (TSO only)             */
-    void          *workext_evalblock;   /* -> user EVALBLOCK              */
-    void          *workext_workarea;    /* -> workarea header             */
-    void          *workext_userfield;   /* User field                     */
-    int            workext_rtproc;      /* Runtime processor word         */
-    void          *workext_source_address; /* -> source image             */
-    int            workext_source_length;  /* Source length               */
-    int            _filler2;            /* reserved                       */
+
+    void *workext_instblk;        /* -> INSTBLK header              */
+    void *workext_cpplptr;        /* -> CPPL (TSO only)             */
+    void *workext_evalblock;      /* -> user EVALBLOCK              */
+    void *workext_workarea;       /* -> workarea header             */
+    void *workext_userfield;      /* User field                     */
+    int workext_rtproc;           /* Runtime processor word         */
+    void *workext_source_address; /* -> source image             */
+    int workext_source_length;    /* Source length               */
+    int _filler2;                 /* reserved                       */
 };
 
 #define workext_flags      _workext_union1._workext_flags
@@ -529,42 +565,48 @@ struct workblok_ext {
 /*  Dataset Information Block (DSIB)                                  */
 /* ================================================================== */
 
-struct dsib_info {
-    unsigned char  dsib_id[8];
-    short int      dsib_length;
-    short int      _filler1;
-    unsigned char  dsib_ddname[8];
-    union {
-        unsigned char  _dsib_flags[4];
-        struct {
-            int            _dsib_lrecl_flag : 1,
-                           _dsib_blksz_flag : 1,
-                           _dsib_dsorg_flag : 1,
-                           _dsib_recfm_flag : 1,
-                           _dsib_get_flag   : 1,
-                           _dsib_put_flag   : 1,
-                           _dsib_mode_flag  : 1,
-                           _dsib_cc_flag    : 1;
-            int            _dsib_trc_flag   : 1,
-                           : 7;
-            unsigned char  _filler2[2];
+struct dsib_info
+{
+    unsigned char dsib_id[8];
+    short int dsib_length;
+    short int _filler1;
+    unsigned char dsib_ddname[8];
+
+    union
+    {
+        unsigned char _dsib_flags[4];
+
+        struct
+        {
+            int _dsib_lrecl_flag : 1,
+                _dsib_blksz_flag : 1,
+                _dsib_dsorg_flag : 1,
+                _dsib_recfm_flag : 1,
+                _dsib_get_flag : 1,
+                _dsib_put_flag : 1,
+                _dsib_mode_flag : 1,
+                _dsib_cc_flag : 1;
+            int _dsib_trc_flag : 1,
+                : 7;
+            unsigned char _filler2[2];
         } _dsib_struct1;
     } _dsib_union1;
-    short int      dsib_lrecl;
-    short int      dsib_blksz;
-    unsigned char  dsib_dsorg[2];
-    unsigned char  dsib_recfm[2];
-    int            dsib_get_cnt;
-    int            dsib_put_cnt;
-    unsigned char  dsib_io_mode;
-    unsigned char  dsib_cc;
-    unsigned char  dsib_trc;
-    unsigned char  _filler3;
-    int            _filler4[3];
+
+    short int dsib_lrecl;
+    short int dsib_blksz;
+    unsigned char dsib_dsorg[2];
+    unsigned char dsib_recfm[2];
+    int dsib_get_cnt;
+    int dsib_put_cnt;
+    unsigned char dsib_io_mode;
+    unsigned char dsib_cc;
+    unsigned char dsib_trc;
+    unsigned char _filler3;
+    int _filler4[3];
 };
 
-#define DSIB_ID     "IRXDSIB "
-#define DSIB_LEN    0x38
+#define DSIB_ID  "IRXDSIB "
+#define DSIB_LEN 0x38
 
 /* DSIB flag accessors */
 #define dsib_flags      _dsib_union1._dsib_flags
@@ -582,34 +624,37 @@ struct dsib_info {
 /*  Compiler Programming Table (COMPGMTB)                             */
 /* ================================================================== */
 
-struct compgmtb_header {
-    void          *compgmtb_first;
-    int            compgmtb_total;
-    int            compgmtb_used;
-    int            compgmtb_length;
-    unsigned char  _filler1[8];
-    unsigned char  compgmtb_ffff[8];
+struct compgmtb_header
+{
+    void *compgmtb_first;
+    int compgmtb_total;
+    int compgmtb_used;
+    int compgmtb_length;
+    unsigned char _filler1[8];
+    unsigned char compgmtb_ffff[8];
 };
 
-struct compgmtb_entry {
-    unsigned char  compgmtb_rtproc[8];
-    unsigned char  compgmtb_compinit[8];
-    unsigned char  compgmtb_compterm[8];
-    unsigned char  compgmtb_compload[8];
-    unsigned char  compgmtb_compvar[8];
-    int            compgmtb_storage[4];
+struct compgmtb_entry
+{
+    unsigned char compgmtb_rtproc[8];
+    unsigned char compgmtb_compinit[8];
+    unsigned char compgmtb_compterm[8];
+    unsigned char compgmtb_compload[8];
+    unsigned char compgmtb_compvar[8];
+    int compgmtb_storage[4];
 };
 
 /* ================================================================== */
 /*  Host Command Environment Parameters                               */
 /* ================================================================== */
 
-struct irx_hostenv_parms {
-    char          *envname;
-    char         **cmdstring;
-    int           *cmdlen;
-    char         **usertoken;
-    int           *retcode;
+struct irx_hostenv_parms
+{
+    char *envname;
+    char **cmdstring;
+    int *cmdlen;
+    char **usertoken;
+    int *retcode;
 };
 
 /* ================================================================== */
@@ -617,29 +662,30 @@ struct irx_hostenv_parms {
 /*  Ref: SC28-1883-0, Chapter 12                                     */
 /* ================================================================== */
 
-struct irxexec_plist {
-    void          *execblk_ptr;         /* -> EXECBLK (or NULL)           */
-    void          *arglist_ptr;         /* -> argument table              */
-    int            flags;               /* Execution flags                */
-    void          *instblk_ptr;         /* -> INSTBLK (or NULL)           */
-    void          *cppl_ptr;            /* -> CPPL (TSO, or NULL)         */
-    void          *evalblk_ptr;         /* -> EVALBLOCK (or NULL)         */
-    void          *wkarea_ptr;          /* -> work area (or NULL)         */
-    void          *userfield_ptr;       /* -> user field (or NULL)        */
-    void          *envblock_ptr;        /* -> ENVBLOCK (or NULL)          */
+struct irxexec_plist
+{
+    void *execblk_ptr;   /* -> EXECBLK (or NULL)           */
+    void *arglist_ptr;   /* -> argument table              */
+    int flags;           /* Execution flags                */
+    void *instblk_ptr;   /* -> INSTBLK (or NULL)           */
+    void *cppl_ptr;      /* -> CPPL (TSO, or NULL)         */
+    void *evalblk_ptr;   /* -> EVALBLOCK (or NULL)         */
+    void *wkarea_ptr;    /* -> work area (or NULL)         */
+    void *userfield_ptr; /* -> user field (or NULL)        */
+    void *envblock_ptr;  /* -> ENVBLOCK (or NULL)          */
 };
 
 /* IRXEXEC flags */
-#define IRXEXEC_COMMAND     0x00000000
-#define IRXEXEC_FUNCTION    0x20000000
-#define IRXEXEC_SUBROUTINE  0x40000000
+#define IRXEXEC_COMMAND    0x00000000
+#define IRXEXEC_FUNCTION   0x20000000
+#define IRXEXEC_SUBROUTINE 0x40000000
 
 /* IRXEXEC return codes */
-#define IRXEXEC_OK          0
-#define IRXEXEC_RCNZ        4
-#define IRXEXEC_NOTFOUND    20
-#define IRXEXEC_NOENV       28
-#define IRXEXEC_BADPLIST    32
-#define IRXEXEC_NOHOSTCMD   (-3)
+#define IRXEXEC_OK        0
+#define IRXEXEC_RCNZ      4
+#define IRXEXEC_NOTFOUND  20
+#define IRXEXEC_NOENV     28
+#define IRXEXEC_BADPLIST  32
+#define IRXEXEC_NOHOSTCMD (-3)
 
 #endif /* IRX_H */

--- a/include/irxctrl.h
+++ b/include/irxctrl.h
@@ -12,34 +12,34 @@
 #ifndef IRXCTRL_H
 #define IRXCTRL_H
 
-#include "lstring.h"
 #include "lstralloc.h"
+#include "lstring.h"
 
 /* ================================================================== */
 /*  Forward declarations                                              */
 /* ================================================================== */
 
 struct irx_parser;
-struct irx_vpool;   /* used by FRAME_CALL for PROCEDURE EXPOSE (WP-17) */
+struct irx_vpool; /* used by FRAME_CALL for PROCEDURE EXPOSE (WP-17) */
 
 /* ================================================================== */
 /*  Frame type codes                                                  */
 /* ================================================================== */
 
-#define FRAME_DO      1
-#define FRAME_CALL    2
-#define FRAME_SELECT  3
+#define FRAME_DO     1
+#define FRAME_CALL   2
+#define FRAME_SELECT 3
 
 /* ================================================================== */
 /*  DO loop variant codes                                             */
 /* ================================================================== */
 
-#define DO_SIMPLE   0   /* DO; ... END  (execute body once)           */
-#define DO_FOREVER  1   /* DO FOREVER                                 */
-#define DO_COUNT    2   /* DO n  (fixed-count repetitive)             */
-#define DO_CTRL     3   /* DO i = start TO end [BY step]              */
-#define DO_WHILE    4   /* DO WHILE cond  (pre-test)                  */
-#define DO_UNTIL    5   /* DO UNTIL cond  (post-test)                 */
+#define DO_SIMPLE  0 /* DO; ... END  (execute body once)           */
+#define DO_FOREVER 1 /* DO FOREVER                                 */
+#define DO_COUNT   2 /* DO n  (fixed-count repetitive)             */
+#define DO_CTRL    3 /* DO i = start TO end [BY step]              */
+#define DO_WHILE   4 /* DO WHILE cond  (pre-test)                  */
+#define DO_UNTIL   5 /* DO UNTIL cond  (post-test)                 */
 
 /* Maximum name length for a control variable or DO label. */
 #define CTRL_NAME_MAX 64
@@ -48,88 +48,92 @@ struct irx_vpool;   /* used by FRAME_CALL for PROCEDURE EXPOSE (WP-17) */
 /*  Label table                                                       */
 /* ================================================================== */
 
-struct irx_label {
-    char  name[CTRL_NAME_MAX];  /* upper-case label name (no colon)   */
-    int   name_len;
-    int   tok_pos;              /* token position of the label symbol  */
+struct irx_label
+{
+    char name[CTRL_NAME_MAX]; /* upper-case label name (no colon)   */
+    int name_len;
+    int tok_pos; /* token position of the label symbol  */
 };
 
-struct irx_label_table {
-    struct irx_label   *entries;
-    int                 count;
-    int                 cap;
-    struct lstr_alloc  *alloc;
+struct irx_label_table
+{
+    struct irx_label *entries;
+    int count;
+    int cap;
+    struct lstr_alloc *alloc;
 };
 
 /* ================================================================== */
 /*  Execution frame                                                   */
 /* ================================================================== */
 
-struct irx_exec_frame {
-    int  frame_type;    /* FRAME_DO / FRAME_CALL / FRAME_SELECT       */
+struct irx_exec_frame
+{
+    int frame_type; /* FRAME_DO / FRAME_CALL / FRAME_SELECT       */
 
     /* --- FRAME_DO fields ----------------------------------------- */
-    int  do_type;       /* DO_SIMPLE / DO_FOREVER / DO_COUNT / ...    */
-    int  loop_start;    /* tok_pos of first body token                */
-    int  loop_end;      /* tok_pos of first token AFTER matching END  */
+    int do_type;    /* DO_SIMPLE / DO_FOREVER / DO_COUNT / ...    */
+    int loop_start; /* tok_pos of first body token                */
+    int loop_end;   /* tok_pos of first token AFTER matching END  */
 
     /* Controlled loop (DO_CTRL) */
     char ctrl_name[CTRL_NAME_MAX];
-    int  ctrl_name_len;
-    long ctrl_val;      /* current value of the control variable      */
-    long ctrl_to;       /* limit (inclusive)                          */
-    long ctrl_by;       /* step (default 1)                           */
+    int ctrl_name_len;
+    long ctrl_val; /* current value of the control variable      */
+    long ctrl_to;  /* limit (inclusive)                          */
+    long ctrl_by;  /* step (default 1)                           */
 
     /* Repetitive loop (DO_COUNT) */
-    long ctrl_count;    /* remaining iterations                       */
+    long ctrl_count; /* remaining iterations                       */
 
     /* Conditional loops (DO_WHILE / DO_UNTIL) */
-    int  cond_tok_pos;  /* tok_pos of the WHILE/UNTIL expression      */
+    int cond_tok_pos; /* tok_pos of the WHILE/UNTIL expression      */
 
     /* Label associated with this DO (for ITERATE/LEAVE label) */
     char do_label[CTRL_NAME_MAX];
-    int  do_label_len;
+    int do_label_len;
 
     /* First iteration flag for DO_UNTIL (body must execute once) */
-    int  first_iter;
+    int first_iter;
 
     /* --- FRAME_CALL fields --------------------------------------- */
-    int  call_return_pos;   /* tok_pos to resume after RETURN         */
-    int  call_line;         /* source line of the CALL (-> SIGL)      */
+    int call_return_pos; /* tok_pos to resume after RETURN         */
+    int call_line;       /* source line of the CALL (-> SIGL)      */
 
     /* WP-17: PROCEDURE EXPOSE */
-    struct irx_vpool *saved_vpool;     /* caller's vpool before PROCEDURE   */
-    Lstr             *saved_args;      /* caller's call_args array           */
-    int              *saved_arg_exists;/* caller's call_arg_exists array     */
-    int               saved_argc;      /* caller's call_argc                 */
-    int               procedure_allowed; /* 1 = PROCEDURE may follow next    */
-    int               has_procedure;   /* 1 = PROCEDURE was executed         */
+    struct irx_vpool *saved_vpool; /* caller's vpool before PROCEDURE   */
+    Lstr *saved_args;              /* caller's call_args array           */
+    int *saved_arg_exists;         /* caller's call_arg_exists array     */
+    int saved_argc;                /* caller's call_argc                 */
+    int procedure_allowed;         /* 1 = PROCEDURE may follow next    */
+    int has_procedure;             /* 1 = PROCEDURE was executed         */
 
     /* --- FRAME_SELECT fields ------------------------------------- */
-    int  select_matched;    /* 1 once a WHEN branch has been taken    */
-    int  select_end;        /* tok_pos of first token AFTER SELECT END */
+    int select_matched; /* 1 once a WHEN branch has been taken    */
+    int select_end;     /* tok_pos of first token AFTER SELECT END */
 };
 
 /* ================================================================== */
 /*  Execution stack                                                   */
 /* ================================================================== */
 
-#define EXEC_STACK_INIT_CAP  16
+#define EXEC_STACK_INIT_CAP 16
 
-struct irx_exec_stack {
-    struct irx_exec_frame  *frames;
-    int                     top;     /* number of active frames        */
-    int                     cap;     /* allocated frame slots          */
-    struct lstr_alloc       *alloc;
+struct irx_exec_stack
+{
+    struct irx_exec_frame *frames;
+    int top; /* number of active frames        */
+    int cap; /* allocated frame slots          */
+    struct lstr_alloc *alloc;
 
     /* "Last label seen" — cleared by kw_do after pick-up. Used to
      * associate a label clause with the immediately following DO. */
-    char  last_label[CTRL_NAME_MAX];
-    int   last_label_len;
+    char last_label[CTRL_NAME_MAX];
+    int last_label_len;
 
     /* EXIT/RETURN state propagated upward through kw_return. */
-    int   exit_requested;
-    int   exit_rc;
+    int exit_requested;
+    int exit_rc;
 };
 
 /* ================================================================== */
@@ -143,39 +147,39 @@ struct irx_exec_stack {
 
 /* Allocate and attach a label table and exec stack to the parser.
  * Must be called from irx_pars_init before any parsing starts. */
-int  irx_ctrl_init   (struct irx_parser *p)            asm("IRXCTLIN");
+int irx_ctrl_init(struct irx_parser *p) asm("IRXCTLIN");
 
 /* Free everything attached by irx_ctrl_init. Safe to call on a
  * partially initialised parser. */
-void irx_ctrl_cleanup(struct irx_parser *p)            asm("IRXCTLCL");
+void irx_ctrl_cleanup(struct irx_parser *p) asm("IRXCTLCL");
 
 /* First-pass scan of the token stream. Populates the label table
  * so that SIGNAL/CALL can resolve names without forward-lookup. */
-int  irx_ctrl_label_scan(struct irx_parser *p)         asm("IRXCTLLS");
+int irx_ctrl_label_scan(struct irx_parser *p) asm("IRXCTLLS");
 
 /* Look up a label by upper-case name. Returns tok_pos (>= 0) or -1. */
-int  irx_ctrl_label_find(struct irx_parser *p,
-                         const char *name,
-                         int name_len)                 asm("IRXCTLLF");
+int irx_ctrl_label_find(struct irx_parser *p,
+                        const char *name,
+                        int name_len) asm("IRXCTLLF");
 
 /* Push a new frame. Returns pointer to the frame (never NULL on
  * success) or NULL on allocator failure. */
 struct irx_exec_frame *irx_ctrl_frame_push(
-                         struct irx_parser *p,
-                         int frame_type)               asm("IRXCTLFP");
+    struct irx_parser *p,
+    int frame_type) asm("IRXCTLFP");
 
 /* Return pointer to the topmost frame, or NULL if the stack is empty. */
 struct irx_exec_frame *irx_ctrl_frame_top(
-                         struct irx_parser *p)         asm("IRXCTLFT");
+    struct irx_parser *p) asm("IRXCTLFT");
 
 /* Pop the topmost frame. No-op if stack is empty. */
-void irx_ctrl_frame_pop(struct irx_parser *p)          asm("IRXCTLFO");
+void irx_ctrl_frame_pop(struct irx_parser *p) asm("IRXCTLFO");
 
 /* Find the innermost DO frame, optionally matching a specific label.
  * label/len may be NULL/0 to find the innermost DO regardless of label.
  * Returns frame index (>= 0) or -1 if not found. */
 int irx_ctrl_find_do(struct irx_parser *p,
                      const char *label,
-                     int label_len)                    asm("IRXCTLFD");
+                     int label_len) asm("IRXCTLFD");
 
 #endif /* IRXCTRL_H */

--- a/include/irxfunc.h
+++ b/include/irxfunc.h
@@ -22,18 +22,18 @@
 /* --- RAB Management (TCB -> TCBUSER -> RAB -> ENVBLOCK chain) --- */
 
 /* Get or create the RAB for the current task */
-int  irx_rab_obtain(struct irx_rab **rab_ptr)           asm("IRXRABOB");
+int irx_rab_obtain(struct irx_rab **rab_ptr) asm("IRXRABOB");
 
 /* Release the RAB for the current task */
-int  irx_rab_release(struct irx_rab *rab)               asm("IRXRABRL");
+int irx_rab_release(struct irx_rab *rab) asm("IRXRABRL");
 
 /* Add an environment node to the RAB chain */
-int  irx_rab_add_env(struct irx_rab *rab,
-                     struct irx_env_node *node)         asm("IRXRABAD");
+int irx_rab_add_env(struct irx_rab *rab,
+                    struct irx_env_node *node) asm("IRXRABAD");
 
 /* Remove an environment node from the RAB chain */
-int  irx_rab_remove_env(struct irx_rab *rab,
-                        struct irx_env_node *node)      asm("IRXRABRM");
+int irx_rab_remove_env(struct irx_rab *rab,
+                       struct irx_env_node *node) asm("IRXRABRM");
 
 /* --- Environment Lifecycle --- */
 
@@ -48,7 +48,7 @@ int  irx_rab_remove_env(struct irx_rab *rab,
  *
  * Returns: 0=OK, 20=init error, 28=storage error
  */
-int  irxinit(void *parms, struct envblock **envblock_ptr);
+int irxinit(void *parms, struct envblock **envblock_ptr);
 
 /* IRXTERM - Terminate a Language Processor Environment
  * Frees all storage associated with the environment,
@@ -59,7 +59,7 @@ int  irxinit(void *parms, struct envblock **envblock_ptr);
  *
  * Returns: 0=OK, 20=term error
  */
-int  irxterm(struct envblock *envblock_ptr);
+int irxterm(struct envblock *envblock_ptr);
 
 /* --- Storage Management Replaceable Routine --- */
 
@@ -75,8 +75,8 @@ int  irxterm(struct envblock *envblock_ptr);
  *
  * Returns: 0=OK, 20=storage not available
  */
-int  irxstor(int function, int length, void **addr_ptr,
-             struct envblock *envblock);
+int irxstor(int function, int length, void **addr_ptr,
+            struct envblock *envblock);
 
 /* --- User ID Replaceable Routine --- */
 
@@ -90,7 +90,7 @@ int  irxstor(int function, int length, void **addr_ptr,
  *
  * Returns: 0=OK, 20=error
  */
-int  irxuid(char *userid, struct envblock *envblock);
+int irxuid(char *userid, struct envblock *envblock);
 
 /* --- Message ID Replaceable Routine --- */
 
@@ -104,7 +104,7 @@ int  irxuid(char *userid, struct envblock *envblock);
  *
  * Returns: 0=OK
  */
-int  irxmsgid(int function, char *prefix, struct envblock *envblock);
+int irxmsgid(int function, char *prefix, struct envblock *envblock);
 
 /* ================================================================== */
 /*  Phase 2+: Stubs for forward reference                             */
@@ -121,27 +121,27 @@ int  irxmsgid(int function, char *prefix, struct envblock *envblock);
  *
  * Returns: 0=OK, 20=error
  */
-int  irxinout(int function, PLstr data, struct envblock *envblock);
+int irxinout(int function, PLstr data, struct envblock *envblock);
 
 /* IRXEXEC - Execute a REXX exec */
-int  irxexec(struct irxexec_plist *plist);
+int irxexec(struct irxexec_plist *plist);
 
 /* IRXEXCOM - Variable access */
-int  irxexcom(char *irxid, void *dummy1, void *dummy2,
-              struct shvblock *shvblock, struct envblock *envblock,
-              int *retval);
+int irxexcom(char *irxid, void *dummy1, void *dummy2,
+             struct shvblock *shvblock, struct envblock *envblock,
+             int *retval);
 
 /* IRXSUBCM - Subcommand table management */
-int  irxsubcm(void *parms, struct envblock *envblock);
+int irxsubcm(void *parms, struct envblock *envblock);
 
 /* IRXRLT - Get result */
-int  irxrlt(void *parms, struct envblock *envblock);
+int irxrlt(void *parms, struct envblock *envblock);
 
 /* IRXIC - Immediate command / Trace control */
-int  irxic(void *parms, struct envblock *envblock);
+int irxic(void *parms, struct envblock *envblock);
 
 /* IRXJCL - Batch entry point (PGM=IRXJCL) */
-int  irxjcl(void *cppl_or_parm);
+int irxjcl(void *cppl_or_parm);
 
 /* ================================================================== */
 /*  Internal Helper Functions                                         */
@@ -157,6 +157,6 @@ struct envblock *irx_find_env(void);
 struct envblock *irx_find_env_by_name(const char *name);
 
 /* Validate an ENVBLOCK (check eye-catcher, pointers) */
-int  irx_validate_envblock(struct envblock *envblock);
+int irx_validate_envblock(struct envblock *envblock);
 
 #endif /* IRXFUNC_H */

--- a/include/irxlstr.h
+++ b/include/irxlstr.h
@@ -40,16 +40,16 @@
 /*  _Lisnum() / irx_datatype().                                       */
 /* ================================================================== */
 
-#define LINTEGER_TY   1   /* validated as an integer literal          */
-#define LREAL_TY      2   /* validated as a real / exponent literal   */
+#define LINTEGER_TY 1 /* validated as an integer literal          */
+#define LREAL_TY    2 /* validated as a real / exponent literal   */
 
 /* ================================================================== */
 /*  _Lisnum() result values                                           */
 /* ================================================================== */
 
-#define LNUM_NOT_NUM  0   /* not a valid REXX number                  */
-#define LNUM_INTEGER  1   /* valid REXX integer (no dot, no exponent) */
-#define LNUM_REAL     2   /* valid REXX real (has dot or exponent)    */
+#define LNUM_NOT_NUM 0 /* not a valid REXX number                  */
+#define LNUM_INTEGER 1 /* valid REXX integer (no dot, no exponent) */
+#define LNUM_REAL    2 /* valid REXX real (has dot or exponent)    */
 
 /* ================================================================== */
 /*  Public API                                                        */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -24,8 +24,8 @@
 #include "irx.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
-#include "lstring.h"
 #include "lstralloc.h"
+#include "lstring.h"
 
 /* ================================================================== */
 /*  Constants                                                         */
@@ -38,46 +38,47 @@
 /*  Return codes                                                      */
 /* ================================================================== */
 
-#define IRXPARS_OK          0
-#define IRXPARS_SYNTAX     20  /* generic SYNTAX error               */
-#define IRXPARS_NOMEM      21  /* allocator failure                  */
-#define IRXPARS_NOVALUE    22  /* uninitialised variable (NOVALUE)   */
-#define IRXPARS_DIVZERO    23  /* division by zero                   */
-#define IRXPARS_BADFUNC    24  /* unknown function in call           */
-#define IRXPARS_BADARG     25  /* bad argument to parser entry       */
+#define IRXPARS_OK      0
+#define IRXPARS_SYNTAX  20 /* generic SYNTAX error               */
+#define IRXPARS_NOMEM   21 /* allocator failure                  */
+#define IRXPARS_NOVALUE 22 /* uninitialised variable (NOVALUE)   */
+#define IRXPARS_DIVZERO 23 /* division by zero                   */
+#define IRXPARS_BADFUNC 24 /* unknown function in call           */
+#define IRXPARS_BADARG  25 /* bad argument to parser entry       */
 
 /* ================================================================== */
 /*  Parser context                                                    */
 /* ================================================================== */
 
-struct irx_parser {
-    struct irx_token    *tokens;       /* token stream                */
-    int                  tok_count;    /* number of tokens            */
-    int                  tok_pos;      /* cursor                      */
+struct irx_parser
+{
+    struct irx_token *tokens; /* token stream                */
+    int tok_count;            /* number of tokens            */
+    int tok_pos;              /* cursor                      */
 
-    struct irx_vpool    *vpool;        /* variable scope              */
-    struct lstr_alloc   *alloc;        /* allocator for Lstr          */
-    struct envblock     *envblock;     /* owning environment          */
+    struct irx_vpool *vpool;   /* variable scope              */
+    struct lstr_alloc *alloc;  /* allocator for Lstr          */
+    struct envblock *envblock; /* owning environment          */
 
-    Lstr                 result;       /* last expression result      */
+    Lstr result; /* last expression result      */
 
-    int                  error_code;   /* IRXPARS_*                   */
-    int                  error_line;   /* source line of the error    */
+    int error_code; /* IRXPARS_*                   */
+    int error_line; /* source line of the error    */
 
-    void                *label_table;  /* label table (WP-15)         */
-    void                *exec_stack;   /* execution stack (WP-15)     */
+    void *label_table; /* label table (WP-15)         */
+    void *exec_stack;  /* execution stack (WP-15)     */
 
-    int                  exit_requested; /* set by EXIT / RETURN      */
-    int                  exit_rc;        /* RC passed to EXIT          */
+    int exit_requested; /* set by EXIT / RETURN      */
+    int exit_rc;        /* RC passed to EXIT          */
 
     /* WP-17: PROCEDURE EXPOSE — current subroutine argument context.
      * call_args[0..call_argc-1] are the argument values; call_arg_exists
      * is a parallel array where 1 = argument was passed, 0 = omitted.
      * Both arrays are heap-allocated (IRX_MAX_ARGS elements each).
      * NULL when no CALL is active (top-level or no args passed). */
-    Lstr  *call_args;       /* current subroutine argument values      */
-    int   *call_arg_exists; /* 1=passed, 0=omitted (per argument)      */
-    int    call_argc;       /* number of argument positions            */
+    Lstr *call_args;      /* current subroutine argument values      */
+    int *call_arg_exists; /* 1=passed, 0=omitted (per argument)      */
+    int call_argc;        /* number of argument positions            */
 };
 
 /* ================================================================== */
@@ -91,9 +92,10 @@ struct irx_parser {
 
 typedef int (*irx_keyword_fn)(struct irx_parser *p);
 
-struct irx_keyword {
-    const char     *kw_name;   /* upper-case ASCII name              */
-    irx_keyword_fn  kw_handler;
+struct irx_keyword
+{
+    const char *kw_name; /* upper-case ASCII name              */
+    irx_keyword_fn kw_handler;
 };
 
 /* ================================================================== */
@@ -103,11 +105,12 @@ struct irx_keyword {
 typedef int (*irx_bif_fn)(struct irx_parser *p,
                           int argc, PLstr *argv, PLstr result);
 
-struct irx_bif {
-    const char *bif_name;      /* upper-case ASCII name              */
-    int         bif_min_args;
-    int         bif_max_args;
-    irx_bif_fn  bif_handler;
+struct irx_bif
+{
+    const char *bif_name; /* upper-case ASCII name              */
+    int bif_min_args;
+    int bif_max_args;
+    irx_bif_fn bif_handler;
 };
 
 /* ================================================================== */
@@ -121,25 +124,25 @@ struct irx_bif {
 /* Initialise a parser context. Does NOT take ownership of tokens or
  * vpool; the caller is responsible for their lifetime. The result
  * Lstr inside the context is zero-initialised and grown on demand. */
-int  irx_pars_init(struct irx_parser *p,
-                   struct irx_token *tokens, int tok_count,
-                   struct irx_vpool *vpool,
-                   struct lstr_alloc *alloc,
-                   struct envblock *envblock)          asm("IRXPARIN");
+int irx_pars_init(struct irx_parser *p,
+                  struct irx_token *tokens, int tok_count,
+                  struct irx_vpool *vpool,
+                  struct lstr_alloc *alloc,
+                  struct envblock *envblock) asm("IRXPARIN");
 
 /* Release allocator-backed memory owned by the context (the result
  * Lstr). Safe to call on a zero-initialised context. */
-void irx_pars_cleanup(struct irx_parser *p)            asm("IRXPARCL");
+void irx_pars_cleanup(struct irx_parser *p) asm("IRXPARCL");
 
 /* Top-level clause loop. Processes every clause in the token stream
  * until TOK_EOF or an error. Returns IRXPARS_OK or an IRXPARS_* code. */
-int  irx_pars_run(struct irx_parser *p)                asm("IRXPARRN");
+int irx_pars_run(struct irx_parser *p) asm("IRXPARRN");
 
 /* Evaluate the expression starting at the current token position
  * into out. Stops at a clause terminator or a right parenthesis at
  * depth 0. Used both internally and by higher-level instructions
  * (SAY, IF, WHILE, etc.) in later work packages. */
-int  irx_pars_eval_expr(struct irx_parser *p,
-                        PLstr out)                     asm("IRXPAREV");
+int irx_pars_eval_expr(struct irx_parser *p,
+                       PLstr out) asm("IRXPAREV");
 
 #endif /* IRXPARS_H */

--- a/include/irxrab.h
+++ b/include/irxrab.h
@@ -33,44 +33,46 @@
 /*  Anchored via TCBUSER on MVS 3.8j                                  */
 /* ================================================================== */
 
-struct irx_rab {
-    unsigned char  rab_id[4];           /* Eye-catcher: 'RAB '            */
-    int            rab_length;          /* Length of this block            */
-    short int      rab_version;         /* Version number                 */
-    short int      rab_env_count;       /* Number of active environments  */
-    void          *rab_first;           /* -> first irx_env_node          */
-    void          *rab_last;            /* -> last irx_env_node           */
-    void          *rab_prev_tcbuser;    /* Saved previous TCBUSER value   */
-    int            rab_flags;           /* RAB status flags               */
-    int            _reserved[2];        /* reserved for future use        */
+struct irx_rab
+{
+    unsigned char rab_id[4]; /* Eye-catcher: 'RAB '            */
+    int rab_length;          /* Length of this block            */
+    short int rab_version;   /* Version number                 */
+    short int rab_env_count; /* Number of active environments  */
+    void *rab_first;         /* -> first irx_env_node          */
+    void *rab_last;          /* -> last irx_env_node           */
+    void *rab_prev_tcbuser;  /* Saved previous TCBUSER value   */
+    int rab_flags;           /* RAB status flags               */
+    int _reserved[2];        /* reserved for future use        */
 };
 
-#define RAB_ID          "RAB "
-#define RAB_VERSION     1
+#define RAB_ID      "RAB "
+#define RAB_VERSION 1
 
 /* RAB flags */
-#define RAB_ACTIVE      0x80000000  /* RAB is initialized and active    */
-#define RAB_TSO         0x40000000  /* Running under TSO                */
+#define RAB_ACTIVE 0x80000000 /* RAB is initialized and active    */
+#define RAB_TSO    0x40000000 /* Running under TSO                */
 
 /* ================================================================== */
 /*  Environment Node (irx_env_node)                                   */
 /*  Wraps ENVBLOCK for chain navigation without modifying IBM layout  */
 /* ================================================================== */
 
-struct irx_env_node {
-    unsigned char  node_id[4];          /* Eye-catcher: 'ENVN'            */
-    int            node_length;         /* Length of this node             */
-    struct irx_env_node *node_next;     /* -> next environment node       */
-    struct irx_env_node *node_prev;     /* -> previous environment node   */
-    struct irx_rab      *node_rab;      /* -> owning RAB                  */
-    struct envblock     *node_envblock; /* -> the IBM ENVBLOCK            */
-    int            node_flags;          /* Node status flags              */
-    int            _reserved;           /* reserved                       */
+struct irx_env_node
+{
+    unsigned char node_id[4];       /* Eye-catcher: 'ENVN'            */
+    int node_length;                /* Length of this node             */
+    struct irx_env_node *node_next; /* -> next environment node       */
+    struct irx_env_node *node_prev; /* -> previous environment node   */
+    struct irx_rab *node_rab;       /* -> owning RAB                  */
+    struct envblock *node_envblock; /* -> the IBM ENVBLOCK            */
+    int node_flags;                 /* Node status flags              */
+    int _reserved;                  /* reserved                       */
 };
 
-#define ENVNODE_ID      "ENVN"
+#define ENVNODE_ID "ENVN"
 
-#define ENVNODE_ACTIVE  0x80000000  /* Environment is active             */
-#define ENVNODE_TERM    0x40000000  /* Being terminated                  */
+#define ENVNODE_ACTIVE 0x80000000 /* Environment is active             */
+#define ENVNODE_TERM   0x40000000 /* Being terminated                  */
 
 #endif /* IRXRAB_H */

--- a/include/irxtokn.h
+++ b/include/irxtokn.h
@@ -21,68 +21,71 @@
 /*  Token types                                                       */
 /* ================================================================== */
 
-#define TOK_SYMBOL      0x01  /* FRED, A.B.C, X12, 'stem.' prefix    */
-#define TOK_STRING      0x02  /* 'hello' or "world"                  */
-#define TOK_NUMBER      0x03  /* 42, 3.14, 1E5                       */
-#define TOK_HEXSTRING   0x04  /* 'FF'x                               */
-#define TOK_BINSTRING   0x05  /* '1010'b                             */
+#define TOK_SYMBOL    0x01 /* FRED, A.B.C, X12, 'stem.' prefix    */
+#define TOK_STRING    0x02 /* 'hello' or "world"                  */
+#define TOK_NUMBER    0x03 /* 42, 3.14, 1E5                       */
+#define TOK_HEXSTRING 0x04 /* 'FF'x                               */
+#define TOK_BINSTRING 0x05 /* '1010'b                             */
 /* Operator characters are emitted one per token; the parser forms   */
 /* composite operators (||, **, //, ==, >=, <=, &&, \=, etc.) from   */
 /* adjacent operator tokens. See docs/tokenizer-notes.md section 3.  */
-#define TOK_OPERATOR    0x06  /* + - * / %                           */
-#define TOK_COMPARISON  0x07  /* = > <                               */
-#define TOK_LOGICAL     0x08  /* & |                                 */
-#define TOK_NOT         0x09  /* \ or EBCDIC NOT sign                */
-#define TOK_CONCAT      0x0A  /* reserved (parser may synthesize)    */
-#define TOK_LPAREN      0x0B  /* (                                   */
-#define TOK_RPAREN      0x0C  /* )                                   */
-#define TOK_COMMA       0x0D  /* ,                                   */
-#define TOK_SEMICOLON   0x0E  /* ;                                   */
-#define TOK_EOC         0x10  /* End of clause (logical newline)     */
-#define TOK_EOF         0x11  /* End of source                       */
+#define TOK_OPERATOR   0x06 /* + - * / %                           */
+#define TOK_COMPARISON 0x07 /* = > <                               */
+#define TOK_LOGICAL    0x08 /* & |                                 */
+#define TOK_NOT        0x09 /* \ or EBCDIC NOT sign                */
+#define TOK_CONCAT     0x0A /* reserved (parser may synthesize)    */
+#define TOK_LPAREN     0x0B /* (                                   */
+#define TOK_RPAREN     0x0C /* )                                   */
+#define TOK_COMMA      0x0D /* ,                                   */
+#define TOK_SEMICOLON  0x0E /* ;                                   */
+#define TOK_EOC        0x10 /* End of clause (logical newline)     */
+#define TOK_EOF        0x11 /* End of source                       */
 
 /* ================================================================== */
 /*  Token flags                                                       */
 /* ================================================================== */
 
-#define TOKF_NONE        0x00
-#define TOKF_QUOTE_DBL   0x01  /* STRING contained doubled quotes     */
-#define TOKF_COMPOUND    0x02  /* SYMBOL is a compound (has a dot)    */
-#define TOKF_CONSTANT    0x04  /* SYMBOL is a constant (starts digit  */
-                               /* or '.')                             */
+#define TOKF_NONE      0x00
+#define TOKF_QUOTE_DBL 0x01 /* STRING contained doubled quotes     */
+#define TOKF_COMPOUND  0x02 /* SYMBOL is a compound (has a dot)    */
+#define TOKF_CONSTANT  0x04 /* SYMBOL is a constant (starts digit  */
+
+/* or '.')                             */
 
 /* ================================================================== */
 /*  Token record (contiguous array, cache-friendly)                   */
 /* ================================================================== */
 
-struct irx_token {
-    unsigned char   tok_type;      /* TOK_*                          */
-    unsigned char   tok_flags;     /* TOKF_*                         */
-    short           tok_col;       /* 1-based column of first byte   */
-    int             tok_line;      /* 1-based line of first byte     */
-    const char     *tok_text;      /* pointer into source buffer     */
-    unsigned short  tok_length;    /* length of token text in bytes  */
-    unsigned short  tok_reserved;  /* pad / future use               */
+struct irx_token
+{
+    unsigned char tok_type;      /* TOK_*                          */
+    unsigned char tok_flags;     /* TOKF_*                         */
+    short tok_col;               /* 1-based column of first byte   */
+    int tok_line;                /* 1-based line of first byte     */
+    const char *tok_text;        /* pointer into source buffer     */
+    unsigned short tok_length;   /* length of token text in bytes  */
+    unsigned short tok_reserved; /* pad / future use               */
 };
 
 /* ================================================================== */
 /*  Error reporting                                                   */
 /* ================================================================== */
 
-#define TOKERR_NONE               0
-#define TOKERR_STORAGE           20  /* irxstor failed                */
-#define TOKERR_UNTERMINATED_STR  30  /* string literal not closed     */
-#define TOKERR_UNTERMINATED_CMT  31  /* comment not closed            */
-#define TOKERR_INVALID_HEX       32  /* bad hex digit in 'xx'x        */
-#define TOKERR_INVALID_BIN       33  /* bad bit digit in 'xx'b        */
-#define TOKERR_ODD_HEX_GROUP     34  /* hex group has odd count       */
-#define TOKERR_BAD_BIN_GROUP     35  /* binary group size not 4/8     */
-#define TOKERR_BAD_CHAR          36  /* unrecognized character        */
+#define TOKERR_NONE             0
+#define TOKERR_STORAGE          20 /* irxstor failed                */
+#define TOKERR_UNTERMINATED_STR 30 /* string literal not closed     */
+#define TOKERR_UNTERMINATED_CMT 31 /* comment not closed            */
+#define TOKERR_INVALID_HEX      32 /* bad hex digit in 'xx'x        */
+#define TOKERR_INVALID_BIN      33 /* bad bit digit in 'xx'b        */
+#define TOKERR_ODD_HEX_GROUP    34 /* hex group has odd count       */
+#define TOKERR_BAD_BIN_GROUP    35 /* binary group size not 4/8     */
+#define TOKERR_BAD_CHAR         36 /* unrecognized character        */
 
-struct irx_tokn_error {
-    int  error_code;     /* TOKERR_*                                  */
-    int  error_line;     /* 1-based, where error was detected         */
-    int  error_col;      /* 1-based                                   */
+struct irx_tokn_error
+{
+    int error_code; /* TOKERR_*                                  */
+    int error_line; /* 1-based, where error was detected         */
+    int error_col;  /* 1-based                                   */
 };
 
 /* ================================================================== */
@@ -107,10 +110,10 @@ struct irx_tokn_error {
  *
  *   Returns 0 on success, non-zero on error (see TOKERR_*).
  */
-int  irx_tokn_run(struct envblock *envblock,
-                  const char *src, int src_len,
-                  struct irx_token **out_tokens, int *out_count,
-                  struct irx_tokn_error *out_error) asm("IRXTOKNR");
+int irx_tokn_run(struct envblock *envblock,
+                 const char *src, int src_len,
+                 struct irx_token **out_tokens, int *out_count,
+                 struct irx_tokn_error *out_error) asm("IRXTOKNR");
 
 /* Release a token array returned by irx_tokn_run.
  *

--- a/include/irxvpool.h
+++ b/include/irxvpool.h
@@ -26,62 +26,64 @@
 #ifndef IRXVPOOL_H
 #define IRXVPOOL_H
 
-#include "lstring.h"
 #include "lstralloc.h"
+#include "lstring.h"
 
 /* ================================================================== */
 /*  Return codes                                                      */
 /* ================================================================== */
 
-#define VPOOL_OK          0   /* success                              */
-#define VPOOL_NOT_FOUND   1   /* variable does not exist              */
-#define VPOOL_LAST        2   /* last variable returned (for NEXT)    */
-#define VPOOL_NOMEM      20   /* allocator failed                     */
-#define VPOOL_BADARG     21   /* invalid argument                     */
+#define VPOOL_OK        0  /* success                              */
+#define VPOOL_NOT_FOUND 1  /* variable does not exist              */
+#define VPOOL_LAST      2  /* last variable returned (for NEXT)    */
+#define VPOOL_NOMEM     20 /* allocator failed                     */
+#define VPOOL_BADARG    21 /* invalid argument                     */
 
 /* ================================================================== */
 /*  Entry flags                                                       */
 /* ================================================================== */
 
-#define VPOOL_DROPPED     0x01  /* entry is tombstoned after DROP    */
-#define VPOOL_EXPOSED_REF 0x02  /* entry is a ref into parent pool   */
-#define VPOOL_UNSET       0x04  /* placeholder created by EXPOSE     */
+#define VPOOL_DROPPED     0x01 /* entry is tombstoned after DROP    */
+#define VPOOL_EXPOSED_REF 0x02 /* entry is a ref into parent pool   */
+#define VPOOL_UNSET       0x04 /* placeholder created by EXPOSE     */
 
 /* ================================================================== */
 /*  Entry                                                             */
 /* ================================================================== */
 
-struct vpool_entry {
-    struct vpool_entry *next;          /* chain within bucket          */
-    Lstr                name;          /* variable name (bytes as-is) */
-    Lstr                value;         /* variable value              */
-    int                 flags;         /* VPOOL_DROPPED / _EXPOSED_REF */
-    struct vpool_entry *exposed_ref;   /* -> parent entry if exposed  */
+struct vpool_entry
+{
+    struct vpool_entry *next;        /* chain within bucket          */
+    Lstr name;                       /* variable name (bytes as-is) */
+    Lstr value;                      /* variable value              */
+    int flags;                       /* VPOOL_DROPPED / _EXPOSED_REF */
+    struct vpool_entry *exposed_ref; /* -> parent entry if exposed  */
 };
 
 /* ================================================================== */
 /*  Pool                                                              */
 /* ================================================================== */
 
-#define VPOOL_ID      "VPOL"
-#define VPOOL_ID_LEN  4
+#define VPOOL_ID     "VPOL"
+#define VPOOL_ID_LEN 4
 
-struct irx_vpool {
-    unsigned char        vp_id[VPOOL_ID_LEN];  /* eye-catcher 'VPOL'   */
-    struct vpool_entry **buckets;              /* bucket array         */
-    int                  bucket_count;         /* current bucket count */
-    int                  entry_count;          /* live entries (incl.
-                                                * exposed refs)        */
-    struct irx_vpool    *parent;               /* -> parent scope      */
-    Lstr                *exposed_stems;        /* array of stem names  */
-    int                  exposed_stem_count;
-    int                  exposed_stem_cap;
-    struct lstr_alloc   *alloc;                /* injected allocator   */
+struct irx_vpool
+{
+    unsigned char vp_id[VPOOL_ID_LEN]; /* eye-catcher 'VPOL'   */
+    struct vpool_entry **buckets;      /* bucket array         */
+    int bucket_count;                  /* current bucket count */
+    int entry_count;                   /* live entries (incl.
+                                        * exposed refs)        */
+    struct irx_vpool *parent;          /* -> parent scope      */
+    Lstr *exposed_stems;               /* array of stem names  */
+    int exposed_stem_count;
+    int exposed_stem_cap;
+    struct lstr_alloc *alloc; /* injected allocator   */
 
     /* NEXT cursor. Do not mutate the pool while iterating. */
-    int                  next_bucket;
-    struct vpool_entry  *next_entry;
-    int                  next_started;
+    int next_bucket;
+    struct vpool_entry *next_entry;
+    int next_started;
 };
 
 /* ================================================================== */
@@ -93,35 +95,35 @@ struct irx_vpool {
 /* ================================================================== */
 
 /* Lifecycle */
-struct irx_vpool *vpool_create (struct lstr_alloc *a,
-                                struct irx_vpool *parent);
-void              vpool_destroy(struct irx_vpool *pool);
+struct irx_vpool *vpool_create(struct lstr_alloc *a,
+                               struct irx_vpool *parent);
+void vpool_destroy(struct irx_vpool *pool);
 
 /* Core operations. `name` is used as-is (no uppercasing). The
  * parser is responsible for producing the canonical name. */
-int vpool_set   (struct irx_vpool *pool,
-                 const PLstr name, const PLstr value);
-int vpool_get   (struct irx_vpool *pool,
-                 const PLstr name, PLstr value);
-int vpool_drop  (struct irx_vpool *pool, const PLstr name);
+int vpool_set(struct irx_vpool *pool,
+              const PLstr name, const PLstr value);
+int vpool_get(struct irx_vpool *pool,
+              const PLstr name, PLstr value);
+int vpool_drop(struct irx_vpool *pool, const PLstr name);
 int vpool_exists(struct irx_vpool *pool,
-                 const PLstr name)                      asm("VPOOLEXI");
+                 const PLstr name) asm("VPOOLEXI");
 
 /* EXPOSE registration. Should be called on the child pool before
  * any set/get operations. `name` for expose_stem must include the
  * trailing dot (e.g. "STEM."). */
-int vpool_expose_var (struct irx_vpool *pool,
-                      const PLstr name)                 asm("VPOOLXPV");
+int vpool_expose_var(struct irx_vpool *pool,
+                     const PLstr name) asm("VPOOLXPV");
 int vpool_expose_stem(struct irx_vpool *pool,
-                      const PLstr stem_name)            asm("VPOOLXPS");
+                      const PLstr stem_name) asm("VPOOLXPS");
 
 /* Iteration. Call vpool_next_reset() before the first vpool_next()
  * to rewind the cursor. vpool_next() returns VPOOL_OK with the
  * current entry's name and value copied out, or VPOOL_LAST after the
  * last entry has been returned, or VPOOL_NOT_FOUND if the pool is
  * empty. `name` and `value` are grown via the pool's allocator. */
-int  vpool_next      (struct irx_vpool *pool,
-                      PLstr name, PLstr value)          asm("VPOOLNXT");
-void vpool_next_reset(struct irx_vpool *pool)           asm("VPOOLNRS");
+int vpool_next(struct irx_vpool *pool,
+               PLstr name, PLstr value) asm("VPOOLNXT");
+void vpool_next_reset(struct irx_vpool *pool) asm("VPOOLNRS");
 
 #endif /* IRXVPOOL_H */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -46,116 +46,117 @@
 /*  Ref: SC28-1883-0, Chapter 16, Page 366                           */
 /* ================================================================== */
 
-#define RXFWRITE        0   /* Write a line (SAY)                      */
-#define RXFREAD         1   /* Read a line (PULL from terminal)        */
-#define RXFREADP        2   /* Read (PULL from stack, then terminal)   */
-#define RXFTWRITE       3   /* Write trace output                      */
-#define RXFWRITERR      4   /* Write error message                     */
-#define RXFOPEN         5   /* Open a dataset                          */
-#define RXFCLOSE        6   /* Close a dataset                         */
-#define RXFREAD_DS      7   /* Read from dataset (EXECIO)              */
-#define RXFWRITE_DS     8   /* Write to dataset (EXECIO)               */
+#define RXFWRITE    0 /* Write a line (SAY)                      */
+#define RXFREAD     1 /* Read a line (PULL from terminal)        */
+#define RXFREADP    2 /* Read (PULL from stack, then terminal)   */
+#define RXFTWRITE   3 /* Write trace output                      */
+#define RXFWRITERR  4 /* Write error message                     */
+#define RXFOPEN     5 /* Open a dataset                          */
+#define RXFCLOSE    6 /* Close a dataset                         */
+#define RXFREAD_DS  7 /* Read from dataset (EXECIO)              */
+#define RXFWRITE_DS 8 /* Write to dataset (EXECIO)               */
 
 /* ================================================================== */
 /*  Storage Management Function Codes                                 */
 /*  Ref: SC28-1883-0, Chapter 16                                     */
 /* ================================================================== */
 
-#define RXSMGET         0   /* Acquire storage (GETMAIN equivalent)    */
-#define RXSMFRE         1   /* Release storage (FREEMAIN equivalent)   */
+#define RXSMGET 0 /* Acquire storage (GETMAIN equivalent)    */
+#define RXSMFRE 1 /* Release storage (FREEMAIN equivalent)   */
 
 /* ================================================================== */
 /*  Signal Condition Flags                                            */
 /*  Ref: SC28-1883-0, Chapter 7                                      */
 /* ================================================================== */
 
-#define COND_ERROR      0x01
-#define COND_HALT       0x02
-#define COND_NOVALUE    0x04
-#define COND_NOTREADY   0x08
-#define COND_SYNTAX     0x10
-#define COND_FAILURE    0x20
+#define COND_ERROR    0x01
+#define COND_HALT     0x02
+#define COND_NOVALUE  0x04
+#define COND_NOTREADY 0x08
+#define COND_SYNTAX   0x10
+#define COND_FAILURE  0x20
 
 /* ================================================================== */
 /*  Internal Work Block Extension (irx_wkblk_int)                     */
 /*  Per-environment interpreter runtime state                         */
 /* ================================================================== */
 
-struct irx_wkblk_int {
-    unsigned char  wkbi_id[4];          /* Eye-catcher: 'WKBI'            */
-    int            wkbi_length;         /* Length of this block            */
-    struct envblock *wkbi_envblock;     /* -> owning ENVBLOCK             */
+struct irx_wkblk_int
+{
+    unsigned char wkbi_id[4];       /* Eye-catcher: 'WKBI'            */
+    int wkbi_length;                /* Length of this block            */
+    struct envblock *wkbi_envblock; /* -> owning ENVBLOCK             */
 
     /* --- NUMERIC settings --- */
-    int            wkbi_digits;         /* NUMERIC DIGITS (default 9)     */
-    int            wkbi_fuzz;           /* NUMERIC FUZZ (default 0)       */
-    int            wkbi_form;           /* NUMERIC FORM (0=SCI, 1=ENG)   */
+    int wkbi_digits; /* NUMERIC DIGITS (default 9)     */
+    int wkbi_fuzz;   /* NUMERIC FUZZ (default 0)       */
+    int wkbi_form;   /* NUMERIC FORM (0=SCI, 1=ENG)   */
 
     /* --- TRACE settings --- */
-    int            wkbi_trace;          /* Current TRACE setting          */
-    int            wkbi_interactive;    /* Interactive trace active (0/1) */
+    int wkbi_trace;       /* Current TRACE setting          */
+    int wkbi_interactive; /* Interactive trace active (0/1) */
 
     /* --- Special variables --- */
-    int            wkbi_sigl;           /* Current SIGL value             */
-    int            wkbi_rc;             /* Current RC value               */
+    int wkbi_sigl; /* Current SIGL value             */
+    int wkbi_rc;   /* Current RC value               */
 
     /* --- Variable Pool --- */
-    void          *wkbi_varpool;        /* -> variable pool root          */
+    void *wkbi_varpool; /* -> variable pool root          */
 
     /* --- Data Stack --- */
-    void          *wkbi_datastack;      /* -> data stack anchor           */
+    void *wkbi_datastack; /* -> data stack anchor           */
 
     /* --- Execution Stack --- */
-    void          *wkbi_execstack;      /* -> internal exec stack         */
+    void *wkbi_execstack; /* -> internal exec stack         */
 
     /* --- Condition Information --- */
-    int            wkbi_condflags;      /* Active SIGNAL ON conditions    */
-    void          *wkbi_condinfo;       /* -> condition information block */
+    int wkbi_condflags;  /* Active SIGNAL ON conditions    */
+    void *wkbi_condinfo; /* -> condition information block */
 
     /* --- Elapsed Time --- */
-    int            wkbi_elapsed_hi;     /* Elapsed time clock (high word) */
-    int            wkbi_elapsed_lo;     /* Elapsed time clock (low word)  */
-    int            wkbi_elapsed_reset;  /* Elapsed time reset flag        */
+    int wkbi_elapsed_hi;    /* Elapsed time clock (high word) */
+    int wkbi_elapsed_lo;    /* Elapsed time clock (low word)  */
+    int wkbi_elapsed_reset; /* Elapsed time reset flag        */
 
     /* --- Error Recovery --- */
-    int            wkbi_error_number;   /* Last REXX error number         */
-    void          *wkbi_error_source;   /* -> source line causing error   */
-    int            wkbi_error_line;     /* Line number of error           */
+    int wkbi_error_number;   /* Last REXX error number         */
+    void *wkbi_error_source; /* -> source line causing error   */
+    int wkbi_error_line;     /* Line number of error           */
 
     /* --- Source Management --- */
-    void          *wkbi_source;         /* -> loaded source image         */
-    int            wkbi_source_len;     /* Length of source image         */
-    void          *wkbi_tokens;         /* -> token stream (after parse)  */
+    void *wkbi_source;   /* -> loaded source image         */
+    int wkbi_source_len; /* Length of source image         */
+    void *wkbi_tokens;   /* -> token stream (after parse)  */
 
     /* --- Labels --- */
-    void          *wkbi_labels;         /* -> label table                 */
+    void *wkbi_labels; /* -> label table                 */
 
     /* --- Exec Cache (per environment) --- */
-    void          *wkbi_cache;          /* -> exec LRU cache              */
+    void *wkbi_cache; /* -> exec LRU cache              */
 
     /* --- Interpreter State --- */
-    int            wkbi_depth;          /* Current call/procedure depth   */
-    int            wkbi_flags;          /* Internal state flags           */
+    int wkbi_depth; /* Current call/procedure depth   */
+    int wkbi_flags; /* Internal state flags           */
 
     /* --- lstring370 allocator bridge (WP-11b) ----------------------- */
     /* Opaque pointer to a `struct lstr_alloc` allocated via irxstor.
      * Set lazily by irx_lstr_init(); freed by irxterm(). Consumers
      * that need the concrete type must include <lstring.h>.          */
-    void          *wkbi_lstr_alloc;
+    void *wkbi_lstr_alloc;
 
-    int            _reserved[3];        /* reserved for future use        */
+    int _reserved[3]; /* reserved for future use        */
 };
 
-#define WKBLK_INT_ID    "WKBI"
+#define WKBLK_INT_ID "WKBI"
 
 /* wkbi_flags values */
-#define WKBI_RUNNING    0x80000000  /* Exec is currently executing       */
-#define WKBI_HALTED     0x40000000  /* HALT condition is pending         */
-#define WKBI_HT_ACTIVE  0x20000000  /* HT (halt typing) is active       */
+#define WKBI_RUNNING   0x80000000 /* Exec is currently executing       */
+#define WKBI_HALTED    0x40000000 /* HALT condition is pending         */
+#define WKBI_HT_ACTIVE 0x20000000 /* HT (halt typing) is active       */
 
 /* Default NUMERIC settings */
-#define NUMERIC_DIGITS_DEFAULT  9
-#define NUMERIC_FUZZ_DEFAULT    0
-#define NUMERIC_DIGITS_MAX      50  /* MVS 3.8j practical limit          */
+#define NUMERIC_DIGITS_DEFAULT 9
+#define NUMERIC_FUZZ_DEFAULT   0
+#define NUMERIC_DIGITS_MAX     50 /* MVS 3.8j practical limit          */
 
 #endif /* IRXWKBLK_H */

--- a/src/irx#ctrl.c
+++ b/src/irx#ctrl.c
@@ -12,12 +12,12 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#include <string.h>
-#include <stddef.h>
 #include <ctype.h>
+#include <stddef.h>
+#include <string.h>
 
-#include "irxpars.h"
 #include "irxctrl.h"
+#include "irxpars.h"
 #include "irxtokn.h"
 
 /* ------------------------------------------------------------------ */
@@ -27,12 +27,16 @@
 /* Upper-case at most CTRL_NAME_MAX-1 bytes from tok_text into dst.
  * Returns the number of bytes written. */
 static int tok_to_upper_name(const struct irx_token *t,
-                              char *dst, int dst_max)
+                             char *dst, int dst_max)
 {
     int n = (int)t->tok_length;
     int i;
-    if (n >= dst_max) n = dst_max - 1;
-    for (i = 0; i < n; i++) {
+    if (n >= dst_max)
+    {
+        n = dst_max - 1;
+    }
+    for (i = 0; i < n; i++)
+    {
         int c = (unsigned char)t->tok_text[i];
         dst[i] = (char)(islower(c) ? toupper(c) : c);
     }
@@ -51,20 +55,25 @@ static int label_table_grow(struct irx_label_table *lt)
     size_t new_size = (size_t)new_cap * sizeof(struct irx_label);
 
     new_entries = (struct irx_label *)
-        lt->alloc->alloc(new_size, lt->alloc->ctx);
-    if (new_entries == NULL) return -1;
+                      lt->alloc->alloc(new_size, lt->alloc->ctx);
+    if (new_entries == NULL)
+    {
+        return -1;
+    }
 
-    if (lt->count > 0 && lt->entries != NULL) {
+    if (lt->count > 0 && lt->entries != NULL)
+    {
         memcpy(new_entries, lt->entries,
                (size_t)lt->count * sizeof(struct irx_label));
     }
-    if (lt->entries != NULL && lt->cap > 0) {
+    if (lt->entries != NULL && lt->cap > 0)
+    {
         lt->alloc->dealloc(lt->entries,
                            (size_t)lt->cap * sizeof(struct irx_label),
                            lt->alloc->ctx);
     }
     lt->entries = new_entries;
-    lt->cap     = new_cap;
+    lt->cap = new_cap;
     return 0;
 }
 
@@ -79,20 +88,25 @@ static int exec_stack_grow(struct irx_exec_stack *es)
     size_t new_size = (size_t)new_cap * sizeof(struct irx_exec_frame);
 
     new_frames = (struct irx_exec_frame *)
-        es->alloc->alloc(new_size, es->alloc->ctx);
-    if (new_frames == NULL) return -1;
+                     es->alloc->alloc(new_size, es->alloc->ctx);
+    if (new_frames == NULL)
+    {
+        return -1;
+    }
 
-    if (es->top > 0 && es->frames != NULL) {
+    if (es->top > 0 && es->frames != NULL)
+    {
         memcpy(new_frames, es->frames,
                (size_t)es->top * sizeof(struct irx_exec_frame));
     }
-    if (es->frames != NULL && es->cap > 0) {
+    if (es->frames != NULL && es->cap > 0)
+    {
         es->alloc->dealloc(es->frames,
                            (size_t)es->cap * sizeof(struct irx_exec_frame),
                            es->alloc->ctx);
     }
     es->frames = new_frames;
-    es->cap    = new_cap;
+    es->cap = new_cap;
     return 0;
 }
 
@@ -103,19 +117,23 @@ static int exec_stack_grow(struct irx_exec_stack *es)
 int irx_ctrl_init(struct irx_parser *p)
 {
     struct irx_label_table *lt;
-    struct irx_exec_stack  *es;
+    struct irx_exec_stack *es;
     size_t lt_size = sizeof(struct irx_label_table);
     size_t es_size = sizeof(struct irx_exec_stack);
 
     lt = (struct irx_label_table *)
-        p->alloc->alloc(lt_size, p->alloc->ctx);
-    if (lt == NULL) return IRXPARS_NOMEM;
+             p->alloc->alloc(lt_size, p->alloc->ctx);
+    if (lt == NULL)
+    {
+        return IRXPARS_NOMEM;
+    }
     memset(lt, 0, lt_size);
     lt->alloc = p->alloc;
 
     es = (struct irx_exec_stack *)
-        p->alloc->alloc(es_size, p->alloc->ctx);
-    if (es == NULL) {
+             p->alloc->alloc(es_size, p->alloc->ctx);
+    if (es == NULL)
+    {
         p->alloc->dealloc(lt, lt_size, p->alloc->ctx);
         return IRXPARS_NOMEM;
     }
@@ -123,20 +141,25 @@ int irx_ctrl_init(struct irx_parser *p)
     es->alloc = p->alloc;
 
     p->label_table = lt;
-    p->exec_stack  = es;
+    p->exec_stack = es;
     return IRXPARS_OK;
 }
 
 void irx_ctrl_cleanup(struct irx_parser *p)
 {
     struct irx_label_table *lt;
-    struct irx_exec_stack  *es;
+    struct irx_exec_stack *es;
 
-    if (p == NULL) return;
+    if (p == NULL)
+    {
+        return;
+    }
 
     lt = (struct irx_label_table *)p->label_table;
-    if (lt != NULL) {
-        if (lt->entries != NULL && lt->cap > 0) {
+    if (lt != NULL)
+    {
+        if (lt->entries != NULL && lt->cap > 0)
+        {
             lt->alloc->dealloc(lt->entries,
                                (size_t)lt->cap * sizeof(struct irx_label),
                                lt->alloc->ctx);
@@ -147,8 +170,10 @@ void irx_ctrl_cleanup(struct irx_parser *p)
     }
 
     es = (struct irx_exec_stack *)p->exec_stack;
-    if (es != NULL) {
-        if (es->frames != NULL && es->cap > 0) {
+    if (es != NULL)
+    {
+        if (es->frames != NULL && es->cap > 0)
+        {
             es->alloc->dealloc(es->frames,
                                (size_t)es->cap * sizeof(struct irx_exec_frame),
                                es->alloc->ctx);
@@ -165,28 +190,48 @@ int irx_ctrl_label_scan(struct irx_parser *p)
         (struct irx_label_table *)p->label_table;
     int i;
 
-    if (lt == NULL) return IRXPARS_NOMEM;
+    if (lt == NULL)
+    {
+        return IRXPARS_NOMEM;
+    }
 
     /* Reset existing table from any prior scan. */
     lt->count = 0;
 
-    for (i = 0; i + 1 < p->tok_count; i++) {
+    for (i = 0; i + 1 < p->tok_count; i++)
+    {
         const struct irx_token *t0 = &p->tokens[i];
         const struct irx_token *t1 = &p->tokens[i + 1];
 
-        if (t0->tok_type != TOK_SYMBOL) continue;
-        if (t0->tok_flags & TOKF_CONSTANT) continue;
-        if (t1->tok_type != TOK_SEMICOLON) continue;
-        if (t1->tok_length != 1 || t1->tok_text[0] != ':') continue;
+        if (t0->tok_type != TOK_SYMBOL)
+        {
+            continue;
+        }
+        if (t0->tok_flags & TOKF_CONSTANT)
+        {
+            continue;
+        }
+        if (t1->tok_type != TOK_SEMICOLON)
+        {
+            continue;
+        }
+        if (t1->tok_length != 1 || t1->tok_text[0] != ':')
+        {
+            continue;
+        }
 
         /* Found SYMBOL ':' — a label. */
-        if (lt->count >= lt->cap) {
-            if (label_table_grow(lt) != 0) return IRXPARS_NOMEM;
+        if (lt->count >= lt->cap)
+        {
+            if (label_table_grow(lt) != 0)
+            {
+                return IRXPARS_NOMEM;
+            }
         }
         struct irx_label *lbl = &lt->entries[lt->count];
         lbl->name_len = tok_to_upper_name(t0, lbl->name,
-                                           CTRL_NAME_MAX);
-        lbl->tok_pos  = i;   /* position of the SYMBOL token     */
+                                          CTRL_NAME_MAX);
+        lbl->tok_pos = i; /* position of the SYMBOL token     */
         lt->count++;
     }
     return IRXPARS_OK;
@@ -199,11 +244,16 @@ int irx_ctrl_label_find(struct irx_parser *p,
         (struct irx_label_table *)p->label_table;
     int i;
 
-    if (lt == NULL || name == NULL || name_len <= 0) return -1;
+    if (lt == NULL || name == NULL || name_len <= 0)
+    {
+        return -1;
+    }
 
-    for (i = 0; i < lt->count; i++) {
+    for (i = 0; i < lt->count; i++)
+    {
         if (lt->entries[i].name_len == name_len &&
-            memcmp(lt->entries[i].name, name, (size_t)name_len) == 0) {
+            memcmp(lt->entries[i].name, name, (size_t)name_len) == 0)
+        {
             return lt->entries[i].tok_pos;
         }
     }
@@ -216,14 +266,21 @@ struct irx_exec_frame *irx_ctrl_frame_push(struct irx_parser *p,
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
     struct irx_exec_frame *frame;
 
-    if (es == NULL) return NULL;
-    if (es->top >= es->cap) {
-        if (exec_stack_grow(es) != 0) return NULL;
+    if (es == NULL)
+    {
+        return NULL;
+    }
+    if (es->top >= es->cap)
+    {
+        if (exec_stack_grow(es) != 0)
+        {
+            return NULL;
+        }
     }
     frame = &es->frames[es->top++];
     memset(frame, 0, sizeof(*frame));
     frame->frame_type = frame_type;
-    frame->loop_end   = -1;
+    frame->loop_end = -1;
     frame->select_end = -1;
     frame->first_iter = 1;
     return frame;
@@ -232,14 +289,20 @@ struct irx_exec_frame *irx_ctrl_frame_push(struct irx_parser *p,
 struct irx_exec_frame *irx_ctrl_frame_top(struct irx_parser *p)
 {
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
-    if (es == NULL || es->top <= 0) return NULL;
+    if (es == NULL || es->top <= 0)
+    {
+        return NULL;
+    }
     return &es->frames[es->top - 1];
 }
 
 void irx_ctrl_frame_pop(struct irx_parser *p)
 {
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
-    if (es == NULL || es->top <= 0) return;
+    if (es == NULL || es->top <= 0)
+    {
+        return;
+    }
     es->top--;
 }
 
@@ -249,14 +312,25 @@ int irx_ctrl_find_do(struct irx_parser *p,
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
     int i;
 
-    if (es == NULL) return -1;
+    if (es == NULL)
+    {
+        return -1;
+    }
 
-    for (i = es->top - 1; i >= 0; i--) {
-        if (es->frames[i].frame_type != FRAME_DO) continue;
-        if (label == NULL || label_len <= 0) return i;  /* any DO */
+    for (i = es->top - 1; i >= 0; i--)
+    {
+        if (es->frames[i].frame_type != FRAME_DO)
+        {
+            continue;
+        }
+        if (label == NULL || label_len <= 0)
+        {
+            return i; /* any DO */
+        }
         if (es->frames[i].do_label_len == label_len &&
             memcmp(es->frames[i].do_label, label,
-                   (size_t)label_len) == 0) {
+                   (size_t)label_len) == 0)
+        {
             return i;
         }
     }

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -13,75 +13,100 @@
 #include <string.h>
 
 #include "irx.h"
-#include "irxfunc.h"
+#include "irxctrl.h"
 #include "irxexec.h"
+#include "irxfunc.h"
 #include "irxlstr.h"
+#include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
-#include "irxpars.h"
-#include "irxctrl.h"
 
 int irx_exec_run(const char *source, int source_len,
                  const char *args, int args_len,
                  int *rc_out, struct envblock *envblock)
 {
-    int                   own_env   = 0;
-    struct irx_token     *tokens    = NULL;
-    int                   tok_count = 0;
+    int own_env = 0;
+    struct irx_token *tokens = NULL;
+    int tok_count = 0;
     struct irx_tokn_error tok_err;
-    struct lstr_alloc    *alloc     = NULL;
-    struct irx_vpool     *vpool     = NULL;
-    struct irx_parser     parser;
-    int                   rc;
+    struct lstr_alloc *alloc = NULL;
+    struct irx_vpool *vpool = NULL;
+    struct irx_parser parser;
+    int rc;
 
-    memset(&parser,  0, sizeof(parser));
+    memset(&parser, 0, sizeof(parser));
     memset(&tok_err, 0, sizeof(tok_err));
 
     /* 1. Environment ------------------------------------------------ */
-    if (envblock == NULL) {
+    if (envblock == NULL)
+    {
         rc = irxinit(NULL, &envblock);
-        if (rc != 0) return rc;
+        if (rc != 0)
+        {
+            return rc;
+        }
         own_env = 1;
     }
 
     /* 2. Allocator bridge (WP-11b) ---------------------------------- */
     alloc = irx_lstr_init(envblock);
-    if (alloc == NULL) { rc = 20; goto cleanup; }
+    if (alloc == NULL)
+    {
+        rc = 20;
+        goto cleanup;
+    }
 
     /* 3. Tokenize --------------------------------------------------- */
     rc = irx_tokn_run(envblock, source, source_len,
                       &tokens, &tok_count, &tok_err);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
 
     /* 4. Variable pool ---------------------------------------------- */
     vpool = vpool_create(alloc, NULL);
-    if (vpool == NULL) { rc = 20; goto cleanup; }
+    if (vpool == NULL)
+    {
+        rc = 20;
+        goto cleanup;
+    }
 
     /* 5. Parser init ------------------------------------------------- */
     rc = irx_pars_init(&parser, tokens, tok_count, vpool, alloc, envblock);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
 
     /* 5b. Top-level argument setup (WP-17) -------------------------- */
-    if (args != NULL && args_len > 0) {
+    if (args != NULL && args_len > 0)
+    {
         Lstr *la;
-        int  *le;
+        int *le;
         la = (Lstr *)alloc->alloc(
             (size_t)IRX_MAX_ARGS * sizeof(Lstr), alloc->ctx);
-        le = (int  *)alloc->alloc(
-            (size_t)IRX_MAX_ARGS * sizeof(int),  alloc->ctx);
-        if (la == NULL || le == NULL) {
+        le = (int *)alloc->alloc(
+            (size_t)IRX_MAX_ARGS * sizeof(int), alloc->ctx);
+        if (la == NULL || le == NULL)
+        {
             if (la != NULL)
+            {
                 alloc->dealloc(la, (size_t)IRX_MAX_ARGS * sizeof(Lstr),
                                alloc->ctx);
+            }
             if (le != NULL)
+            {
                 alloc->dealloc(le, (size_t)IRX_MAX_ARGS * sizeof(int),
                                alloc->ctx);
+            }
             rc = 20;
             goto cleanup;
         }
         memset(la, 0, (size_t)IRX_MAX_ARGS * sizeof(Lstr));
         memset(le, 0, (size_t)IRX_MAX_ARGS * sizeof(int));
-        if (Lfx(alloc, &la[0], (size_t)args_len) != LSTR_OK) {
+        if (Lfx(alloc, &la[0], (size_t)args_len) != LSTR_OK)
+        {
             alloc->dealloc(la, (size_t)IRX_MAX_ARGS * sizeof(Lstr),
                            alloc->ctx);
             alloc->dealloc(le, (size_t)IRX_MAX_ARGS * sizeof(int),
@@ -90,29 +115,43 @@ int irx_exec_run(const char *source, int source_len,
             goto cleanup;
         }
         memcpy(la[0].pstr, args, (size_t)args_len);
-        la[0].len  = (size_t)args_len;
+        la[0].len = (size_t)args_len;
         la[0].type = LSTRING_TY;
-        le[0]                = 1;
-        parser.call_args       = la;
+        le[0] = 1;
+        parser.call_args = la;
         parser.call_arg_exists = le;
-        parser.call_argc       = 1;
+        parser.call_argc = 1;
     }
 
     /* 6. Label scan ------------------------------------------------- */
     rc = irx_ctrl_label_scan(&parser);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
 
     /* 7. Execute ----------------------------------------------------- */
     rc = irx_pars_run(&parser);
 
     if (rc_out != NULL)
+    {
         *rc_out = parser.exit_rc;
+    }
 
 cleanup:
     irx_ctrl_cleanup(&parser);
     irx_pars_cleanup(&parser);
-    if (vpool  != NULL) vpool_destroy(vpool);
-    if (tokens != NULL) irx_tokn_free(envblock, tokens, tok_count);
-    if (own_env)        irxterm(envblock);
+    if (vpool != NULL)
+    {
+        vpool_destroy(vpool);
+    }
+    if (tokens != NULL)
+    {
+        irx_tokn_free(envblock, tokens, tok_count);
+    }
+    if (own_env)
+    {
+        irxterm(envblock);
+    }
     return rc;
 }

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -13,28 +13,31 @@
 /* ------------------------------------------------------------------ */
 
 #include <string.h>
+
 #include "irx.h"
-#include "irxrab.h"
-#include "irxwkblk.h"
 #include "irxfunc.h"
 #include "irxio.h"
+#include "irxrab.h"
+#include "irxwkblk.h"
 
 /* Default host command environments */
-#define DEFAULT_HOSTENV_TSO     "TSO     "
-#define DEFAULT_HOSTENV_MVS     "MVS     "
-#define DEFAULT_HOSTENV_LINK    "LINK    "
-#define DEFAULT_HANDLER_NAME    "IRXSTAM "
+#define DEFAULT_HOSTENV_TSO  "TSO     "
+#define DEFAULT_HOSTENV_MVS  "MVS     "
+#define DEFAULT_HOSTENV_LINK "LINK    "
+#define DEFAULT_HANDLER_NAME "IRXSTAM "
 
 /* Default number of subcommand table entries */
-#define DEFAULT_SUBCOMTB_ENTRIES    8
+#define DEFAULT_SUBCOMTB_ENTRIES 8
 
 /* Internal helper: allocate via irxstor with error propagation */
-#define ALLOC(ptr, size, envblk) \
-    do { \
-        void *_tmp = NULL; \
+#define ALLOC(ptr, size, envblk)                                  \
+    do                                                            \
+    {                                                             \
+        void *_tmp = NULL;                                        \
         int _rc = irxstor(RXSMGET, (int)(size), &_tmp, (envblk)); \
-        if (_rc != 0) goto cleanup; \
-        (ptr) = _tmp; \
+        if (_rc != 0)                                             \
+            goto cleanup;                                         \
+        (ptr) = _tmp;                                             \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -49,8 +52,8 @@ static int init_parmblock(struct parmblock **pb_out,
 
     ALLOC(pb, sizeof(struct parmblock), envblk);
 
-    memcpy(pb->parmblock_id,      PARMBLOCK_ID,            8);
-    memcpy(pb->parmblock_version, PARMBLOCK_VERSION_0200,  4);
+    memcpy(pb->parmblock_id, PARMBLOCK_ID, 8);
+    memcpy(pb->parmblock_version, PARMBLOCK_VERSION_0200, 4);
     memcpy(pb->parmblock_language, "ENU", 3);
 
     /* Default flags: nothing special */
@@ -79,7 +82,7 @@ static int init_subcomtb(struct subcomtb_header **hdr_out,
                          struct envblock *envblk)
 {
     struct subcomtb_header *hdr = NULL;
-    struct subcomtb_entry  *entries = NULL;
+    struct subcomtb_entry *entries = NULL;
     int used = 0;
 
     ALLOC(hdr, sizeof(struct subcomtb_header), envblk);
@@ -87,27 +90,27 @@ static int init_subcomtb(struct subcomtb_header **hdr_out,
           envblk);
 
     /* MVS environment (always present) */
-    memcpy(entries[used].subcomtb_name,    DEFAULT_HOSTENV_MVS,  8);
+    memcpy(entries[used].subcomtb_name, DEFAULT_HOSTENV_MVS, 8);
     memcpy(entries[used].subcomtb_routine, DEFAULT_HANDLER_NAME, 8);
     memset(entries[used].subcomtb_token, ' ', 16);
     used++;
 
     /* TSO environment (if TSO flag set or running under TSO) */
-    memcpy(entries[used].subcomtb_name,    DEFAULT_HOSTENV_TSO,  8);
+    memcpy(entries[used].subcomtb_name, DEFAULT_HOSTENV_TSO, 8);
     memcpy(entries[used].subcomtb_routine, DEFAULT_HANDLER_NAME, 8);
     memset(entries[used].subcomtb_token, ' ', 16);
     used++;
 
     /* LINK environment */
-    memcpy(entries[used].subcomtb_name,    DEFAULT_HOSTENV_LINK, 8);
+    memcpy(entries[used].subcomtb_name, DEFAULT_HOSTENV_LINK, 8);
     memcpy(entries[used].subcomtb_routine, DEFAULT_HANDLER_NAME, 8);
     memset(entries[used].subcomtb_token, ' ', 16);
     used++;
 
     /* Populate header */
-    hdr->subcomtb_first  = entries;
-    hdr->subcomtb_total  = DEFAULT_SUBCOMTB_ENTRIES;
-    hdr->subcomtb_used   = used;
+    hdr->subcomtb_first = entries;
+    hdr->subcomtb_total = DEFAULT_SUBCOMTB_ENTRIES;
+    hdr->subcomtb_used = used;
     hdr->subcomtb_length = SUBCOMTB_ENTRY_LEN;
     memcpy(hdr->subcomtb_initial, DEFAULT_HOSTENV_MVS, 8);
     memset(hdr->_filler1, 0, 8);
@@ -121,11 +124,13 @@ static int init_subcomtb(struct subcomtb_header **hdr_out,
 
 cleanup:
     /* Partial cleanup */
-    if (entries != NULL) {
+    if (entries != NULL)
+    {
         void *p = entries;
         irxstor(RXSMFRE, 0, &p, envblk);
     }
-    if (hdr != NULL) {
+    if (hdr != NULL)
+    {
         void *p = hdr;
         irxstor(RXSMFRE, 0, &p, envblk);
     }
@@ -155,36 +160,36 @@ static int init_irxexte(struct irxexte **exte_out,
      */
 
     /* Phase 1: Storage, User ID, Message ID */
-    exte->irxinit       = NULL;  /* Will be set after init completes */
-    exte->irxterm       = NULL;  /* Same */
-    exte->irxuid        = (void *)irxuid;
-    exte->userid_routine= (void *)irxuid;
-    exte->irxmsgid      = (void *)irxmsgid;
+    exte->irxinit = NULL; /* Will be set after init completes */
+    exte->irxterm = NULL; /* Same */
+    exte->irxuid = (void *)irxuid;
+    exte->userid_routine = (void *)irxuid;
+    exte->irxmsgid = (void *)irxmsgid;
     exte->msgid_routine = (void *)irxmsgid;
 
     /* Phase 2+: stubs */
-    exte->irxexec       = NULL;
-    exte->irxexcom      = NULL;
-    exte->irxjcl        = NULL;
-    exte->irxrlt        = NULL;
-    exte->irxsubcm      = NULL;
-    exte->irxic         = NULL;
-    exte->irxterma      = NULL;
-    exte->load_routine  = NULL;
-    exte->irxload       = NULL;
+    exte->irxexec = NULL;
+    exte->irxexcom = NULL;
+    exte->irxjcl = NULL;
+    exte->irxrlt = NULL;
+    exte->irxsubcm = NULL;
+    exte->irxic = NULL;
+    exte->irxterma = NULL;
+    exte->load_routine = NULL;
+    exte->irxload = NULL;
 
     /* Phase 2 (WP-14): Default and active I/O routine */
-    exte->io_routine    = (void *)irxinout;
-    exte->irxinout      = (void *)irxinout;
+    exte->io_routine = (void *)irxinout;
+    exte->irxinout = (void *)irxinout;
     exte->stack_routine = NULL;
-    exte->irxstk        = NULL;
-    exte->irxsay        = NULL;
-    exte->irxers        = NULL;
-    exte->irxhst        = NULL;
-    exte->irxhlt        = NULL;
-    exte->irxtxt        = NULL;
-    exte->irxlin        = NULL;
-    exte->irxrte        = NULL;
+    exte->irxstk = NULL;
+    exte->irxsay = NULL;
+    exte->irxers = NULL;
+    exte->irxhst = NULL;
+    exte->irxhlt = NULL;
+    exte->irxtxt = NULL;
+    exte->irxlin = NULL;
+    exte->irxrte = NULL;
 
     *exte_out = exte;
     return 0;
@@ -205,20 +210,20 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
     ALLOC(wk, sizeof(struct irx_wkblk_int), envblk);
 
     memcpy(wk->wkbi_id, WKBLK_INT_ID, 4);
-    wk->wkbi_length   = (int)sizeof(struct irx_wkblk_int);
+    wk->wkbi_length = (int)sizeof(struct irx_wkblk_int);
     wk->wkbi_envblock = envblk;
 
     /* NUMERIC defaults */
-    wk->wkbi_digits   = NUMERIC_DIGITS_DEFAULT;
-    wk->wkbi_fuzz     = NUMERIC_FUZZ_DEFAULT;
-    wk->wkbi_form     = NUMFORM_SCIENTIFIC;
+    wk->wkbi_digits = NUMERIC_DIGITS_DEFAULT;
+    wk->wkbi_fuzz = NUMERIC_FUZZ_DEFAULT;
+    wk->wkbi_form = NUMFORM_SCIENTIFIC;
 
     /* TRACE default */
-    wk->wkbi_trace    = TRACE_NORMAL;
+    wk->wkbi_trace = TRACE_NORMAL;
 
     /* Special variables */
-    wk->wkbi_sigl     = 0;
-    wk->wkbi_rc       = 0;
+    wk->wkbi_sigl = 0;
+    wk->wkbi_rc = 0;
 
     /* All pointer fields are already NULL from irxstor zero-fill */
 
@@ -251,22 +256,24 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
 {
     int rc = 0;
 
-    struct irx_rab         *rab      = NULL;
-    struct envblock        *envblk   = NULL;
-    struct parmblock       *pb       = NULL;
-    struct workblok_ext    *wkext    = NULL;
-    struct irxexte         *exte     = NULL;
-    struct subcomtb_header *subcmd   = NULL;
-    struct irx_wkblk_int   *wkbi    = NULL;
-    struct irx_env_node    *node     = NULL;
+    struct irx_rab *rab = NULL;
+    struct envblock *envblk = NULL;
+    struct parmblock *pb = NULL;
+    struct workblok_ext *wkext = NULL;
+    struct irxexte *exte = NULL;
+    struct subcomtb_header *subcmd = NULL;
+    struct irx_wkblk_int *wkbi = NULL;
+    struct irx_env_node *node = NULL;
 
-    if (envblock_ptr == NULL) {
+    if (envblock_ptr == NULL)
+    {
         return 20;
     }
 
     /* 1. Obtain RAB */
     rc = irx_rab_obtain(&rab);
-    if (rc != 0) {
+    if (rc != 0)
+    {
         return 28;
     }
 
@@ -275,18 +282,24 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
         void *storage = NULL;
         rc = irxstor(RXSMGET, (int)sizeof(struct envblock),
                      &storage, NULL);
-        if (rc != 0) goto cleanup;
+        if (rc != 0)
+        {
+            goto cleanup;
+        }
         envblk = (struct envblock *)storage;
     }
 
     /* Populate ENVBLOCK eye-catcher and version */
-    memcpy(envblk->envblock_id,      ENVBLOCK_ID,           8);
+    memcpy(envblk->envblock_id, ENVBLOCK_ID, 8);
     memcpy(envblk->envblock_version, ENVBLOCK_VERSION_0100, 4);
     envblk->envblock_length = (int)sizeof(struct envblock);
 
     /* 3. PARMBLOCK */
     rc = init_parmblock(&pb, parms, envblk);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
     envblk->envblock_parmblock = pb;
 
     /* 4. Work Block Extension (IBM standard) */
@@ -294,23 +307,35 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
         void *storage = NULL;
         rc = irxstor(RXSMGET, (int)sizeof(struct workblok_ext),
                      &storage, envblk);
-        if (rc != 0) goto cleanup;
+        if (rc != 0)
+        {
+            goto cleanup;
+        }
         wkext = (struct workblok_ext *)storage;
     }
     envblk->envblock_workblok_ext = wkext;
 
     /* 5. IRXEXTE */
     rc = init_irxexte(&exte, envblk);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
     envblk->envblock_irxexte = exte;
 
     /* 6. SUBCOMTB (host command environments) */
     rc = init_subcomtb(&subcmd, pb, envblk);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
 
     /* 7. Internal Work Block (interpreter state) */
     rc = init_wkblk_int(&wkbi, envblk);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
 
     /* Link internal work block via envblock_userfield */
     envblk->envblock_userfield = wkbi;
@@ -320,17 +345,23 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
         void *storage = NULL;
         rc = irxstor(RXSMGET, (int)sizeof(struct irx_env_node),
                      &storage, envblk);
-        if (rc != 0) goto cleanup;
+        if (rc != 0)
+        {
+            goto cleanup;
+        }
         node = (struct irx_env_node *)storage;
     }
 
     memcpy(node->node_id, ENVNODE_ID, 4);
-    node->node_length   = (int)sizeof(struct irx_env_node);
+    node->node_length = (int)sizeof(struct irx_env_node);
     node->node_envblock = envblk;
-    node->node_flags    = ENVNODE_ACTIVE;
+    node->node_flags = ENVNODE_ACTIVE;
 
     rc = irx_rab_add_env(rab, node);
-    if (rc != 0) goto cleanup;
+    if (rc != 0)
+    {
+        goto cleanup;
+    }
 
     /* 9. Init exit — deferred to Phase 6 */
 
@@ -341,28 +372,34 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
 cleanup:
     /* Reverse-order cleanup of whatever was allocated */
     /* Note: irxstor handles NULL gracefully */
-    if (node != NULL) {
+    if (node != NULL)
+    {
         void *p = node;
         irxstor(RXSMFRE, 0, &p, envblk);
     }
-    if (wkbi != NULL) {
+    if (wkbi != NULL)
+    {
         void *p = wkbi;
         irxstor(RXSMFRE, 0, &p, envblk);
     }
     /* subcmd entries freed inside init_subcomtb on its own failure */
-    if (exte != NULL) {
+    if (exte != NULL)
+    {
         void *p = exte;
         irxstor(RXSMFRE, 0, &p, envblk);
     }
-    if (wkext != NULL) {
+    if (wkext != NULL)
+    {
         void *p = wkext;
         irxstor(RXSMFRE, 0, &p, envblk);
     }
-    if (pb != NULL) {
+    if (pb != NULL)
+    {
         void *p = pb;
         irxstor(RXSMFRE, 0, &p, envblk);
     }
-    if (envblk != NULL) {
+    if (envblk != NULL)
+    {
         void *p = envblk;
         irxstor(RXSMFRE, 0, &p, NULL);
     }

--- a/src/irx#io.c
+++ b/src/irx#io.c
@@ -18,31 +18,32 @@
 #include <stdio.h>
 
 #include "irx.h"
+#include "irxio.h"
 #include "irxwkblk.h"
 #include "lstring.h"
-#include "irxio.h"
 
 int irxinout(int function, PLstr data, struct envblock *envblock)
 {
-    (void)envblock;     /* reserved for WP-33 dataset / stack I/O */
+    (void)envblock; /* reserved for WP-33 dataset / stack I/O */
 
-    switch (function) {
+    switch (function)
+    {
+        case RXFWRITE:   /* SAY output                             */
+        case RXFWRITERR: /* Error message output                   */
+        case RXFTWRITE:  /* Trace output                           */
+            if (data != NULL && data->pstr != NULL && data->len > 0)
+            {
+                fwrite(data->pstr, 1, (size_t)data->len, stdout);
+            }
+            fputc('\n', stdout);
+            return 0;
 
-    case RXFWRITE:      /* SAY output                             */
-    case RXFWRITERR:    /* Error message output                   */
-    case RXFTWRITE:     /* Trace output                           */
-        if (data != NULL && data->pstr != NULL && data->len > 0) {
-            fwrite(data->pstr, 1, (size_t)data->len, stdout);
-        }
-        fputc('\n', stdout);
-        return 0;
+        case RXFREAD:  /* PULL from terminal (WP-33)             */
+        case RXFREADP: /* PULL from stack then terminal (WP-33)  */
+            /* TODO WP-33: implement PULL / LINEIN */
+            return 20;
 
-    case RXFREAD:       /* PULL from terminal (WP-33)             */
-    case RXFREADP:      /* PULL from stack then terminal (WP-33)  */
-        /* TODO WP-33: implement PULL / LINEIN */
-        return 20;
-
-    default:
-        return 20;
+        default:
+            return 20;
     }
 }

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -8,15 +8,15 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
+#include <ctype.h>
 #include <stddef.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "irx.h"
-#include "irxwkblk.h"
 #include "irxfunc.h"
-#include "lstring.h"
 #include "irxlstr.h"
+#include "irxwkblk.h"
+#include "lstring.h"
 
 /* ------------------------------------------------------------------ */
 /*  Allocator bridge                                                  */
@@ -30,46 +30,59 @@
 static void *rexx_lstr_alloc(size_t size, void *ctx)
 {
     struct envblock *env = (struct envblock *)ctx;
-    void            *ptr = NULL;
-    int              rc;
+    void *ptr = NULL;
+    int rc;
 
     rc = irxstor(RXSMGET, (int)size, &ptr, env);
-    if (rc != 0) return NULL;
+    if (rc != 0)
+    {
+        return NULL;
+    }
     return ptr;
 }
 
 static void rexx_lstr_dealloc(void *ptr, size_t size, void *ctx)
 {
     struct envblock *env = (struct envblock *)ctx;
-    void            *p   = ptr;
+    void *p = ptr;
 
-    (void)size;   /* irxstor's free path doesn't use the length */
+    (void)size; /* irxstor's free path doesn't use the length */
     irxstor(RXSMFRE, (int)size, &p, env);
 }
 
 struct lstr_alloc *irx_lstr_init(struct envblock *envblock)
 {
     struct irx_wkblk_int *wkbi;
-    struct lstr_alloc    *alloc;
-    void                 *mem = NULL;
-    int                   rc;
+    struct lstr_alloc *alloc;
+    void *mem = NULL;
+    int rc;
 
-    if (envblock == NULL) return NULL;
+    if (envblock == NULL)
+    {
+        return NULL;
+    }
 
     wkbi = (struct irx_wkblk_int *)envblock->envblock_userfield;
-    if (wkbi == NULL) return NULL;
+    if (wkbi == NULL)
+    {
+        return NULL;
+    }
 
-    if (wkbi->wkbi_lstr_alloc != NULL) {
+    if (wkbi->wkbi_lstr_alloc != NULL)
+    {
         return (struct lstr_alloc *)wkbi->wkbi_lstr_alloc;
     }
 
     rc = irxstor(RXSMGET, (int)sizeof(struct lstr_alloc), &mem, envblock);
-    if (rc != 0) return NULL;
+    if (rc != 0)
+    {
+        return NULL;
+    }
 
     alloc = (struct lstr_alloc *)mem;
-    alloc->alloc   = rexx_lstr_alloc;
+    alloc->alloc = rexx_lstr_alloc;
     alloc->dealloc = rexx_lstr_dealloc;
-    alloc->ctx     = envblock;
+    alloc->ctx = envblock;
 
     wkbi->wkbi_lstr_alloc = alloc;
     return alloc;
@@ -93,39 +106,77 @@ struct lstr_alloc *irx_lstr_init(struct envblock *envblock)
 static int classify_number(const unsigned char *p, size_t n)
 {
     size_t i = 0;
-    int    saw_dot      = 0;
-    int    saw_exp      = 0;
-    int    saw_mantissa = 0;
+    int saw_dot = 0;
+    int saw_exp = 0;
+    int saw_mantissa = 0;
 
     /* Leading whitespace */
-    while (i < n && isspace(p[i])) i++;
-    if (i >= n) return LNUM_NOT_NUM;
+    while (i < n && isspace(p[i]))
+    {
+        i++;
+    }
+    if (i >= n)
+    {
+        return LNUM_NOT_NUM;
+    }
 
     /* Optional sign */
-    if (p[i] == '+' || p[i] == '-') i++;
+    if (p[i] == '+' || p[i] == '-')
+    {
+        i++;
+    }
 
     /* Mantissa: digits, optional dot, optional digits; or . digits */
-    while (i < n && isdigit(p[i])) { i++; saw_mantissa = 1; }
-    if (i < n && p[i] == '.') {
+    while (i < n && isdigit(p[i]))
+    {
+        i++;
+        saw_mantissa = 1;
+    }
+    if (i < n && p[i] == '.')
+    {
         saw_dot = 1;
         i++;
-        while (i < n && isdigit(p[i])) { i++; saw_mantissa = 1; }
+        while (i < n && isdigit(p[i]))
+        {
+            i++;
+            saw_mantissa = 1;
+        }
     }
-    if (!saw_mantissa) return LNUM_NOT_NUM;
+    if (!saw_mantissa)
+    {
+        return LNUM_NOT_NUM;
+    }
 
     /* Optional exponent */
-    if (i < n && (p[i] == 'E' || p[i] == 'e')) {
+    if (i < n && (p[i] == 'E' || p[i] == 'e'))
+    {
         int saw_exp_digit = 0;
         saw_exp = 1;
         i++;
-        if (i < n && (p[i] == '+' || p[i] == '-')) i++;
-        while (i < n && isdigit(p[i])) { i++; saw_exp_digit = 1; }
-        if (!saw_exp_digit) return LNUM_NOT_NUM;
+        if (i < n && (p[i] == '+' || p[i] == '-'))
+        {
+            i++;
+        }
+        while (i < n && isdigit(p[i]))
+        {
+            i++;
+            saw_exp_digit = 1;
+        }
+        if (!saw_exp_digit)
+        {
+            return LNUM_NOT_NUM;
+        }
     }
 
     /* Trailing whitespace */
-    while (i < n && isspace(p[i])) i++;
-    if (i != n) return LNUM_NOT_NUM;
+    while (i < n && isspace(p[i]))
+    {
+        i++;
+    }
+    if (i != n)
+    {
+        return LNUM_NOT_NUM;
+    }
 
     return (saw_dot || saw_exp) ? LNUM_REAL : LNUM_INTEGER;
 }
@@ -134,14 +185,32 @@ int _Lisnum(PLstr s)
 {
     int class;
 
-    if (s == NULL) return LNUM_NOT_NUM;
-    if (s->type == LINTEGER_TY) return LNUM_INTEGER;
-    if (s->type == LREAL_TY)    return LNUM_REAL;
-    if (s->pstr == NULL || s->len == 0) return LNUM_NOT_NUM;
+    if (s == NULL)
+    {
+        return LNUM_NOT_NUM;
+    }
+    if (s->type == LINTEGER_TY)
+    {
+        return LNUM_INTEGER;
+    }
+    if (s->type == LREAL_TY)
+    {
+        return LNUM_REAL;
+    }
+    if (s->pstr == NULL || s->len == 0)
+    {
+        return LNUM_NOT_NUM;
+    }
 
     class = classify_number(s->pstr, s->len);
-    if (class == LNUM_INTEGER) s->type = LINTEGER_TY;
-    else if (class == LNUM_REAL) s->type = LREAL_TY;
+    if (class == LNUM_INTEGER)
+    {
+        s->type = LINTEGER_TY;
+    }
+    else if (class == LNUM_REAL)
+    {
+        s->type = LREAL_TY;
+    }
     return class;
 }
 
@@ -155,39 +224,78 @@ int _Lisnum(PLstr s)
 
 static int is_symbol_char(int c)
 {
-    if (isalnum(c)) return 1;
-    switch (c) {
-    case '_': case '@': case '#': case '$':
-    case '?': case '!': case '.':
+    if (isalnum(c))
+    {
         return 1;
-    default:
-        return 0;
+    }
+    switch (c)
+    {
+        case '_':
+        case '@':
+        case '#':
+        case '$':
+        case '?':
+        case '!':
+        case '.':
+            return 1;
+        default:
+            return 0;
     }
 }
 
 static int all_match(const unsigned char *p, size_t n, int (*pred)(int))
 {
     size_t i;
-    for (i = 0; i < n; i++) {
-        if (!pred(p[i])) return 0;
+    for (i = 0; i < n; i++)
+    {
+        if (!pred(p[i]))
+        {
+            return 0;
+        }
     }
     return 1;
 }
 
-static int is_binary_char(int c) { return c == '0' || c == '1'; }
-static int is_alnum(int c)       { return isalnum(c); }
-static int is_lower(int c)       { return islower(c); }
-static int is_upper(int c)       { return isupper(c); }
-static int is_alpha(int c)       { return isalpha(c); }
+static int is_binary_char(int c)
+{
+    return c == '0' || c == '1';
+}
+
+static int is_alnum(int c)
+{
+    return isalnum(c);
+}
+
+static int is_lower(int c)
+{
+    return islower(c);
+}
+
+static int is_upper(int c)
+{
+    return isupper(c);
+}
+
+static int is_alpha(int c)
+{
+    return isalpha(c);
+}
 
 /* Hex with embedded blanks allowed between byte boundaries. */
 static int check_hex(const unsigned char *p, size_t n)
 {
     size_t i;
     size_t digits = 0;
-    for (i = 0; i < n; i++) {
-        if (p[i] == ' ' || p[i] == '\t') continue;
-        if (!isxdigit(p[i])) return 0;
+    for (i = 0; i < n; i++)
+    {
+        if (p[i] == ' ' || p[i] == '\t')
+        {
+            continue;
+        }
+        if (!isxdigit(p[i]))
+        {
+            return 0;
+        }
         digits++;
     }
     return digits > 0;
@@ -203,47 +311,51 @@ static int check_whole(const unsigned char *p, size_t n)
 
 int irx_datatype(PLstr s, char option)
 {
-    if (s == NULL || s->pstr == NULL || s->len == 0) return 0;
-
-    switch (option) {
-    case '\0':
-    case 'N':
-    case 'n':
-        return classify_number(s->pstr, s->len) != LNUM_NOT_NUM;
-
-    case 'A':
-    case 'a':
-        return all_match(s->pstr, s->len, is_alnum);
-
-    case 'B':
-    case 'b':
-        return all_match(s->pstr, s->len, is_binary_char);
-
-    case 'L':
-    case 'l':
-        return all_match(s->pstr, s->len, is_lower);
-
-    case 'M':
-    case 'm':
-        return all_match(s->pstr, s->len, is_alpha);
-
-    case 'S':
-    case 's':
-        return all_match(s->pstr, s->len, is_symbol_char);
-
-    case 'U':
-    case 'u':
-        return all_match(s->pstr, s->len, is_upper);
-
-    case 'W':
-    case 'w':
-        return check_whole(s->pstr, s->len);
-
-    case 'X':
-    case 'x':
-        return check_hex(s->pstr, s->len);
-
-    default:
+    if (s == NULL || s->pstr == NULL || s->len == 0)
+    {
         return 0;
+    }
+
+    switch (option)
+    {
+        case '\0':
+        case 'N':
+        case 'n':
+            return classify_number(s->pstr, s->len) != LNUM_NOT_NUM;
+
+        case 'A':
+        case 'a':
+            return all_match(s->pstr, s->len, is_alnum);
+
+        case 'B':
+        case 'b':
+            return all_match(s->pstr, s->len, is_binary_char);
+
+        case 'L':
+        case 'l':
+            return all_match(s->pstr, s->len, is_lower);
+
+        case 'M':
+        case 'm':
+            return all_match(s->pstr, s->len, is_alpha);
+
+        case 'S':
+        case 's':
+            return all_match(s->pstr, s->len, is_symbol_char);
+
+        case 'U':
+        case 'u':
+            return all_match(s->pstr, s->len, is_upper);
+
+        case 'W':
+        case 'w':
+            return check_whole(s->pstr, s->len);
+
+        case 'X':
+        case 'x':
+            return check_hex(s->pstr, s->len);
+
+        default:
+            return 0;
     }
 }

--- a/src/irx#msid.c
+++ b/src/irx#msid.c
@@ -11,32 +11,35 @@
 /* ------------------------------------------------------------------ */
 
 #include <string.h>
+
 #include "irx.h"
 #include "irxfunc.h"
 
-#define MSGID_GET   0
-#define MSGID_SET   1
+#define MSGID_GET 0
+#define MSGID_SET 1
 
 static char default_prefix[4] = "IRX";
 
 int irxmsgid(int function, char *prefix, struct envblock *envblock)
 {
-    (void)envblock;  /* unused for now */
+    (void)envblock; /* unused for now */
 
-    if (prefix == NULL) {
+    if (prefix == NULL)
+    {
         return 20;
     }
 
-    switch (function) {
-    case MSGID_GET:
-        memcpy(prefix, default_prefix, 3);
-        return 0;
+    switch (function)
+    {
+        case MSGID_GET:
+            memcpy(prefix, default_prefix, 3);
+            return 0;
 
-    case MSGID_SET:
-        memcpy(default_prefix, prefix, 3);
-        return 0;
+        case MSGID_SET:
+            memcpy(default_prefix, prefix, 3);
+            return 0;
 
-    default:
-        return 20;
+        default:
+            return 20;
     }
 }

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -13,21 +13,21 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#include <stddef.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdio.h>
 #include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "irx.h"
-#include "irxwkblk.h"
-#include "lstring.h"
-#include "lstralloc.h"
+#include "irxctrl.h"
 #include "irxlstr.h"
+#include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
-#include "irxpars.h"
-#include "irxctrl.h"
+#include "irxwkblk.h"
+#include "lstralloc.h"
+#include "lstring.h"
 
 /* ------------------------------------------------------------------ */
 /*  Lstr scratch helpers                                              */
@@ -37,10 +37,16 @@ static int lstr_set_bytes(struct lstr_alloc *a, PLstr s,
                           const char *buf, size_t len)
 {
     int rc = Lfx(a, s, len);
-    if (rc != LSTR_OK) return rc;
-    if (len > 0) memcpy(s->pstr, buf, len);
-    s->len  = len;
-    s->type = LSTRING_TY;   /* invalidate any cached numeric type */
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
+    if (len > 0)
+    {
+        memcpy(s->pstr, buf, len);
+    }
+    s->len = len;
+    s->type = LSTRING_TY; /* invalidate any cached numeric type */
     return LSTR_OK;
 }
 
@@ -50,9 +56,11 @@ static int lstr_set_bytes(struct lstr_alloc *a, PLstr s,
 
 static int fail(struct irx_parser *p, int code)
 {
-    if (p->error_code == IRXPARS_OK) {
+    if (p->error_code == IRXPARS_OK)
+    {
         p->error_code = code;
-        if (p->tok_pos < p->tok_count) {
+        if (p->tok_pos < p->tok_count)
+        {
             p->error_line = p->tokens[p->tok_pos].tok_line;
         }
     }
@@ -66,7 +74,10 @@ static int fail(struct irx_parser *p, int code)
 static const struct irx_token *peek_tok(struct irx_parser *p, int off)
 {
     int idx = p->tok_pos + off;
-    if (idx < 0 || idx >= p->tok_count) return NULL;
+    if (idx < 0 || idx >= p->tok_count)
+    {
+        return NULL;
+    }
     return &p->tokens[idx];
 }
 
@@ -77,21 +88,36 @@ static const struct irx_token *cur_tok(struct irx_parser *p)
 
 static void advance_tok(struct irx_parser *p)
 {
-    if (p->tok_pos < p->tok_count) p->tok_pos++;
+    if (p->tok_pos < p->tok_count)
+    {
+        p->tok_pos++;
+    }
 }
 
 static int tok_is_op_char(const struct irx_token *t, unsigned char type,
                           char ch)
 {
-    if (t == NULL) return 0;
-    if (t->tok_type != type) return 0;
-    if (t->tok_length != 1) return 0;
+    if (t == NULL)
+    {
+        return 0;
+    }
+    if (t->tok_type != type)
+    {
+        return 0;
+    }
+    if (t->tok_length != 1)
+    {
+        return 0;
+    }
     return t->tok_text[0] == ch;
 }
 
 static int tok_ends_clause(const struct irx_token *t)
 {
-    if (t == NULL) return 1;
+    if (t == NULL)
+    {
+        return 1;
+    }
     return t->tok_type == TOK_EOC ||
            t->tok_type == TOK_EOF ||
            t->tok_type == TOK_SEMICOLON;
@@ -104,11 +130,16 @@ static int tok_ends_clause(const struct irx_token *t)
 static int tok_source_end_col(const struct irx_token *t)
 {
     int end = (int)t->tok_col + (int)t->tok_length;
-    switch (t->tok_type) {
-    case TOK_STRING:    return end + 2;
-    case TOK_HEXSTRING: return end + 3;
-    case TOK_BINSTRING: return end + 3;
-    default:            return end;
+    switch (t->tok_type)
+    {
+        case TOK_STRING:
+            return end + 2;
+        case TOK_HEXSTRING:
+            return end + 3;
+        case TOK_BINSTRING:
+            return end + 3;
+        default:
+            return end;
     }
 }
 
@@ -119,8 +150,14 @@ static int tok_source_end_col(const struct irx_token *t)
 static int toks_adjacent(const struct irx_token *a,
                          const struct irx_token *b)
 {
-    if (a == NULL || b == NULL) return 0;
-    if (a->tok_line != b->tok_line) return 0;
+    if (a == NULL || b == NULL)
+    {
+        return 0;
+    }
+    if (a->tok_line != b->tok_line)
+    {
+        return 0;
+    }
     return tok_source_end_col(a) == (int)b->tok_col;
 }
 
@@ -139,18 +176,32 @@ static void dedouble_string(PLstr s)
     int saw_single = 0;
     int saw_double = 0;
 
-    for (i = 0; i + 1 < s->len; i++) {
-        if (s->pstr[i] == '\'' && s->pstr[i + 1] == '\'') saw_single = 1;
-        if (s->pstr[i] == '"'  && s->pstr[i + 1] == '"')  saw_double = 1;
+    for (i = 0; i + 1 < s->len; i++)
+    {
+        if (s->pstr[i] == '\'' && s->pstr[i + 1] == '\'')
+        {
+            saw_single = 1;
+        }
+        if (s->pstr[i] == '"' && s->pstr[i + 1] == '"')
+        {
+            saw_double = 1;
+        }
     }
-    if (saw_double && !saw_single) pair = '"';
+    if (saw_double && !saw_single)
+    {
+        pair = '"';
+    }
 
-    for (i = 0; i < s->len; ) {
+    for (i = 0; i < s->len;)
+    {
         if (i + 1 < s->len && s->pstr[i] == pair &&
-            s->pstr[i + 1] == pair) {
+            s->pstr[i + 1] == pair)
+        {
             s->pstr[out++] = pair;
             i += 2;
-        } else {
+        }
+        else
+        {
             s->pstr[out++] = s->pstr[i++];
         }
     }
@@ -164,9 +215,13 @@ static void dedouble_string(PLstr s)
 static void upper_bytes(unsigned char *p, size_t n)
 {
     size_t i;
-    for (i = 0; i < n; i++) {
+    for (i = 0; i < n; i++)
+    {
         int c = p[i];
-        if (islower(c)) p[i] = (unsigned char)toupper(c);
+        if (islower(c))
+        {
+            p[i] = (unsigned char)toupper(c);
+        }
     }
 }
 
@@ -175,7 +230,10 @@ static int set_upper_from_tok(struct lstr_alloc *a, PLstr dst,
                               const struct irx_token *t)
 {
     int rc = lstr_set_bytes(a, dst, t->tok_text, t->tok_length);
-    if (rc != LSTR_OK) return rc;
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
     upper_bytes(dst->pstr, dst->len);
     return LSTR_OK;
 }
@@ -191,25 +249,44 @@ static int lstr_to_long(PLstr s, long *out)
     long v;
     size_t i, first, last;
 
-    if (_Lisnum(s) == LNUM_NOT_NUM) return 0;
+    if (_Lisnum(s) == LNUM_NOT_NUM)
+    {
+        return 0;
+    }
     /* Strip leading/trailing blanks into a local null-terminated copy. */
     first = 0;
     while (first < s->len && (s->pstr[first] == ' ' ||
-                              s->pstr[first] == '\t')) first++;
+                              s->pstr[first] == '\t'))
+    {
+        first++;
+    }
     last = s->len;
     while (last > first && (s->pstr[last - 1] == ' ' ||
-                            s->pstr[last - 1] == '\t')) last--;
-    if (last - first >= sizeof(buf)) return 0;
-    for (i = 0; i < last - first; i++) buf[i] = (char)s->pstr[first + i];
+                            s->pstr[last - 1] == '\t'))
+    {
+        last--;
+    }
+    if (last - first >= sizeof(buf))
+    {
+        return 0;
+    }
+    for (i = 0; i < last - first; i++)
+    {
+        buf[i] = (char)s->pstr[first + i];
+    }
     buf[last - first] = '\0';
 
     v = strtol(buf, &end, 10);
-    if (*end != '\0') {
+    if (*end != '\0')
+    {
         /* Allow the REAL form produced by _Lisnum by reparsing with
          * strtod - but Phase 2 stores integers, so fall back to
          * integer part via double cast. */
         double d = strtod(buf, &end);
-        if (*end != '\0') return 0;
+        if (*end != '\0')
+        {
+            return 0;
+        }
         v = (long)d;
     }
     *out = v;
@@ -220,7 +297,10 @@ static int long_to_lstr(struct lstr_alloc *a, PLstr dst, long v)
 {
     char buf[32];
     int n = sprintf(buf, "%ld", v);
-    if (n < 0) return LSTR_ERR_NOMEM;
+    if (n < 0)
+    {
+        return LSTR_ERR_NOMEM;
+    }
     return lstr_set_bytes(a, dst, buf, (size_t)n);
 }
 
@@ -241,12 +321,22 @@ static int compare_strict(PLstr a, PLstr b)
 {
     size_t n = a->len < b->len ? a->len : b->len;
     int cmp;
-    if (n > 0) {
+    if (n > 0)
+    {
         cmp = memcmp(a->pstr, b->pstr, n);
-        if (cmp != 0) return cmp < 0 ? -1 : 1;
+        if (cmp != 0)
+        {
+            return cmp < 0 ? -1 : 1;
+        }
     }
-    if (a->len < b->len) return -1;
-    if (a->len > b->len) return 1;
+    if (a->len < b->len)
+    {
+        return -1;
+    }
+    if (a->len > b->len)
+    {
+        return 1;
+    }
     return 0;
 }
 
@@ -259,9 +349,16 @@ static int compare_normal(PLstr a, PLstr b)
 
     anum = lstr_to_long(a, &la);
     bnum = lstr_to_long(b, &lb);
-    if (anum && bnum) {
-        if (la < lb) return -1;
-        if (la > lb) return 1;
+    if (anum && bnum)
+    {
+        if (la < lb)
+        {
+            return -1;
+        }
+        if (la > lb)
+        {
+            return 1;
+        }
         return 0;
     }
 
@@ -270,16 +367,29 @@ static int compare_normal(PLstr a, PLstr b)
      * dropped first; any remaining length difference is then
      * padded with spaces on the right. */
     la_len = a->len;
-    while (la_len > 0 && a->pstr[la_len - 1] == ' ') la_len--;
+    while (la_len > 0 && a->pstr[la_len - 1] == ' ')
+    {
+        la_len--;
+    }
     lb_len = b->len;
-    while (lb_len > 0 && b->pstr[lb_len - 1] == ' ') lb_len--;
+    while (lb_len > 0 && b->pstr[lb_len - 1] == ' ')
+    {
+        lb_len--;
+    }
 
     max_len = la_len > lb_len ? la_len : lb_len;
-    for (i = 0; i < max_len; i++) {
+    for (i = 0; i < max_len; i++)
+    {
         ca = (unsigned char)(i < la_len ? a->pstr[i] : ' ');
         cb = (unsigned char)(i < lb_len ? b->pstr[i] : ' ');
-        if (ca < cb) return -1;
-        if (ca > cb) return 1;
+        if (ca < cb)
+        {
+            return -1;
+        }
+        if (ca > cb)
+        {
+            return 1;
+        }
     }
     return 0;
 }
@@ -303,74 +413,100 @@ static int bif_arg(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
 {
     int n;
     char nbuf[16];
-    int  nlen;
+    int nlen;
 
     /* ARG() -> number of arguments. */
-    if (argc == 0) {
+    if (argc == 0)
+    {
         return long_to_lstr(p->alloc, result, (long)p->call_argc);
     }
 
     /* Empty index string is a syntax error. */
-    if (argv[0]->len == 0) return fail(p, IRXPARS_SYNTAX);
+    if (argv[0]->len == 0)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
     /* Get positional index n (1-based). */
     nlen = (argv[0]->len < (int)sizeof(nbuf) - 1)
-           ? (int)argv[0]->len : (int)(sizeof(nbuf) - 1);
+               ? (int)argv[0]->len
+               : (int)(sizeof(nbuf) - 1);
     memcpy(nbuf, argv[0]->pstr, (size_t)nlen);
     nbuf[nlen] = '\0';
     n = atoi(nbuf);
-    if (n < 1) return fail(p, IRXPARS_SYNTAX);
+    if (n < 1)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
-    if (argc == 1) {
+    if (argc == 1)
+    {
         /* ARG(n) -> value of argument n or "". */
         if (n <= p->call_argc && p->call_arg_exists != NULL &&
             p->call_arg_exists[n - 1] &&
-            p->call_args != NULL) {
+            p->call_args != NULL)
+        {
             int rc = Lstrcpy(p->alloc, result, &p->call_args[n - 1]);
             return (rc == LSTR_OK) ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
         }
         return (lstr_set_bytes(p->alloc, result, "", 0) == LSTR_OK)
-               ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
+                   ? IRXPARS_OK
+                   : fail(p, IRXPARS_NOMEM);
     }
 
     /* argc == 2: 'E' (exists) or 'O' (omitted) option. */
-    if (argv[1]->len != 1) return fail(p, IRXPARS_SYNTAX);
-    int   flag;
-    int   exists;
+    if (argv[1]->len != 1)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
+    int flag;
+    int exists;
     unsigned char opt = argv[1]->pstr[0];
-    char  answer;
+    char answer;
 
-    if (islower(opt)) opt = (unsigned char)toupper(opt);
+    if (islower(opt))
+    {
+        opt = (unsigned char)toupper(opt);
+    }
     exists = (n <= p->call_argc && p->call_arg_exists != NULL &&
-              p->call_arg_exists[n - 1]) ? 1 : 0;
+              p->call_arg_exists[n - 1])
+                 ? 1
+                 : 0;
 
-    if (opt == 'E') {
+    if (opt == 'E')
+    {
         flag = exists;
-    } else if (opt == 'O') {
+    }
+    else if (opt == 'O')
+    {
         flag = !exists;
-    } else {
+    }
+    else
+    {
         return fail(p, IRXPARS_SYNTAX);
     }
 
     answer = flag ? '1' : '0';
     return (lstr_set_bytes(p->alloc, result, &answer, 1) == LSTR_OK)
-           ? IRXPARS_OK : fail(p, IRXPARS_NOMEM);
+               ? IRXPARS_OK
+               : fail(p, IRXPARS_NOMEM);
 }
 
 static const struct irx_bif g_bif_table[] = {
-    { "LENGTH", 1, 1, bif_length },
-    { "ARG",    0, 2, bif_arg    }
-};
+    {"LENGTH", 1, 1, bif_length},
+    {"ARG", 0, 2, bif_arg}};
 static const int g_bif_count = (int)(sizeof(g_bif_table) /
                                      sizeof(g_bif_table[0]));
 
 static const struct irx_bif *find_bif(const unsigned char *name, size_t len)
 {
     int i;
-    for (i = 0; i < g_bif_count; i++) {
+    for (i = 0; i < g_bif_count; i++)
+    {
         const char *bn = g_bif_table[i].bif_name;
         size_t bl = strlen(bn);
-        if (bl == len && memcmp(bn, name, len) == 0) {
+        if (bl == len && memcmp(bn, name, len) == 0)
+        {
             return &g_bif_table[i];
         }
     }
@@ -394,24 +530,31 @@ static int kw_say(struct irx_parser *p)
 
     Lzeroinit(&result);
 
-    if (tok_ends_clause(cur_tok(p))) {
+    if (tok_ends_clause(cur_tok(p)))
+    {
         /* SAY with no expression -> output an empty line */
         rc = Lfx(p->alloc, &result, 0);
-        if (rc != LSTR_OK) {
+        if (rc != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
         result.len = 0;
-    } else {
+    }
+    else
+    {
         rc = irx_pars_eval_expr(p, &result);
-        if (rc != IRXPARS_OK) {
+        if (rc != IRXPARS_OK)
+        {
             Lfree(p->alloc, &result);
             return rc;
         }
     }
 
-    if (p->envblock != NULL) {
+    if (p->envblock != NULL)
+    {
         exte = (struct irxexte *)p->envblock->envblock_irxexte;
-        if (exte != NULL && exte->io_routine != NULL) {
+        if (exte != NULL && exte->io_routine != NULL)
+        {
             io_fn = (int (*)(int, PLstr, struct envblock *))exte->io_routine;
             io_fn(RXFWRITE, &result, p->envblock);
         }
@@ -426,7 +569,7 @@ static int kw_say(struct irx_parser *p)
 /* ------------------------------------------------------------------ */
 
 static int parse_add(struct irx_parser *p, PLstr out);
-static int parse_or (struct irx_parser *p, PLstr out);
+static int parse_or(struct irx_parser *p, PLstr out);
 
 /* ------------------------------------------------------------------ */
 /*  WP-15 helper: case-insensitive symbol comparison                  */
@@ -436,12 +579,25 @@ static int sym_matches(const struct irx_token *t, const char *name)
 {
     size_t n = strlen(name);
     size_t i;
-    if (t == NULL || t->tok_type != TOK_SYMBOL) return 0;
-    if ((size_t)t->tok_length != n) return 0;
-    for (i = 0; i < n; i++) {
+    if (t == NULL || t->tok_type != TOK_SYMBOL)
+    {
+        return 0;
+    }
+    if ((size_t)t->tok_length != n)
+    {
+        return 0;
+    }
+    for (i = 0; i < n; i++)
+    {
         int c = (unsigned char)t->tok_text[i];
-        if (islower(c)) c = toupper(c);
-        if (c != (unsigned char)name[i]) return 0;
+        if (islower(c))
+        {
+            c = toupper(c);
+        }
+        if (c != (unsigned char)name[i])
+        {
+            return 0;
+        }
     }
     return 1;
 }
@@ -452,8 +608,12 @@ static int sym_to_upper(const struct irx_token *t, char *dst, int dst_max)
 {
     int n = (int)t->tok_length;
     int i;
-    if (n >= dst_max) n = dst_max - 1;
-    for (i = 0; i < n; i++) {
+    if (n >= dst_max)
+    {
+        n = dst_max - 1;
+    }
+    for (i = 0; i < n; i++)
+    {
         int c = (unsigned char)t->tok_text[i];
         dst[i] = (char)(islower(c) ? toupper(c) : c);
     }
@@ -477,15 +637,22 @@ static int tok_is_kw(struct irx_parser *p, int pos, const char *kw)
     const struct irx_token *tnext;
     const struct irx_token *tnext2;
 
-    if (pos < 0 || pos >= p->tok_count) return 0;
+    if (pos < 0 || pos >= p->tok_count)
+    {
+        return 0;
+    }
     t = &p->tokens[pos];
-    if (!sym_matches(t, kw)) return 0;
+    if (!sym_matches(t, kw))
+    {
+        return 0;
+    }
     /* Exclude assignment: SYMBOL = (but not SYMBOL ==) */
-    tnext  = (pos + 1 < p->tok_count) ? &p->tokens[pos + 1] : NULL;
+    tnext = (pos + 1 < p->tok_count) ? &p->tokens[pos + 1] : NULL;
     tnext2 = (pos + 2 < p->tok_count) ? &p->tokens[pos + 2] : NULL;
     if (tok_is_op_char(tnext, TOK_COMPARISON, '=') &&
-        !tok_is_op_char(tnext2, TOK_COMPARISON, '=')) {
-        return 0;  /* it's an assignment */
+        !tok_is_op_char(tnext2, TOK_COMPARISON, '='))
+    {
+        return 0; /* it's an assignment */
     }
     return 1;
 }
@@ -493,16 +660,26 @@ static int tok_is_kw(struct irx_parser *p, int pos, const char *kw)
 static int find_end_after(struct irx_parser *p, int from)
 {
     int depth = 1;
-    int pos   = from;
+    int pos = from;
 
-    while (pos < p->tok_count) {
+    while (pos < p->tok_count)
+    {
         const struct irx_token *t = &p->tokens[pos];
-        if (t->tok_type == TOK_EOF) break;
-        if (tok_is_kw(p, pos, "DO") || tok_is_kw(p, pos, "SELECT")) {
+        if (t->tok_type == TOK_EOF)
+        {
+            break;
+        }
+        if (tok_is_kw(p, pos, "DO") || tok_is_kw(p, pos, "SELECT"))
+        {
             depth++;
-        } else if (tok_is_kw(p, pos, "END")) {
+        }
+        else if (tok_is_kw(p, pos, "END"))
+        {
             depth--;
-            if (depth == 0) return pos + 1;
+            if (depth == 0)
+            {
+                return pos + 1;
+            }
         }
         pos++;
     }
@@ -515,16 +692,32 @@ static int find_end_after(struct irx_parser *p, int from)
 static void skip_to_clause_end(struct irx_parser *p)
 {
     int depth = 0;
-    while (p->tok_pos < p->tok_count) {
+    while (p->tok_pos < p->tok_count)
+    {
         const struct irx_token *t = cur_tok(p);
-        if (t == NULL) break;
-        if (t->tok_type == TOK_LPAREN) { depth++; advance_tok(p); continue; }
-        if (t->tok_type == TOK_RPAREN) {
-            if (depth > 0) depth--;
+        if (t == NULL)
+        {
+            break;
+        }
+        if (t->tok_type == TOK_LPAREN)
+        {
+            depth++;
             advance_tok(p);
             continue;
         }
-        if (depth == 0 && tok_ends_clause(t)) break;
+        if (t->tok_type == TOK_RPAREN)
+        {
+            if (depth > 0)
+            {
+                depth--;
+            }
+            advance_tok(p);
+            continue;
+        }
+        if (depth == 0 && tok_ends_clause(t))
+        {
+            break;
+        }
         advance_tok(p);
     }
 }
@@ -540,16 +733,25 @@ static int skip_instruction(struct irx_parser *p)
 
     /* Eat leading EOC */
     while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+    {
         advance_tok(p);
+    }
 
     t = cur_tok(p);
-    if (t == NULL || t->tok_type == TOK_EOF) return IRXPARS_OK;
+    if (t == NULL || t->tok_type == TOK_EOF)
+    {
+        return IRXPARS_OK;
+    }
 
     /* DO or SELECT block: jump to token after matching END */
     if (tok_is_kw(p, p->tok_pos, "DO") ||
-        tok_is_kw(p, p->tok_pos, "SELECT")) {
+        tok_is_kw(p, p->tok_pos, "SELECT"))
+    {
         int end_pos = find_end_after(p, p->tok_pos + 1);
-        if (end_pos < 0) return fail(p, IRXPARS_SYNTAX);
+        if (end_pos < 0)
+        {
+            return fail(p, IRXPARS_SYNTAX);
+        }
         p->tok_pos = end_pos;
         return IRXPARS_OK;
     }
@@ -564,19 +766,23 @@ static int skip_instruction(struct irx_parser *p)
 
 static int set_var_str(struct irx_parser *p,
                        const char *name, int name_len,
-                       const char *val,  int val_len)
+                       const char *val, int val_len)
 {
     Lstr k, v;
-    int  rc;
+    int rc;
 
     Lzeroinit(&k);
     Lzeroinit(&v);
 
     rc = lstr_set_bytes(p->alloc, &k, name, (size_t)name_len);
-    if (rc != LSTR_OK) { return fail(p, IRXPARS_NOMEM); }
+    if (rc != LSTR_OK)
+    {
+        return fail(p, IRXPARS_NOMEM);
+    }
 
     rc = lstr_set_bytes(p->alloc, &v, val, (size_t)val_len);
-    if (rc != LSTR_OK) {
+    if (rc != LSTR_OK)
+    {
         Lfree(p->alloc, &k);
         return fail(p, IRXPARS_NOMEM);
     }
@@ -591,8 +797,11 @@ static int set_var_long(struct irx_parser *p,
                         const char *name, int name_len, long val)
 {
     char buf[32];
-    int  n = sprintf(buf, "%ld", val);
-    if (n < 0) return fail(p, IRXPARS_NOMEM);
+    int n = sprintf(buf, "%ld", val);
+    if (n < 0)
+    {
+        return fail(p, IRXPARS_NOMEM);
+    }
     return set_var_str(p, name, name_len, buf, n);
 }
 
@@ -627,60 +836,70 @@ static int do_should_iterate(struct irx_parser *p,
 {
     Lstr cond;
     long cond_val;
-    int  iterate;
+    int iterate;
 
-    switch (f->do_type) {
+    switch (f->do_type)
+    {
+        case DO_SIMPLE:
+            return 0; /* body executes once */
 
-    case DO_SIMPLE:
-        return 0;   /* body executes once */
+        case DO_FOREVER:
+            return 1;
 
-    case DO_FOREVER:
-        return 1;
+        case DO_COUNT:
+            if (f->ctrl_count <= 0)
+            {
+                return 0;
+            }
+            f->ctrl_count--;
+            return (f->ctrl_count >= 0) ? 1 : 0;
 
-    case DO_COUNT:
-        if (f->ctrl_count <= 0) return 0;
-        f->ctrl_count--;
-        return (f->ctrl_count >= 0) ? 1 : 0;
-
-    case DO_CTRL: {
-        /* Increment control variable, then check bounds. */
-        f->ctrl_val += f->ctrl_by;
-        if (f->ctrl_by >= 0) {
-            iterate = (f->ctrl_val <= f->ctrl_to);
-        } else {
-            iterate = (f->ctrl_val >= f->ctrl_to);
+        case DO_CTRL:
+        {
+            /* Increment control variable, then check bounds. */
+            f->ctrl_val += f->ctrl_by;
+            if (f->ctrl_by >= 0)
+            {
+                iterate = (f->ctrl_val <= f->ctrl_to);
+            }
+            else
+            {
+                iterate = (f->ctrl_val >= f->ctrl_to);
+            }
+            if (iterate && f->ctrl_name_len > 0)
+            {
+                set_var_long(p, f->ctrl_name, f->ctrl_name_len,
+                             f->ctrl_val);
+            }
+            return iterate;
         }
-        if (iterate && f->ctrl_name_len > 0) {
-            set_var_long(p, f->ctrl_name, f->ctrl_name_len,
-                         f->ctrl_val);
-        }
-        return iterate;
-    }
 
-    case DO_WHILE:
-        Lzeroinit(&cond);
-        if (eval_at(p, f->cond_tok_pos, &cond) != IRXPARS_OK) {
+        case DO_WHILE:
+            Lzeroinit(&cond);
+            if (eval_at(p, f->cond_tok_pos, &cond) != IRXPARS_OK)
+            {
+                Lfree(p->alloc, &cond);
+                return 0;
+            }
+            iterate = lstr_to_long(&cond, &cond_val) && (cond_val != 0);
             Lfree(p->alloc, &cond);
-            return 0;
-        }
-        iterate = lstr_to_long(&cond, &cond_val) && (cond_val != 0);
-        Lfree(p->alloc, &cond);
-        return iterate;
+            return iterate;
 
-    case DO_UNTIL:
-        /* Body always ran at least once before END is reached. */
-        Lzeroinit(&cond);
-        if (eval_at(p, f->cond_tok_pos, &cond) != IRXPARS_OK) {
+        case DO_UNTIL:
+            /* Body always ran at least once before END is reached. */
+            Lzeroinit(&cond);
+            if (eval_at(p, f->cond_tok_pos, &cond) != IRXPARS_OK)
+            {
+                Lfree(p->alloc, &cond);
+                return 0;
+            }
+            /* UNTIL: stop when cond is true */
+            iterate = !(lstr_to_long(&cond, &cond_val) && (cond_val != 0));
             Lfree(p->alloc, &cond);
-            return 0;
-        }
-        /* UNTIL: stop when cond is true */
-        iterate = !(lstr_to_long(&cond, &cond_val) && (cond_val != 0));
-        Lfree(p->alloc, &cond);
-        return iterate;
+            return iterate;
 
-    default:
-        return 0;
+        default:
+            return 0;
     }
 }
 
@@ -705,8 +924,15 @@ static int kw_nop(struct irx_parser *p)
 /*  THEN / ELSE — syntax barriers only, never standalone instructions  */
 /* ------------------------------------------------------------------ */
 
-static int kw_then(struct irx_parser *p) { return fail(p, IRXPARS_SYNTAX); }
-static int kw_else(struct irx_parser *p) { return fail(p, IRXPARS_SYNTAX); }
+static int kw_then(struct irx_parser *p)
+{
+    return fail(p, IRXPARS_SYNTAX);
+}
+
+static int kw_else(struct irx_parser *p)
+{
+    return fail(p, IRXPARS_SYNTAX);
+}
 
 /* ------------------------------------------------------------------ */
 /*  EXIT [expr]                                                       */
@@ -717,20 +943,23 @@ static int kw_exit(struct irx_parser *p)
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
     long rc_val = 0;
 
-    if (!tok_ends_clause(cur_tok(p))) {
+    if (!tok_ends_clause(cur_tok(p)))
+    {
         Lstr result;
         Lzeroinit(&result);
-        if (irx_pars_eval_expr(p, &result) == IRXPARS_OK) {
+        if (irx_pars_eval_expr(p, &result) == IRXPARS_OK)
+        {
             lstr_to_long(&result, &rc_val);
         }
         Lfree(p->alloc, &result);
     }
 
     p->exit_requested = 1;
-    p->exit_rc        = (int)rc_val;
-    if (es != NULL) {
+    p->exit_rc = (int)rc_val;
+    if (es != NULL)
+    {
         es->exit_requested = 1;
-        es->exit_rc        = (int)rc_val;
+        es->exit_rc = (int)rc_val;
     }
     return IRXPARS_OK;
 }
@@ -741,8 +970,8 @@ static int kw_exit(struct irx_parser *p)
 
 static int kw_do(struct irx_parser *p)
 {
-    struct irx_exec_stack  *es  = (struct irx_exec_stack *)p->exec_stack;
-    struct irx_exec_frame  *f;
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    struct irx_exec_frame *f;
     const struct irx_token *t;
     int rc = IRXPARS_OK;
     Lstr tmp;
@@ -750,41 +979,58 @@ static int kw_do(struct irx_parser *p)
     Lzeroinit(&tmp);
 
     f = irx_ctrl_frame_push(p, FRAME_DO);
-    if (f == NULL) return fail(p, IRXPARS_NOMEM);
+    if (f == NULL)
+    {
+        return fail(p, IRXPARS_NOMEM);
+    }
 
     /* Inherit label from exec_stack->last_label if set. */
-    if (es != NULL && es->last_label_len > 0) {
+    if (es != NULL && es->last_label_len > 0)
+    {
         int n = es->last_label_len;
-        if (n >= CTRL_NAME_MAX) n = CTRL_NAME_MAX - 1;
+        if (n >= CTRL_NAME_MAX)
+        {
+            n = CTRL_NAME_MAX - 1;
+        }
         memcpy(f->do_label, es->last_label, (size_t)n);
-        f->do_label[n]   = '\0';
-        f->do_label_len  = n;
+        f->do_label[n] = '\0';
+        f->do_label_len = n;
         es->last_label_len = 0;
-        es->last_label[0]  = '\0';
+        es->last_label[0] = '\0';
     }
 
     t = cur_tok(p);
 
     /* ---- DO FOREVER ---- */
-    if (sym_matches(t, "FOREVER")) {
+    if (sym_matches(t, "FOREVER"))
+    {
         advance_tok(p);
         f->do_type = DO_FOREVER;
         goto body;
     }
 
     /* ---- DO WHILE cond ---- */
-    if (sym_matches(t, "WHILE")) {
+    if (sym_matches(t, "WHILE"))
+    {
         advance_tok(p);
-        f->do_type     = DO_WHILE;
+        f->do_type = DO_WHILE;
         f->cond_tok_pos = p->tok_pos;
         /* Evaluate once to (a) validate syntax and (b) check first time */
         rc = irx_pars_eval_expr(p, &tmp);
-        if (rc != IRXPARS_OK) goto done;
+        if (rc != IRXPARS_OK)
+        {
+            goto done;
+        }
         long cv = 0;
-        if (!lstr_to_long(&tmp, &cv) || cv == 0) {
+        if (!lstr_to_long(&tmp, &cv) || cv == 0)
+        {
             /* Condition false on entry: find END and jump past */
             int end_pos = find_end_after(p, p->tok_pos);
-            if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
+            if (end_pos < 0)
+            {
+                rc = fail(p, IRXPARS_SYNTAX);
+                goto done;
+            }
             irx_ctrl_frame_pop(p);
             p->tok_pos = end_pos;
             goto done;
@@ -793,64 +1039,89 @@ static int kw_do(struct irx_parser *p)
     }
 
     /* ---- DO UNTIL cond ---- */
-    if (sym_matches(t, "UNTIL")) {
+    if (sym_matches(t, "UNTIL"))
+    {
         advance_tok(p);
-        f->do_type      = DO_UNTIL;
+        f->do_type = DO_UNTIL;
         f->cond_tok_pos = p->tok_pos;
         /* Skip past the UNTIL expression so loop_start lands on body. */
         rc = irx_pars_eval_expr(p, &tmp);
-        if (rc != IRXPARS_OK) goto done;
+        if (rc != IRXPARS_OK)
+        {
+            goto done;
+        }
         /* UNTIL always executes body at least once. */
         goto body;
     }
 
     /* ---- DO SYMBOL = start TO end [BY step] ---- */
     if (t != NULL && t->tok_type == TOK_SYMBOL &&
-        !(t->tok_flags & TOKF_CONSTANT)) {
+        !(t->tok_flags & TOKF_CONSTANT))
+    {
         const struct irx_token *tnext = peek_tok(p, 1);
-        if (tok_is_op_char(tnext, TOK_COMPARISON, '=')) {
+        if (tok_is_op_char(tnext, TOK_COMPARISON, '='))
+        {
             /* Check it's not == */
             const struct irx_token *tnext2 = peek_tok(p, 2);
-            if (!tok_is_op_char(tnext2, TOK_COMPARISON, '=')) {
+            if (!tok_is_op_char(tnext2, TOK_COMPARISON, '='))
+            {
                 /* DO ctrl_var = start TO end [BY step] */
-                f->do_type      = DO_CTRL;
-                f->ctrl_by      = 1;  /* default step */
+                f->do_type = DO_CTRL;
+                f->ctrl_by = 1; /* default step */
                 f->ctrl_name_len = sym_to_upper(t, f->ctrl_name,
                                                 CTRL_NAME_MAX);
-                advance_tok(p);  /* SYMBOL */
-                advance_tok(p);  /* =      */
+                advance_tok(p); /* SYMBOL */
+                advance_tok(p); /* =      */
 
                 /* start expression: use parse_add to stop at TO/BY/WHILE */
                 rc = parse_add(p, &tmp);
-                if (rc != IRXPARS_OK) goto done;
-                if (!lstr_to_long(&tmp, &f->ctrl_val)) {
-                    rc = fail(p, IRXPARS_SYNTAX); goto done;
+                if (rc != IRXPARS_OK)
+                {
+                    goto done;
+                }
+                if (!lstr_to_long(&tmp, &f->ctrl_val))
+                {
+                    rc = fail(p, IRXPARS_SYNTAX);
+                    goto done;
                 }
                 Lfree(p->alloc, &tmp);
                 Lzeroinit(&tmp);
 
                 /* TO */
-                if (!sym_matches(cur_tok(p), "TO")) {
-                    rc = fail(p, IRXPARS_SYNTAX); goto done;
+                if (!sym_matches(cur_tok(p), "TO"))
+                {
+                    rc = fail(p, IRXPARS_SYNTAX);
+                    goto done;
                 }
                 advance_tok(p);
 
                 /* end expression */
                 rc = parse_add(p, &tmp);
-                if (rc != IRXPARS_OK) goto done;
-                if (!lstr_to_long(&tmp, &f->ctrl_to)) {
-                    rc = fail(p, IRXPARS_SYNTAX); goto done;
+                if (rc != IRXPARS_OK)
+                {
+                    goto done;
+                }
+                if (!lstr_to_long(&tmp, &f->ctrl_to))
+                {
+                    rc = fail(p, IRXPARS_SYNTAX);
+                    goto done;
                 }
                 Lfree(p->alloc, &tmp);
                 Lzeroinit(&tmp);
 
                 /* Optional BY */
-                if (sym_matches(cur_tok(p), "BY")) {
+                if (sym_matches(cur_tok(p), "BY"))
+                {
                     advance_tok(p);
                     rc = parse_add(p, &tmp);
-                    if (rc != IRXPARS_OK) goto done;
-                    if (!lstr_to_long(&tmp, &f->ctrl_by)) {
-                        rc = fail(p, IRXPARS_SYNTAX); goto done;
+                    if (rc != IRXPARS_OK)
+                    {
+                        goto done;
+                    }
+                    if (!lstr_to_long(&tmp, &f->ctrl_by))
+                    {
+                        rc = fail(p, IRXPARS_SYNTAX);
+                        goto done;
                     }
                     Lfree(p->alloc, &tmp);
                     Lzeroinit(&tmp);
@@ -858,10 +1129,14 @@ static int kw_do(struct irx_parser *p)
 
                 /* Optional WHILE/UNTIL: skip expression (future WP). */
                 if (sym_matches(cur_tok(p), "WHILE") ||
-                    sym_matches(cur_tok(p), "UNTIL")) {
+                    sym_matches(cur_tok(p), "UNTIL"))
+                {
                     advance_tok(p);
                     rc = irx_pars_eval_expr(p, &tmp);
-                    if (rc != IRXPARS_OK) goto done;
+                    if (rc != IRXPARS_OK)
+                    {
+                        goto done;
+                    }
                     Lfree(p->alloc, &tmp);
                     Lzeroinit(&tmp);
                 }
@@ -869,18 +1144,28 @@ static int kw_do(struct irx_parser *p)
                 /* Set initial ctrl var value. */
                 rc = set_var_long(p, f->ctrl_name, f->ctrl_name_len,
                                   f->ctrl_val);
-                if (rc != IRXPARS_OK) goto done;
+                if (rc != IRXPARS_OK)
+                {
+                    goto done;
+                }
 
                 /* Check initial condition: if start > end (BY>0) skip. */
                 int skip = 0;
                 if (f->ctrl_by >= 0 && f->ctrl_val > f->ctrl_to)
+                {
                     skip = 1;
+                }
                 if (f->ctrl_by < 0 && f->ctrl_val < f->ctrl_to)
+                {
                     skip = 1;
-                if (skip) {
+                }
+                if (skip)
+                {
                     int end_pos = find_end_after(p, p->tok_pos);
-                    if (end_pos < 0) {
-                        rc = fail(p, IRXPARS_SYNTAX); goto done;
+                    if (end_pos < 0)
+                    {
+                        rc = fail(p, IRXPARS_SYNTAX);
+                        goto done;
                     }
                     irx_ctrl_frame_pop(p);
                     p->tok_pos = end_pos;
@@ -892,25 +1177,36 @@ static int kw_do(struct irx_parser *p)
     }
 
     /* ---- DO n (repetitive count) ---- */
-    if (t != NULL && !tok_ends_clause(t)) {
+    if (t != NULL && !tok_ends_clause(t))
+    {
         /* Could be DO n where n is an expression. */
         f->do_type = DO_COUNT;
         rc = parse_add(p, &tmp);
-        if (rc != IRXPARS_OK) goto done;
-        if (!lstr_to_long(&tmp, &f->ctrl_count)) {
-            rc = fail(p, IRXPARS_SYNTAX); goto done;
+        if (rc != IRXPARS_OK)
+        {
+            goto done;
+        }
+        if (!lstr_to_long(&tmp, &f->ctrl_count))
+        {
+            rc = fail(p, IRXPARS_SYNTAX);
+            goto done;
         }
         Lfree(p->alloc, &tmp);
         Lzeroinit(&tmp);
-        if (f->ctrl_count <= 0) {
+        if (f->ctrl_count <= 0)
+        {
             /* Zero or negative: skip entire body. */
             int end_pos = find_end_after(p, p->tok_pos);
-            if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
+            if (end_pos < 0)
+            {
+                rc = fail(p, IRXPARS_SYNTAX);
+                goto done;
+            }
             irx_ctrl_frame_pop(p);
             p->tok_pos = end_pos;
             goto done;
         }
-        f->ctrl_count--;  /* already executing first iteration */
+        f->ctrl_count--; /* already executing first iteration */
         goto body;
     }
 
@@ -924,10 +1220,16 @@ body:
     {
         int end_pos;
         while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        {
             advance_tok(p);
+        }
         f->loop_start = p->tok_pos;
         end_pos = find_end_after(p, p->tok_pos);
-        if (end_pos < 0) { rc = fail(p, IRXPARS_SYNTAX); goto done; }
+        if (end_pos < 0)
+        {
+            rc = fail(p, IRXPARS_SYNTAX);
+            goto done;
+        }
         f->loop_end = end_pos;
     }
 
@@ -946,15 +1248,21 @@ static int kw_end(struct irx_parser *p)
 
     /* Consume optional name after END (REXX allows END loopname). */
     if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_SYMBOL &&
-        !tok_ends_clause(cur_tok(p))) {
+        !tok_ends_clause(cur_tok(p)))
+    {
         advance_tok(p);
     }
 
-    if (f == NULL) return fail(p, IRXPARS_SYNTAX);
+    if (f == NULL)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
-    if (f->frame_type == FRAME_SELECT) {
+    if (f->frame_type == FRAME_SELECT)
+    {
         /* End of SELECT block. */
-        if (!f->select_matched) {
+        if (!f->select_matched)
+        {
             /* No WHEN matched and no OTHERWISE was present. */
             return fail(p, IRXPARS_SYNTAX);
         }
@@ -962,12 +1270,18 @@ static int kw_end(struct irx_parser *p)
         return IRXPARS_OK;
     }
 
-    if (f->frame_type != FRAME_DO) return fail(p, IRXPARS_SYNTAX);
+    if (f->frame_type != FRAME_DO)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
-    if (do_should_iterate(p, f)) {
+    if (do_should_iterate(p, f))
+    {
         /* Go back to loop body. */
         p->tok_pos = f->loop_start;
-    } else {
+    }
+    else
+    {
         /* Exit loop: tok_pos is already past END (set to loop_end). */
         p->tok_pos = f->loop_end;
         irx_ctrl_frame_pop(p);
@@ -982,14 +1296,15 @@ static int kw_end(struct irx_parser *p)
 static int kw_iterate(struct irx_parser *p)
 {
     char label[CTRL_NAME_MAX];
-    int  label_len = 0;
-    int  frame_idx;
+    int label_len = 0;
+    int frame_idx;
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
     struct irx_exec_frame *f;
 
     /* Optional label */
     if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_SYMBOL &&
-        !tok_ends_clause(cur_tok(p))) {
+        !tok_ends_clause(cur_tok(p)))
+    {
         label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
         advance_tok(p);
     }
@@ -997,7 +1312,10 @@ static int kw_iterate(struct irx_parser *p)
     frame_idx = irx_ctrl_find_do(p,
                                  label_len > 0 ? label : NULL,
                                  label_len);
-    if (frame_idx < 0) return fail(p, IRXPARS_SYNTAX);
+    if (frame_idx < 0)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
     f = &es->frames[frame_idx];
 
@@ -1005,19 +1323,29 @@ static int kw_iterate(struct irx_parser *p)
     es->top = frame_idx + 1;
 
     /* Advance the loop: for DO_CTRL increment ctrl var before jumping. */
-    if (f->do_type == DO_CTRL) {
+    if (f->do_type == DO_CTRL)
+    {
         f->ctrl_val += f->ctrl_by;
         /* Check bounds */
         int in_range;
-        if (f->ctrl_by >= 0) in_range = (f->ctrl_val <= f->ctrl_to);
-        else                 in_range = (f->ctrl_val >= f->ctrl_to);
-        if (!in_range) {
+        if (f->ctrl_by >= 0)
+        {
+            in_range = (f->ctrl_val <= f->ctrl_to);
+        }
+        else
+        {
+            in_range = (f->ctrl_val >= f->ctrl_to);
+        }
+        if (!in_range)
+        {
             p->tok_pos = f->loop_end;
             irx_ctrl_frame_pop(p);
             return IRXPARS_OK;
         }
         set_var_long(p, f->ctrl_name, f->ctrl_name_len, f->ctrl_val);
-    } else if (f->do_type == DO_WHILE) {
+    }
+    else if (f->do_type == DO_WHILE)
+    {
         /* Re-evaluate WHILE condition. */
         Lstr cond;
         long cv = 0;
@@ -1025,7 +1353,8 @@ static int kw_iterate(struct irx_parser *p)
         eval_at(p, f->cond_tok_pos, &cond);
         lstr_to_long(&cond, &cv);
         Lfree(p->alloc, &cond);
-        if (!cv) {
+        if (!cv)
+        {
             p->tok_pos = f->loop_end;
             irx_ctrl_frame_pop(p);
             return IRXPARS_OK;
@@ -1043,14 +1372,15 @@ static int kw_iterate(struct irx_parser *p)
 static int kw_leave(struct irx_parser *p)
 {
     char label[CTRL_NAME_MAX];
-    int  label_len = 0;
-    int  frame_idx;
+    int label_len = 0;
+    int frame_idx;
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
     struct irx_exec_frame *f;
 
     /* Optional label */
     if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_SYMBOL &&
-        !tok_ends_clause(cur_tok(p))) {
+        !tok_ends_clause(cur_tok(p)))
+    {
         label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
         advance_tok(p);
     }
@@ -1058,7 +1388,10 @@ static int kw_leave(struct irx_parser *p)
     frame_idx = irx_ctrl_find_do(p,
                                  label_len > 0 ? label : NULL,
                                  label_len);
-    if (frame_idx < 0) return fail(p, IRXPARS_SYNTAX);
+    if (frame_idx < 0)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
     f = &es->frames[frame_idx];
     p->tok_pos = f->loop_end;
@@ -1076,12 +1409,16 @@ static int kw_if(struct irx_parser *p)
 {
     Lstr cond;
     long cond_val = 0;
-    int  cond_true;
-    int  rc;
+    int cond_true;
+    int rc;
 
     Lzeroinit(&cond);
     rc = irx_pars_eval_expr(p, &cond);
-    if (rc != IRXPARS_OK) { Lfree(p->alloc, &cond); return rc; }
+    if (rc != IRXPARS_OK)
+    {
+        Lfree(p->alloc, &cond);
+        return rc;
+    }
     lstr_to_long(&cond, &cond_val);
     cond_true = (cond_val != 0);
     Lfree(p->alloc, &cond);
@@ -1089,65 +1426,104 @@ static int kw_if(struct irx_parser *p)
     /* Consume THEN (required). */
     /* Skip any EOC between condition and THEN. */
     while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+    {
         advance_tok(p);
+    }
     if (!sym_matches(cur_tok(p), "THEN"))
+    {
         return fail(p, IRXPARS_SYNTAX);
-    advance_tok(p);  /* consume THEN */
+    }
+    advance_tok(p); /* consume THEN */
 
     /* Skip any EOC/whitespace between THEN and its clause. */
     while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+    {
         advance_tok(p);
+    }
 
-    if (cond_true) {
+    if (cond_true)
+    {
         struct irx_exec_stack *es =
             (struct irx_exec_stack *)p->exec_stack;
         int depth_before = es ? es->top : 0;
 
         /* Execute THEN branch. */
         rc = exec_clause(p);
-        if (rc != IRXPARS_OK) return rc;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
 
         /* If THEN was DO/SELECT, run the block until that frame exits. */
         while (rc == IRXPARS_OK && !p->exit_requested &&
-               es != NULL && es->top > depth_before) {
+               es != NULL && es->top > depth_before)
+        {
             const struct irx_token *ct = cur_tok(p);
-            if (ct == NULL || ct->tok_type == TOK_EOF) break;
+            if (ct == NULL || ct->tok_type == TOK_EOF)
+            {
+                break;
+            }
             rc = exec_clause(p);
         }
-        if (rc != IRXPARS_OK) return rc;
-        if (p->exit_requested) return IRXPARS_OK;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
+        if (p->exit_requested)
+        {
+            return IRXPARS_OK;
+        }
 
         /* Consume trailing terminators of the THEN clause. */
         while (cur_tok(p) != NULL &&
                (cur_tok(p)->tok_type == TOK_EOC ||
                 cur_tok(p)->tok_type == TOK_SEMICOLON))
+        {
             advance_tok(p);
+        }
 
         /* Check for ELSE and skip it. */
         while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        {
             advance_tok(p);
-        if (sym_matches(cur_tok(p), "ELSE")) {
+        }
+        if (sym_matches(cur_tok(p), "ELSE"))
+        {
             advance_tok(p);
             while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+            {
                 advance_tok(p);
+            }
             rc = skip_instruction(p);
         }
-    } else {
+    }
+    else
+    {
         /* Skip THEN branch. */
         rc = skip_instruction(p);
-        if (rc != IRXPARS_OK) return rc;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
         while (cur_tok(p) != NULL &&
                (cur_tok(p)->tok_type == TOK_EOC ||
                 cur_tok(p)->tok_type == TOK_SEMICOLON))
+        {
             advance_tok(p);
+        }
 
         /* Check for ELSE and execute it. */
         while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        {
             advance_tok(p);
-        if (sym_matches(cur_tok(p), "ELSE")) {
+        }
+        if (sym_matches(cur_tok(p), "ELSE"))
+        {
             advance_tok(p);
             while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+            {
                 advance_tok(p);
+            }
             rc = exec_clause(p);
         }
     }
@@ -1163,13 +1539,19 @@ static int kw_select(struct irx_parser *p)
     struct irx_exec_frame *f;
 
     f = irx_ctrl_frame_push(p, FRAME_SELECT);
-    if (f == NULL) return fail(p, IRXPARS_NOMEM);
+    if (f == NULL)
+    {
+        return fail(p, IRXPARS_NOMEM);
+    }
 
     f->select_matched = 0;
 
     /* Find the matching END so WHEN can jump past it. */
     f->select_end = find_end_after(p, p->tok_pos);
-    if (f->select_end < 0) return fail(p, IRXPARS_SYNTAX);
+    if (f->select_end < 0)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
     return IRXPARS_OK;
 }
@@ -1179,56 +1561,85 @@ static int kw_when(struct irx_parser *p)
     struct irx_exec_frame *f = irx_ctrl_frame_top(p);
     Lstr cond;
     long cond_val = 0;
-    int  cond_true;
-    int  rc;
+    int cond_true;
+    int rc;
 
     if (f == NULL || f->frame_type != FRAME_SELECT)
+    {
         return fail(p, IRXPARS_SYNTAX);
+    }
 
     Lzeroinit(&cond);
 
-    if (f->select_matched) {
+    if (f->select_matched)
+    {
         /* A prior WHEN already matched: skip this WHEN entirely
          * (condition + THEN + clause) and jump to the next WHEN,
          * OTHERWISE, or END. cond was never allocated — no Lfree. */
         /* Skip condition */
         rc = skip_instruction(p);
-        if (rc != IRXPARS_OK) return rc;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
         /* Consume THEN */
         while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        {
             advance_tok(p);
-        if (sym_matches(cur_tok(p), "THEN")) advance_tok(p);
+        }
+        if (sym_matches(cur_tok(p), "THEN"))
+        {
+            advance_tok(p);
+        }
         /* Skip THEN clause */
         while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+        {
             advance_tok(p);
+        }
         rc = skip_instruction(p);
         return rc;
     }
 
     rc = irx_pars_eval_expr(p, &cond);
-    if (rc != IRXPARS_OK) { Lfree(p->alloc, &cond); return rc; }
+    if (rc != IRXPARS_OK)
+    {
+        Lfree(p->alloc, &cond);
+        return rc;
+    }
     lstr_to_long(&cond, &cond_val);
     cond_true = (cond_val != 0);
     Lfree(p->alloc, &cond);
 
     /* Consume THEN */
     while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+    {
         advance_tok(p);
+    }
     if (!sym_matches(cur_tok(p), "THEN"))
+    {
         return fail(p, IRXPARS_SYNTAX);
+    }
     advance_tok(p);
 
     while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+    {
         advance_tok(p);
+    }
 
-    if (cond_true) {
+    if (cond_true)
+    {
         f->select_matched = 1;
         rc = exec_clause(p);
-        if (rc != IRXPARS_OK) return rc;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
         /* Jump to after SELECT END — kw_end will pop the frame. */
         /* Leave tok_pos at select_end so END/OTHERWISE are skipped. */
         /* Don't jump yet; let the normal clause loop encounter END. */
-    } else {
+    }
+    else
+    {
         rc = skip_instruction(p);
     }
     return rc;
@@ -1239,9 +1650,12 @@ static int kw_otherwise(struct irx_parser *p)
     struct irx_exec_frame *f = irx_ctrl_frame_top(p);
 
     if (f == NULL || f->frame_type != FRAME_SELECT)
+    {
         return fail(p, IRXPARS_SYNTAX);
+    }
 
-    if (f->select_matched) {
+    if (f->select_matched)
+    {
         /* Already matched: skip the OTHERWISE body. */
         return skip_instruction(p);
     }
@@ -1258,24 +1672,26 @@ static int kw_otherwise(struct irx_parser *p)
 
 static int kw_call(struct irx_parser *p)
 {
-    char   label[CTRL_NAME_MAX];
-    int    label_len;
-    int    label_pos;
-    int    return_pos;
-    int    call_line;
+    char label[CTRL_NAME_MAX];
+    int label_len;
+    int label_pos;
+    int return_pos;
+    int call_line;
     struct irx_exec_frame *f;
-    char   linebuf[32];
-    int    n;
-    Lstr  *new_args   = NULL;
-    int   *new_exists = NULL;
-    int    argc       = 0;
-    int    after_comma = 0;
-    int    rc;
-    int    i;
+    char linebuf[32];
+    int n;
+    Lstr *new_args = NULL;
+    int *new_exists = NULL;
+    int argc = 0;
+    int after_comma = 0;
+    int rc;
+    int i;
 
     /* CALL must be followed by a label name (symbol). */
     if (cur_tok(p) == NULL || cur_tok(p)->tok_type != TOK_SYMBOL)
+    {
         return fail(p, IRXPARS_SYNTAX);
+    }
 
     label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
     call_line = cur_tok(p)->tok_line;
@@ -1285,25 +1701,30 @@ static int kw_call(struct irx_parser *p)
     new_args = (Lstr *)p->alloc->alloc(
         (size_t)IRX_MAX_ARGS * sizeof(Lstr), p->alloc->ctx);
     new_exists = (int *)p->alloc->alloc(
-        (size_t)IRX_MAX_ARGS * sizeof(int),  p->alloc->ctx);
-    if (new_args == NULL || new_exists == NULL) {
+        (size_t)IRX_MAX_ARGS * sizeof(int), p->alloc->ctx);
+    if (new_args == NULL || new_exists == NULL)
+    {
         rc = fail(p, IRXPARS_NOMEM);
         goto err;
     }
-    memset(new_args,   0, (size_t)IRX_MAX_ARGS * sizeof(Lstr));
+    memset(new_args, 0, (size_t)IRX_MAX_ARGS * sizeof(Lstr));
     memset(new_exists, 0, (size_t)IRX_MAX_ARGS * sizeof(int));
 
     /* Parse comma-separated arguments until clause end.
      * An omitted argument is an empty slot between commas, or
      * before the first comma, or after the last comma. */
-    if (!tok_ends_clause(cur_tok(p))) {
-        for (;;) {
-            if (argc >= IRX_MAX_ARGS) {
+    if (!tok_ends_clause(cur_tok(p)))
+    {
+        for (;;)
+        {
+            if (argc >= IRX_MAX_ARGS)
+            {
                 rc = fail(p, IRXPARS_SYNTAX);
                 goto err;
             }
             if (cur_tok(p) != NULL &&
-                cur_tok(p)->tok_type == TOK_COMMA) {
+                cur_tok(p)->tok_type == TOK_COMMA)
+            {
                 /* Omitted argument at this position. */
                 Lzeroinit(&new_args[argc]);
                 new_exists[argc] = 0;
@@ -1312,10 +1733,13 @@ static int kw_call(struct irx_parser *p)
                 after_comma = 1;
                 continue;
             }
-            if (tok_ends_clause(cur_tok(p))) {
+            if (tok_ends_clause(cur_tok(p)))
+            {
                 /* Trailing comma means one more omitted argument. */
-                if (after_comma) {
-                    if (argc >= IRX_MAX_ARGS) {
+                if (after_comma)
+                {
+                    if (argc >= IRX_MAX_ARGS)
+                    {
                         rc = fail(p, IRXPARS_SYNTAX);
                         goto err;
                     }
@@ -1328,7 +1752,8 @@ static int kw_call(struct irx_parser *p)
             /* Evaluate the expression for this argument position. */
             Lzeroinit(&new_args[argc]);
             rc = irx_pars_eval_expr(p, &new_args[argc]);
-            if (rc != IRXPARS_OK) {
+            if (rc != IRXPARS_OK)
+            {
                 /* eval may have partially allocated into new_args[argc]. */
                 Lfree(p->alloc, &new_args[argc]);
                 goto err;
@@ -1337,7 +1762,8 @@ static int kw_call(struct irx_parser *p)
             argc++;
             after_comma = 0;
             if (cur_tok(p) != NULL &&
-                cur_tok(p)->tok_type == TOK_COMMA) {
+                cur_tok(p)->tok_type == TOK_COMMA)
+            {
                 advance_tok(p);
                 after_comma = 1;
                 continue;
@@ -1352,30 +1778,32 @@ static int kw_call(struct irx_parser *p)
 
     /* Look up the label. */
     label_pos = irx_ctrl_label_find(p, label, label_len);
-    if (label_pos < 0) {
+    if (label_pos < 0)
+    {
         rc = fail(p, IRXPARS_BADFUNC);
         goto err;
     }
 
     /* Push CALL frame, saving the current argument context. */
     f = irx_ctrl_frame_push(p, FRAME_CALL);
-    if (f == NULL) {
+    if (f == NULL)
+    {
         rc = fail(p, IRXPARS_NOMEM);
         goto err;
     }
-    f->call_return_pos   = return_pos;
-    f->call_line         = call_line;
-    f->saved_vpool       = NULL;
-    f->saved_args        = p->call_args;
-    f->saved_arg_exists  = p->call_arg_exists;
-    f->saved_argc        = p->call_argc;
+    f->call_return_pos = return_pos;
+    f->call_line = call_line;
+    f->saved_vpool = NULL;
+    f->saved_args = p->call_args;
+    f->saved_arg_exists = p->call_arg_exists;
+    f->saved_argc = p->call_argc;
     f->procedure_allowed = 1;
-    f->has_procedure     = 0;
+    f->has_procedure = 0;
 
     /* Install the new argument context. */
-    p->call_args       = new_args;
+    p->call_args = new_args;
     p->call_arg_exists = new_exists;
-    p->call_argc       = argc;
+    p->call_argc = argc;
 
     /* Set SIGL special variable. */
     n = sprintf(linebuf, "%d", call_line);
@@ -1386,13 +1814,18 @@ static int kw_call(struct irx_parser *p)
     return IRXPARS_OK;
 
 err:
-    if (new_args != NULL) {
-        for (i = 0; i < argc; i++) Lfree(p->alloc, &new_args[i]);
+    if (new_args != NULL)
+    {
+        for (i = 0; i < argc; i++)
+        {
+            Lfree(p->alloc, &new_args[i]);
+        }
         p->alloc->dealloc(new_args,
                           (size_t)IRX_MAX_ARGS * sizeof(Lstr),
                           p->alloc->ctx);
     }
-    if (new_exists != NULL) {
+    if (new_exists != NULL)
+    {
         p->alloc->dealloc(new_exists,
                           (size_t)IRX_MAX_ARGS * sizeof(int),
                           p->alloc->ctx);
@@ -1408,39 +1841,57 @@ static int kw_return(struct irx_parser *p)
 {
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
     struct irx_exec_frame *f;
-    Lstr   result;
-    int    have_result = 0;
-    int    i, j;
+    Lstr result;
+    int have_result = 0;
+    int i, j;
 
     Lzeroinit(&result);
 
-    if (!tok_ends_clause(cur_tok(p))) {
+    if (!tok_ends_clause(cur_tok(p)))
+    {
         int rc = irx_pars_eval_expr(p, &result);
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &result); return rc; }
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &result);
+            return rc;
+        }
         have_result = 1;
     }
 
     /* Locate the nearest enclosing CALL frame. */
-    if (es == NULL) goto no_call_frame;
-
-    for (i = es->top - 1; i >= 0; i--) {
-        if (es->frames[i].frame_type == FRAME_CALL) break;
+    if (es == NULL)
+    {
+        goto no_call_frame;
     }
-    if (i < 0) goto no_call_frame;
+
+    for (i = es->top - 1; i >= 0; i--)
+    {
+        if (es->frames[i].frame_type == FRAME_CALL)
+        {
+            break;
+        }
+    }
+    if (i < 0)
+    {
+        goto no_call_frame;
+    }
 
     f = &es->frames[i];
 
     /* Restore the caller's variable pool if PROCEDURE was executed. */
-    if (f->has_procedure) {
+    if (f->has_procedure)
+    {
         vpool_destroy(p->vpool);   /* destroy child pool */
         p->vpool = f->saved_vpool; /* restore caller's pool */
     }
 
     /* Set RESULT in the caller's variable pool (now restored). */
-    if (have_result) {
+    if (have_result)
+    {
         Lstr key;
         Lzeroinit(&key);
-        if (lstr_set_bytes(p->alloc, &key, "RESULT", 6) == LSTR_OK) {
+        if (lstr_set_bytes(p->alloc, &key, "RESULT", 6) == LSTR_OK)
+        {
             vpool_set(p->vpool, &key, &result);
             Lfree(p->alloc, &key);
         }
@@ -1448,32 +1899,38 @@ static int kw_return(struct irx_parser *p)
     Lfree(p->alloc, &result);
 
     /* Restore the caller's argument context. */
-    if (p->call_args != NULL) {
+    if (p->call_args != NULL)
+    {
         for (j = 0; j < p->call_argc; j++)
+        {
             Lfree(p->alloc, &p->call_args[j]);
+        }
         p->alloc->dealloc(p->call_args,
                           (size_t)IRX_MAX_ARGS * sizeof(Lstr),
                           p->alloc->ctx);
     }
-    if (p->call_arg_exists != NULL) {
+    if (p->call_arg_exists != NULL)
+    {
         p->alloc->dealloc(p->call_arg_exists,
                           (size_t)IRX_MAX_ARGS * sizeof(int),
                           p->alloc->ctx);
     }
-    p->call_args       = f->saved_args;
+    p->call_args = f->saved_args;
     p->call_arg_exists = f->saved_arg_exists;
-    p->call_argc       = f->saved_argc;
+    p->call_argc = f->saved_argc;
 
     p->tok_pos = f->call_return_pos;
-    es->top    = i;   /* pop everything up to and including CALL frame */
+    es->top = i; /* pop everything up to and including CALL frame */
     return IRXPARS_OK;
 
 no_call_frame:
     /* No CALL frame on stack: set RESULT at top level, treat as EXIT 0. */
-    if (have_result) {
+    if (have_result)
+    {
         Lstr key;
         Lzeroinit(&key);
-        if (lstr_set_bytes(p->alloc, &key, "RESULT", 6) == LSTR_OK) {
+        if (lstr_set_bytes(p->alloc, &key, "RESULT", 6) == LSTR_OK)
+        {
             vpool_set(p->vpool, &key, &result);
             Lfree(p->alloc, &key);
         }
@@ -1490,80 +1947,107 @@ no_call_frame:
 
 static int kw_procedure(struct irx_parser *p)
 {
-    struct irx_exec_stack  *es = (struct irx_exec_stack *)p->exec_stack;
-    struct irx_exec_frame  *f;
-    struct irx_vpool       *child;
+    struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
+    struct irx_exec_frame *f;
+    struct irx_vpool *child;
     const struct irx_token *t;
-    char   kw[8];
-    int    kw_len;
-    int    i;
+    char kw[8];
+    int kw_len;
+    int i;
 
     /* Find the nearest enclosing CALL frame. */
-    if (es == NULL) return fail(p, IRXPARS_SYNTAX);
-    for (i = es->top - 1; i >= 0; i--) {
-        if (es->frames[i].frame_type == FRAME_CALL) break;
+    if (es == NULL)
+    {
+        return fail(p, IRXPARS_SYNTAX);
     }
-    if (i < 0) return fail(p, IRXPARS_SYNTAX);
+    for (i = es->top - 1; i >= 0; i--)
+    {
+        if (es->frames[i].frame_type == FRAME_CALL)
+        {
+            break;
+        }
+    }
+    if (i < 0)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
     f = &es->frames[i];
-    if (!f->procedure_allowed) return fail(p, IRXPARS_SYNTAX);
+    if (!f->procedure_allowed)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
     /* Mark PROCEDURE as executed for this CALL frame. */
     f->procedure_allowed = 0;
-    f->has_procedure     = 1;
+    f->has_procedure = 1;
 
     /* Create an isolated child variable pool. */
     child = vpool_create(p->alloc, p->vpool);
-    if (child == NULL) return fail(p, IRXPARS_NOMEM);
+    if (child == NULL)
+    {
+        return fail(p, IRXPARS_NOMEM);
+    }
 
     /* Save caller's pool and switch to child pool. */
     f->saved_vpool = p->vpool;
-    p->vpool       = child;
+    p->vpool = child;
 
     /* Parse optional EXPOSE keyword and variable list. */
     t = cur_tok(p);
     if (t != NULL && !tok_ends_clause(t) && t->tok_type == TOK_SYMBOL &&
-        t->tok_length == 6) {
+        t->tok_length == 6)
+    {
         kw_len = sym_to_upper(t, kw, (int)sizeof(kw));
-        if (kw_len == 6 && memcmp(kw, "EXPOSE", 6) == 0) {
-            advance_tok(p);   /* consume EXPOSE */
+        if (kw_len == 6 && memcmp(kw, "EXPOSE", 6) == 0)
+        {
+            advance_tok(p); /* consume EXPOSE */
 
             /* Parse each name in the expose list. */
-            while (!tok_ends_clause(cur_tok(p))) {
-                Lstr   ename;
-                int    rc;
+            while (!tok_ends_clause(cur_tok(p)))
+            {
+                Lstr ename;
+                int rc;
                 size_t el;
 
                 t = cur_tok(p);
-                if (t == NULL) break;
+                if (t == NULL)
+                {
+                    break;
+                }
 
                 /* Indirect expose: (varname) — look up varname in the
                  * caller's pool, split its value by whitespace, expose
                  * each resulting name (or stem if it ends with '.'). */
-                if (t->tok_type == TOK_LPAREN) {
-                    Lstr   iname;
-                    Lstr   ival;
+                if (t->tok_type == TOK_LPAREN)
+                {
+                    Lstr iname;
+                    Lstr ival;
                     size_t ipos;
                     size_t ilen;
 
-                    advance_tok(p);               /* consume ( */
+                    advance_tok(p); /* consume ( */
                     t = cur_tok(p);
                     if (t == NULL || t->tok_type != TOK_SYMBOL)
+                    {
                         return fail(p, IRXPARS_SYNTAX);
+                    }
 
                     Lzeroinit(&iname);
-                    if (set_upper_from_tok(p->alloc, &iname, t) != LSTR_OK) {
+                    if (set_upper_from_tok(p->alloc, &iname, t) != LSTR_OK)
+                    {
                         Lfree(p->alloc, &iname);
                         return fail(p, IRXPARS_NOMEM);
                     }
-                    advance_tok(p);               /* consume varname */
+                    advance_tok(p); /* consume varname */
 
                     t = cur_tok(p);
-                    if (t == NULL || t->tok_type != TOK_RPAREN) {
+                    if (t == NULL || t->tok_type != TOK_RPAREN)
+                    {
                         Lfree(p->alloc, &iname);
                         return fail(p, IRXPARS_SYNTAX);
                     }
-                    advance_tok(p);               /* consume ) */
+                    advance_tok(p); /* consume ) */
 
                     /* Look up in the caller's pool (f->saved_vpool). */
                     Lzeroinit(&ival);
@@ -1573,48 +2057,65 @@ static int kw_procedure(struct irx_parser *p)
                     /* Split ival by whitespace and expose each word. */
                     ilen = ival.len;
                     ipos = 0;
-                    while (ipos < ilen) {
+                    while (ipos < ilen)
+                    {
                         size_t wstart;
                         size_t wend;
 
                         while (ipos < ilen &&
                                isspace((unsigned char)ival.pstr[ipos]))
+                        {
                             ipos++;
+                        }
                         wstart = ipos;
                         while (ipos < ilen &&
                                !isspace((unsigned char)ival.pstr[ipos]))
+                        {
                             ipos++;
+                        }
                         wend = ipos;
-                        if (wend == wstart) break;
+                        if (wend == wstart)
+                        {
+                            break;
+                        }
 
                         Lzeroinit(&ename);
                         if (Lfx(p->alloc, &ename,
-                                wend - wstart) != LSTR_OK) {
+                                wend - wstart) != LSTR_OK)
+                        {
                             Lfree(p->alloc, &ival);
                             return fail(p, IRXPARS_NOMEM);
                         }
                         memcpy(ename.pstr, ival.pstr + wstart,
                                wend - wstart);
-                        ename.len  = wend - wstart;
+                        ename.len = wend - wstart;
                         ename.type = LSTRING_TY;
                         upper_bytes(ename.pstr, ename.len);
 
                         el = ename.len;
                         if (el > 0 && ename.pstr[el - 1] == '.')
+                        {
                             vpool_expose_stem(child, &ename);
+                        }
                         else
+                        {
                             vpool_expose_var(child, &ename);
+                        }
                         Lfree(p->alloc, &ename);
                     }
                     Lfree(p->alloc, &ival);
                     continue;
                 }
 
-                if (t->tok_type != TOK_SYMBOL) break;
+                if (t->tok_type != TOK_SYMBOL)
+                {
+                    break;
+                }
 
                 Lzeroinit(&ename);
                 rc = set_upper_from_tok(p->alloc, &ename, t);
-                if (rc != LSTR_OK) {
+                if (rc != LSTR_OK)
+                {
                     Lfree(p->alloc, &ename);
                     return fail(p, IRXPARS_NOMEM);
                 }
@@ -1622,9 +2123,12 @@ static int kw_procedure(struct irx_parser *p)
 
                 /* Names ending with '.' are stem names. */
                 el = ename.len;
-                if (el > 0 && ename.pstr[el - 1] == '.') {
+                if (el > 0 && ename.pstr[el - 1] == '.')
+                {
                     vpool_expose_stem(child, &ename);
-                } else {
+                }
+                else
+                {
                     vpool_expose_var(child, &ename);
                 }
                 Lfree(p->alloc, &ename);
@@ -1651,52 +2155,68 @@ static int kw_procedure(struct irx_parser *p)
 #define ARG_VAR(vars, i) ((vars) + (i) * CTRL_NAME_MAX)
 
 static int arg_assign_words(struct irx_parser *p,
-                             const unsigned char *src, size_t srclen,
-                             size_t *pos_inout,
-                             char *vars, int *var_lens,
-                             int nvar)
+                            const unsigned char *src, size_t srclen,
+                            size_t *pos_inout,
+                            char *vars, int *var_lens,
+                            int nvar)
 {
-    int    i;
+    int i;
     size_t pos = *pos_inout;
 
-    for (i = 0; i < nvar; i++) {
-        Lstr   val;
-        Lstr   key;
+    for (i = 0; i < nvar; i++)
+    {
+        Lstr val;
+        Lstr key;
         size_t wstart;
         size_t wend;
-        int    rc;
+        int rc;
 
         Lzeroinit(&val);
         Lzeroinit(&key);
 
         /* Skip leading whitespace. */
-        while (pos < srclen && isspace((unsigned char)src[pos])) pos++;
+        while (pos < srclen && isspace((unsigned char)src[pos]))
+        {
+            pos++;
+        }
         wstart = pos;
 
-        if (i == nvar - 1) {
+        if (i == nvar - 1)
+        {
             /* Last var: rest of string, trailing-stripped. */
             wend = srclen;
             while (wend > wstart && isspace((unsigned char)src[wend - 1]))
+            {
                 wend--;
-        } else {
+            }
+        }
+        else
+        {
             /* Non-last var: next non-space run. */
-            while (pos < srclen && !isspace((unsigned char)src[pos])) pos++;
+            while (pos < srclen && !isspace((unsigned char)src[pos]))
+            {
+                pos++;
+            }
             wend = pos;
         }
 
-        if (wend > wstart) {
+        if (wend > wstart)
+        {
             size_t vlen = wend - wstart;
             if (Lfx(p->alloc, &val, vlen) != LSTR_OK)
+            {
                 return fail(p, IRXPARS_NOMEM);
+            }
             memcpy(val.pstr, src + wstart, vlen);
-            val.len  = vlen;
+            val.len = vlen;
             val.type = LSTRING_TY;
             upper_bytes(val.pstr, vlen);
         }
 
         rc = lstr_set_bytes(p->alloc, &key, ARG_VAR(vars, i),
                             (size_t)var_lens[i]);
-        if (rc != LSTR_OK) {
+        if (rc != LSTR_OK)
+        {
             Lfree(p->alloc, &val);
             return fail(p, IRXPARS_NOMEM);
         }
@@ -1718,47 +2238,60 @@ static int kw_arg(struct irx_parser *p)
      * Variable name storage is heap-allocated (IRX_MAX_ARGS *
      * CTRL_NAME_MAX bytes) to keep the parser stack frame small
      * on MVS 24-bit targets. */
-    char   *vars;
-    int    *var_lens;
-    int    nvar;
-    int    arg_idx = 0;
-    int    hit_comma;
-    int    rc     = IRXPARS_OK;
+    char *vars;
+    int *var_lens;
+    int nvar;
+    int arg_idx = 0;
+    int hit_comma;
+    int rc = IRXPARS_OK;
     size_t pos;
     const unsigned char *src;
     size_t srclen;
-    size_t vars_size     = (size_t)IRX_MAX_ARGS * CTRL_NAME_MAX;
+    size_t vars_size = (size_t)IRX_MAX_ARGS * CTRL_NAME_MAX;
     size_t var_lens_size = (size_t)IRX_MAX_ARGS * sizeof(int);
 
-    vars     = (char *)p->alloc->alloc(vars_size, p->alloc->ctx);
-    var_lens = (int  *)p->alloc->alloc(var_lens_size, p->alloc->ctx);
-    if (vars == NULL || var_lens == NULL) {
+    vars = (char *)p->alloc->alloc(vars_size, p->alloc->ctx);
+    var_lens = (int *)p->alloc->alloc(var_lens_size, p->alloc->ctx);
+    if (vars == NULL || var_lens == NULL)
+    {
         if (vars != NULL)
+        {
             p->alloc->dealloc(vars, vars_size, p->alloc->ctx);
+        }
         if (var_lens != NULL)
+        {
             p->alloc->dealloc(var_lens, var_lens_size, p->alloc->ctx);
+        }
         return fail(p, IRXPARS_NOMEM);
     }
 
-    while (!tok_ends_clause(cur_tok(p))) {
+    while (!tok_ends_clause(cur_tok(p)))
+    {
         const struct irx_token *t;
 
         /* Collect variable names until comma or clause end. */
         nvar = 0;
         hit_comma = 0;
-        while (!tok_ends_clause(cur_tok(p))) {
+        while (!tok_ends_clause(cur_tok(p)))
+        {
             t = cur_tok(p);
-            if (t == NULL) break;
-            if (t->tok_type == TOK_COMMA) {
+            if (t == NULL)
+            {
+                break;
+            }
+            if (t->tok_type == TOK_COMMA)
+            {
                 advance_tok(p);
                 hit_comma = 1;
                 break;
             }
-            if (t->tok_type != TOK_SYMBOL) {
+            if (t->tok_type != TOK_SYMBOL)
+            {
                 skip_to_clause_end(p);
                 goto done;
             }
-            if (nvar < IRX_MAX_ARGS) {
+            if (nvar < IRX_MAX_ARGS)
+            {
                 var_lens[nvar] = sym_to_upper(t, ARG_VAR(vars, nvar),
                                               CTRL_NAME_MAX);
                 nvar++;
@@ -1767,29 +2300,37 @@ static int kw_arg(struct irx_parser *p)
         }
 
         /* Assign words from the current argument to the collected vars. */
-        src    = NULL;
+        src = NULL;
         srclen = 0;
-        pos    = 0;
+        pos = 0;
         if (arg_idx < p->call_argc && p->call_arg_exists != NULL &&
             p->call_arg_exists[arg_idx] && p->call_args != NULL &&
-            p->call_args[arg_idx].pstr != NULL) {
-            src    = p->call_args[arg_idx].pstr;
+            p->call_args[arg_idx].pstr != NULL)
+        {
+            src = p->call_args[arg_idx].pstr;
             srclen = p->call_args[arg_idx].len;
         }
 
-        if (nvar > 0) {
+        if (nvar > 0)
+        {
             rc = arg_assign_words(p, src, srclen, &pos,
                                   vars, var_lens, nvar);
-            if (rc != IRXPARS_OK) goto done;
+            if (rc != IRXPARS_OK)
+            {
+                goto done;
+            }
         }
 
         arg_idx++;
 
-        if (!hit_comma) break;   /* no comma: done */
+        if (!hit_comma)
+        {
+            break; /* no comma: done */
+        }
     }
 
 done:
-    p->alloc->dealloc(vars,     vars_size,     p->alloc->ctx);
+    p->alloc->dealloc(vars, vars_size, p->alloc->ctx);
     p->alloc->dealloc(var_lens, var_lens_size, p->alloc->ctx);
     return rc;
 }
@@ -1802,20 +2343,28 @@ static int kw_signal(struct irx_parser *p)
 {
     struct irx_exec_stack *es = (struct irx_exec_stack *)p->exec_stack;
     char label[CTRL_NAME_MAX];
-    int  label_len;
-    int  label_pos;
+    int label_len;
+    int label_pos;
 
     if (cur_tok(p) == NULL || cur_tok(p)->tok_type != TOK_SYMBOL)
+    {
         return fail(p, IRXPARS_SYNTAX);
+    }
 
     label_len = sym_to_upper(cur_tok(p), label, CTRL_NAME_MAX);
     advance_tok(p);
 
     label_pos = irx_ctrl_label_find(p, label, label_len);
-    if (label_pos < 0) return fail(p, IRXPARS_SYNTAX);
+    if (label_pos < 0)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
 
     /* Clear the entire execution stack (SIGNAL discards all frames). */
-    if (es != NULL) es->top = 0;
+    if (es != NULL)
+    {
+        es->top = 0;
+    }
 
     /* Jump to label (past SYMBOL ':' tokens). */
     p->tok_pos = label_pos + 2;
@@ -1831,35 +2380,36 @@ static int kw_signal(struct irx_parser *p)
 /* ------------------------------------------------------------------ */
 
 static const struct irx_keyword g_keyword_table[] = {
-    { "SAY",       kw_say       },
-    { "NOP",       kw_nop       },
-    { "EXIT",      kw_exit      },
-    { "DO",        kw_do        },
-    { "END",       kw_end       },
-    { "ITERATE",   kw_iterate   },
-    { "LEAVE",     kw_leave     },
-    { "IF",        kw_if        },
-    { "THEN",      kw_then      }, /* barrier only — IF consumes THEN   */
-    { "ELSE",      kw_else      }, /* barrier only — IF consumes ELSE   */
-    { "SELECT",    kw_select    },
-    { "WHEN",      kw_when      },
-    { "OTHERWISE", kw_otherwise },
-    { "CALL",      kw_call      },
-    { "RETURN",    kw_return    },
-    { "SIGNAL",    kw_signal    },
-    { "PROCEDURE", kw_procedure },
-    { "ARG",       kw_arg       },
-    { NULL,        NULL         }
-};
+    {"SAY", kw_say},
+    {"NOP", kw_nop},
+    {"EXIT", kw_exit},
+    {"DO", kw_do},
+    {"END", kw_end},
+    {"ITERATE", kw_iterate},
+    {"LEAVE", kw_leave},
+    {"IF", kw_if},
+    {"THEN", kw_then}, /* barrier only — IF consumes THEN   */
+    {"ELSE", kw_else}, /* barrier only — IF consumes ELSE   */
+    {"SELECT", kw_select},
+    {"WHEN", kw_when},
+    {"OTHERWISE", kw_otherwise},
+    {"CALL", kw_call},
+    {"RETURN", kw_return},
+    {"SIGNAL", kw_signal},
+    {"PROCEDURE", kw_procedure},
+    {"ARG", kw_arg},
+    {NULL, NULL}};
 
 static const struct irx_keyword *find_keyword(const unsigned char *name,
                                               size_t len)
 {
     int i;
-    for (i = 0; g_keyword_table[i].kw_name != NULL; i++) {
+    for (i = 0; g_keyword_table[i].kw_name != NULL; i++)
+    {
         const char *kn = g_keyword_table[i].kw_name;
         size_t kl = strlen(kn);
-        if (kl == len && memcmp(kn, name, len) == 0) {
+        if (kl == len && memcmp(kn, name, len) == 0)
+        {
             return &g_keyword_table[i];
         }
     }
@@ -1870,15 +2420,15 @@ static const struct irx_keyword *find_keyword(const unsigned char *name,
 /*  Forward declarations                                              */
 /* ------------------------------------------------------------------ */
 
-static int parse_or        (struct irx_parser *p, PLstr out);
-static int parse_and       (struct irx_parser *p, PLstr out);
+static int parse_or(struct irx_parser *p, PLstr out);
+static int parse_and(struct irx_parser *p, PLstr out);
 static int parse_comparison(struct irx_parser *p, PLstr out);
-static int parse_concat    (struct irx_parser *p, PLstr out);
-static int parse_add       (struct irx_parser *p, PLstr out);
-static int parse_mul       (struct irx_parser *p, PLstr out);
-static int parse_power     (struct irx_parser *p, PLstr out);
-static int parse_prefix    (struct irx_parser *p, PLstr out);
-static int parse_primary   (struct irx_parser *p, PLstr out);
+static int parse_concat(struct irx_parser *p, PLstr out);
+static int parse_add(struct irx_parser *p, PLstr out);
+static int parse_mul(struct irx_parser *p, PLstr out);
+static int parse_power(struct irx_parser *p, PLstr out);
+static int parse_prefix(struct irx_parser *p, PLstr out);
+static int parse_primary(struct irx_parser *p, PLstr out);
 
 /* ------------------------------------------------------------------ */
 /*  Compound-tail resolution                                          */
@@ -1899,29 +2449,40 @@ static int resolve_compound_name(struct irx_parser *p,
 
     Lzeroinit(&part);
 
-    for (i = 0; i < len; i++) {
-        if (src[i] == '.') { first_dot = i; break; }
+    for (i = 0; i < len; i++)
+    {
+        if (src[i] == '.')
+        {
+            first_dot = i;
+            break;
+        }
     }
-    if (first_dot < 0) {
+    if (first_dot < 0)
+    {
         /* Not compound after all. */
         return set_upper_from_tok(p->alloc, out, t);
     }
 
     /* Stem prefix includes the trailing dot. */
-    if (lstr_set_bytes(p->alloc, out, src, (size_t)(first_dot + 1))
-        != LSTR_OK) {
+    if (lstr_set_bytes(p->alloc, out, src, (size_t)(first_dot + 1)) != LSTR_OK)
+    {
         return fail(p, IRXPARS_NOMEM);
     }
     upper_bytes(out->pstr, out->len);
 
     /* Walk each tail part. */
     start = first_dot + 1;
-    while (start <= len) {
+    while (start <= len)
+    {
         int end = start;
-        while (end < len && src[end] != '.') end++;
+        while (end < len && src[end] != '.')
+        {
+            end++;
+        }
 
         /* Empty tail segment (e.g. "a..b"): treat as literal empty. */
-        if (end > start) {
+        if (end > start)
+        {
             Lstr key, value;
             int has_value = 0;
             int rc;
@@ -1930,7 +2491,8 @@ static int resolve_compound_name(struct irx_parser *p,
 
             rc = lstr_set_bytes(p->alloc, &key, src + start,
                                 (size_t)(end - start));
-            if (rc != LSTR_OK) {
+            if (rc != LSTR_OK)
+            {
                 Lfree(p->alloc, &key);
                 return fail(p, IRXPARS_NOMEM);
             }
@@ -1942,20 +2504,29 @@ static int resolve_compound_name(struct irx_parser *p,
             if (isalpha(key.pstr[0]) || key.pstr[0] == '_' ||
                 key.pstr[0] == '@' || key.pstr[0] == '#' ||
                 key.pstr[0] == '$' || key.pstr[0] == '?' ||
-                key.pstr[0] == '!') {
+                key.pstr[0] == '!')
+            {
                 rc = vpool_get(p->vpool, &key, &value);
-                if (rc == VPOOL_OK) has_value = 1;
+                if (rc == VPOOL_OK)
+                {
+                    has_value = 1;
+                }
             }
 
-            if (has_value) {
-                if (Lstrcat(p->alloc, out, &value) != LSTR_OK) {
+            if (has_value)
+            {
+                if (Lstrcat(p->alloc, out, &value) != LSTR_OK)
+                {
                     Lfree(p->alloc, &key);
                     Lfree(p->alloc, &value);
                     return fail(p, IRXPARS_NOMEM);
                 }
-            } else {
+            }
+            else
+            {
                 /* Uninitialised tail symbol - use its literal name. */
-                if (Lstrcat(p->alloc, out, &key) != LSTR_OK) {
+                if (Lstrcat(p->alloc, out, &key) != LSTR_OK)
+                {
                     Lfree(p->alloc, &key);
                     Lfree(p->alloc, &value);
                     return fail(p, IRXPARS_NOMEM);
@@ -1965,9 +2536,13 @@ static int resolve_compound_name(struct irx_parser *p,
             Lfree(p->alloc, &value);
         }
 
-        if (end >= len) break;
+        if (end >= len)
+        {
+            break;
+        }
         /* Consume the separator dot into the derived name. */
-        if (Lcat(p->alloc, out, ".") != LSTR_OK) {
+        if (Lcat(p->alloc, out, ".") != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
         start = end + 1;
@@ -1988,22 +2563,29 @@ static int lookup_variable(struct irx_parser *p,
 
     Lzeroinit(&name);
 
-    if (t->tok_flags & TOKF_COMPOUND) {
+    if (t->tok_flags & TOKF_COMPOUND)
+    {
         rc = resolve_compound_name(p, t, &name);
-        if (rc != IRXPARS_OK) {
+        if (rc != IRXPARS_OK)
+        {
             Lfree(p->alloc, &name);
             return rc;
         }
-    } else {
-        if (set_upper_from_tok(p->alloc, &name, t) != LSTR_OK) {
+    }
+    else
+    {
+        if (set_upper_from_tok(p->alloc, &name, t) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
 
     rc = vpool_get(p->vpool, &name, out);
-    if (rc != VPOOL_OK) {
+    if (rc != VPOOL_OK)
+    {
         /* NOVALUE - use the derived upper-case name as the value. */
-        if (Lstrcpy(p->alloc, out, &name) != LSTR_OK) {
+        if (Lstrcpy(p->alloc, out, &name) != LSTR_OK)
+        {
             Lfree(p->alloc, &name);
             return fail(p, IRXPARS_NOMEM);
         }
@@ -2033,7 +2615,8 @@ static int parse_function_call(struct irx_parser *p,
     const struct irx_bif *bif;
     Lstr upname;
 
-    for (i = 0; i < IRX_MAX_ARGS; i++) {
+    for (i = 0; i < IRX_MAX_ARGS; i++)
+    {
         Lzeroinit(&argvals[i]);
         argptrs[i] = &argvals[i];
     }
@@ -2042,24 +2625,34 @@ static int parse_function_call(struct irx_parser *p,
     /* Consume '(' */
     advance_tok(p);
 
-    if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_RPAREN) {
+    if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_RPAREN)
+    {
         advance_tok(p);
-    } else {
-        for (;;) {
-            if (argc >= IRX_MAX_ARGS) {
+    }
+    else
+    {
+        for (;;)
+        {
+            if (argc >= IRX_MAX_ARGS)
+            {
                 rc = fail(p, IRXPARS_SYNTAX);
                 goto done;
             }
             rc = parse_or(p, &argvals[argc]);
-            if (rc != IRXPARS_OK) goto done;
+            if (rc != IRXPARS_OK)
+            {
+                goto done;
+            }
             argc++;
 
-            if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_COMMA) {
+            if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_COMMA)
+            {
                 advance_tok(p);
                 continue;
             }
             if (cur_tok(p) != NULL &&
-                cur_tok(p)->tok_type == TOK_RPAREN) {
+                cur_tok(p)->tok_type == TOK_RPAREN)
+            {
                 advance_tok(p);
                 break;
             }
@@ -2068,17 +2661,20 @@ static int parse_function_call(struct irx_parser *p,
         }
     }
 
-    if (set_upper_from_tok(p->alloc, &upname, name_tok) != LSTR_OK) {
+    if (set_upper_from_tok(p->alloc, &upname, name_tok) != LSTR_OK)
+    {
         rc = fail(p, IRXPARS_NOMEM);
         goto done;
     }
 
     bif = find_bif(upname.pstr, upname.len);
-    if (bif == NULL) {
+    if (bif == NULL)
+    {
         rc = fail(p, IRXPARS_BADFUNC);
         goto done;
     }
-    if (argc < bif->bif_min_args || argc > bif->bif_max_args) {
+    if (argc < bif->bif_min_args || argc > bif->bif_max_args)
+    {
         rc = fail(p, IRXPARS_SYNTAX);
         goto done;
     }
@@ -2087,7 +2683,10 @@ static int parse_function_call(struct irx_parser *p,
 
 done:
     Lfree(p->alloc, &upname);
-    for (i = 0; i < argc; i++) Lfree(p->alloc, &argvals[i]);
+    for (i = 0; i < argc; i++)
+    {
+        Lfree(p->alloc, &argvals[i]);
+    }
     return rc;
 }
 
@@ -2100,16 +2699,22 @@ static int parse_primary(struct irx_parser *p, PLstr out)
     const struct irx_token *t = cur_tok(p);
     int rc;
 
-    if (t == NULL || tok_ends_clause(t)) {
+    if (t == NULL || tok_ends_clause(t))
+    {
         return fail(p, IRXPARS_SYNTAX);
     }
 
-    if (t->tok_type == TOK_LPAREN) {
+    if (t->tok_type == TOK_LPAREN)
+    {
         advance_tok(p);
         rc = parse_or(p, out);
-        if (rc != IRXPARS_OK) return rc;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
         if (cur_tok(p) == NULL ||
-            cur_tok(p)->tok_type != TOK_RPAREN) {
+            cur_tok(p)->tok_type != TOK_RPAREN)
+        {
             return fail(p, IRXPARS_SYNTAX);
         }
         advance_tok(p);
@@ -2118,33 +2723,44 @@ static int parse_primary(struct irx_parser *p, PLstr out)
 
     if (t->tok_type == TOK_STRING ||
         t->tok_type == TOK_HEXSTRING ||
-        t->tok_type == TOK_BINSTRING) {
+        t->tok_type == TOK_BINSTRING)
+    {
         /* Hex/bin decoding is not required by WP-13 acceptance; we  */
         /* store the raw string body for now. A later WP will decode */
         /* to bytes via Lx2c / Lb2x.                                  */
-        if (lstr_set_bytes(p->alloc, out, t->tok_text, t->tok_length)
-            != LSTR_OK) return fail(p, IRXPARS_NOMEM);
+        if (lstr_set_bytes(p->alloc, out, t->tok_text, t->tok_length) != LSTR_OK)
+        {
+            return fail(p, IRXPARS_NOMEM);
+        }
         if (t->tok_type == TOK_STRING &&
-            (t->tok_flags & TOKF_QUOTE_DBL) != 0) {
+            (t->tok_flags & TOKF_QUOTE_DBL) != 0)
+        {
             dedouble_string(out);
         }
         advance_tok(p);
         return IRXPARS_OK;
     }
 
-    if (t->tok_type == TOK_NUMBER) {
-        if (lstr_set_bytes(p->alloc, out, t->tok_text, t->tok_length)
-            != LSTR_OK) return fail(p, IRXPARS_NOMEM);
+    if (t->tok_type == TOK_NUMBER)
+    {
+        if (lstr_set_bytes(p->alloc, out, t->tok_text, t->tok_length) != LSTR_OK)
+        {
+            return fail(p, IRXPARS_NOMEM);
+        }
         advance_tok(p);
         return IRXPARS_OK;
     }
 
-    if (t->tok_type == TOK_SYMBOL) {
+    if (t->tok_type == TOK_SYMBOL)
+    {
         /* Constant symbol (starts with digit or dot) that is not a  */
         /* valid number becomes a literal string with its own text.  */
-        if (t->tok_flags & TOKF_CONSTANT) {
-            if (lstr_set_bytes(p->alloc, out, t->tok_text, t->tok_length)
-                != LSTR_OK) return fail(p, IRXPARS_NOMEM);
+        if (t->tok_flags & TOKF_CONSTANT)
+        {
+            if (lstr_set_bytes(p->alloc, out, t->tok_text, t->tok_length) != LSTR_OK)
+            {
+                return fail(p, IRXPARS_NOMEM);
+            }
             advance_tok(p);
             return IRXPARS_OK;
         }
@@ -2152,15 +2768,19 @@ static int parse_primary(struct irx_parser *p, PLstr out)
         /* Function call: SYMBOL immediately followed by '('. */
         const struct irx_token *nxt = peek_tok(p, 1);
         if (nxt != NULL && nxt->tok_type == TOK_LPAREN &&
-            toks_adjacent(t, nxt)) {
+            toks_adjacent(t, nxt))
+        {
             const struct irx_token *name_tok = t;
-            advance_tok(p);   /* consume SYMBOL */
+            advance_tok(p); /* consume SYMBOL */
             return parse_function_call(p, name_tok, out);
         }
 
         /* Plain variable reference. */
         rc = lookup_variable(p, t, out);
-        if (rc != IRXPARS_OK) return rc;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
         advance_tok(p);
         return IRXPARS_OK;
     }
@@ -2178,36 +2798,60 @@ static int parse_prefix(struct irx_parser *p, PLstr out)
     int negate = 0;
     int logical_not = 0;
 
-    while (t != NULL) {
-        if (t->tok_type == TOK_NOT) {
+    while (t != NULL)
+    {
+        if (t->tok_type == TOK_NOT)
+        {
             logical_not = !logical_not;
             advance_tok(p);
-        } else if (tok_is_op_char(t, TOK_OPERATOR, '+')) {
+        }
+        else if (tok_is_op_char(t, TOK_OPERATOR, '+'))
+        {
             advance_tok(p);
-        } else if (tok_is_op_char(t, TOK_OPERATOR, '-')) {
+        }
+        else if (tok_is_op_char(t, TOK_OPERATOR, '-'))
+        {
             negate = !negate;
             advance_tok(p);
-        } else {
+        }
+        else
+        {
             break;
         }
         t = cur_tok(p);
     }
 
     int rc = parse_primary(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    if (negate) {
+    if (negate)
+    {
         long v;
-        if (!lstr_to_long(out, &v)) return fail(p, IRXPARS_SYNTAX);
-        if (long_to_lstr(p->alloc, out, -v) != LSTR_OK) {
+        if (!lstr_to_long(out, &v))
+        {
+            return fail(p, IRXPARS_SYNTAX);
+        }
+        if (long_to_lstr(p->alloc, out, -v) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
-    if (logical_not) {
+    if (logical_not)
+    {
         long v;
-        if (!lstr_to_long(out, &v)) return fail(p, IRXPARS_SYNTAX);
-        if (v != 0 && v != 1) return fail(p, IRXPARS_SYNTAX);
-        if (long_to_lstr(p->alloc, out, v ? 0 : 1) != LSTR_OK) {
+        if (!lstr_to_long(out, &v))
+        {
+            return fail(p, IRXPARS_SYNTAX);
+        }
+        if (v != 0 && v != 1)
+        {
+            return fail(p, IRXPARS_SYNTAX);
+        }
+        if (long_to_lstr(p->alloc, out, v ? 0 : 1) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
@@ -2229,30 +2873,46 @@ static int next_is_power(struct irx_parser *p)
 static int parse_power(struct irx_parser *p, PLstr out)
 {
     int rc = parse_prefix(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    if (next_is_power(p)) {
+    if (next_is_power(p))
+    {
         Lstr rhs;
         long base, exp, result;
         Lzeroinit(&rhs);
 
-        advance_tok(p);   /* first  * */
-        advance_tok(p);   /* second * */
+        advance_tok(p); /* first  * */
+        advance_tok(p); /* second * */
 
-        rc = parse_power(p, &rhs);   /* recurse = right-associative */
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+        rc = parse_power(p, &rhs); /* recurse = right-associative */
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return rc;
+        }
 
-        if (!lstr_to_long(out, &base) || !lstr_to_long(&rhs, &exp)) {
+        if (!lstr_to_long(out, &base) || !lstr_to_long(&rhs, &exp))
+        {
             Lfree(p->alloc, &rhs);
             return fail(p, IRXPARS_SYNTAX);
         }
         Lfree(p->alloc, &rhs);
 
-        if (exp < 0) return fail(p, IRXPARS_SYNTAX);
+        if (exp < 0)
+        {
+            return fail(p, IRXPARS_SYNTAX);
+        }
         result = 1;
-        while (exp-- > 0) result *= base;
+        while (exp-- > 0)
+        {
+            result *= base;
+        }
 
-        if (long_to_lstr(p->alloc, out, result) != LSTR_OK) {
+        if (long_to_lstr(p->alloc, out, result) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
@@ -2266,9 +2926,13 @@ static int parse_power(struct irx_parser *p, PLstr out)
 static int parse_mul(struct irx_parser *p, PLstr out)
 {
     int rc = parse_power(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    for (;;) {
+    for (;;)
+    {
         const struct irx_token *t0 = cur_tok(p);
         const struct irx_token *t1 = peek_tok(p, 1);
         char op;
@@ -2277,51 +2941,88 @@ static int parse_mul(struct irx_parser *p, PLstr out)
 
         /* `**` is handled one level up (parse_power recurses back),  */
         /* so we stop here if we see it, to avoid eating the `*`.    */
-        if (next_is_power(p)) break;
+        if (next_is_power(p))
+        {
+            break;
+        }
 
-        if (tok_is_op_char(t0, TOK_OPERATOR, '*')) op = '*';
-        else if (tok_is_op_char(t0, TOK_OPERATOR, '/')) {
-            if (tok_is_op_char(t1, TOK_OPERATOR, '/')) {
-                op = 'm';   /* // integer remainder */
-            } else {
+        if (tok_is_op_char(t0, TOK_OPERATOR, '*'))
+        {
+            op = '*';
+        }
+        else if (tok_is_op_char(t0, TOK_OPERATOR, '/'))
+        {
+            if (tok_is_op_char(t1, TOK_OPERATOR, '/'))
+            {
+                op = 'm'; /* // integer remainder */
+            }
+            else
+            {
                 op = '/';
             }
         }
-        else if (tok_is_op_char(t0, TOK_OPERATOR, '%')) op = '%';
-        else break;
+        else if (tok_is_op_char(t0, TOK_OPERATOR, '%'))
+        {
+            op = '%';
+        }
+        else
+        {
+            break;
+        }
 
         advance_tok(p);
-        if (op == 'm') advance_tok(p);
+        if (op == 'm')
+        {
+            advance_tok(p);
+        }
 
         Lzeroinit(&rhs);
         rc = parse_power(p, &rhs);
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return rc;
+        }
 
-        if (!lstr_to_long(out, &a) || !lstr_to_long(&rhs, &b)) {
+        if (!lstr_to_long(out, &a) || !lstr_to_long(&rhs, &b))
+        {
             Lfree(p->alloc, &rhs);
             return fail(p, IRXPARS_SYNTAX);
         }
         Lfree(p->alloc, &rhs);
 
-        switch (op) {
-        case '*': r = a * b; break;
-        case '/':
-            if (b == 0) return fail(p, IRXPARS_DIVZERO);
-            r = a / b;
-            break;
-        case 'm':
-            if (b == 0) return fail(p, IRXPARS_DIVZERO);
-            r = a - (a / b) * b;
-            break;
-        case '%':
-            if (b == 0) return fail(p, IRXPARS_DIVZERO);
-            r = a / b;
-            break;
-        default:
-            return fail(p, IRXPARS_SYNTAX);
+        switch (op)
+        {
+            case '*':
+                r = a * b;
+                break;
+            case '/':
+                if (b == 0)
+                {
+                    return fail(p, IRXPARS_DIVZERO);
+                }
+                r = a / b;
+                break;
+            case 'm':
+                if (b == 0)
+                {
+                    return fail(p, IRXPARS_DIVZERO);
+                }
+                r = a - (a / b) * b;
+                break;
+            case '%':
+                if (b == 0)
+                {
+                    return fail(p, IRXPARS_DIVZERO);
+                }
+                r = a / b;
+                break;
+            default:
+                return fail(p, IRXPARS_SYNTAX);
         }
 
-        if (long_to_lstr(p->alloc, out, r) != LSTR_OK) {
+        if (long_to_lstr(p->alloc, out, r) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
@@ -2335,32 +3036,51 @@ static int parse_mul(struct irx_parser *p, PLstr out)
 static int parse_add(struct irx_parser *p, PLstr out)
 {
     int rc = parse_mul(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    for (;;) {
+    for (;;)
+    {
         const struct irx_token *t = cur_tok(p);
         char op;
         Lstr rhs;
         long a, b, r;
 
-        if (tok_is_op_char(t, TOK_OPERATOR, '+')) op = '+';
-        else if (tok_is_op_char(t, TOK_OPERATOR, '-')) op = '-';
-        else break;
+        if (tok_is_op_char(t, TOK_OPERATOR, '+'))
+        {
+            op = '+';
+        }
+        else if (tok_is_op_char(t, TOK_OPERATOR, '-'))
+        {
+            op = '-';
+        }
+        else
+        {
+            break;
+        }
 
         advance_tok(p);
 
         Lzeroinit(&rhs);
         rc = parse_mul(p, &rhs);
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return rc;
+        }
 
-        if (!lstr_to_long(out, &a) || !lstr_to_long(&rhs, &b)) {
+        if (!lstr_to_long(out, &a) || !lstr_to_long(&rhs, &b))
+        {
             Lfree(p->alloc, &rhs);
             return fail(p, IRXPARS_SYNTAX);
         }
         Lfree(p->alloc, &rhs);
 
         r = (op == '+') ? (a + b) : (a - b);
-        if (long_to_lstr(p->alloc, out, r) != LSTR_OK) {
+        if (long_to_lstr(p->alloc, out, r) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
@@ -2373,26 +3093,34 @@ static int parse_add(struct irx_parser *p, PLstr out)
 
 static int tok_starts_term(const struct irx_token *t)
 {
-    if (t == NULL) return 0;
-    switch (t->tok_type) {
-    case TOK_SYMBOL:
-    case TOK_STRING:
-    case TOK_NUMBER:
-    case TOK_HEXSTRING:
-    case TOK_BINSTRING:
-    case TOK_LPAREN:
-        return 1;
-    default:
+    if (t == NULL)
+    {
         return 0;
+    }
+    switch (t->tok_type)
+    {
+        case TOK_SYMBOL:
+        case TOK_STRING:
+        case TOK_NUMBER:
+        case TOK_HEXSTRING:
+        case TOK_BINSTRING:
+        case TOK_LPAREN:
+            return 1;
+        default:
+            return 0;
     }
 }
 
 static int parse_concat(struct irx_parser *p, PLstr out)
 {
     int rc = parse_add(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    for (;;) {
+    for (;;)
+    {
         const struct irx_token *t0 = cur_tok(p);
         const struct irx_token *t1 = peek_tok(p, 1);
         const struct irx_token *prev;
@@ -2401,9 +3129,12 @@ static int parse_concat(struct irx_parser *p, PLstr out)
         Lstr rhs;
 
         if (tok_is_op_char(t0, TOK_LOGICAL, '|') &&
-            tok_is_op_char(t1, TOK_LOGICAL, '|')) {
+            tok_is_op_char(t1, TOK_LOGICAL, '|'))
+        {
             explicit_concat = 1;
-        } else if (tok_starts_term(t0)) {
+        }
+        else if (tok_starts_term(t0))
+        {
             /* Implicit concat. The left operand's last token lives
              * at tok_pos - 1. If there's a column gap (same line,
              * whitespace between) it's blank concat; otherwise it's
@@ -2412,54 +3143,74 @@ static int parse_concat(struct irx_parser *p, PLstr out)
              * Keyword check: a symbol that is a known keyword (THEN,
              * ELSE, WHEN, DO, END, etc.) cannot start a concatenated
              * term — it is a clause-level delimiter, not an operand. */
-            if (t0->tok_type == TOK_SYMBOL) {
+            if (t0->tok_type == TOK_SYMBOL)
+            {
                 /* If the symbol is immediately followed by '(' it is a
                  * function call, not a keyword instruction — do not stop. */
                 const struct irx_token *tnxt = peek_tok(p, 1);
                 int is_func = (tnxt != NULL &&
                                tnxt->tok_type == TOK_LPAREN &&
                                toks_adjacent(t0, tnxt));
-                if (!is_func) {
+                if (!is_func)
+                {
                     char kbuf[32];
-                    int  kn = (int)t0->tok_length;
-                    if (kn < (int)sizeof(kbuf)) {
+                    int kn = (int)t0->tok_length;
+                    if (kn < (int)sizeof(kbuf))
+                    {
                         memcpy(kbuf, t0->tok_text, (size_t)kn);
                         kbuf[kn] = '\0';
                         upper_bytes((unsigned char *)kbuf, (size_t)kn);
                         if (find_keyword((unsigned char *)kbuf,
-                                         (size_t)kn) != NULL) {
+                                         (size_t)kn) != NULL)
+                        {
                             break; /* keyword: stop concatenation */
                         }
                     }
                 }
             }
             prev = peek_tok(p, -1);
-            if (prev == NULL || prev->tok_line != t0->tok_line) break;
-            if (toks_adjacent(prev, t0)) {
+            if (prev == NULL || prev->tok_line != t0->tok_line)
+            {
+                break;
+            }
+            if (toks_adjacent(prev, t0))
+            {
                 blank_concat = 0;
-            } else {
+            }
+            else
+            {
                 blank_concat = 1;
             }
-        } else {
+        }
+        else
+        {
             break;
         }
 
-        if (explicit_concat) {
+        if (explicit_concat)
+        {
             advance_tok(p);
             advance_tok(p);
         }
 
         Lzeroinit(&rhs);
         rc = parse_add(p, &rhs);
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return rc;
+        }
 
-        if (blank_concat) {
-            if (Lcat(p->alloc, out, " ") != LSTR_OK) {
+        if (blank_concat)
+        {
+            if (Lcat(p->alloc, out, " ") != LSTR_OK)
+            {
                 Lfree(p->alloc, &rhs);
                 return fail(p, IRXPARS_NOMEM);
             }
         }
-        if (Lstrcat(p->alloc, out, &rhs) != LSTR_OK) {
+        if (Lstrcat(p->alloc, out, &rhs) != LSTR_OK)
+        {
             Lfree(p->alloc, &rhs);
             return fail(p, IRXPARS_NOMEM);
         }
@@ -2473,14 +3224,14 @@ static int parse_concat(struct irx_parser *p, PLstr out)
 /* ------------------------------------------------------------------ */
 
 /* Operator codes for the comparison layer. */
-#define CMP_EQ     1   /* =   */
-#define CMP_NE     2   /* \=  */
-#define CMP_EQS    3   /* ==  */
-#define CMP_NES    4   /* \== */
-#define CMP_GT     5   /* >   */
-#define CMP_LT     6   /* <   */
-#define CMP_GE     7   /* >=  */
-#define CMP_LE     8   /* <=  */
+#define CMP_EQ  1 /* =   */
+#define CMP_NE  2 /* \=  */
+#define CMP_EQS 3 /* ==  */
+#define CMP_NES 4 /* \== */
+#define CMP_GT  5 /* >   */
+#define CMP_LT  6 /* <   */
+#define CMP_GE  7 /* >=  */
+#define CMP_LE  8 /* <=  */
 
 static int match_comparison(struct irx_parser *p, int *out_op)
 {
@@ -2488,26 +3239,38 @@ static int match_comparison(struct irx_parser *p, int *out_op)
     const struct irx_token *t1 = peek_tok(p, 1);
     const struct irx_token *t2 = peek_tok(p, 2);
 
-    if (t0 == NULL) return 0;
+    if (t0 == NULL)
+    {
+        return 0;
+    }
 
-    if (t0->tok_type == TOK_NOT) {
-        if (tok_is_op_char(t1, TOK_COMPARISON, '=')) {
-            if (tok_is_op_char(t2, TOK_COMPARISON, '=')) {
+    if (t0->tok_type == TOK_NOT)
+    {
+        if (tok_is_op_char(t1, TOK_COMPARISON, '='))
+        {
+            if (tok_is_op_char(t2, TOK_COMPARISON, '='))
+            {
                 *out_op = CMP_NES;
-                advance_tok(p); advance_tok(p); advance_tok(p);
+                advance_tok(p);
+                advance_tok(p);
+                advance_tok(p);
                 return 1;
             }
             *out_op = CMP_NE;
-            advance_tok(p); advance_tok(p);
+            advance_tok(p);
+            advance_tok(p);
             return 1;
         }
         return 0;
     }
 
-    if (tok_is_op_char(t0, TOK_COMPARISON, '=')) {
-        if (tok_is_op_char(t1, TOK_COMPARISON, '=')) {
+    if (tok_is_op_char(t0, TOK_COMPARISON, '='))
+    {
+        if (tok_is_op_char(t1, TOK_COMPARISON, '='))
+        {
             *out_op = CMP_EQS;
-            advance_tok(p); advance_tok(p);
+            advance_tok(p);
+            advance_tok(p);
             return 1;
         }
         *out_op = CMP_EQ;
@@ -2515,10 +3278,13 @@ static int match_comparison(struct irx_parser *p, int *out_op)
         return 1;
     }
 
-    if (tok_is_op_char(t0, TOK_COMPARISON, '>')) {
-        if (tok_is_op_char(t1, TOK_COMPARISON, '=')) {
+    if (tok_is_op_char(t0, TOK_COMPARISON, '>'))
+    {
+        if (tok_is_op_char(t1, TOK_COMPARISON, '='))
+        {
             *out_op = CMP_GE;
-            advance_tok(p); advance_tok(p);
+            advance_tok(p);
+            advance_tok(p);
             return 1;
         }
         *out_op = CMP_GT;
@@ -2526,10 +3292,13 @@ static int match_comparison(struct irx_parser *p, int *out_op)
         return 1;
     }
 
-    if (tok_is_op_char(t0, TOK_COMPARISON, '<')) {
-        if (tok_is_op_char(t1, TOK_COMPARISON, '=')) {
+    if (tok_is_op_char(t0, TOK_COMPARISON, '<'))
+    {
+        if (tok_is_op_char(t1, TOK_COMPARISON, '='))
+        {
             *out_op = CMP_LE;
-            advance_tok(p); advance_tok(p);
+            advance_tok(p);
+            advance_tok(p);
             return 1;
         }
         *out_op = CMP_LT;
@@ -2543,38 +3312,71 @@ static int match_comparison(struct irx_parser *p, int *out_op)
 static int parse_comparison(struct irx_parser *p, PLstr out)
 {
     int rc = parse_concat(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
     int op;
     Lstr rhs;
     int c, result;
 
-    if (!match_comparison(p, &op)) return IRXPARS_OK;
+    if (!match_comparison(p, &op))
+    {
+        return IRXPARS_OK;
+    }
 
     Lzeroinit(&rhs);
     rc = parse_concat(p, &rhs);
-    if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+    if (rc != IRXPARS_OK)
+    {
+        Lfree(p->alloc, &rhs);
+        return rc;
+    }
 
-    if (op == CMP_EQS || op == CMP_NES) {
+    if (op == CMP_EQS || op == CMP_NES)
+    {
         c = compare_strict(out, &rhs);
-    } else {
+    }
+    else
+    {
         c = compare_normal(out, &rhs);
     }
     Lfree(p->alloc, &rhs);
 
-    switch (op) {
-    case CMP_EQ:  result = (c == 0); break;
-    case CMP_NE:  result = (c != 0); break;
-    case CMP_EQS: result = (c == 0); break;
-    case CMP_NES: result = (c != 0); break;
-    case CMP_GT:  result = (c >  0); break;
-    case CMP_LT:  result = (c <  0); break;
-    case CMP_GE:  result = (c >= 0); break;
-    case CMP_LE:  result = (c <= 0); break;
-    default:      result = 0; break;
+    switch (op)
+    {
+        case CMP_EQ:
+            result = (c == 0);
+            break;
+        case CMP_NE:
+            result = (c != 0);
+            break;
+        case CMP_EQS:
+            result = (c == 0);
+            break;
+        case CMP_NES:
+            result = (c != 0);
+            break;
+        case CMP_GT:
+            result = (c > 0);
+            break;
+        case CMP_LT:
+            result = (c < 0);
+            break;
+        case CMP_GE:
+            result = (c >= 0);
+            break;
+        case CMP_LE:
+            result = (c <= 0);
+            break;
+        default:
+            result = 0;
+            break;
     }
 
-    if (long_to_lstr(p->alloc, out, (long)result) != LSTR_OK) {
+    if (long_to_lstr(p->alloc, out, (long)result) != LSTR_OK)
+    {
         return fail(p, IRXPARS_NOMEM);
     }
     return IRXPARS_OK;
@@ -2588,8 +3390,14 @@ static int parse_comparison(struct irx_parser *p, PLstr out)
 static int as_bool(PLstr s, int *out)
 {
     long v;
-    if (!lstr_to_long(s, &v)) return 0;
-    if (v != 0 && v != 1) return 0;
+    if (!lstr_to_long(s, &v))
+    {
+        return 0;
+    }
+    if (v != 0 && v != 1)
+    {
+        return 0;
+    }
     *out = (int)v;
     return 1;
 }
@@ -2597,9 +3405,13 @@ static int as_bool(PLstr s, int *out)
 static int parse_and(struct irx_parser *p, PLstr out)
 {
     int rc = parse_comparison(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    for (;;) {
+    for (;;)
+    {
         const struct irx_token *t0 = peek_tok(p, 0);
         const struct irx_token *t1 = peek_tok(p, 1);
         Lstr rhs;
@@ -2607,22 +3419,34 @@ static int parse_and(struct irx_parser *p, PLstr out)
 
         /* `&&` is XOR at the parse_or level, so we require the next
          * token NOT to be another `&`. */
-        if (!tok_is_op_char(t0, TOK_LOGICAL, '&')) break;
-        if (tok_is_op_char(t1, TOK_LOGICAL, '&')) break;
+        if (!tok_is_op_char(t0, TOK_LOGICAL, '&'))
+        {
+            break;
+        }
+        if (tok_is_op_char(t1, TOK_LOGICAL, '&'))
+        {
+            break;
+        }
 
         advance_tok(p);
 
         Lzeroinit(&rhs);
         rc = parse_comparison(p, &rhs);
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return rc;
+        }
 
-        if (!as_bool(out, &a) || !as_bool(&rhs, &b)) {
+        if (!as_bool(out, &a) || !as_bool(&rhs, &b))
+        {
             Lfree(p->alloc, &rhs);
             return fail(p, IRXPARS_SYNTAX);
         }
         Lfree(p->alloc, &rhs);
 
-        if (long_to_lstr(p->alloc, out, (long)(a && b)) != LSTR_OK) {
+        if (long_to_lstr(p->alloc, out, (long)(a && b)) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
@@ -2632,9 +3456,13 @@ static int parse_and(struct irx_parser *p, PLstr out)
 static int parse_or(struct irx_parser *p, PLstr out)
 {
     int rc = parse_and(p, out);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    for (;;) {
+    for (;;)
+    {
         const struct irx_token *t0 = peek_tok(p, 0);
         const struct irx_token *t1 = peek_tok(p, 1);
         int is_or = 0;
@@ -2643,35 +3471,49 @@ static int parse_or(struct irx_parser *p, PLstr out)
         int a, b, r;
 
         if (tok_is_op_char(t0, TOK_LOGICAL, '|') &&
-            !tok_is_op_char(t1, TOK_LOGICAL, '|')) {
+            !tok_is_op_char(t1, TOK_LOGICAL, '|'))
+        {
             is_or = 1;
-        } else if (tok_is_op_char(t0, TOK_LOGICAL, '&') &&
-                   tok_is_op_char(t1, TOK_LOGICAL, '&')) {
+        }
+        else if (tok_is_op_char(t0, TOK_LOGICAL, '&') &&
+                 tok_is_op_char(t1, TOK_LOGICAL, '&'))
+        {
             is_xor = 1;
-        } else {
+        }
+        else
+        {
             break;
         }
 
-        if (is_xor) {
+        if (is_xor)
+        {
             advance_tok(p);
             advance_tok(p);
-        } else {
+        }
+        else
+        {
             advance_tok(p);
         }
         (void)is_or;
 
         Lzeroinit(&rhs);
         rc = parse_and(p, &rhs);
-        if (rc != IRXPARS_OK) { Lfree(p->alloc, &rhs); return rc; }
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return rc;
+        }
 
-        if (!as_bool(out, &a) || !as_bool(&rhs, &b)) {
+        if (!as_bool(out, &a) || !as_bool(&rhs, &b))
+        {
             Lfree(p->alloc, &rhs);
             return fail(p, IRXPARS_SYNTAX);
         }
         Lfree(p->alloc, &rhs);
 
         r = is_xor ? (a ^ b) : (a | b);
-        if (long_to_lstr(p->alloc, out, (long)r) != LSTR_OK) {
+        if (long_to_lstr(p->alloc, out, (long)r) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
     }
@@ -2695,23 +3537,34 @@ static int exec_assignment(struct irx_parser *p)
     Lzeroinit(&name);
     Lzeroinit(&value);
 
-    if (name_tok->tok_flags & TOKF_COMPOUND) {
+    if (name_tok->tok_flags & TOKF_COMPOUND)
+    {
         rc = resolve_compound_name(p, name_tok, &name);
-        if (rc != IRXPARS_OK) goto done;
-    } else {
-        if (set_upper_from_tok(p->alloc, &name, name_tok) != LSTR_OK) {
+        if (rc != IRXPARS_OK)
+        {
+            goto done;
+        }
+    }
+    else
+    {
+        if (set_upper_from_tok(p->alloc, &name, name_tok) != LSTR_OK)
+        {
             rc = fail(p, IRXPARS_NOMEM);
             goto done;
         }
     }
 
-    advance_tok(p);   /* SYMBOL */
-    advance_tok(p);   /* =      */
+    advance_tok(p); /* SYMBOL */
+    advance_tok(p); /* =      */
 
     rc = irx_pars_eval_expr(p, &value);
-    if (rc != IRXPARS_OK) goto done;
+    if (rc != IRXPARS_OK)
+    {
+        goto done;
+    }
 
-    if (vpool_set(p->vpool, &name, &value) != VPOOL_OK) {
+    if (vpool_set(p->vpool, &name, &value) != VPOOL_OK)
+    {
         rc = fail(p, IRXPARS_NOMEM);
         goto done;
     }
@@ -2750,7 +3603,9 @@ static void proc_allowed_clear(struct irx_parser *p)
 {
     struct irx_exec_frame *f = irx_ctrl_frame_top(p);
     if (f != NULL && f->frame_type == FRAME_CALL)
+    {
         f->procedure_allowed = 0;
+    }
 }
 
 static int is_assignment_here(struct irx_parser *p)
@@ -2759,11 +3614,23 @@ static int is_assignment_here(struct irx_parser *p)
     const struct irx_token *t1 = peek_tok(p, 1);
     const struct irx_token *t2 = peek_tok(p, 2);
 
-    if (t0 == NULL || t0->tok_type != TOK_SYMBOL) return 0;
-    if (t0->tok_flags & TOKF_CONSTANT) return 0;
-    if (!tok_is_op_char(t1, TOK_COMPARISON, '=')) return 0;
+    if (t0 == NULL || t0->tok_type != TOK_SYMBOL)
+    {
+        return 0;
+    }
+    if (t0->tok_flags & TOKF_CONSTANT)
+    {
+        return 0;
+    }
+    if (!tok_is_op_char(t1, TOK_COMPARISON, '='))
+    {
+        return 0;
+    }
     /* Exclude `==` which is strict comparison, not assignment. */
-    if (tok_is_op_char(t2, TOK_COMPARISON, '=')) return 0;
+    if (tok_is_op_char(t2, TOK_COMPARISON, '='))
+    {
+        return 0;
+    }
     return 1;
 }
 
@@ -2772,36 +3639,45 @@ static int exec_clause(struct irx_parser *p)
     const struct irx_token *t0;
 
     /* Skip empty clauses. */
-    while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC) {
+    while (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_EOC)
+    {
         advance_tok(p);
     }
 
     t0 = cur_tok(p);
-    if (t0 == NULL || t0->tok_type == TOK_EOF) return IRXPARS_OK;
+    if (t0 == NULL || t0->tok_type == TOK_EOF)
+    {
+        return IRXPARS_OK;
+    }
 
     /* Null clause (just a semicolon) also does nothing. */
-    if (t0->tok_type == TOK_SEMICOLON) {
+    if (t0->tok_type == TOK_SEMICOLON)
+    {
         advance_tok(p);
         return IRXPARS_OK;
     }
 
     /* Rule 1: assignment. */
-    if (is_assignment_here(p)) {
+    if (is_assignment_here(p))
+    {
         proc_allowed_clear(p);
         return exec_assignment(p);
     }
 
     /* Rule 2: label - SYMBOL followed by SEMICOLON (the colon). */
-    if (t0->tok_type == TOK_SYMBOL) {
+    if (t0->tok_type == TOK_SYMBOL)
+    {
         const struct irx_token *t1 = peek_tok(p, 1);
         if (t1 != NULL && t1->tok_type == TOK_SEMICOLON &&
-            t1->tok_length == 1 && t1->tok_text[0] == ':') {
+            t1->tok_length == 1 && t1->tok_text[0] == ':')
+        {
             /* Label declaration: record in exec_stack->last_label so
              * the immediately following DO can associate it.
              * Labels do NOT clear procedure_allowed. */
             struct irx_exec_stack *es =
                 (struct irx_exec_stack *)p->exec_stack;
-            if (es != NULL) {
+            if (es != NULL)
+            {
                 es->last_label_len = sym_to_upper(
                     t0, es->last_label, CTRL_NAME_MAX);
             }
@@ -2814,17 +3690,21 @@ static int exec_clause(struct irx_parser *p)
         Lstr upname;
         const struct irx_keyword *kw;
         Lzeroinit(&upname);
-        if (set_upper_from_tok(p->alloc, &upname, t0) != LSTR_OK) {
+        if (set_upper_from_tok(p->alloc, &upname, t0) != LSTR_OK)
+        {
             return fail(p, IRXPARS_NOMEM);
         }
         kw = find_keyword(upname.pstr, upname.len);
         Lfree(p->alloc, &upname);
-        if (kw != NULL) {
+        if (kw != NULL)
+        {
             /* PROCEDURE is allowed only as first executable clause
              * in a subroutine; it checks procedure_allowed itself.
              * All other keywords clear the flag before executing. */
             if (kw->kw_handler != kw_procedure)
+            {
                 proc_allowed_clear(p);
+            }
             advance_tok(p);
             return kw->kw_handler(p);
         }
@@ -2846,43 +3726,54 @@ int irx_pars_init(struct irx_parser *p,
                   struct envblock *envblock)
 {
     int rc;
-    if (p == NULL || tokens == NULL || vpool == NULL || alloc == NULL) {
+    if (p == NULL || tokens == NULL || vpool == NULL || alloc == NULL)
+    {
         return IRXPARS_BADARG;
     }
     memset(p, 0, sizeof(*p));
-    p->tokens    = tokens;
+    p->tokens = tokens;
     p->tok_count = tok_count;
-    p->tok_pos   = 0;
-    p->vpool     = vpool;
-    p->alloc     = alloc;
-    p->envblock  = envblock;
+    p->tok_pos = 0;
+    p->vpool = vpool;
+    p->alloc = alloc;
+    p->envblock = envblock;
     Lzeroinit(&p->result);
     p->error_code = IRXPARS_OK;
     p->error_line = 0;
 
     rc = irx_ctrl_init(p);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
     return IRXPARS_OK;
 }
 
 void irx_pars_cleanup(struct irx_parser *p)
 {
-    if (p == NULL) return;
+    if (p == NULL)
+    {
+        return;
+    }
     irx_ctrl_cleanup(p);
     Lfree(p->alloc, &p->result);
 
     /* Free call_args if any remain (WP-17). */
-    if (p->alloc != NULL && p->call_args != NULL) {
+    if (p->alloc != NULL && p->call_args != NULL)
+    {
         int i;
         for (i = 0; i < p->call_argc; i++)
+        {
             Lfree(p->alloc, &p->call_args[i]);
+        }
         p->alloc->dealloc(p->call_args,
                           (size_t)IRX_MAX_ARGS * sizeof(Lstr),
                           p->alloc->ctx);
         p->call_args = NULL;
     }
-    if (p->alloc != NULL && p->call_arg_exists != NULL) {
+    if (p->alloc != NULL && p->call_arg_exists != NULL)
+    {
         p->alloc->dealloc(p->call_arg_exists,
                           (size_t)IRX_MAX_ARGS * sizeof(int),
                           p->alloc->ctx);
@@ -2892,32 +3783,52 @@ void irx_pars_cleanup(struct irx_parser *p)
 
 int irx_pars_eval_expr(struct irx_parser *p, PLstr out)
 {
-    if (p == NULL || out == NULL) return IRXPARS_BADARG;
+    if (p == NULL || out == NULL)
+    {
+        return IRXPARS_BADARG;
+    }
     return parse_or(p, out);
 }
 
 int irx_pars_run(struct irx_parser *p)
 {
     int rc;
-    if (p == NULL) return IRXPARS_BADARG;
+    if (p == NULL)
+    {
+        return IRXPARS_BADARG;
+    }
 
     /* First pass: build the label table for CALL/SIGNAL. */
     rc = irx_ctrl_label_scan(p);
-    if (rc != IRXPARS_OK) return rc;
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
-    while (p->tok_pos < p->tok_count) {
+    while (p->tok_pos < p->tok_count)
+    {
         const struct irx_token *t = cur_tok(p);
-        if (t == NULL || t->tok_type == TOK_EOF) break;
+        if (t == NULL || t->tok_type == TOK_EOF)
+        {
+            break;
+        }
 
         rc = exec_clause(p);
-        if (rc != IRXPARS_OK) return rc;
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
 
-        if (p->exit_requested) break;
+        if (p->exit_requested)
+        {
+            break;
+        }
 
         /* Consume trailing clause terminators. */
         while (cur_tok(p) != NULL &&
                (cur_tok(p)->tok_type == TOK_EOC ||
-                cur_tok(p)->tok_type == TOK_SEMICOLON)) {
+                cur_tok(p)->tok_type == TOK_SEMICOLON))
+        {
             advance_tok(p);
         }
     }

--- a/src/irx#rab.c
+++ b/src/irx#rab.c
@@ -13,17 +13,18 @@
 /* ------------------------------------------------------------------ */
 
 #include <string.h>
+
 #include "irx.h"
+#include "irxfunc.h"
 #include "irxrab.h"
 #include "irxwkblk.h"
-#include "irxfunc.h"
 
 #ifdef __MVS__
 /* MVS 3.8j: access TCB via PSA -> current TCB */
 /* PSA+X'218' -> current TCB address */
 /* TCB+X'A8'  -> TCBUSER field       */
-#define PSA_CURTCB_OFFSET   0x218
-#define TCB_USER_OFFSET     0x0A8
+#define PSA_CURTCB_OFFSET 0x218
+#define TCB_USER_OFFSET   0x0A8
 
 static void **get_tcbuser_ptr(void)
 {
@@ -52,20 +53,23 @@ static void **get_tcbuser_ptr(void)
 
 int irx_rab_obtain(struct irx_rab **rab_ptr)
 {
-    void         **tcbuser_ptr;
+    void **tcbuser_ptr;
     struct irx_rab *rab;
 
-    if (rab_ptr == NULL) {
+    if (rab_ptr == NULL)
+    {
         return 20;
     }
 
     tcbuser_ptr = get_tcbuser_ptr();
 
     /* Check if RAB already exists */
-    if (*tcbuser_ptr != NULL) {
+    if (*tcbuser_ptr != NULL)
+    {
         rab = (struct irx_rab *)(*tcbuser_ptr);
         if (memcmp(rab->rab_id, RAB_ID, 4) == 0 &&
-            (rab->rab_flags & RAB_ACTIVE)) {
+            (rab->rab_flags & RAB_ACTIVE))
+        {
             *rab_ptr = rab;
             return 0;
         }
@@ -75,19 +79,20 @@ int irx_rab_obtain(struct irx_rab **rab_ptr)
     void *storage = NULL;
     int rc = irxstor(RXSMGET, (int)sizeof(struct irx_rab),
                      &storage, NULL);
-    if (rc != 0) {
+    if (rc != 0)
+    {
         return 20;
     }
     rab = (struct irx_rab *)storage;
 
     /* Initialize RAB */
     memcpy(rab->rab_id, RAB_ID, 4);
-    rab->rab_length    = (int)sizeof(struct irx_rab);
-    rab->rab_version   = RAB_VERSION;
+    rab->rab_length = (int)sizeof(struct irx_rab);
+    rab->rab_version = RAB_VERSION;
     rab->rab_env_count = 0;
-    rab->rab_first     = NULL;
-    rab->rab_last      = NULL;
-    rab->rab_flags     = RAB_ACTIVE;
+    rab->rab_first = NULL;
+    rab->rab_last = NULL;
+    rab->rab_flags = RAB_ACTIVE;
 
     /* Save previous TCBUSER and install RAB */
     rab->rab_prev_tcbuser = *tcbuser_ptr;
@@ -111,11 +116,13 @@ int irx_rab_release(struct irx_rab *rab)
     void **tcbuser_ptr;
 
     if (rab == NULL ||
-        memcmp(rab->rab_id, RAB_ID, 4) != 0) {
+        memcmp(rab->rab_id, RAB_ID, 4) != 0)
+    {
         return 20;
     }
 
-    if (rab->rab_env_count > 0) {
+    if (rab->rab_env_count > 0)
+    {
         return 4;
     }
 
@@ -136,17 +143,21 @@ int irx_rab_release(struct irx_rab *rab)
 
 int irx_rab_add_env(struct irx_rab *rab, struct irx_env_node *node)
 {
-    if (rab == NULL || node == NULL) {
+    if (rab == NULL || node == NULL)
+    {
         return 20;
     }
 
-    node->node_rab  = rab;
+    node->node_rab = rab;
     node->node_next = NULL;
     node->node_prev = (struct irx_env_node *)rab->rab_last;
 
-    if (rab->rab_last != NULL) {
+    if (rab->rab_last != NULL)
+    {
         ((struct irx_env_node *)rab->rab_last)->node_next = node;
-    } else {
+    }
+    else
+    {
         rab->rab_first = node;
     }
 
@@ -162,25 +173,32 @@ int irx_rab_add_env(struct irx_rab *rab, struct irx_env_node *node)
 
 int irx_rab_remove_env(struct irx_rab *rab, struct irx_env_node *node)
 {
-    if (rab == NULL || node == NULL) {
+    if (rab == NULL || node == NULL)
+    {
         return 20;
     }
 
-    if (node->node_prev != NULL) {
+    if (node->node_prev != NULL)
+    {
         node->node_prev->node_next = node->node_next;
-    } else {
+    }
+    else
+    {
         rab->rab_first = node->node_next;
     }
 
-    if (node->node_next != NULL) {
+    if (node->node_next != NULL)
+    {
         node->node_next->node_prev = node->node_prev;
-    } else {
+    }
+    else
+    {
         rab->rab_last = node->node_prev;
     }
 
     node->node_next = NULL;
     node->node_prev = NULL;
-    node->node_rab  = NULL;
+    node->node_rab = NULL;
     rab->rab_env_count--;
 
     return 0;
@@ -194,23 +212,26 @@ int irx_rab_remove_env(struct irx_rab *rab, struct irx_env_node *node)
 
 struct envblock *irx_find_env(void)
 {
-    void         **tcbuser_ptr;
+    void **tcbuser_ptr;
     struct irx_rab *rab;
     struct irx_env_node *node;
 
     tcbuser_ptr = get_tcbuser_ptr();
-    if (*tcbuser_ptr == NULL) {
+    if (*tcbuser_ptr == NULL)
+    {
         return NULL;
     }
 
     rab = (struct irx_rab *)(*tcbuser_ptr);
-    if (memcmp(rab->rab_id, RAB_ID, 4) != 0) {
+    if (memcmp(rab->rab_id, RAB_ID, 4) != 0)
+    {
         return NULL;
     }
 
     /* Most recent = last in chain */
     node = (struct irx_env_node *)rab->rab_last;
-    if (node == NULL) {
+    if (node == NULL)
+    {
         return NULL;
     }
 

--- a/src/irx#stor.c
+++ b/src/irx#stor.c
@@ -16,11 +16,11 @@
 #include <string.h>
 
 #include "irx.h"
-#include "irxwkblk.h"
 #include "irxfunc.h"
+#include "irxwkblk.h"
 
 #ifdef __MVS__
-#include <clibos.h>     /* getmain(), freemain() — crent370 */
+#include <clibos.h> /* getmain(), freemain() — crent370 */
 #endif
 
 /* ------------------------------------------------------------------ */
@@ -40,52 +40,66 @@ int irxstor(int function, int length, void **addr_ptr,
     int subpool = 0;
 
     /* Determine subpool from PARMBLOCK if available */
-    if (envblock != NULL && envblock->envblock_parmblock != NULL) {
+    if (envblock != NULL && envblock->envblock_parmblock != NULL)
+    {
         struct parmblock *pb = (struct parmblock *)envblock->envblock_parmblock;
-        if (pb->parmblock_subpool > 0) {
+        if (pb->parmblock_subpool > 0)
+        {
             subpool = pb->parmblock_subpool;
         }
     }
 
-    switch (function) {
-
-    case RXSMGET:
-        if (length <= 0 || addr_ptr == NULL) {
-            return 20;
-        }
+    switch (function)
+    {
+        case RXSMGET:
+            if (length <= 0 || addr_ptr == NULL)
+            {
+                return 20;
+            }
 #ifdef __MVS__
-        if (subpool > 0) {
-            /* Specific subpool: use GETMAIN R,LV=,SP= */
-            void *ptr = getmain((unsigned)length, subpool);
-            if (ptr == NULL) return 20;
-            memset(ptr, 0, (unsigned)length);
-            *addr_ptr = ptr;
-        } else
+            if (subpool > 0)
+            {
+                /* Specific subpool: use GETMAIN R,LV=,SP= */
+                void *ptr = getmain((unsigned)length, subpool);
+                if (ptr == NULL)
+                {
+                    return 20;
+                }
+                memset(ptr, 0, (unsigned)length);
+                *addr_ptr = ptr;
+            }
+            else
 #endif
-        {
-            /* Default: crent370 heap (calloc zeros the memory) */
-            void *ptr = calloc(1, (size_t)length);
-            if (ptr == NULL) return 20;
-            *addr_ptr = ptr;
-        }
-        return 0;
+            {
+                /* Default: crent370 heap (calloc zeros the memory) */
+                void *ptr = calloc(1, (size_t)length);
+                if (ptr == NULL)
+                {
+                    return 20;
+                }
+                *addr_ptr = ptr;
+            }
+            return 0;
 
-    case RXSMFRE:
-        if (addr_ptr == NULL || *addr_ptr == NULL) {
-            return 20;
-        }
+        case RXSMFRE:
+            if (addr_ptr == NULL || *addr_ptr == NULL)
+            {
+                return 20;
+            }
 #ifdef __MVS__
-        if (subpool > 0) {
-            freemain(*addr_ptr);
-        } else
+            if (subpool > 0)
+            {
+                freemain(*addr_ptr);
+            }
+            else
 #endif
-        {
-            free(*addr_ptr);
-        }
-        *addr_ptr = NULL;
-        return 0;
+            {
+                free(*addr_ptr);
+            }
+            *addr_ptr = NULL;
+            return 0;
 
-    default:
-        return 20;
+        default:
+            return 20;
     }
 }

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -12,15 +12,17 @@
 /* ------------------------------------------------------------------ */
 
 #include <string.h>
+
 #include "irx.h"
+#include "irxfunc.h"
 #include "irxrab.h"
 #include "irxwkblk.h"
-#include "irxfunc.h"
 
 /* Internal helper: free via irxstor, NULL-safe */
 static void stor_free(void **ptr, struct envblock *envblk)
 {
-    if (ptr != NULL && *ptr != NULL) {
+    if (ptr != NULL && *ptr != NULL)
+    {
         irxstor(RXSMFRE, 0, ptr, envblk);
     }
 }
@@ -46,15 +48,16 @@ static void stor_free(void **ptr, struct envblock *envblk)
 
 int irxterm(struct envblock *envblk)
 {
-    struct irx_wkblk_int   *wkbi;
-    struct parmblock       *pb;
+    struct irx_wkblk_int *wkbi;
+    struct parmblock *pb;
     struct subcomtb_header *subcmd;
-    struct irx_rab         *rab;
-    struct irx_env_node    *node;
+    struct irx_rab *rab;
+    struct irx_env_node *node;
 
     /* 1. Validate */
     if (envblk == NULL ||
-        memcmp(envblk->envblock_id, ENVBLOCK_ID, 8) != 0) {
+        memcmp(envblk->envblock_id, ENVBLOCK_ID, 8) != 0)
+    {
         return 20;
     }
 
@@ -62,13 +65,15 @@ int irxterm(struct envblock *envblk)
 
     /* 3. Free internal Work Block */
     wkbi = (struct irx_wkblk_int *)envblk->envblock_userfield;
-    if (wkbi != NULL) {
+    if (wkbi != NULL)
+    {
         /* TODO Phase 2+: Free variable pool, data stack,
          * exec stack, token stream, label table, cache
          * that hang off wkbi before freeing wkbi itself */
 
         /* Free the lstring370 allocator bridge if it was installed. */
-        if (wkbi->wkbi_lstr_alloc != NULL) {
+        if (wkbi->wkbi_lstr_alloc != NULL)
+        {
             stor_free(&wkbi->wkbi_lstr_alloc, envblk);
         }
 
@@ -78,9 +83,11 @@ int irxterm(struct envblock *envblk)
 
     /* 4. Free SUBCOMTB */
     pb = (struct parmblock *)envblk->envblock_parmblock;
-    if (pb != NULL) {
+    if (pb != NULL)
+    {
         subcmd = (struct subcomtb_header *)pb->parmblock_subcomtb;
-        if (subcmd != NULL) {
+        if (subcmd != NULL)
+        {
             stor_free((void **)&subcmd->subcomtb_first, envblk);
             pb->parmblock_subcomtb = NULL;
             stor_free((void **)&subcmd, envblk);
@@ -110,13 +117,17 @@ int irxterm(struct envblock *envblk)
     tcbuser_ptr = &_simulated_tcbuser;
 #endif
 
-    if (*tcbuser_ptr != NULL) {
+    if (*tcbuser_ptr != NULL)
+    {
         rab = (struct irx_rab *)(*tcbuser_ptr);
-        if (memcmp(rab->rab_id, RAB_ID, 4) == 0) {
+        if (memcmp(rab->rab_id, RAB_ID, 4) == 0)
+        {
             /* Find node for this envblock */
             cur = (struct irx_env_node *)rab->rab_first;
-            while (cur != NULL) {
-                if (cur->node_envblock == envblk) {
+            while (cur != NULL)
+            {
+                if (cur->node_envblock == envblk)
+                {
                     node = cur;
                     irx_rab_remove_env(rab, node);
                     stor_free((void **)&node, envblk);
@@ -132,7 +143,8 @@ int irxterm(struct envblock *envblk)
     irxstor(RXSMFRE, 0, &p, NULL);
 
     /* 11. Release RAB if empty */
-    if (rab != NULL && rab->rab_env_count == 0) {
+    if (rab != NULL && rab->rab_env_count == 0)
+    {
         irx_rab_release(rab);
     }
 

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -13,35 +13,36 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 
 #include "irx.h"
-#include "irxwkblk.h"
 #include "irxfunc.h"
 #include "irxtokn.h"
+#include "irxwkblk.h"
 
 /* ------------------------------------------------------------------ */
 /*  Tokenizer context - private, stack-allocated per call             */
 /* ------------------------------------------------------------------ */
 
-struct tok_ctx {
-    const char        *src;          /* source buffer                */
-    int                src_len;      /* total length in bytes        */
-    int                pos;          /* byte offset into src         */
-    int                line;         /* 1-based, current position    */
-    int                col;          /* 1-based, current position    */
+struct tok_ctx
+{
+    const char *src; /* source buffer                */
+    int src_len;     /* total length in bytes        */
+    int pos;         /* byte offset into src         */
+    int line;        /* 1-based, current position    */
+    int col;         /* 1-based, current position    */
 
-    struct irx_token  *tokens;       /* grown array                  */
-    int                tok_count;    /* live entries                 */
-    int                tok_capacity; /* allocated slots              */
+    struct irx_token *tokens; /* grown array                  */
+    int tok_count;            /* live entries                 */
+    int tok_capacity;         /* allocated slots              */
 
-    struct envblock   *envblock;     /* for irxstor                  */
+    struct envblock *envblock; /* for irxstor                  */
 
-    int                err_code;     /* TOKERR_*                     */
-    int                err_line;
-    int                err_col;
+    int err_code; /* TOKERR_*                     */
+    int err_line;
+    int err_col;
 };
 
 /* Initial/grown token array capacity. 64 handles small execs in one  */
@@ -60,12 +61,21 @@ struct tok_ctx {
  * one of the REXX special starters). */
 static int is_symbol_start(int c)
 {
-    if (isalpha(c)) return 1;
-    switch (c) {
-    case '_': case '@': case '#': case '$': case '?': case '!':
+    if (isalpha(c))
+    {
         return 1;
-    default:
-        return 0;
+    }
+    switch (c)
+    {
+        case '_':
+        case '@':
+        case '#':
+        case '$':
+        case '?':
+        case '!':
+            return 1;
+        default:
+            return 0;
     }
 }
 
@@ -73,12 +83,22 @@ static int is_symbol_start(int c)
  * included; dots make a symbol compound. */
 static int is_symbol_char(int c)
 {
-    if (isalnum(c)) return 1;
-    switch (c) {
-    case '_': case '@': case '#': case '$': case '?': case '!': case '.':
+    if (isalnum(c))
+    {
         return 1;
-    default:
-        return 0;
+    }
+    switch (c)
+    {
+        case '_':
+        case '@':
+        case '#':
+        case '$':
+        case '?':
+        case '!':
+        case '.':
+            return 1;
+        default:
+            return 0;
     }
 }
 
@@ -87,9 +107,15 @@ static int is_symbol_char(int c)
  * per SC28-1883-0, and is not required in cross-compile mode. */
 static int is_not_sign(int c)
 {
-    if (c == '\\') return 1;
+    if (c == '\\')
+    {
+        return 1;
+    }
 #ifdef __MVS__
-    if (c == 0x5F) return 1;   /* EBCDIC logical-not */
+    if (c == 0x5F)
+    {
+        return 1; /* EBCDIC logical-not */
+    }
 #endif
     return 0;
 }
@@ -101,11 +127,15 @@ static int is_not_sign(int c)
 static void advance(struct tok_ctx *ctx, int n)
 {
     int i;
-    for (i = 0; i < n && ctx->pos < ctx->src_len; i++) {
-        if (ctx->src[ctx->pos] == '\n') {
+    for (i = 0; i < n && ctx->pos < ctx->src_len; i++)
+    {
+        if (ctx->src[ctx->pos] == '\n')
+        {
             ctx->line++;
             ctx->col = 1;
-        } else {
+        }
+        else
+        {
             ctx->col++;
         }
         ctx->pos++;
@@ -115,7 +145,10 @@ static void advance(struct tok_ctx *ctx, int n)
 static int peek(struct tok_ctx *ctx, int off)
 {
     int p = ctx->pos + off;
-    if (p < 0 || p >= ctx->src_len) return -1;
+    if (p < 0 || p >= ctx->src_len)
+    {
+        return -1;
+    }
     return (unsigned char)ctx->src[p];
 }
 
@@ -131,11 +164,13 @@ static int grow_tokens(struct tok_ctx *ctx)
     int rc = irxstor(RXSMGET,
                      (int)(new_cap * sizeof(struct irx_token)),
                      &new_ptr, ctx->envblock);
-    if (rc != 0) {
+    if (rc != 0)
+    {
         ctx->err_code = TOKERR_STORAGE;
         return 20;
     }
-    if (ctx->tokens != NULL) {
+    if (ctx->tokens != NULL)
+    {
         memcpy(new_ptr, ctx->tokens,
                ctx->tok_count * sizeof(struct irx_token));
         void *p = ctx->tokens;
@@ -157,16 +192,20 @@ static int emit(struct tok_ctx *ctx,
 {
     struct irx_token *t;
 
-    if (ctx->tok_count >= ctx->tok_capacity) {
-        if (grow_tokens(ctx) != 0) return 20;
+    if (ctx->tok_count >= ctx->tok_capacity)
+    {
+        if (grow_tokens(ctx) != 0)
+        {
+            return 20;
+        }
     }
     t = &ctx->tokens[ctx->tok_count++];
-    t->tok_type     = type;
-    t->tok_flags    = flags;
-    t->tok_col      = (short)start_col;
-    t->tok_line     = start_line;
-    t->tok_text     = text;
-    t->tok_length   = (unsigned short)length;
+    t->tok_type = type;
+    t->tok_flags = flags;
+    t->tok_col = (short)start_col;
+    t->tok_line = start_line;
+    t->tok_text = text;
+    t->tok_length = (unsigned short)length;
     t->tok_reserved = 0;
     return 0;
 }
@@ -184,23 +223,32 @@ static int skip_comment(struct tok_ctx *ctx)
     int depth = 1;
     /* We are positioned just past the opening '/' '*'. */
     advance(ctx, 2);
-    while (ctx->pos < ctx->src_len) {
+    while (ctx->pos < ctx->src_len)
+    {
         int c0 = peek(ctx, 0);
         int c1 = peek(ctx, 1);
-        if (c0 == '/' && c1 == '*') {
+        if (c0 == '/' && c1 == '*')
+        {
             depth++;
             advance(ctx, 2);
-        } else if (c0 == '*' && c1 == '/') {
+        }
+        else if (c0 == '*' && c1 == '/')
+        {
             depth--;
             advance(ctx, 2);
-            if (depth == 0) return 0;
-        } else {
+            if (depth == 0)
+            {
+                return 0;
+            }
+        }
+        else
+        {
             advance(ctx, 1);
         }
     }
     ctx->err_code = TOKERR_UNTERMINATED_CMT;
     ctx->err_line = ctx->line;
-    ctx->err_col  = ctx->col;
+    ctx->err_col = ctx->col;
     return 20;
 }
 
@@ -208,14 +256,23 @@ static int skip_comment(struct tok_ctx *ctx)
  * newlines - the caller decides whether a newline ends a clause. */
 static int skip_inline_ws(struct tok_ctx *ctx)
 {
-    while (ctx->pos < ctx->src_len) {
+    while (ctx->pos < ctx->src_len)
+    {
         int c0 = peek(ctx, 0);
         int c1 = peek(ctx, 1);
-        if (c0 == ' ' || c0 == '\t' || c0 == '\r') {
+        if (c0 == ' ' || c0 == '\t' || c0 == '\r')
+        {
             advance(ctx, 1);
-        } else if (c0 == '/' && c1 == '*') {
-            if (skip_comment(ctx) != 0) return 20;
-        } else {
+        }
+        else if (c0 == '/' && c1 == '*')
+        {
+            if (skip_comment(ctx) != 0)
+            {
+                return 20;
+            }
+        }
+        else
+        {
             break;
         }
     }
@@ -236,10 +293,12 @@ static int emit_eoc(struct tok_ctx *ctx, int at_line, int at_col)
 {
     /* Suppress EOC at the very start of the stream (leading blank
      * lines / leading comments produce no clause). */
-    if (ctx->tok_count == 0) {
+    if (ctx->tok_count == 0)
+    {
         return 0;
     }
-    if (ctx->tokens[ctx->tok_count - 1].tok_type == TOK_COMMA) {
+    if (ctx->tokens[ctx->tok_count - 1].tok_type == TOK_COMMA)
+    {
         /* Continuation: keep the comma (it is also the argument
          * separator in CALL / function-call contexts) and suppress
          * the EOC only. Per SC28-1883-0 Chapter 2: "A clause is
@@ -248,7 +307,8 @@ static int emit_eoc(struct tok_ctx *ctx, int at_line, int at_col)
         return 0;
     }
     /* Collapse multiple consecutive EOCs. */
-    if (ctx->tokens[ctx->tok_count - 1].tok_type == TOK_EOC) {
+    if (ctx->tokens[ctx->tok_count - 1].tok_type == TOK_EOC)
+    {
         return 0;
     }
     return emit(ctx, TOK_EOC, TOKF_NONE, NULL, 0, at_line, at_col);
@@ -261,7 +321,7 @@ static int emit_eoc(struct tok_ctx *ctx, int at_line, int at_col)
 static int scan_string(struct tok_ctx *ctx)
 {
     int start_line = ctx->line;
-    int start_col  = ctx->col;
+    int start_col = ctx->col;
     int text_start;
     int quote = peek(ctx, 0);
     int doubled = 0;
@@ -269,13 +329,16 @@ static int scan_string(struct tok_ctx *ctx)
     unsigned char type = TOK_STRING;
     unsigned char flags = TOKF_NONE;
 
-    advance(ctx, 1);              /* consume opening quote */
+    advance(ctx, 1); /* consume opening quote */
     text_start = ctx->pos;
 
-    while (ctx->pos < ctx->src_len) {
+    while (ctx->pos < ctx->src_len)
+    {
         int c = peek(ctx, 0);
-        if (c == quote) {
-            if (peek(ctx, 1) == quote) {
+        if (c == quote)
+        {
+            if (peek(ctx, 1) == quote)
+            {
                 /* Doubled quote - literal. */
                 doubled = 1;
                 advance(ctx, 2);
@@ -286,19 +349,21 @@ static int scan_string(struct tok_ctx *ctx)
         }
         /* REXX strings do not span lines; an embedded newline is an
          * unterminated-string error. */
-        if (c == '\n') {
+        if (c == '\n')
+        {
             ctx->err_code = TOKERR_UNTERMINATED_STR;
             ctx->err_line = start_line;
-            ctx->err_col  = start_col;
+            ctx->err_col = start_col;
             return 20;
         }
         advance(ctx, 1);
     }
 
-    if (ctx->pos >= ctx->src_len) {
+    if (ctx->pos >= ctx->src_len)
+    {
         ctx->err_code = TOKERR_UNTERMINATED_STR;
         ctx->err_line = start_line;
-        ctx->err_col  = start_col;
+        ctx->err_col = start_col;
         return 20;
     }
 
@@ -306,57 +371,75 @@ static int scan_string(struct tok_ctx *ctx)
     int body_len = ctx->pos - text_start;
     const char *body = ctx->src + text_start;
 
-    advance(ctx, 1);          /* consume closing quote */
+    advance(ctx, 1); /* consume closing quote */
 
     /* Check for x/X or b/B suffix indicating hex/bin string. */
     suffix = peek(ctx, 0);
-    if (suffix == 'x' || suffix == 'X') {
+    if (suffix == 'x' || suffix == 'X')
+    {
         int hex_digits = 0;
         int i;
-        for (i = 0; i < body_len; i++) {
+        for (i = 0; i < body_len; i++)
+        {
             int bc = (unsigned char)body[i];
-            if (bc == ' ' || bc == '\t') continue;
-            if (!isxdigit(bc)) {
+            if (bc == ' ' || bc == '\t')
+            {
+                continue;
+            }
+            if (!isxdigit(bc))
+            {
                 ctx->err_code = TOKERR_INVALID_HEX;
                 ctx->err_line = start_line;
-                ctx->err_col  = start_col;
+                ctx->err_col = start_col;
                 return 20;
             }
             hex_digits++;
         }
-        if ((hex_digits & 1) != 0) {
+        if ((hex_digits & 1) != 0)
+        {
             ctx->err_code = TOKERR_ODD_HEX_GROUP;
             ctx->err_line = start_line;
-            ctx->err_col  = start_col;
+            ctx->err_col = start_col;
             return 20;
         }
         type = TOK_HEXSTRING;
         advance(ctx, 1);
-    } else if (suffix == 'b' || suffix == 'B') {
+    }
+    else if (suffix == 'b' || suffix == 'B')
+    {
         int bits = 0;
         int i;
-        for (i = 0; i < body_len; i++) {
+        for (i = 0; i < body_len; i++)
+        {
             int bc = (unsigned char)body[i];
-            if (bc == ' ' || bc == '\t') continue;
-            if (bc != '0' && bc != '1') {
+            if (bc == ' ' || bc == '\t')
+            {
+                continue;
+            }
+            if (bc != '0' && bc != '1')
+            {
                 ctx->err_code = TOKERR_INVALID_BIN;
                 ctx->err_line = start_line;
-                ctx->err_col  = start_col;
+                ctx->err_col = start_col;
                 return 20;
             }
             bits++;
         }
-        if ((bits & 3) != 0) {
+        if ((bits & 3) != 0)
+        {
             ctx->err_code = TOKERR_BAD_BIN_GROUP;
             ctx->err_line = start_line;
-            ctx->err_col  = start_col;
+            ctx->err_col = start_col;
             return 20;
         }
         type = TOK_BINSTRING;
         advance(ctx, 1);
     }
 
-    if (doubled) flags |= TOKF_QUOTE_DBL;
+    if (doubled)
+    {
+        flags |= TOKF_QUOTE_DBL;
+    }
     return emit(ctx, type, flags, body, body_len,
                 start_line, start_col);
 }
@@ -377,31 +460,57 @@ static int looks_like_number(const char *s, int len)
     int saw_digit = 0;
     int saw_dot = 0;
 
-    if (len == 0) return 0;
+    if (len == 0)
+    {
+        return 0;
+    }
 
     /* Optional leading '.' handled by the digit loop. */
-    while (i < len) {
+    while (i < len)
+    {
         int c = (unsigned char)s[i];
-        if (isdigit(c)) {
+        if (isdigit(c))
+        {
             saw_digit = 1;
             i++;
-        } else if (c == '.' && !saw_dot) {
+        }
+        else if (c == '.' && !saw_dot)
+        {
             saw_dot = 1;
             i++;
-        } else {
+        }
+        else
+        {
             break;
         }
     }
-    if (!saw_digit) return 0;
-    if (i == len) return 1;
+    if (!saw_digit)
+    {
+        return 0;
+    }
+    if (i == len)
+    {
+        return 1;
+    }
 
     /* Exponent: E[+-]digits */
-    if (s[i] == 'E' || s[i] == 'e') {
+    if (s[i] == 'E' || s[i] == 'e')
+    {
         i++;
-        if (i < len && (s[i] == '+' || s[i] == '-')) i++;
-        if (i == len) return 0;
-        while (i < len) {
-            if (!isdigit((unsigned char)s[i])) return 0;
+        if (i < len && (s[i] == '+' || s[i] == '-'))
+        {
+            i++;
+        }
+        if (i == len)
+        {
+            return 0;
+        }
+        while (i < len)
+        {
+            if (!isdigit((unsigned char)s[i]))
+            {
+                return 0;
+            }
             i++;
         }
         return 1;
@@ -412,19 +521,26 @@ static int looks_like_number(const char *s, int len)
 static int scan_symbol_or_number(struct tok_ctx *ctx)
 {
     int start_line = ctx->line;
-    int start_col  = ctx->col;
-    int start_pos  = ctx->pos;
-    int saw_dot    = 0;
-    int first      = peek(ctx, 0);
+    int start_col = ctx->col;
+    int start_pos = ctx->pos;
+    int saw_dot = 0;
+    int first = peek(ctx, 0);
     unsigned char flags = TOKF_NONE;
     unsigned char type;
     const char *text;
     int length;
 
-    while (ctx->pos < ctx->src_len) {
+    while (ctx->pos < ctx->src_len)
+    {
         int c = peek(ctx, 0);
-        if (!is_symbol_char(c)) break;
-        if (c == '.') saw_dot = 1;
+        if (!is_symbol_char(c))
+        {
+            break;
+        }
+        if (c == '.')
+        {
+            saw_dot = 1;
+        }
         advance(ctx, 1);
     }
 
@@ -433,31 +549,43 @@ static int scan_symbol_or_number(struct tok_ctx *ctx)
      * the symbol_char run above. */
     if ((isdigit(first) || first == '.') &&
         ctx->pos > start_pos &&
-        (peek(ctx, 0) == '+' || peek(ctx, 0) == '-')) {
+        (peek(ctx, 0) == '+' || peek(ctx, 0) == '-'))
+    {
         char prev = ctx->src[ctx->pos - 1];
-        if (prev == 'E' || prev == 'e') {
+        if (prev == 'E' || prev == 'e')
+        {
             advance(ctx, 1);
             while (ctx->pos < ctx->src_len &&
-                   isdigit(peek(ctx, 0))) {
+                   isdigit(peek(ctx, 0)))
+            {
                 advance(ctx, 1);
             }
         }
     }
 
     length = ctx->pos - start_pos;
-    text   = ctx->src + start_pos;
+    text = ctx->src + start_pos;
 
-    if (saw_dot) flags |= TOKF_COMPOUND;
+    if (saw_dot)
+    {
+        flags |= TOKF_COMPOUND;
+    }
 
     /* A constant symbol starts with a digit or a dot. */
-    if (isdigit(first) || first == '.') {
+    if (isdigit(first) || first == '.')
+    {
         flags |= TOKF_CONSTANT;
-        if (looks_like_number(text, length)) {
+        if (looks_like_number(text, length))
+        {
             type = TOK_NUMBER;
-        } else {
+        }
+        else
+        {
             type = TOK_SYMBOL;
         }
-    } else {
+    }
+    else
+    {
         type = TOK_SYMBOL;
     }
 
@@ -478,53 +606,64 @@ static int scan_symbol_or_number(struct tok_ctx *ctx)
 static int scan_operator(struct tok_ctx *ctx)
 {
     int start_line = ctx->line;
-    int start_col  = ctx->col;
-    int start_pos  = ctx->pos;
+    int start_col = ctx->col;
+    int start_pos = ctx->pos;
     int c0 = peek(ctx, 0);
     unsigned char type;
 
     /* NOT character (backslash, plus EBCDIC logical-not on MVS). */
-    if (is_not_sign(c0)) {
+    if (is_not_sign(c0))
+    {
         type = TOK_NOT;
-    } else {
-        switch (c0) {
-        case '(':
-            advance(ctx, 1);
-            return emit(ctx, TOK_LPAREN, TOKF_NONE,
-                        ctx->src + start_pos, 1, start_line, start_col);
-        case ')':
-            advance(ctx, 1);
-            return emit(ctx, TOK_RPAREN, TOKF_NONE,
-                        ctx->src + start_pos, 1, start_line, start_col);
-        case ',':
-            advance(ctx, 1);
-            return emit(ctx, TOK_COMMA, TOKF_NONE,
-                        ctx->src + start_pos, 1, start_line, start_col);
-        case ';':
-        case ':':
-            /* Both terminate a clause. The colon after a label
-             * symbol is recognised by the parser from context. */
-            advance(ctx, 1);
-            return emit(ctx, TOK_SEMICOLON, TOKF_NONE,
-                        ctx->src + start_pos, 1, start_line, start_col);
+    }
+    else
+    {
+        switch (c0)
+        {
+            case '(':
+                advance(ctx, 1);
+                return emit(ctx, TOK_LPAREN, TOKF_NONE,
+                            ctx->src + start_pos, 1, start_line, start_col);
+            case ')':
+                advance(ctx, 1);
+                return emit(ctx, TOK_RPAREN, TOKF_NONE,
+                            ctx->src + start_pos, 1, start_line, start_col);
+            case ',':
+                advance(ctx, 1);
+                return emit(ctx, TOK_COMMA, TOKF_NONE,
+                            ctx->src + start_pos, 1, start_line, start_col);
+            case ';':
+            case ':':
+                /* Both terminate a clause. The colon after a label
+                 * symbol is recognised by the parser from context. */
+                advance(ctx, 1);
+                return emit(ctx, TOK_SEMICOLON, TOKF_NONE,
+                            ctx->src + start_pos, 1, start_line, start_col);
 
-        case '+': case '-': case '*': case '/': case '%':
-            type = TOK_OPERATOR;
-            break;
+            case '+':
+            case '-':
+            case '*':
+            case '/':
+            case '%':
+                type = TOK_OPERATOR;
+                break;
 
-        case '=': case '>': case '<':
-            type = TOK_COMPARISON;
-            break;
+            case '=':
+            case '>':
+            case '<':
+                type = TOK_COMPARISON;
+                break;
 
-        case '&': case '|':
-            type = TOK_LOGICAL;
-            break;
+            case '&':
+            case '|':
+                type = TOK_LOGICAL;
+                break;
 
-        default:
-            ctx->err_code = TOKERR_BAD_CHAR;
-            ctx->err_line = start_line;
-            ctx->err_col  = start_col;
-            return 20;
+            default:
+                ctx->err_code = TOKERR_BAD_CHAR;
+                ctx->err_line = start_line;
+                ctx->err_col = start_col;
+                return 20;
         }
     }
 
@@ -539,41 +678,67 @@ static int scan_operator(struct tok_ctx *ctx)
 
 static int tokenize(struct tok_ctx *ctx)
 {
-    while (ctx->pos < ctx->src_len) {
+    while (ctx->pos < ctx->src_len)
+    {
         int c;
 
-        if (skip_inline_ws(ctx) != 0) return 20;
-        if (ctx->pos >= ctx->src_len) break;
+        if (skip_inline_ws(ctx) != 0)
+        {
+            return 20;
+        }
+        if (ctx->pos >= ctx->src_len)
+        {
+            break;
+        }
 
         c = peek(ctx, 0);
 
-        if (c == '\n') {
+        if (c == '\n')
+        {
             int l = ctx->line;
             int k = ctx->col;
             advance(ctx, 1);
-            if (emit_eoc(ctx, l, k) != 0) return 20;
+            if (emit_eoc(ctx, l, k) != 0)
+            {
+                return 20;
+            }
             continue;
         }
 
-        if (c == '\'' || c == '"') {
-            if (scan_string(ctx) != 0) return 20;
+        if (c == '\'' || c == '"')
+        {
+            if (scan_string(ctx) != 0)
+            {
+                return 20;
+            }
             continue;
         }
 
         if (is_symbol_start(c) || isdigit(c) ||
-            (c == '.' && isdigit(peek(ctx, 1)))) {
-            if (scan_symbol_or_number(ctx) != 0) return 20;
+            (c == '.' && isdigit(peek(ctx, 1))))
+        {
+            if (scan_symbol_or_number(ctx) != 0)
+            {
+                return 20;
+            }
             continue;
         }
 
-        if (scan_operator(ctx) != 0) return 20;
+        if (scan_operator(ctx) != 0)
+        {
+            return 20;
+        }
     }
 
     /* Ensure clause terminates. */
     if (ctx->tok_count > 0 &&
-        ctx->tokens[ctx->tok_count - 1].tok_type != TOK_EOC) {
+        ctx->tokens[ctx->tok_count - 1].tok_type != TOK_EOC)
+    {
         if (emit(ctx, TOK_EOC, TOKF_NONE, NULL, 0,
-                 ctx->line, ctx->col) != 0) return 20;
+                 ctx->line, ctx->col) != 0)
+        {
+            return 20;
+        }
     }
 
     return emit(ctx, TOK_EOF, TOKF_NONE, NULL, 0,
@@ -593,48 +758,54 @@ int irx_tokn_run(struct envblock *envblock,
     int rc;
 
     if (out_tokens == NULL || out_count == NULL ||
-        src == NULL || src_len < 0) {
-        if (out_error != NULL) {
+        src == NULL || src_len < 0)
+    {
+        if (out_error != NULL)
+        {
             out_error->error_code = TOKERR_BAD_CHAR;
             out_error->error_line = 0;
-            out_error->error_col  = 0;
+            out_error->error_col = 0;
         }
         return 20;
     }
 
     memset(&ctx, 0, sizeof(ctx));
-    ctx.src      = src;
-    ctx.src_len  = src_len;
-    ctx.line     = 1;
-    ctx.col      = 1;
+    ctx.src = src;
+    ctx.src_len = src_len;
+    ctx.line = 1;
+    ctx.col = 1;
     ctx.envblock = envblock;
 
     rc = tokenize(&ctx);
 
-    if (rc != 0) {
-        if (ctx.tokens != NULL) {
+    if (rc != 0)
+    {
+        if (ctx.tokens != NULL)
+        {
             void *p = ctx.tokens;
             irxstor(RXSMFRE,
                     (int)(ctx.tok_capacity * sizeof(struct irx_token)),
                     &p, envblock);
         }
-        if (out_error != NULL) {
+        if (out_error != NULL)
+        {
             out_error->error_code = ctx.err_code;
             out_error->error_line = ctx.err_line;
-            out_error->error_col  = ctx.err_col;
+            out_error->error_col = ctx.err_col;
         }
         *out_tokens = NULL;
-        *out_count  = 0;
+        *out_count = 0;
         return rc;
     }
 
-    if (out_error != NULL) {
+    if (out_error != NULL)
+    {
         out_error->error_code = TOKERR_NONE;
         out_error->error_line = 0;
-        out_error->error_col  = 0;
+        out_error->error_col = 0;
     }
     *out_tokens = ctx.tokens;
-    *out_count  = ctx.tok_count;
+    *out_count = ctx.tok_count;
     return 0;
 }
 
@@ -647,7 +818,10 @@ void irx_tokn_free(struct envblock *envblock,
      * the allocation, and irxstor ignores the length argument when
      * backed by the crent370 heap (see irxstor implementation). */
     void *p;
-    if (tokens == NULL) return;
+    if (tokens == NULL)
+    {
+        return;
+    }
     p = tokens;
     irxstor(RXSMFRE, (int)(count * sizeof(struct irx_token)),
             &p, envblock);

--- a/src/irx#uid.c
+++ b/src/irx#uid.c
@@ -12,12 +12,14 @@
 /* ------------------------------------------------------------------ */
 
 #include <string.h>
+
 #include "irx.h"
 #include "irxfunc.h"
 
 int irxuid(char *userid, struct envblock *envblock)
 {
-    if (userid == NULL) {
+    if (userid == NULL)
+    {
         return 20;
     }
 
@@ -34,16 +36,20 @@ int irxuid(char *userid, struct envblock *envblock)
 
     /* PSA+X'224' -> current ASCB */
     void *ascb = *(void **)0x224;
-    if (ascb != NULL) {
+    if (ascb != NULL)
+    {
         /* ASCB+X'6C' -> ASXB */
         void *asxb = *(void **)((char *)ascb + 0x6C);
-        if (asxb != NULL) {
+        if (asxb != NULL)
+        {
             /* ASXB+X'14' -> LWA (Logon Work Area) */
             void *lwa = *(void **)((char *)asxb + 0x14);
-            if (lwa != NULL) {
+            if (lwa != NULL)
+            {
                 /* LWA+X'18' -> PSCB */
                 void *pscb = *(void **)((char *)lwa + 0x18);
-                if (pscb != NULL) {
+                if (pscb != NULL)
+                {
                     /* PSCB+X'00' = PSCBUSER (7 bytes) */
                     memcpy(userid, (char *)pscb, 7);
                     return 0;
@@ -58,7 +64,10 @@ int irxuid(char *userid, struct envblock *envblock)
     /* Cross-compile: use getlogin() or environment */
     const char *user = "TESTUSER";
     int len = (int)strlen(user);
-    if (len > 8) len = 8;
+    if (len > 8)
+    {
+        len = 8;
+    }
     memcpy(userid, user, len);
 #endif
 

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -17,28 +17,31 @@
 #include <stddef.h>
 #include <string.h>
 
-#include "lstring.h"
-#include "lstralloc.h"
 #include "irxvpool.h"
+#include "lstralloc.h"
+#include "lstring.h"
 
 /* ------------------------------------------------------------------ */
 /*  Capacity management                                               */
 /* ------------------------------------------------------------------ */
 
 static const int vp_primes[] = {
-    67, 137, 277, 557, 1117, 2237, 4483, 8963
-};
-#define VP_PRIME_COUNT  8
-#define VP_INITIAL      67
-#define VP_MAX_LOAD     4    /* entries per bucket before resize */
+    67, 137, 277, 557, 1117, 2237, 4483, 8963};
+#define VP_PRIME_COUNT 8
+#define VP_INITIAL     67
+#define VP_MAX_LOAD    4 /* entries per bucket before resize */
 
 static int next_prime_after(int current)
 {
     int i;
-    for (i = 0; i < VP_PRIME_COUNT; i++) {
-        if (vp_primes[i] > current) return vp_primes[i];
+    for (i = 0; i < VP_PRIME_COUNT; i++)
+    {
+        if (vp_primes[i] > current)
+        {
+            return vp_primes[i];
+        }
     }
-    return current;  /* already at or above the largest listed prime */
+    return current; /* already at or above the largest listed prime */
 }
 
 /* djb2 hash (Dan Bernstein) over the raw bytes of the name. */
@@ -46,7 +49,8 @@ static unsigned long hash_bytes(const unsigned char *p, size_t n)
 {
     unsigned long h = 5381UL;
     size_t i;
-    for (i = 0; i < n; i++) {
+    for (i = 0; i < n; i++)
+    {
         h = ((h << 5) + h) + p[i];
     }
     return h;
@@ -58,36 +62,48 @@ static unsigned long hash_bytes(const unsigned char *p, size_t n)
 
 static void *vp_alloc_raw(struct lstr_alloc *a, size_t size)
 {
-    if (a == NULL) return NULL;
+    if (a == NULL)
+    {
+        return NULL;
+    }
     return (*a->alloc)(size, a->ctx);
 }
 
 static void vp_free_raw(struct lstr_alloc *a, void *ptr, size_t size)
 {
-    if (a == NULL || ptr == NULL) return;
+    if (a == NULL || ptr == NULL)
+    {
+        return;
+    }
     (*a->dealloc)(ptr, size, a->ctx);
 }
 
 static void vp_entry_init(struct vpool_entry *e)
 {
-    e->next         = NULL;
+    e->next = NULL;
     Lzeroinit(&e->name);
     Lzeroinit(&e->value);
-    e->flags        = 0;
-    e->exposed_ref  = NULL;
+    e->flags = 0;
+    e->exposed_ref = NULL;
 }
 
 static struct vpool_entry *vp_entry_new(struct lstr_alloc *a)
 {
     struct vpool_entry *e;
     e = (struct vpool_entry *)vp_alloc_raw(a, sizeof(struct vpool_entry));
-    if (e != NULL) vp_entry_init(e);
+    if (e != NULL)
+    {
+        vp_entry_init(e);
+    }
     return e;
 }
 
 static void vp_entry_free(struct lstr_alloc *a, struct vpool_entry *e)
 {
-    if (e == NULL) return;
+    if (e == NULL)
+    {
+        return;
+    }
     Lfree(a, &e->name);
     Lfree(a, &e->value);
     vp_free_raw(a, e, sizeof(struct vpool_entry));
@@ -100,7 +116,10 @@ static struct vpool_entry **vp_alloc_buckets(struct lstr_alloc *a,
     struct vpool_entry **buckets;
     size_t bytes = (size_t)count * sizeof(struct vpool_entry *);
     buckets = (struct vpool_entry **)vp_alloc_raw(a, bytes);
-    if (buckets != NULL) memset(buckets, 0, bytes);
+    if (buckets != NULL)
+    {
+        memset(buckets, 0, bytes);
+    }
     return buckets;
 }
 
@@ -113,18 +132,25 @@ struct irx_vpool *vpool_create(struct lstr_alloc *a,
 {
     struct irx_vpool *pool;
 
-    if (a == NULL) return NULL;
+    if (a == NULL)
+    {
+        return NULL;
+    }
 
     pool = (struct irx_vpool *)vp_alloc_raw(a, sizeof(struct irx_vpool));
-    if (pool == NULL) return NULL;
+    if (pool == NULL)
+    {
+        return NULL;
+    }
 
     memset(pool, 0, sizeof(*pool));
     memcpy(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN);
-    pool->alloc        = a;
-    pool->parent       = parent;
+    pool->alloc = a;
+    pool->parent = parent;
     pool->bucket_count = VP_INITIAL;
-    pool->buckets      = vp_alloc_buckets(a, VP_INITIAL);
-    if (pool->buckets == NULL) {
+    pool->buckets = vp_alloc_buckets(a, VP_INITIAL);
+    if (pool->buckets == NULL)
+    {
         vp_free_raw(a, pool, sizeof(*pool));
         return NULL;
     }
@@ -134,15 +160,19 @@ struct irx_vpool *vpool_create(struct lstr_alloc *a,
 static void vp_free_exposed_stems(struct irx_vpool *pool)
 {
     int i;
-    if (pool->exposed_stems == NULL) return;
-    for (i = 0; i < pool->exposed_stem_count; i++) {
+    if (pool->exposed_stems == NULL)
+    {
+        return;
+    }
+    for (i = 0; i < pool->exposed_stem_count; i++)
+    {
         Lfree(pool->alloc, &pool->exposed_stems[i]);
     }
     vp_free_raw(pool->alloc, pool->exposed_stems,
                 (size_t)pool->exposed_stem_cap * sizeof(Lstr));
-    pool->exposed_stems      = NULL;
+    pool->exposed_stems = NULL;
     pool->exposed_stem_count = 0;
-    pool->exposed_stem_cap   = 0;
+    pool->exposed_stem_cap = 0;
 }
 
 void vpool_destroy(struct irx_vpool *pool)
@@ -150,14 +180,22 @@ void vpool_destroy(struct irx_vpool *pool)
     int i;
     struct lstr_alloc *a;
 
-    if (pool == NULL) return;
-    if (memcmp(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN) != 0) return;
+    if (pool == NULL)
+    {
+        return;
+    }
+    if (memcmp(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN) != 0)
+    {
+        return;
+    }
 
     a = pool->alloc;
 
-    for (i = 0; i < pool->bucket_count; i++) {
+    for (i = 0; i < pool->bucket_count; i++)
+    {
         struct vpool_entry *e = pool->buckets[i];
-        while (e != NULL) {
+        while (e != NULL)
+        {
             struct vpool_entry *next = e->next;
             vp_entry_free(a, e);
             e = next;
@@ -165,7 +203,7 @@ void vpool_destroy(struct irx_vpool *pool)
     }
     vp_free_raw(a, pool->buckets,
                 (size_t)pool->bucket_count *
-                sizeof(struct vpool_entry *));
+                    sizeof(struct vpool_entry *));
 
     vp_free_exposed_stems(pool);
 
@@ -187,10 +225,12 @@ static struct vpool_entry *find_in_bucket(struct vpool_entry *head,
                                           const PLstr name)
 {
     struct vpool_entry *e;
-    for (e = head; e != NULL; e = e->next) {
+    for (e = head; e != NULL; e = e->next)
+    {
         if (e->name.len == name->len &&
             (name->len == 0 ||
-             memcmp(e->name.pstr, name->pstr, name->len) == 0)) {
+             memcmp(e->name.pstr, name->pstr, name->len) == 0))
+        {
             return e;
         }
     }
@@ -205,18 +245,27 @@ static int maybe_resize(struct irx_vpool *pool)
     struct vpool_entry **new_buckets;
     int i;
 
-    if (pool->entry_count <= pool->bucket_count * VP_MAX_LOAD) {
+    if (pool->entry_count <= pool->bucket_count * VP_MAX_LOAD)
+    {
         return VPOOL_OK;
     }
     new_count = next_prime_after(pool->bucket_count);
-    if (new_count == pool->bucket_count) return VPOOL_OK;  /* at max */
+    if (new_count == pool->bucket_count)
+    {
+        return VPOOL_OK; /* at max */
+    }
 
     new_buckets = vp_alloc_buckets(pool->alloc, new_count);
-    if (new_buckets == NULL) return VPOOL_NOMEM;
+    if (new_buckets == NULL)
+    {
+        return VPOOL_NOMEM;
+    }
 
-    for (i = 0; i < pool->bucket_count; i++) {
+    for (i = 0; i < pool->bucket_count; i++)
+    {
         struct vpool_entry *e = pool->buckets[i];
-        while (e != NULL) {
+        while (e != NULL)
+        {
             struct vpool_entry *next = e->next;
             unsigned long h = hash_bytes(e->name.pstr, e->name.len);
             int idx = (int)(h % (unsigned long)new_count);
@@ -228,14 +277,14 @@ static int maybe_resize(struct irx_vpool *pool)
 
     vp_free_raw(pool->alloc, pool->buckets,
                 (size_t)pool->bucket_count *
-                sizeof(struct vpool_entry *));
-    pool->buckets      = new_buckets;
+                    sizeof(struct vpool_entry *));
+    pool->buckets = new_buckets;
     pool->bucket_count = new_count;
 
     /* Iteration cursor is invalidated by resize. */
     pool->next_started = 0;
-    pool->next_bucket  = 0;
-    pool->next_entry   = NULL;
+    pool->next_bucket = 0;
+    pool->next_entry = NULL;
 
     return VPOOL_OK;
 }
@@ -249,7 +298,10 @@ static int name_matches_stem(const PLstr name, const PLstr stem)
     /* The stem name includes its trailing dot. A compound name
      * "STEM.X" matches "STEM.", and so does the bare default
      * "STEM." itself. */
-    if (stem->len == 0 || name->len < stem->len) return 0;
+    if (stem->len == 0 || name->len < stem->len)
+    {
+        return 0;
+    }
     return memcmp(name->pstr, stem->pstr, stem->len) == 0;
 }
 
@@ -257,9 +309,16 @@ static int matches_exposed_stem(const struct irx_vpool *pool,
                                 const PLstr name)
 {
     int i;
-    if (pool->exposed_stem_count == 0) return 0;
-    for (i = 0; i < pool->exposed_stem_count; i++) {
-        if (name_matches_stem(name, &pool->exposed_stems[i])) return 1;
+    if (pool->exposed_stem_count == 0)
+    {
+        return 0;
+    }
+    for (i = 0; i < pool->exposed_stem_count; i++)
+    {
+        if (name_matches_stem(name, &pool->exposed_stems[i]))
+        {
+            return 1;
+        }
     }
     return 0;
 }
@@ -269,8 +328,12 @@ static int matches_exposed_stem(const struct irx_vpool *pool,
 static int first_dot(const PLstr name)
 {
     size_t i;
-    for (i = 0; i < name->len; i++) {
-        if (name->pstr[i] == '.') return (int)i;
+    for (i = 0; i < name->len; i++)
+    {
+        if (name->pstr[i] == '.')
+        {
+            return (int)i;
+        }
     }
     return -1;
 }
@@ -297,16 +360,24 @@ static void unlink_entry(struct irx_vpool *pool, int idx,
                          struct vpool_entry *target)
 {
     struct vpool_entry *prev = NULL;
-    struct vpool_entry *cur  = pool->buckets[idx];
-    while (cur != NULL) {
-        if (cur == target) {
-            if (prev == NULL) pool->buckets[idx] = cur->next;
-            else prev->next = cur->next;
+    struct vpool_entry *cur = pool->buckets[idx];
+    while (cur != NULL)
+    {
+        if (cur == target)
+        {
+            if (prev == NULL)
+            {
+                pool->buckets[idx] = cur->next;
+            }
+            else
+            {
+                prev->next = cur->next;
+            }
             pool->entry_count--;
             return;
         }
         prev = cur;
-        cur  = cur->next;
+        cur = cur->next;
     }
 }
 
@@ -318,7 +389,8 @@ static void unlink_entry(struct irx_vpool *pool, int idx,
 static struct vpool_entry *resolve_ref(struct vpool_entry *e)
 {
     while (e != NULL && (e->flags & VPOOL_EXPOSED_REF) &&
-           e->exposed_ref != NULL) {
+           e->exposed_ref != NULL)
+    {
         e = e->exposed_ref;
     }
     return e;
@@ -330,34 +402,59 @@ int vpool_set(struct irx_vpool *pool, const PLstr name, const PLstr value)
     struct vpool_entry *e;
     int rc;
 
-    if (pool == NULL || name == NULL || value == NULL) return VPOOL_BADARG;
-    if (memcmp(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN) != 0) return VPOOL_BADARG;
+    if (pool == NULL || name == NULL || value == NULL)
+    {
+        return VPOOL_BADARG;
+    }
+    if (memcmp(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN) != 0)
+    {
+        return VPOOL_BADARG;
+    }
 
     /* Stem-EXPOSE delegation. */
-    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL)
+    {
         return vpool_set(pool->parent, name, value);
     }
 
     idx = bucket_index(pool, name);
     e = find_in_bucket(pool->buckets[idx], name);
 
-    if (e != NULL) {
+    if (e != NULL)
+    {
         struct vpool_entry *tgt = resolve_ref(e);
-        if (tgt == NULL) return VPOOL_BADARG;
+        if (tgt == NULL)
+        {
+            return VPOOL_BADARG;
+        }
         rc = Lstrcpy(pool->alloc, &tgt->value, value);
-        if (rc != LSTR_OK) return VPOOL_NOMEM;
+        if (rc != LSTR_OK)
+        {
+            return VPOOL_NOMEM;
+        }
         tgt->flags &= ~VPOOL_UNSET;
         return VPOOL_OK;
     }
 
     /* Create a new local entry. */
     e = vp_entry_new(pool->alloc);
-    if (e == NULL) return VPOOL_NOMEM;
+    if (e == NULL)
+    {
+        return VPOOL_NOMEM;
+    }
 
     rc = Lstrcpy(pool->alloc, &e->name, name);
-    if (rc != LSTR_OK) { vp_entry_free(pool->alloc, e); return VPOOL_NOMEM; }
+    if (rc != LSTR_OK)
+    {
+        vp_entry_free(pool->alloc, e);
+        return VPOOL_NOMEM;
+    }
     rc = Lstrcpy(pool->alloc, &e->value, value);
-    if (rc != LSTR_OK) { vp_entry_free(pool->alloc, e); return VPOOL_NOMEM; }
+    if (rc != LSTR_OK)
+    {
+        vp_entry_free(pool->alloc, e);
+        return VPOOL_NOMEM;
+    }
 
     return link_entry(pool, e);
 }
@@ -368,19 +465,25 @@ int vpool_get(struct irx_vpool *pool, const PLstr name, PLstr value)
     struct vpool_entry *e;
     int rc;
 
-    if (pool == NULL || name == NULL || value == NULL) return VPOOL_BADARG;
+    if (pool == NULL || name == NULL || value == NULL)
+    {
+        return VPOOL_BADARG;
+    }
 
     /* Stem-EXPOSE delegation. */
-    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL)
+    {
         return vpool_get(pool->parent, name, value);
     }
 
     idx = bucket_index(pool, name);
     e = find_in_bucket(pool->buckets[idx], name);
 
-    if (e != NULL) {
+    if (e != NULL)
+    {
         struct vpool_entry *tgt = resolve_ref(e);
-        if (tgt != NULL && !(tgt->flags & VPOOL_UNSET)) {
+        if (tgt != NULL && !(tgt->flags & VPOOL_UNSET))
+        {
             rc = Lstrcpy(pool->alloc, value, &tgt->value);
             return (rc == LSTR_OK) ? VPOOL_OK : VPOOL_NOMEM;
         }
@@ -390,27 +493,31 @@ int vpool_get(struct irx_vpool *pool, const PLstr name, PLstr value)
      * last character), look up "STEM." as the fallback. The stem key
      * includes the first dot. */
     int dot = first_dot(name);
-    if (dot >= 0) {
+    if (dot >= 0)
+    {
         Lstr stem_key;
-        int  stem_idx;
+        int stem_idx;
         struct vpool_entry *stem_e;
 
-        stem_key.pstr   = name->pstr;
-        stem_key.len    = (size_t)(dot + 1);
+        stem_key.pstr = name->pstr;
+        stem_key.len = (size_t)(dot + 1);
         stem_key.maxlen = stem_key.len;
-        stem_key.type   = LSTRING_TY;
+        stem_key.type = LSTRING_TY;
 
         /* Don't fall into infinite recursion: only fall back on a
          * true compound, i.e. there is at least one character
          * after the dot (otherwise the caller already asked for
          * the stem default). */
-        if (name->len > stem_key.len) {
+        if (name->len > stem_key.len)
+        {
             stem_idx = bucket_index(pool, &stem_key);
-            stem_e   = find_in_bucket(pool->buckets[stem_idx],
-                                      &stem_key);
-            if (stem_e != NULL) {
+            stem_e = find_in_bucket(pool->buckets[stem_idx],
+                                    &stem_key);
+            if (stem_e != NULL)
+            {
                 struct vpool_entry *tgt = resolve_ref(stem_e);
-                if (tgt != NULL && !(tgt->flags & VPOOL_UNSET)) {
+                if (tgt != NULL && !(tgt->flags & VPOOL_UNSET))
+                {
                     rc = Lstrcpy(pool->alloc, value, &tgt->value);
                     return (rc == LSTR_OK) ? VPOOL_OK : VPOOL_NOMEM;
                 }
@@ -426,17 +533,25 @@ int vpool_drop(struct irx_vpool *pool, const PLstr name)
     int idx;
     struct vpool_entry *e;
 
-    if (pool == NULL || name == NULL) return VPOOL_BADARG;
+    if (pool == NULL || name == NULL)
+    {
+        return VPOOL_BADARG;
+    }
 
-    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL)
+    {
         return vpool_drop(pool->parent, name);
     }
 
     idx = bucket_index(pool, name);
     e = find_in_bucket(pool->buckets[idx], name);
-    if (e == NULL) return VPOOL_NOT_FOUND;
+    if (e == NULL)
+    {
+        return VPOOL_NOT_FOUND;
+    }
 
-    if ((e->flags & VPOOL_EXPOSED_REF) && pool->parent != NULL) {
+    if ((e->flags & VPOOL_EXPOSED_REF) && pool->parent != NULL)
+    {
         /* Drop the backing entry in the parent, then remove our ref. */
         vpool_drop(pool->parent, name);
     }
@@ -451,18 +566,28 @@ int vpool_exists(struct irx_vpool *pool, const PLstr name)
     int idx;
     struct vpool_entry *e;
 
-    if (pool == NULL || name == NULL) return 0;
+    if (pool == NULL || name == NULL)
+    {
+        return 0;
+    }
 
-    if (matches_exposed_stem(pool, name) && pool->parent != NULL) {
+    if (matches_exposed_stem(pool, name) && pool->parent != NULL)
+    {
         return vpool_exists(pool->parent, name);
     }
 
     idx = bucket_index(pool, name);
     e = find_in_bucket(pool->buckets[idx], name);
-    if (e == NULL) return 0;
+    if (e == NULL)
+    {
+        return 0;
+    }
 
     struct vpool_entry *tgt = resolve_ref(e);
-    if (tgt == NULL) return 0;
+    if (tgt == NULL)
+    {
+        return 0;
+    }
     return (tgt->flags & VPOOL_UNSET) ? 0 : 1;
 }
 
@@ -477,15 +602,22 @@ int vpool_expose_var(struct irx_vpool *pool, const PLstr name)
     int rc;
     int pidx;
 
-    if (pool == NULL || name == NULL) return VPOOL_BADARG;
-    if (pool->parent == NULL) return VPOOL_OK;   /* top-level scope */
+    if (pool == NULL || name == NULL)
+    {
+        return VPOOL_BADARG;
+    }
+    if (pool->parent == NULL)
+    {
+        return VPOOL_OK; /* top-level scope */
+    }
 
     /* If an entry with this name already exists locally (e.g. the
      * caller called EXPOSE twice), drop it and re-create as a ref. */
     int idx = bucket_index(pool, name);
     struct vpool_entry *existing =
         find_in_bucket(pool->buckets[idx], name);
-    if (existing != NULL) {
+    if (existing != NULL)
+    {
         unlink_entry(pool, idx, existing);
         vp_entry_free(pool->alloc, existing);
     }
@@ -493,17 +625,23 @@ int vpool_expose_var(struct irx_vpool *pool, const PLstr name)
     /* Look up or create a placeholder entry in the parent. */
     pidx = bucket_index(pool->parent, name);
     parent_e = find_in_bucket(pool->parent->buckets[pidx], name);
-    if (parent_e == NULL) {
+    if (parent_e == NULL)
+    {
         parent_e = vp_entry_new(pool->alloc);
-        if (parent_e == NULL) return VPOOL_NOMEM;
+        if (parent_e == NULL)
+        {
+            return VPOOL_NOMEM;
+        }
         rc = Lstrcpy(pool->alloc, &parent_e->name, name);
-        if (rc != LSTR_OK) {
+        if (rc != LSTR_OK)
+        {
             vp_entry_free(pool->alloc, parent_e);
             return VPOOL_NOMEM;
         }
         parent_e->flags |= VPOOL_UNSET;
         rc = link_entry(pool->parent, parent_e);
-        if (rc != VPOOL_OK) {
+        if (rc != VPOOL_OK)
+        {
             /* link_entry already did entry_count--; undo and free. */
             unlink_entry(pool->parent,
                          bucket_index(pool->parent, name), parent_e);
@@ -514,13 +652,17 @@ int vpool_expose_var(struct irx_vpool *pool, const PLstr name)
 
     /* Install a ref entry in the child. */
     child_e = vp_entry_new(pool->alloc);
-    if (child_e == NULL) return VPOOL_NOMEM;
+    if (child_e == NULL)
+    {
+        return VPOOL_NOMEM;
+    }
     rc = Lstrcpy(pool->alloc, &child_e->name, name);
-    if (rc != LSTR_OK) {
+    if (rc != LSTR_OK)
+    {
         vp_entry_free(pool->alloc, child_e);
         return VPOOL_NOMEM;
     }
-    child_e->flags      |= VPOOL_EXPOSED_REF;
+    child_e->flags |= VPOOL_EXPOSED_REF;
     child_e->exposed_ref = parent_e;
 
     return link_entry(pool, child_e);
@@ -530,31 +672,46 @@ int vpool_expose_stem(struct irx_vpool *pool, const PLstr stem_name)
 {
     int rc;
 
-    if (pool == NULL || stem_name == NULL) return VPOOL_BADARG;
-    if (pool->parent == NULL) return VPOOL_OK;
+    if (pool == NULL || stem_name == NULL)
+    {
+        return VPOOL_BADARG;
+    }
+    if (pool->parent == NULL)
+    {
+        return VPOOL_OK;
+    }
 
     /* Grow the exposed_stems array as needed. */
-    if (pool->exposed_stem_count == pool->exposed_stem_cap) {
+    if (pool->exposed_stem_count == pool->exposed_stem_cap)
+    {
         int new_cap = pool->exposed_stem_cap == 0
-                      ? 4 : pool->exposed_stem_cap * 2;
+                          ? 4
+                          : pool->exposed_stem_cap * 2;
         Lstr *new_arr = (Lstr *)vp_alloc_raw(pool->alloc,
-                        (size_t)new_cap * sizeof(Lstr));
-        if (new_arr == NULL) return VPOOL_NOMEM;
+                                             (size_t)new_cap * sizeof(Lstr));
+        if (new_arr == NULL)
+        {
+            return VPOOL_NOMEM;
+        }
         memset(new_arr, 0, (size_t)new_cap * sizeof(Lstr));
-        if (pool->exposed_stems != NULL) {
+        if (pool->exposed_stems != NULL)
+        {
             memcpy(new_arr, pool->exposed_stems,
                    (size_t)pool->exposed_stem_count * sizeof(Lstr));
             vp_free_raw(pool->alloc, pool->exposed_stems,
                         (size_t)pool->exposed_stem_cap * sizeof(Lstr));
         }
-        pool->exposed_stems    = new_arr;
+        pool->exposed_stems = new_arr;
         pool->exposed_stem_cap = new_cap;
     }
 
     Lstr *slot = &pool->exposed_stems[pool->exposed_stem_count];
     Lzeroinit(slot);
     rc = Lstrcpy(pool->alloc, slot, stem_name);
-    if (rc != LSTR_OK) return VPOOL_NOMEM;
+    if (rc != LSTR_OK)
+    {
+        return VPOOL_NOMEM;
+    }
     pool->exposed_stem_count++;
     return VPOOL_OK;
 }
@@ -565,10 +722,13 @@ int vpool_expose_stem(struct irx_vpool *pool, const PLstr stem_name)
 
 void vpool_next_reset(struct irx_vpool *pool)
 {
-    if (pool == NULL) return;
+    if (pool == NULL)
+    {
+        return;
+    }
     pool->next_started = 0;
-    pool->next_bucket  = 0;
-    pool->next_entry   = NULL;
+    pool->next_bucket = 0;
+    pool->next_entry = NULL;
 }
 
 int vpool_next(struct irx_vpool *pool, PLstr name, PLstr value)
@@ -577,15 +737,22 @@ int vpool_next(struct irx_vpool *pool, PLstr name, PLstr value)
     struct vpool_entry *tgt;
     int rc;
 
-    if (pool == NULL || name == NULL || value == NULL) return VPOOL_BADARG;
+    if (pool == NULL || name == NULL || value == NULL)
+    {
+        return VPOOL_BADARG;
+    }
 
-    if (!pool->next_started) {
-        pool->next_bucket  = 0;
-        pool->next_entry   = NULL;
+    if (!pool->next_started)
+    {
+        pool->next_bucket = 0;
+        pool->next_entry = NULL;
         pool->next_started = 1;
-    } else if (pool->next_entry != NULL) {
+    }
+    else if (pool->next_entry != NULL)
+    {
         pool->next_entry = pool->next_entry->next;
-        if (pool->next_entry == NULL) {
+        if (pool->next_entry == NULL)
+        {
             /* Finished this bucket chain; scan forward. */
             pool->next_bucket++;
         }
@@ -593,24 +760,41 @@ int vpool_next(struct irx_vpool *pool, PLstr name, PLstr value)
 
     /* Find the next live entry, skipping empty buckets. */
     while (pool->next_entry == NULL &&
-           pool->next_bucket < pool->bucket_count) {
+           pool->next_bucket < pool->bucket_count)
+    {
         pool->next_entry = pool->buckets[pool->next_bucket];
-        if (pool->next_entry == NULL) pool->next_bucket++;
+        if (pool->next_entry == NULL)
+        {
+            pool->next_bucket++;
+        }
     }
 
-    if (pool->next_entry == NULL) {
-        if (pool->entry_count == 0) return VPOOL_NOT_FOUND;
+    if (pool->next_entry == NULL)
+    {
+        if (pool->entry_count == 0)
+        {
+            return VPOOL_NOT_FOUND;
+        }
         return VPOOL_LAST;
     }
 
-    e   = pool->next_entry;
+    e = pool->next_entry;
     tgt = resolve_ref(e);
-    if (tgt == NULL) return VPOOL_BADARG;
+    if (tgt == NULL)
+    {
+        return VPOOL_BADARG;
+    }
 
     rc = Lstrcpy(pool->alloc, name, &e->name);
-    if (rc != LSTR_OK) return VPOOL_NOMEM;
+    if (rc != LSTR_OK)
+    {
+        return VPOOL_NOMEM;
+    }
     rc = Lstrcpy(pool->alloc, value, &tgt->value);
-    if (rc != LSTR_OK) return VPOOL_NOMEM;
+    if (rc != LSTR_OK)
+    {
+        return VPOOL_NOMEM;
+    }
 
     /* Pre-advance so the caller can detect the final entry: if the
      * advance lands us at the end, next call returns VPOOL_LAST. */

--- a/test/test_control.c
+++ b/test/test_control.c
@@ -16,31 +16,35 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "lstring.h"
-#include "lstralloc.h"
+#include "irxctrl.h"
+#include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
-#include "irxpars.h"
-#include "irxctrl.h"
+#include "lstralloc.h"
+#include "lstring.h"
 
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -50,7 +54,10 @@ static int tests_failed = 0;
 static int lstr_eq_cstr(const Lstr *s, const char *cstr)
 {
     size_t n = strlen(cstr);
-    if (s->len != n) return 0;
+    if (s->len != n)
+    {
+        return 0;
+    }
     return memcmp(s->pstr, cstr, n) == 0;
 }
 
@@ -62,15 +69,16 @@ static void set_lstr(struct lstr_alloc *a, PLstr s, const char *c)
 static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
                       const char *src)
 {
-    struct irx_token    *tokens = NULL;
-    int                  count  = 0;
+    struct irx_token *tokens = NULL;
+    int count = 0;
     struct irx_tokn_error tok_err;
-    struct irx_parser    parser;
-    int                  rc;
+    struct irx_parser parser;
+    int rc;
 
     rc = irx_tokn_run(NULL, src, (int)strlen(src), &tokens, &count,
                       &tok_err);
-    if (rc != 0) {
+    if (rc != 0)
+    {
         printf("    tokenizer failed: rc=%d code=%d line=%d col=%d\n",
                rc, tok_err.error_code, tok_err.error_line,
                tok_err.error_col);
@@ -78,14 +86,16 @@ static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
     }
 
     rc = irx_pars_init(&parser, tokens, count, pool, a, NULL);
-    if (rc != IRXPARS_OK) {
+    if (rc != IRXPARS_OK)
+    {
         irx_tokn_free(NULL, tokens, count);
         printf("    irx_pars_init failed: rc=%d\n", rc);
         return rc;
     }
 
     rc = irx_pars_run(&parser);
-    if (rc != IRXPARS_OK) {
+    if (rc != IRXPARS_OK)
+    {
         printf("    parser rc=%d error=%d line=%d\n", rc,
                parser.error_code, parser.error_line);
     }
@@ -99,21 +109,23 @@ static int get_var_eq(struct lstr_alloc *a, struct irx_vpool *pool,
                       const char *name, const char *expected)
 {
     Lstr key, val;
-    int  rc, eq;
+    int rc, eq;
 
     Lzeroinit(&key);
     Lzeroinit(&val);
     set_lstr(a, &key, name);
 
     rc = vpool_get(pool, &key, &val);
-    if (rc != VPOOL_OK) {
+    if (rc != VPOOL_OK)
+    {
         printf("    vpool_get(%s) rc=%d\n", name, rc);
         Lfree(a, &key);
         Lfree(a, &val);
         return 0;
     }
     eq = lstr_eq_cstr(&val, expected);
-    if (!eq) {
+    if (!eq)
+    {
         printf("    %s = '%.*s' (expected '%s')\n",
                name, (int)val.len, (const char *)val.pstr, expected);
     }
@@ -129,43 +141,51 @@ static int get_var_eq(struct lstr_alloc *a, struct irx_vpool *pool,
 /* CF#1: DO i = 1 TO 5; x = x + i; END */
 static void test_cf1_do_counted_loop(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#1: DO i = 1 TO 5; x = x + i; END ---\n");
 
     /* Pre-set x = 0 */
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO i = 1 TO 5\n"
-        "  x = x + i\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO i = 1 TO 5\n"
+                     "  x = x + i\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "15"), "X = '15' (1+2+3+4+5)");
-    CHECK(get_var_eq(a, pool, "I", "5"),  "I = '5' (final value)");
+    CHECK(get_var_eq(a, pool, "I", "5"), "I = '5' (final value)");
     vpool_destroy(pool);
 }
 
 /* CF#2: DO WHILE x < 10 (pre-test) */
 static void test_cf2_do_while(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#2: DO WHILE x < 10 ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO WHILE x < 10\n"
-        "  x = x + 3\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO WHILE x < 10\n"
+                     "  x = x + 3\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "12"), "X = '12' (0+3+3+3+3)");
     vpool_destroy(pool);
 }
@@ -173,20 +193,24 @@ static void test_cf2_do_while(void)
 /* CF#3: DO UNTIL x > 10 (post-test, runs at least once) */
 static void test_cf3_do_until(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#3: DO UNTIL x > 10 ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO UNTIL x > 10\n"
-        "  x = x + 4\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO UNTIL x > 10\n"
+                     "  x = x + 4\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "12"), "X = '12' (0+4+4+4)");
     vpool_destroy(pool);
 }
@@ -194,22 +218,26 @@ static void test_cf3_do_until(void)
 /* CF#4: Nested DO loops */
 static void test_cf4_nested_do(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#4: Nested DO loops ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "N"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "N");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO i = 1 TO 3\n"
-        "  DO j = 1 TO 3\n"
-        "    n = n + 1\n"
-        "  END\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO i = 1 TO 3\n"
+                     "  DO j = 1 TO 3\n"
+                     "    n = n + 1\n"
+                     "  END\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "N", "9"), "N = '9' (3x3 iterations)");
     vpool_destroy(pool);
 }
@@ -217,13 +245,14 @@ static void test_cf4_nested_do(void)
 /* CF#5: IF THEN ELSE — true branch */
 static void test_cf5_if_true(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#5: IF 1 THEN x = 'yes'; ELSE x = 'no' ---\n");
 
     CHECK(run_source(a, pool,
-        "IF 1 THEN x = 'yes'\n"
-        "ELSE x = 'no'\n") == IRXPARS_OK, "parser OK");
+                     "IF 1 THEN x = 'yes'\n"
+                     "ELSE x = 'no'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "yes"), "X = 'yes' (true branch)");
     vpool_destroy(pool);
 }
@@ -231,13 +260,14 @@ static void test_cf5_if_true(void)
 /* CF#6: IF THEN ELSE — false branch */
 static void test_cf6_if_false(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#6: IF 0 THEN x = 'yes'; ELSE x = 'no' ---\n");
 
     CHECK(run_source(a, pool,
-        "IF 0 THEN x = 'yes'\n"
-        "ELSE x = 'no'\n") == IRXPARS_OK, "parser OK");
+                     "IF 0 THEN x = 'yes'\n"
+                     "ELSE x = 'no'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "no"), "X = 'no' (false branch)");
     vpool_destroy(pool);
 }
@@ -245,21 +275,26 @@ static void test_cf6_if_false(void)
 /* CF#7: Nested IF — ELSE binds to inner IF */
 static void test_cf7_nested_if_else(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#7: IF a THEN IF b THEN c ELSE d (ELSE binds to inner) ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "A"); set_lstr(a, &v, "1");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "A");
+    set_lstr(a, &v, "1");
     vpool_set(pool, &k, &v);
-    set_lstr(a, &k, "B"); set_lstr(a, &v, "0");
+    set_lstr(a, &k, "B");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "IF a THEN IF b THEN x = 'c'\n"
-        "ELSE x = 'd'\n") == IRXPARS_OK, "parser OK");
+                     "IF a THEN IF b THEN x = 'c'\n"
+                     "ELSE x = 'd'\n") == IRXPARS_OK,
+          "parser OK");
     /* ELSE binds to inner IF (b=0), so x='d' */
     CHECK(get_var_eq(a, pool, "X", "d"), "X = 'd' (ELSE bound to inner IF)");
     vpool_destroy(pool);
@@ -268,22 +303,26 @@ static void test_cf7_nested_if_else(void)
 /* CF#8: SELECT with first WHEN matching */
 static void test_cf8_select_first_when(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#8: SELECT; WHEN n=1 THEN x='one'; WHEN n=2 THEN x='two'; END ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "N"); set_lstr(a, &v, "1");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "N");
+    set_lstr(a, &v, "1");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "SELECT\n"
-        "  WHEN n = 1 THEN x = 'one'\n"
-        "  WHEN n = 2 THEN x = 'two'\n"
-        "  OTHERWISE x = 'other'\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "SELECT\n"
+                     "  WHEN n = 1 THEN x = 'one'\n"
+                     "  WHEN n = 2 THEN x = 'two'\n"
+                     "  OTHERWISE x = 'other'\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "one"), "X = 'one'");
     vpool_destroy(pool);
 }
@@ -291,22 +330,26 @@ static void test_cf8_select_first_when(void)
 /* CF#9: SELECT with second WHEN matching */
 static void test_cf9_select_second_when(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#9: SELECT n=2 matches second WHEN ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "N"); set_lstr(a, &v, "2");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "N");
+    set_lstr(a, &v, "2");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "SELECT\n"
-        "  WHEN n = 1 THEN x = 'one'\n"
-        "  WHEN n = 2 THEN x = 'two'\n"
-        "  OTHERWISE x = 'other'\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "SELECT\n"
+                     "  WHEN n = 1 THEN x = 'one'\n"
+                     "  WHEN n = 2 THEN x = 'two'\n"
+                     "  OTHERWISE x = 'other'\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "two"), "X = 'two'");
     vpool_destroy(pool);
 }
@@ -314,22 +357,26 @@ static void test_cf9_select_second_when(void)
 /* CF#10: SELECT with OTHERWISE */
 static void test_cf10_select_otherwise(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#10: SELECT n=99 falls through to OTHERWISE ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "N"); set_lstr(a, &v, "99");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "N");
+    set_lstr(a, &v, "99");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "SELECT\n"
-        "  WHEN n = 1 THEN x = 'one'\n"
-        "  WHEN n = 2 THEN x = 'two'\n"
-        "  OTHERWISE x = 'other'\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "SELECT\n"
+                     "  WHEN n = 1 THEN x = 'one'\n"
+                     "  WHEN n = 2 THEN x = 'two'\n"
+                     "  OTHERWISE x = 'other'\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "other"), "X = 'other'");
     vpool_destroy(pool);
 }
@@ -337,38 +384,43 @@ static void test_cf10_select_otherwise(void)
 /* CF#11: SELECT with no match and no OTHERWISE -> SYNTAX error */
 static void test_cf11_select_no_match(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#11: SELECT no match, no OTHERWISE -> SYNTAX error ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "N"); set_lstr(a, &v, "99");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "N");
+    set_lstr(a, &v, "99");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "SELECT\n"
-        "  WHEN n = 1 THEN x = 'one'\n"
-        "END\n") != IRXPARS_OK, "returns error (no OTHERWISE, no match)");
+                     "SELECT\n"
+                     "  WHEN n = 1 THEN x = 'one'\n"
+                     "END\n") != IRXPARS_OK,
+          "returns error (no OTHERWISE, no match)");
     vpool_destroy(pool);
 }
 
 /* CF#12: CALL label -> RETURN -> resumes */
 static void test_cf12_call_return(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#12: CALL label; RETURN ---\n");
 
     CHECK(run_source(a, pool,
-        "x = 1\n"
-        "CALL mysub\n"
-        "x = x + 10\n"
-        "EXIT 0\n"
-        "mysub:\n"
-        "  x = x + 100\n"
-        "RETURN\n") == IRXPARS_OK, "parser OK");
+                     "x = 1\n"
+                     "CALL mysub\n"
+                     "x = x + 10\n"
+                     "EXIT 0\n"
+                     "mysub:\n"
+                     "  x = x + 100\n"
+                     "RETURN\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "111"), "X = '111' (1+100+10)");
     vpool_destroy(pool);
 }
@@ -376,15 +428,16 @@ static void test_cf12_call_return(void)
 /* CF#13: CALL sets SIGL */
 static void test_cf13_call_sigl(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#13: CALL sets SIGL to call line ---\n");
 
     CHECK(run_source(a, pool,
-        "CALL sub\n"    /* line 1 */
-        "EXIT 0\n"
-        "sub:\n"
-        "RETURN\n") == IRXPARS_OK, "parser OK");
+                     "CALL sub\n" /* line 1 */
+                     "EXIT 0\n"
+                     "sub:\n"
+                     "RETURN\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "SIGL", "1"), "SIGL = '1'");
     vpool_destroy(pool);
 }
@@ -392,15 +445,16 @@ static void test_cf13_call_sigl(void)
 /* CF#14: RETURN sets RESULT */
 static void test_cf14_return_result(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#14: RETURN expr sets RESULT ---\n");
 
     CHECK(run_source(a, pool,
-        "CALL add\n"
-        "EXIT 0\n"
-        "add:\n"
-        "RETURN 42\n") == IRXPARS_OK, "parser OK");
+                     "CALL add\n"
+                     "EXIT 0\n"
+                     "add:\n"
+                     "RETURN 42\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "RESULT", "42"), "RESULT = '42'");
     vpool_destroy(pool);
 }
@@ -408,14 +462,15 @@ static void test_cf14_return_result(void)
 /* CF#15: EXIT terminates execution */
 static void test_cf15_exit(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#15: EXIT 0 terminates, code after is not run ---\n");
 
     CHECK(run_source(a, pool,
-        "x = 'before'\n"
-        "EXIT 0\n"
-        "x = 'after'\n") == IRXPARS_OK, "parser OK");
+                     "x = 'before'\n"
+                     "EXIT 0\n"
+                     "x = 'after'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "before"), "X = 'before' (EXIT stopped)");
     vpool_destroy(pool);
 }
@@ -423,18 +478,19 @@ static void test_cf15_exit(void)
 /* CF#16: SIGNAL label clears stack and transfers control */
 static void test_cf16_signal(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#16: SIGNAL label clears stack, transfers control ---\n");
 
     CHECK(run_source(a, pool,
-        "x = 'start'\n"
-        "DO i = 1 TO 100\n"
-        "  SIGNAL done\n"
-        "END\n"
-        "x = 'unreachable'\n"
-        "done:\n"
-        "x = 'signalled'\n") == IRXPARS_OK, "parser OK");
+                     "x = 'start'\n"
+                     "DO i = 1 TO 100\n"
+                     "  SIGNAL done\n"
+                     "END\n"
+                     "x = 'unreachable'\n"
+                     "done:\n"
+                     "x = 'signalled'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "signalled"), "X = 'signalled'");
     vpool_destroy(pool);
 }
@@ -442,14 +498,15 @@ static void test_cf16_signal(void)
 /* CF#17: NOP is valid as THEN target */
 static void test_cf17_nop(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#17: NOP as THEN target ---\n");
 
     CHECK(run_source(a, pool,
-        "x = 'ok'\n"
-        "IF 1 THEN NOP\n"
-        "ELSE x = 'bad'\n") == IRXPARS_OK, "parser OK");
+                     "x = 'ok'\n"
+                     "IF 1 THEN NOP\n"
+                     "ELSE x = 'bad'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "ok"), "X = 'ok' (NOP took THEN)");
     vpool_destroy(pool);
 }
@@ -457,22 +514,26 @@ static void test_cf17_nop(void)
 /* CF#18: ITERATE skips to next iteration */
 static void test_cf18_iterate(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#18: ITERATE skips to next loop iteration ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     /* Sum only even numbers 1..6 -> 2+4+6 = 12 */
     CHECK(run_source(a, pool,
-        "DO i = 1 TO 6\n"
-        "  IF i // 2 = 1 THEN ITERATE\n"  /* skip odd */
-        "  x = x + i\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO i = 1 TO 6\n"
+                     "  IF i // 2 = 1 THEN ITERATE\n" /* skip odd */
+                     "  x = x + i\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "12"), "X = '12' (2+4+6)");
     vpool_destroy(pool);
 }
@@ -480,21 +541,25 @@ static void test_cf18_iterate(void)
 /* CF#19: LEAVE exits the loop */
 static void test_cf19_leave(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#19: LEAVE exits the loop early ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO i = 1 TO 100\n"
-        "  x = x + 1\n"
-        "  IF i = 5 THEN LEAVE\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO i = 1 TO 100\n"
+                     "  x = x + 1\n"
+                     "  IF i = 5 THEN LEAVE\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "5"), "X = '5' (LEAVE after 5 iters)");
     vpool_destroy(pool);
 }
@@ -502,15 +567,16 @@ static void test_cf19_leave(void)
 /* CF#20: Label table built before execution (SIGNAL forward jump) */
 static void test_cf20_signal_forward(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- CF#20: SIGNAL forward-jump to a label defined later ---\n");
 
     CHECK(run_source(a, pool,
-        "SIGNAL target\n"
-        "x = 'skipped'\n"
-        "target:\n"
-        "x = 'reached'\n") == IRXPARS_OK, "parser OK");
+                     "SIGNAL target\n"
+                     "x = 'skipped'\n"
+                     "target:\n"
+                     "x = 'reached'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "reached"), "X = 'reached'");
     vpool_destroy(pool);
 }
@@ -518,24 +584,29 @@ static void test_cf20_signal_forward(void)
 /* CF#21: No global state — two independent parsers */
 static void test_cf21_no_global_state(void)
 {
-    struct lstr_alloc *a     = lstr_default_alloc();
-    struct irx_vpool  *pool_a = vpool_create(a, NULL);
-    struct irx_vpool  *pool_b = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool_a = vpool_create(a, NULL);
+    struct irx_vpool *pool_b = vpool_create(a, NULL);
     printf("\n--- CF#21: Two independent parsers, no shared state ---\n");
 
     /* Pre-initialize N=0 in each pool so n+i arithmetic works. */
     Lstr k2, v2;
-    Lzeroinit(&k2); Lzeroinit(&v2);
-    set_lstr(a, &k2, "N"); set_lstr(a, &v2, "0");
+    Lzeroinit(&k2);
+    Lzeroinit(&v2);
+    set_lstr(a, &k2, "N");
+    set_lstr(a, &v2, "0");
     vpool_set(pool_a, &k2, &v2);
     vpool_set(pool_b, &k2, &v2);
-    Lfree(a, &k2); Lfree(a, &v2);
+    Lfree(a, &k2);
+    Lfree(a, &v2);
 
     CHECK(run_source(a, pool_a,
-        "DO i = 1 TO 3; n = n + i; END\n") == IRXPARS_OK, "parser A OK");
+                     "DO i = 1 TO 3; n = n + i; END\n") == IRXPARS_OK,
+          "parser A OK");
     CHECK(run_source(a, pool_b,
-        "DO i = 1 TO 4; n = n + i; END\n") == IRXPARS_OK, "parser B OK");
-    CHECK(get_var_eq(a, pool_a, "N", "6"),  "pool A: N = '6'  (1+2+3)");
+                     "DO i = 1 TO 4; n = n + i; END\n") == IRXPARS_OK,
+          "parser B OK");
+    CHECK(get_var_eq(a, pool_a, "N", "6"), "pool A: N = '6'  (1+2+3)");
     CHECK(get_var_eq(a, pool_b, "N", "10"), "pool B: N = '10' (1+2+3+4)");
 
     vpool_destroy(pool_a);
@@ -545,21 +616,25 @@ static void test_cf21_no_global_state(void)
 /* CF#22: DO FOREVER + LEAVE */
 static void test_cf22_do_forever(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#22: DO FOREVER with LEAVE ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO FOREVER\n"
-        "  x = x + 1\n"
-        "  IF x >= 3 THEN LEAVE\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO FOREVER\n"
+                     "  x = x + 1\n"
+                     "  IF x >= 3 THEN LEAVE\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "3"), "X = '3'");
     vpool_destroy(pool);
 }
@@ -567,20 +642,24 @@ static void test_cf22_do_forever(void)
 /* CF#23: DO n (repetitive count) */
 static void test_cf23_do_count(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#23: DO 4 (four iterations) ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO 4\n"
-        "  x = x + 1\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO 4\n"
+                     "  x = x + 1\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "4"), "X = '4'");
     vpool_destroy(pool);
 }
@@ -588,18 +667,22 @@ static void test_cf23_do_count(void)
 /* CF#24: IF without ELSE */
 static void test_cf24_if_no_else(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#24: IF without ELSE (false branch -> skip) ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "original");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "original");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "IF 0 THEN x = 'changed'\n") == IRXPARS_OK, "parser OK");
+                     "IF 0 THEN x = 'changed'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "original"), "X unchanged");
     vpool_destroy(pool);
 }
@@ -607,89 +690,105 @@ static void test_cf24_if_no_else(void)
 /* CF#25: IF with DO block in THEN branch */
 static void test_cf25_if_do_block(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#25: IF THEN DO ... END ELSE simple ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "C"); set_lstr(a, &v, "1");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "C");
+    set_lstr(a, &v, "1");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "IF c THEN\n"
-        "  DO\n"
-        "    x = 'block'\n"
-        "    y = 'ran'\n"
-        "  END\n"
-        "ELSE x = 'skip'\n") == IRXPARS_OK, "parser OK");
+                     "IF c THEN\n"
+                     "  DO\n"
+                     "    x = 'block'\n"
+                     "    y = 'ran'\n"
+                     "  END\n"
+                     "ELSE x = 'skip'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "block"), "X = 'block'");
-    CHECK(get_var_eq(a, pool, "Y", "ran"),   "Y = 'ran'");
+    CHECK(get_var_eq(a, pool, "Y", "ran"), "Y = 'ran'");
     vpool_destroy(pool);
 }
 
 /* CF#26: DO i = 5 TO 1 BY -1 (negative step, countdown) */
 static void test_cf26_do_ctrl_neg_step(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#26: DO i = 5 TO 1 BY -1 (negative step) ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO i = 5 TO 1 BY -1\n"
-        "  x = x + i\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO i = 5 TO 1 BY -1\n"
+                     "  x = x + i\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "15"), "X = '15' (5+4+3+2+1)");
-    CHECK(get_var_eq(a, pool, "I", "1"),  "I = '1' (final value)");
+    CHECK(get_var_eq(a, pool, "I", "1"), "I = '1' (final value)");
     vpool_destroy(pool);
 }
 
 /* CF#27: DO i = 1 TO 10 BY 2 (step > 1) */
 static void test_cf27_do_ctrl_step2(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#27: DO i = 1 TO 10 BY 2 (step > 1) ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO i = 1 TO 10 BY 2\n"
-        "  x = x + i\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO i = 1 TO 10 BY 2\n"
+                     "  x = x + i\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "25"), "X = '25' (1+3+5+7+9)");
-    CHECK(get_var_eq(a, pool, "I", "9"),  "I = '9' (final value)");
+    CHECK(get_var_eq(a, pool, "I", "9"), "I = '9' (final value)");
     vpool_destroy(pool);
 }
 
 /* CF#28: DO i = 1 TO 10 BY 3 (step doesn't land on limit exactly) */
 static void test_cf28_do_ctrl_step3(void)
 {
-    struct lstr_alloc *a    = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- CF#28: DO i = 1 TO 10 BY 3 (step doesn't land on limit) ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "0");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool,
-        "DO i = 1 TO 10 BY 3\n"
-        "  x = x + i\n"
-        "END\n") == IRXPARS_OK, "parser OK");
+                     "DO i = 1 TO 10 BY 3\n"
+                     "  x = x + i\n"
+                     "END\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(get_var_eq(a, pool, "X", "22"), "X = '22' (1+4+7+10)");
     CHECK(get_var_eq(a, pool, "I", "10"), "I = '10' (final value)");
     vpool_destroy(pool);

--- a/test/test_hello.c
+++ b/test/test_hello.c
@@ -24,9 +24,8 @@
 #include <string.h>
 
 #include "irx.h"
-#include "irxwkblk.h"
-#include "irxfunc.h"
 #include "irxexec.h"
+#include "irxfunc.h"
 #include "irxwkblk.h"
 #include "lstring.h"
 
@@ -34,20 +33,24 @@
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -57,12 +60,12 @@ static int tests_failed = 0;
 #define OUT_BUF_SIZE 4096
 
 static char g_out[OUT_BUF_SIZE];
-static int  g_out_len = 0;
+static int g_out_len = 0;
 
 static void reset_output(void)
 {
     g_out_len = 0;
-    g_out[0]  = '\0';
+    g_out[0] = '\0';
 }
 
 /* Returns 1 if the accumulated output contains the given line. */
@@ -71,9 +74,12 @@ static int output_contains(const char *line)
     int line_len = (int)strlen(line);
     int i;
 
-    for (i = 0; i <= g_out_len - line_len; i++) {
+    for (i = 0; i <= g_out_len - line_len; i++)
+    {
         if (memcmp(g_out + i, line, (size_t)line_len) == 0)
+        {
             return 1;
+        }
     }
     return 0;
 }
@@ -81,14 +87,15 @@ static int output_contains(const char *line)
 static int mock_io(int function, PLstr data, struct envblock *envblock)
 {
     (void)envblock;
-    if (function == RXFWRITE && data != NULL
-            && data->pstr != NULL && data->len > 0) {
+    if (function == RXFWRITE && data != NULL && data->pstr != NULL && data->len > 0)
+    {
         int n = (int)data->len;
-        if (g_out_len + n + 1 < OUT_BUF_SIZE) {
+        if (g_out_len + n + 1 < OUT_BUF_SIZE)
+        {
             memcpy(g_out + g_out_len, data->pstr, (size_t)n);
-            g_out_len          += n;
-            g_out[g_out_len++]  = '\n';
-            g_out[g_out_len]    = '\0';
+            g_out_len += n;
+            g_out[g_out_len++] = '\n';
+            g_out[g_out_len] = '\0';
         }
     }
     return 0;
@@ -98,7 +105,9 @@ static void install_mock(struct envblock *env)
 {
     struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
     if (exte != NULL)
+    {
         exte->io_routine = (void *)mock_io;
+    }
 }
 
 /* Run source through irx_exec_run, installing mock I/O first. */
@@ -108,7 +117,10 @@ static int run_with_mock(const char *src, int *exit_rc_out)
     int rc;
 
     rc = irxinit(NULL, &env);
-    if (rc != 0) return rc;
+    if (rc != 0)
+    {
+        return rc;
+    }
 
     install_mock(env);
     reset_output();
@@ -138,7 +150,7 @@ static void test_hw1_hello_world(void)
         "exit 0\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "EXIT return code is 0");
     CHECK(output_contains("Hello World from REXX/370!"),
           "first SAY: 'Hello World from REXX/370!'");
@@ -163,7 +175,7 @@ static void test_hw2_do_loop_sum(void)
         "exit sum\n",
         &exit_rc);
 
-    CHECK(rc == 0,       "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 55, "EXIT return code is 55");
     CHECK(output_contains("Sum 1..10 = 55"),
           "SAY: 'Sum 1..10 = 55'");
@@ -182,10 +194,11 @@ static void test_hw3_null_envblock(void)
 
     /* Redirect irxinout output to /dev/null by hijacking the real
      * irxinout (it uses printf); just verify rc is correct. */
-    const char *src = "x = 6 * 7\n" "exit x\n";
+    const char *src = "x = 6 * 7\n"
+                      "exit x\n";
     rc = irx_exec_run(src, (int)strlen(src), NULL, 0, &exit_rc, NULL);
 
-    CHECK(rc == 0,       "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 42, "EXIT return code is 42");
 
     (void)exte; /* suppress unused warning */
@@ -216,7 +229,7 @@ static void test_hw5_exit_nonzero(void)
         "exit 7\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 7, "EXIT return code is 7");
 }
 
@@ -232,7 +245,7 @@ static void test_hw6_no_exit_clause(void)
         "x = 1\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit_rc is 0 (no EXIT in source)");
 }
 

--- a/test/test_irxlstr.c
+++ b/test/test_irxlstr.c
@@ -16,37 +16,41 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "irx.h"
+#include "irxfunc.h"
+#include "irxlstr.h"
 #include "irxrab.h"
 #include "irxwkblk.h"
-#include "irxfunc.h"
-#include "lstring.h"
 #include "lstralloc.h"
-#include "irxlstr.h"
+#include "lstring.h"
 
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -57,10 +61,10 @@ static int tests_failed = 0;
 static Lstr make_lstr(const char *cstr)
 {
     Lstr s;
-    s.pstr   = (unsigned char *)(uintptr_t)cstr;
-    s.len    = strlen(cstr);
+    s.pstr = (unsigned char *)(uintptr_t)cstr;
+    s.len = strlen(cstr);
     s.maxlen = s.len;
-    s.type   = LSTRING_TY;
+    s.type = LSTRING_TY;
     return s;
 }
 
@@ -146,7 +150,7 @@ static void test_datatype_numeric(void)
     printf("\n--- Test: irx_datatype N / no-option ---\n");
 
     s = make_lstr("42");
-    CHECK(irx_datatype(&s, 0)   == 1, "'42' is NUM (no option)");
+    CHECK(irx_datatype(&s, 0) == 1, "'42' is NUM (no option)");
     CHECK(irx_datatype(&s, 'N') == 1, "'42' is NUM ('N')");
 
     s = make_lstr("abc");
@@ -213,7 +217,7 @@ static void test_datatype_classifiers(void)
 
 static void test_allocator_bridge(void)
 {
-    struct envblock   *env = NULL;
+    struct envblock *env = NULL;
     struct irx_wkblk_int *wkbi;
     struct lstr_alloc *alloc;
     struct lstr_alloc *alloc2;
@@ -223,13 +227,16 @@ static void test_allocator_bridge(void)
 
     rc = irxinit(NULL, &env);
     CHECK(rc == 0 && env != NULL, "irxinit succeeds");
-    if (env == NULL) return;
+    if (env == NULL)
+    {
+        return;
+    }
 
     alloc = irx_lstr_init(env);
     CHECK(alloc != NULL, "irx_lstr_init returns non-NULL");
-    CHECK(alloc->alloc   != NULL, "alloc function pointer set");
+    CHECK(alloc->alloc != NULL, "alloc function pointer set");
     CHECK(alloc->dealloc != NULL, "dealloc function pointer set");
-    CHECK(alloc->ctx == env,      "ctx is the envblock");
+    CHECK(alloc->ctx == env, "ctx is the envblock");
 
     /* Second call must return the same pointer (cached in wkbi). */
     alloc2 = irx_lstr_init(env);
@@ -242,7 +249,8 @@ static void test_allocator_bridge(void)
     /* Exercise the bridge by alloc/free via the callbacks directly. */
     void *mem = (*alloc->alloc)(64, alloc->ctx);
     CHECK(mem != NULL, "bridged alloc(64) succeeds");
-    if (mem != NULL) {
+    if (mem != NULL)
+    {
         memset(mem, 0xAB, 64);
         (*alloc->dealloc)(mem, 64, alloc->ctx);
     }
@@ -269,7 +277,10 @@ int main(void)
 
     printf("\n=== Results: %d/%d passed",
            tests_passed, tests_run);
-    if (tests_failed > 0) printf(", %d FAILED", tests_failed);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
     printf(" ===\n");
 
     return tests_failed > 0 ? 1 : 0;

--- a/test/test_parser.c
+++ b/test/test_parser.c
@@ -21,30 +21,34 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "lstring.h"
-#include "lstralloc.h"
+#include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
-#include "irxpars.h"
+#include "lstralloc.h"
+#include "lstring.h"
 
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -54,7 +58,10 @@ static int tests_failed = 0;
 static int lstr_eq_cstr(const Lstr *s, const char *cstr)
 {
     size_t n = strlen(cstr);
-    if (s->len != n) return 0;
+    if (s->len != n)
+    {
+        return 0;
+    }
     return memcmp(s->pstr, cstr, n) == 0;
 }
 
@@ -69,15 +76,16 @@ static void set_lstr(struct lstr_alloc *a, PLstr s, const char *c)
 static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
                       const char *src)
 {
-    struct irx_token    *tokens = NULL;
-    int                  count  = 0;
+    struct irx_token *tokens = NULL;
+    int count = 0;
     struct irx_tokn_error tok_err;
-    struct irx_parser    parser;
-    int                  rc;
+    struct irx_parser parser;
+    int rc;
 
     rc = irx_tokn_run(NULL, src, (int)strlen(src), &tokens, &count,
                       &tok_err);
-    if (rc != 0) {
+    if (rc != 0)
+    {
         printf("    tokenizer failed: rc=%d code=%d line=%d col=%d\n",
                rc, tok_err.error_code, tok_err.error_line,
                tok_err.error_col);
@@ -85,14 +93,16 @@ static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
     }
 
     rc = irx_pars_init(&parser, tokens, count, pool, a, NULL);
-    if (rc != IRXPARS_OK) {
+    if (rc != IRXPARS_OK)
+    {
         irx_tokn_free(NULL, tokens, count);
         printf("    irx_pars_init failed: rc=%d\n", rc);
         return rc;
     }
 
     rc = irx_pars_run(&parser);
-    if (rc != IRXPARS_OK) {
+    if (rc != IRXPARS_OK)
+    {
         printf("    parser rc=%d error=%d line=%d\n", rc,
                parser.error_code, parser.error_line);
     }
@@ -115,14 +125,16 @@ static int get_var_eq(struct lstr_alloc *a, struct irx_vpool *pool,
     set_lstr(a, &key, name);
 
     rc = vpool_get(pool, &key, &val);
-    if (rc != VPOOL_OK) {
+    if (rc != VPOOL_OK)
+    {
         printf("    vpool_get(%s) rc=%d\n", name, rc);
         Lfree(a, &key);
         Lfree(a, &val);
         return 0;
     }
     eq = lstr_eq_cstr(&val, expected);
-    if (!eq) {
+    if (!eq)
+    {
         printf("    %s = '%.*s' (expected '%s')\n",
                name, (int)val.len, (const char *)val.pstr, expected);
     }
@@ -138,7 +150,7 @@ static int get_var_eq(struct lstr_alloc *a, struct irx_vpool *pool,
 static void test_ac1_assignment_arithmetic(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#1: x = 2 + 3 ---\n");
     CHECK(run_source(a, pool, "x = 2 + 3\n") == IRXPARS_OK, "parser OK");
     CHECK(get_var_eq(a, pool, "X", "5"), "X = '5'");
@@ -148,7 +160,7 @@ static void test_ac1_assignment_arithmetic(void)
 static void test_ac2_blank_concat(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#2: x = 'hello' 'world' ---\n");
     CHECK(run_source(a, pool, "x = 'hello' 'world'\n") == IRXPARS_OK,
           "parser OK");
@@ -159,15 +171,19 @@ static void test_ac2_blank_concat(void)
 static void test_ac3_explicit_concat(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- AC#3: x = a || b  (a='foo', b='bar') ---\n");
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "A"); set_lstr(a, &v, "foo");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "A");
+    set_lstr(a, &v, "foo");
     vpool_set(pool, &k, &v);
-    set_lstr(a, &k, "B"); set_lstr(a, &v, "bar");
+    set_lstr(a, &k, "B");
+    set_lstr(a, &v, "bar");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool, "x = a || b\n") == IRXPARS_OK,
           "parser OK");
@@ -178,7 +194,7 @@ static void test_ac3_explicit_concat(void)
 static void test_ac4_precedence(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#4: x = 2 + 3 * 4 ---\n");
     CHECK(run_source(a, pool, "x = 2 + 3 * 4\n") == IRXPARS_OK,
           "parser OK");
@@ -189,7 +205,7 @@ static void test_ac4_precedence(void)
 static void test_ac5_power_right_assoc(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#5: x = 2 ** 3 ** 2 ---\n");
     CHECK(run_source(a, pool, "x = 2 ** 3 ** 2\n") == IRXPARS_OK,
           "parser OK");
@@ -200,7 +216,7 @@ static void test_ac5_power_right_assoc(void)
 static void test_ac6_eq_case_sensitive(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#6: normal '=' is case-sensitive, blank-padded ---\n");
 
     CHECK(run_source(a, pool, "r = ('abc' = 'ABC')\n") == IRXPARS_OK,
@@ -228,7 +244,7 @@ static void test_ac6_eq_case_sensitive(void)
 static void test_ac7_strict_eq(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#7: r = ('abc' == 'ABC') ---\n");
     CHECK(run_source(a, pool, "r = ('abc' == 'ABC')\n") == IRXPARS_OK,
           "parser OK");
@@ -239,7 +255,7 @@ static void test_ac7_strict_eq(void)
 static void test_ac8_function_length(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#8: x = LENGTH('hello') ---\n");
     CHECK(run_source(a, pool, "x = LENGTH('hello')\n") == IRXPARS_OK,
           "parser OK");
@@ -250,7 +266,7 @@ static void test_ac8_function_length(void)
 static void test_ac9_nested_parens(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#9: x = (2 + 3) * (4 + 5) ---\n");
     CHECK(run_source(a, pool, "x = (2 + 3) * (4 + 5)\n") == IRXPARS_OK,
           "parser OK");
@@ -261,16 +277,20 @@ static void test_ac9_nested_parens(void)
 static void test_ac10_compound(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     printf("\n--- AC#10: I='FOO'; STEM.FOO='bar'; x = STEM.I ---\n");
 
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "I"); set_lstr(a, &v, "FOO");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "I");
+    set_lstr(a, &v, "FOO");
     vpool_set(pool, &k, &v);
-    set_lstr(a, &k, "STEM.FOO"); set_lstr(a, &v, "bar");
+    set_lstr(a, &k, "STEM.FOO");
+    set_lstr(a, &v, "bar");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool, "x = STEM.I\n") == IRXPARS_OK,
           "parser OK");
@@ -282,7 +302,7 @@ static void test_ac10_compound(void)
 static void test_ac11_say_equals(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#11: SAY = 5  (assignment, not keyword) ---\n");
     CHECK(run_source(a, pool, "SAY = 5\n") == IRXPARS_OK, "parser OK");
     CHECK(get_var_eq(a, pool, "SAY", "5"), "SAY = '5'");
@@ -292,7 +312,7 @@ static void test_ac11_say_equals(void)
 static void test_ac12_strict_not_assignment(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     Lstr k, v;
     int rc_set;
     int not_set;
@@ -300,10 +320,13 @@ static void test_ac12_strict_not_assignment(void)
     printf("\n--- AC#12: x == 5  (command, not assignment) ---\n");
 
     /* Pre-populate X so that a mistaken assignment would overwrite it. */
-    Lzeroinit(&k); Lzeroinit(&v);
-    set_lstr(a, &k, "X"); set_lstr(a, &v, "preset");
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "preset");
     vpool_set(pool, &k, &v);
-    Lfree(a, &k); Lfree(a, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
 
     CHECK(run_source(a, pool, "x == 5\n") == IRXPARS_OK, "parser OK");
     rc_set = get_var_eq(a, pool, "X", "preset");
@@ -315,7 +338,7 @@ static void test_ac12_strict_not_assignment(void)
 static void test_ac13_abuttal_vs_blank(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool = vpool_create(a, NULL);
+    struct irx_vpool *pool = vpool_create(a, NULL);
     printf("\n--- AC#13: doubled quotes and blank concat ---\n");
 
     CHECK(run_source(a, pool, "y = 'a''b'\n") == IRXPARS_OK,
@@ -333,8 +356,8 @@ static void test_ac14_no_global_state(void)
 {
     /* Two independent pools run side-by-side must not interfere. */
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool_a = vpool_create(a, NULL);
-    struct irx_vpool  *pool_b = vpool_create(a, NULL);
+    struct irx_vpool *pool_a = vpool_create(a, NULL);
+    struct irx_vpool *pool_b = vpool_create(a, NULL);
 
     printf("\n--- AC#14: two pools side-by-side (no globals) ---\n");
 
@@ -342,7 +365,7 @@ static void test_ac14_no_global_state(void)
           "parser OK (pool A)");
     CHECK(run_source(a, pool_b, "n = 10 * 10\n") == IRXPARS_OK,
           "parser OK (pool B)");
-    CHECK(get_var_eq(a, pool_a, "N", "3"),  "pool A: N = '3'");
+    CHECK(get_var_eq(a, pool_a, "N", "3"), "pool A: N = '3'");
     CHECK(get_var_eq(a, pool_b, "N", "100"), "pool B: N = '100'");
 
     vpool_destroy(pool_a);

--- a/test/test_phase1.c
+++ b/test/test_phase1.c
@@ -16,30 +16,35 @@
 
 #include <stdio.h>
 #include <string.h>
+
 #include "irx.h"
+#include "irxfunc.h"
 #include "irxrab.h"
 #include "irxwkblk.h"
-#include "irxfunc.h"
 
 /* Cross-compile: expose simulated TCBUSER from irxrab.c */
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -48,9 +53,9 @@ static int tests_failed = 0;
 
 static void test_single_env(void)
 {
-    struct envblock      *envblk = NULL;
-    struct parmblock     *pb;
-    struct irxexte       *exte;
+    struct envblock *envblk = NULL;
+    struct parmblock *pb;
+    struct irxexte *exte;
     struct irx_wkblk_int *wkbi;
     int rc;
 
@@ -61,7 +66,10 @@ static void test_single_env(void)
     CHECK(rc == 0, "irxinit returns 0");
     CHECK(envblk != NULL, "envblock is not NULL");
 
-    if (envblk == NULL) return;
+    if (envblk == NULL)
+    {
+        return;
+    }
 
     /* Validate ENVBLOCK */
     CHECK(memcmp(envblk->envblock_id, ENVBLOCK_ID, 8) == 0,
@@ -72,7 +80,8 @@ static void test_single_env(void)
     /* Validate PARMBLOCK link */
     pb = (struct parmblock *)envblk->envblock_parmblock;
     CHECK(pb != NULL, "parmblock is linked");
-    if (pb != NULL) {
+    if (pb != NULL)
+    {
         CHECK(memcmp(pb->parmblock_id, PARMBLOCK_ID, 8) == 0,
               "parmblock eye-catcher is IRXPARMS");
         CHECK(pb->parmblock_subcomtb != NULL,
@@ -82,7 +91,8 @@ static void test_single_env(void)
     /* Validate IRXEXTE link */
     exte = (struct irxexte *)envblk->envblock_irxexte;
     CHECK(exte != NULL, "irxexte is linked");
-    if (exte != NULL) {
+    if (exte != NULL)
+    {
         CHECK(exte->irxexte_entry_count == IRXEXTE_ENTRY_COUNT,
               "irxexte has correct entry count");
         CHECK(exte->irxuid != NULL,
@@ -94,7 +104,8 @@ static void test_single_env(void)
     /* Validate internal Work Block */
     wkbi = (struct irx_wkblk_int *)envblk->envblock_userfield;
     CHECK(wkbi != NULL, "internal wkblk is linked via userfield");
-    if (wkbi != NULL) {
+    if (wkbi != NULL)
+    {
         CHECK(memcmp(wkbi->wkbi_id, WKBLK_INT_ID, 4) == 0,
               "wkblk eye-catcher is WKBI");
         CHECK(wkbi->wkbi_digits == NUMERIC_DIGITS_DEFAULT,
@@ -223,7 +234,8 @@ int main(void)
 
     printf("\n=== Results: %d/%d passed",
            tests_passed, tests_run);
-    if (tests_failed > 0) {
+    if (tests_failed > 0)
+    {
         printf(", %d FAILED", tests_failed);
     }
     printf(" ===\n");

--- a/test/test_procedure.c
+++ b/test/test_procedure.c
@@ -20,29 +20,33 @@
 #include <string.h>
 
 #include "irx.h"
-#include "irxwkblk.h"
-#include "irxfunc.h"
 #include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
 #include "lstring.h"
 
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -52,20 +56,24 @@ static int tests_failed = 0;
 #define OUT_BUF_SIZE 4096
 
 static char g_out[OUT_BUF_SIZE];
-static int  g_out_len = 0;
+static int g_out_len = 0;
 
 static void reset_output(void)
 {
     g_out_len = 0;
-    g_out[0]  = '\0';
+    g_out[0] = '\0';
 }
 
 static int output_contains(const char *line)
 {
     int line_len = (int)strlen(line);
     int i;
-    for (i = 0; i <= g_out_len - line_len; i++) {
-        if (memcmp(g_out + i, line, (size_t)line_len) == 0) return 1;
+    for (i = 0; i <= g_out_len - line_len; i++)
+    {
+        if (memcmp(g_out + i, line, (size_t)line_len) == 0)
+        {
+            return 1;
+        }
     }
     return 0;
 }
@@ -73,14 +81,15 @@ static int output_contains(const char *line)
 static int mock_io(int function, PLstr data, struct envblock *envblock)
 {
     (void)envblock;
-    if (function == RXFWRITE && data != NULL
-            && data->pstr != NULL && data->len > 0) {
+    if (function == RXFWRITE && data != NULL && data->pstr != NULL && data->len > 0)
+    {
         int n = (int)data->len;
-        if (g_out_len + n + 1 < OUT_BUF_SIZE) {
+        if (g_out_len + n + 1 < OUT_BUF_SIZE)
+        {
             memcpy(g_out + g_out_len, data->pstr, (size_t)n);
-            g_out_len          += n;
-            g_out[g_out_len++]  = '\n';
-            g_out[g_out_len]    = '\0';
+            g_out_len += n;
+            g_out[g_out_len++] = '\n';
+            g_out[g_out_len] = '\0';
         }
     }
     return 0;
@@ -90,7 +99,9 @@ static void install_mock(struct envblock *env)
 {
     struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
     if (exte != NULL)
+    {
         exte->io_routine = (void *)mock_io;
+    }
 }
 
 static int run_src(const char *src, int *exit_rc_out)
@@ -99,7 +110,10 @@ static int run_src(const char *src, int *exit_rc_out)
     int rc;
 
     rc = irxinit(NULL, &env);
-    if (rc != 0) return rc;
+    if (rc != 0)
+    {
+        return rc;
+    }
 
     install_mock(env);
     reset_output();
@@ -111,13 +125,16 @@ static int run_src(const char *src, int *exit_rc_out)
 }
 
 static int run_src_with_args(const char *src, const char *args,
-                              int *exit_rc_out)
+                             int *exit_rc_out)
 {
     struct envblock *env = NULL;
     int rc;
 
     rc = irxinit(NULL, &env);
-    if (rc != 0) return rc;
+    if (rc != 0)
+    {
+        return rc;
+    }
 
     install_mock(env);
     reset_output();
@@ -152,7 +169,7 @@ static void test_pr01_call_no_procedure(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,     "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("x = 99"),
           "SAY shows x=99 (sub modified caller's var)");
@@ -181,7 +198,7 @@ static void test_pr02_procedure_isolates(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("x = 42"),
           "SAY shows x=42 (PROCEDURE kept sub's x private)");
@@ -213,7 +230,7 @@ static void test_pr03_expose_var(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("x = 99"),
           "SAY shows x=99 (exposed var modified)");
@@ -243,7 +260,7 @@ static void test_pr04_return_value(void)
         "  return n + n\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("result = 42"),
           "SAY shows result=42 (RETURN value)");
@@ -271,7 +288,7 @@ static void test_pr05_call_multiple_args(void)
         "  return a + b\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("sum = 10"),
           "SAY shows sum=10 (3+7)");
@@ -298,7 +315,7 @@ static void test_pr06_arg_bif_count(void)
         "  return arg()\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("count = 3"),
           "ARG() returns 3");
@@ -325,7 +342,7 @@ static void test_pr07_arg_bif_nth(void)
         "  return arg(2)\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("world"),
           "ARG(2) returns 'world'");
@@ -353,7 +370,7 @@ static void test_pr08_arg_bif_exists_omitted(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("1 0 1"),
           "exists: arg1=1, arg2=0 (omitted), arg3=1");
@@ -389,7 +406,7 @@ static void test_pr09_nested_calls(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("x = 1"),
           "x stays 1 in caller after nested PROCEDURE calls");
@@ -417,7 +434,7 @@ static void test_pr10_arg_uppercase(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("HELLO WORLD"),
           "ARG uppercases 'hello world' to 'HELLO WORLD'");
@@ -447,11 +464,11 @@ static void test_pr11_arg_word_split(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
-    CHECK(output_contains("ALPHA"),  "first word: ALPHA");
-    CHECK(output_contains("BETA"),   "second word: BETA");
-    CHECK(output_contains("GAMMA"),  "rest: GAMMA");
+    CHECK(output_contains("ALPHA"), "first word: ALPHA");
+    CHECK(output_contains("BETA"), "second word: BETA");
+    CHECK(output_contains("GAMMA"), "rest: GAMMA");
 }
 
 /* ------------------------------------------------------------------ */
@@ -471,7 +488,7 @@ static void test_pr12_toplevel_arg_bif_no_args(void)
         "exit 0\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("0"),
           "ARG() at top level with no args returns 0");
@@ -497,10 +514,10 @@ static void test_pr13_toplevel_arg_with_args(void)
         "hello world",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
-    CHECK(output_contains("HELLO"),  "ARG first word = HELLO");
-    CHECK(output_contains("1"),      "ARG() = 1 (one arg string passed)");
+    CHECK(output_contains("HELLO"), "ARG first word = HELLO");
+    CHECK(output_contains("1"), "ARG() = 1 (one arg string passed)");
 }
 
 /* ------------------------------------------------------------------ */
@@ -530,7 +547,7 @@ static void test_pr14_procedure_all_private(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("1 2 3"),
           "a b c unchanged (all private via PROCEDURE)");
@@ -563,7 +580,7 @@ static void test_pr15_expose_multiple(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("10 2 30"),
           "a=10 (exposed), b=2 (private), c=30 (exposed)");
@@ -602,7 +619,7 @@ static void test_pr16_expose_indirect(void)
         "  return\n",
         &exit_rc);
 
-    CHECK(rc == 0,      "irx_exec_run returns 0");
+    CHECK(rc == 0, "irx_exec_run returns 0");
     CHECK(exit_rc == 0, "exit code 0");
     CHECK(output_contains("11 22 ONE TWO"),
           "a, b, stem.* all exposed via (names) indirect");

--- a/test/test_say.c
+++ b/test/test_say.c
@@ -23,33 +23,37 @@
 #include <string.h>
 
 #include "irx.h"
-#include "irxwkblk.h"
 #include "irxfunc.h"
 #include "irxio.h"
-#include "lstring.h"
-#include "lstralloc.h"
+#include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
-#include "irxpars.h"
+#include "irxwkblk.h"
+#include "lstralloc.h"
+#include "lstring.h"
 
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -57,33 +61,37 @@ static int tests_failed = 0;
 /* ------------------------------------------------------------------ */
 
 static char g_captured[512];
-static int  g_captured_len  = 0;
-static int  g_mock_called   = 0;
-static int  g_mock_function = -1;
+static int g_captured_len = 0;
+static int g_mock_called = 0;
+static int g_mock_function = -1;
 
 static int mock_io(int function, PLstr data, struct envblock *envblock)
 {
     (void)envblock;
     g_mock_called++;
-    g_mock_function   = function;
-    g_captured_len    = 0;
-    g_captured[0]     = '\0';
-    if (data != NULL && data->pstr != NULL && data->len > 0) {
+    g_mock_function = function;
+    g_captured_len = 0;
+    g_captured[0] = '\0';
+    if (data != NULL && data->pstr != NULL && data->len > 0)
+    {
         int n = (int)data->len;
-        if (n > (int)sizeof(g_captured) - 1) n = (int)sizeof(g_captured) - 1;
+        if (n > (int)sizeof(g_captured) - 1)
+        {
+            n = (int)sizeof(g_captured) - 1;
+        }
         memcpy(g_captured, data->pstr, (size_t)n);
-        g_captured_len    = n;
-        g_captured[n]     = '\0';
+        g_captured_len = n;
+        g_captured[n] = '\0';
     }
     return 0;
 }
 
 static void reset_mock(void)
 {
-    g_mock_called   = 0;
+    g_mock_called = 0;
     g_mock_function = -1;
-    g_captured_len  = 0;
-    g_captured[0]   = '\0';
+    g_captured_len = 0;
+    g_captured[0] = '\0';
 }
 
 /* ------------------------------------------------------------------ */
@@ -94,7 +102,8 @@ static void reset_mock(void)
 static void install_mock(struct envblock *env)
 {
     struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
-    if (exte != NULL) {
+    if (exte != NULL)
+    {
         exte->io_routine = (void *)mock_io;
     }
 }
@@ -103,39 +112,43 @@ static void install_mock(struct envblock *env)
  * Returns IRXPARS_OK or an error code. */
 static int run_source(struct envblock *env, const char *src)
 {
-    struct lstr_alloc   *a       = lstr_default_alloc();
-    struct irx_token    *tokens  = NULL;
-    int                  count   = 0;
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_token *tokens = NULL;
+    int count = 0;
     struct irx_tokn_error tok_err;
-    struct irx_parser    parser;
+    struct irx_parser parser;
     struct irx_wkblk_int *wk;
-    struct irx_vpool     *pool;
-    int                  rc;
+    struct irx_vpool *pool;
+    int rc;
 
     rc = irx_tokn_run(NULL, src, (int)strlen(src), &tokens, &count, &tok_err);
-    if (rc != 0) {
+    if (rc != 0)
+    {
         printf("    tokenizer failed: rc=%d code=%d line=%d col=%d\n",
                rc, tok_err.error_code, tok_err.error_line, tok_err.error_col);
         return -1;
     }
 
     /* Obtain (or create) the variable pool from the work block */
-    wk   = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
     pool = (struct irx_vpool *)wk->wkbi_varpool;
-    if (pool == NULL) {
+    if (pool == NULL)
+    {
         pool = vpool_create(a, NULL);
         wk->wkbi_varpool = pool;
     }
 
     rc = irx_pars_init(&parser, tokens, count, pool, a, env);
-    if (rc != IRXPARS_OK) {
+    if (rc != IRXPARS_OK)
+    {
         irx_tokn_free(NULL, tokens, count);
         printf("    irx_pars_init failed: rc=%d\n", rc);
         return rc;
     }
 
     rc = irx_pars_run(&parser);
-    if (rc != IRXPARS_OK) {
+    if (rc != IRXPARS_OK)
+    {
         printf("    parser rc=%d error=%d line=%d\n",
                rc, parser.error_code, parser.error_line);
     }
@@ -154,7 +167,10 @@ static void test_sa1_say_literal(void)
     struct envblock *env = NULL;
     printf("\n--- SA#1: SAY 'hello' ---\n");
     CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
-    if (env == NULL) return;
+    if (env == NULL)
+    {
+        return;
+    }
     install_mock(env);
     reset_mock();
 
@@ -162,7 +178,8 @@ static void test_sa1_say_literal(void)
     CHECK(g_mock_called == 1, "io_routine called once");
     CHECK(g_mock_function == RXFWRITE, "function is RXFWRITE");
     CHECK(g_captured_len == 5 &&
-          memcmp(g_captured, "hello", 5) == 0, "output is 'hello'");
+              memcmp(g_captured, "hello", 5) == 0,
+          "output is 'hello'");
 
     irxterm(env);
 }
@@ -172,14 +189,18 @@ static void test_sa2_say_expression(void)
     struct envblock *env = NULL;
     printf("\n--- SA#2: SAY 2 + 3 ---\n");
     CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
-    if (env == NULL) return;
+    if (env == NULL)
+    {
+        return;
+    }
     install_mock(env);
     reset_mock();
 
     CHECK(run_source(env, "SAY 2 + 3\n") == IRXPARS_OK, "parser OK");
     CHECK(g_mock_called == 1, "io_routine called once");
     CHECK(g_captured_len == 1 &&
-          g_captured[0] == '5', "output is '5'");
+              g_captured[0] == '5',
+          "output is '5'");
 
     irxterm(env);
 }
@@ -189,7 +210,10 @@ static void test_sa3_say_empty(void)
     struct envblock *env = NULL;
     printf("\n--- SA#3: SAY (no expression -> empty line) ---\n");
     CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
-    if (env == NULL) return;
+    if (env == NULL)
+    {
+        return;
+    }
     install_mock(env);
     reset_mock();
 
@@ -205,14 +229,18 @@ static void test_sa4_say_concat(void)
     struct envblock *env = NULL;
     printf("\n--- SA#4: SAY 'foo' || 'bar' ---\n");
     CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
-    if (env == NULL) return;
+    if (env == NULL)
+    {
+        return;
+    }
     install_mock(env);
     reset_mock();
 
     CHECK(run_source(env, "SAY 'foo' || 'bar'\n") == IRXPARS_OK, "parser OK");
     CHECK(g_mock_called == 1, "io_routine called once");
     CHECK(g_captured_len == 6 &&
-          memcmp(g_captured, "foobar", 6) == 0, "output is 'foobar'");
+              memcmp(g_captured, "foobar", 6) == 0,
+          "output is 'foobar'");
 
     irxterm(env);
 }
@@ -222,18 +250,23 @@ static void test_sa5_say_multiple(void)
     struct envblock *env = NULL;
     printf("\n--- SA#5: three SAY instructions in sequence ---\n");
     CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
-    if (env == NULL) return;
+    if (env == NULL)
+    {
+        return;
+    }
     install_mock(env);
     reset_mock();
 
     CHECK(run_source(env,
                      "SAY 'one'\n"
                      "SAY 'two'\n"
-                     "SAY 'three'\n") == IRXPARS_OK, "parser OK");
+                     "SAY 'three'\n") == IRXPARS_OK,
+          "parser OK");
     CHECK(g_mock_called == 3, "io_routine called 3 times");
     /* Last captured value is 'three' */
     CHECK(g_captured_len == 5 &&
-          memcmp(g_captured, "three", 5) == 0, "last output is 'three'");
+              memcmp(g_captured, "three", 5) == 0,
+          "last output is 'three'");
 
     irxterm(env);
 }
@@ -247,11 +280,11 @@ static void test_sa6_irxinout_direct(void)
     Lzeroinit(&s);
     /* Use a stack buffer — point pstr at a string literal */
     s.pstr = (unsigned char *)"test";
-    s.len  = 4;
+    s.len = 4;
 
     /* Just verify it returns 0 and does not crash */
     CHECK(irxinout(RXFWRITE, &s, NULL) == 0, "RXFWRITE returns 0");
-    CHECK(irxinout(RXFREAD,  &s, NULL) == 20, "RXFREAD returns 20 (stub)");
+    CHECK(irxinout(RXFREAD, &s, NULL) == 20, "RXFREAD returns 20 (stub)");
     CHECK(irxinout(RXFREADP, &s, NULL) == 20, "RXFREADP returns 20 (stub)");
 }
 
@@ -259,23 +292,28 @@ static void test_sa7_say_no_envblock(void)
 {
     /* SAY with NULL envblock in parser must not crash.
      * The output is silently dropped (no io_routine to call). */
-    struct lstr_alloc   *a      = lstr_default_alloc();
-    struct irx_vpool    *pool   = vpool_create(a, NULL);
-    struct irx_token    *tokens = NULL;
-    int                  count  = 0;
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct irx_token *tokens = NULL;
+    int count = 0;
     struct irx_tokn_error tok_err;
-    struct irx_parser    parser;
-    int                  rc;
+    struct irx_parser parser;
+    int rc;
 
     printf("\n--- SA#7: SAY with NULL envblock (no crash) ---\n");
 
     rc = irx_tokn_run(NULL, "SAY 'silent'\n", 13, &tokens, &count, &tok_err);
     CHECK(rc == 0, "tokenizer OK");
-    if (rc != 0) { vpool_destroy(pool); return; }
+    if (rc != 0)
+    {
+        vpool_destroy(pool);
+        return;
+    }
 
     rc = irx_pars_init(&parser, tokens, count, pool, a, NULL);
     CHECK(rc == IRXPARS_OK, "irx_pars_init OK");
-    if (rc == IRXPARS_OK) {
+    if (rc == IRXPARS_OK)
+    {
         rc = irx_pars_run(&parser);
         CHECK(rc == IRXPARS_OK, "parser OK (output silently dropped)");
         irx_pars_cleanup(&parser);

--- a/test/test_tokenizer.c
+++ b/test/test_tokenizer.c
@@ -12,33 +12,37 @@
 /* ------------------------------------------------------------------ */
 
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "irx.h"
-#include "irxrab.h"
-#include "irxwkblk.h"
 #include "irxfunc.h"
+#include "irxrab.h"
 #include "irxtokn.h"
+#include "irxwkblk.h"
 
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -48,7 +52,10 @@ static int tests_failed = 0;
 static int tok_text_eq(const struct irx_token *t, const char *s)
 {
     int n = (int)strlen(s);
-    if (t->tok_length != (unsigned short)n) return 0;
+    if (t->tok_length != (unsigned short)n)
+    {
+        return 0;
+    }
     return memcmp(t->tok_text, s, (size_t)n) == 0;
 }
 
@@ -74,13 +81,14 @@ static void test_hello_world(void)
     rc = run("say 'Hello World'", &toks, &n, &err);
     CHECK(rc == 0, "tokenizer returns 0");
     CHECK(n == 4, "produces 4 tokens (SYMBOL STRING EOC EOF)");
-    if (n >= 4) {
+    if (n >= 4)
+    {
         CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "say"),
               "[0] SYMBOL 'say'");
         CHECK(toks[1].tok_type == TOK_STRING && tok_text_eq(&toks[1], "Hello World"),
               "[1] STRING 'Hello World'");
-        CHECK(toks[2].tok_type == TOK_EOC,  "[2] EOC");
-        CHECK(toks[3].tok_type == TOK_EOF,  "[3] EOF");
+        CHECK(toks[2].tok_type == TOK_EOC, "[2] EOC");
+        CHECK(toks[3].tok_type == TOK_EOF, "[3] EOF");
     }
     irx_tokn_free(NULL, toks, n);
 }
@@ -95,7 +103,8 @@ static void test_compound_symbol(void)
 
     run("stem.i.j", &toks, &n, &err);
     CHECK(n == 3, "3 tokens (SYMBOL EOC EOF)");
-    if (n >= 1) {
+    if (n >= 1)
+    {
         CHECK(toks[0].tok_type == TOK_SYMBOL,
               "[0] is SYMBOL");
         CHECK(tok_text_eq(&toks[0], "stem.i.j"),
@@ -116,9 +125,10 @@ static void test_hex_string(void)
 
     run("'FF'x", &toks, &n, &err);
     CHECK(n == 3, "3 tokens (HEXSTRING EOC EOF)");
-    if (n >= 1) {
+    if (n >= 1)
+    {
         CHECK(toks[0].tok_type == TOK_HEXSTRING, "[0] HEXSTRING");
-        CHECK(tok_text_eq(&toks[0], "FF"),       "[0] body 'FF'");
+        CHECK(tok_text_eq(&toks[0], "FF"), "[0] body 'FF'");
     }
     irx_tokn_free(NULL, toks, n);
 }
@@ -133,9 +143,10 @@ static void test_bin_string(void)
 
     run("'1010'b", &toks, &n, &err);
     CHECK(n == 3, "3 tokens (BINSTRING EOC EOF)");
-    if (n >= 1) {
+    if (n >= 1)
+    {
         CHECK(toks[0].tok_type == TOK_BINSTRING, "[0] BINSTRING");
-        CHECK(tok_text_eq(&toks[0], "1010"),     "[0] body '1010'");
+        CHECK(tok_text_eq(&toks[0], "1010"), "[0] body '1010'");
     }
     irx_tokn_free(NULL, toks, n);
 }
@@ -150,7 +161,8 @@ static void test_string_doubling(void)
 
     run("'it''s'", &toks, &n, &err);
     CHECK(n == 3, "3 tokens");
-    if (n >= 1) {
+    if (n >= 1)
+    {
         CHECK(toks[0].tok_type == TOK_STRING, "[0] STRING");
         /* Body retains the doubling - decoding is the parser's job. */
         CHECK(tok_text_eq(&toks[0], "it''s"),
@@ -175,7 +187,8 @@ static void test_operators_single_char(void)
     rc = run("a||b", &toks, &n, &err);
     CHECK(rc == 0, "'a||b' tokenizes");
     CHECK(n == 6, "6 tokens (SYM | | SYM EOC EOF)");
-    if (n >= 6) {
+    if (n >= 6)
+    {
         CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "a"),
               "[0] SYMBOL a");
         CHECK(toks[1].tok_type == TOK_LOGICAL && tok_text_eq(&toks[1], "|"),
@@ -188,10 +201,12 @@ static void test_operators_single_char(void)
     irx_tokn_free(NULL, toks, n);
 
     /* ** as two TOK_OPERATOR */
-    toks = NULL; n = 0;
+    toks = NULL;
+    n = 0;
     rc = run("2**3", &toks, &n, &err);
     CHECK(rc == 0, "'2**3' tokenizes");
-    if (n >= 4) {
+    if (n >= 4)
+    {
         CHECK(toks[0].tok_type == TOK_NUMBER, "[0] NUMBER 2");
         CHECK(toks[1].tok_type == TOK_OPERATOR && tok_text_eq(&toks[1], "*"),
               "[1] OPERATOR '*'");
@@ -202,10 +217,12 @@ static void test_operators_single_char(void)
     irx_tokn_free(NULL, toks, n);
 
     /* \= as NOT followed by COMPARISON */
-    toks = NULL; n = 0;
+    toks = NULL;
+    n = 0;
     rc = run("a\\=b", &toks, &n, &err);
     CHECK(rc == 0, "'a\\=b' tokenizes");
-    if (n >= 4) {
+    if (n >= 4)
+    {
         CHECK(toks[1].tok_type == TOK_NOT && tok_text_eq(&toks[1], "\\"),
               "[1] NOT '\\'");
         CHECK(toks[2].tok_type == TOK_COMPARISON && tok_text_eq(&toks[2], "="),
@@ -214,10 +231,12 @@ static void test_operators_single_char(void)
     irx_tokn_free(NULL, toks, n);
 
     /* >= as two COMPARISONs */
-    toks = NULL; n = 0;
+    toks = NULL;
+    n = 0;
     rc = run("a>=b", &toks, &n, &err);
     CHECK(rc == 0, "'a>=b' tokenizes");
-    if (n >= 4) {
+    if (n >= 4)
+    {
         CHECK(toks[1].tok_type == TOK_COMPARISON && tok_text_eq(&toks[1], ">"),
               "[1] COMPARISON '>'");
         CHECK(toks[2].tok_type == TOK_COMPARISON && tok_text_eq(&toks[2], "="),
@@ -226,10 +245,12 @@ static void test_operators_single_char(void)
     irx_tokn_free(NULL, toks, n);
 
     /* Comment between || characters - parser will still see two | */
-    toks = NULL; n = 0;
+    toks = NULL;
+    n = 0;
     rc = run("a| /* gap */ |b", &toks, &n, &err);
     CHECK(rc == 0, "'a| /* gap */ |b' tokenizes (comment inside ||)");
-    if (n >= 4) {
+    if (n >= 4)
+    {
         CHECK(toks[1].tok_type == TOK_LOGICAL && tok_text_eq(&toks[1], "|"),
               "first | preserved");
         CHECK(toks[2].tok_type == TOK_LOGICAL && tok_text_eq(&toks[2], "|"),
@@ -249,15 +270,18 @@ static void test_punctuation(void)
 
     rc = run("a;b", &toks, &n, &err);
     CHECK(rc == 0, "'a;b' tokenizes");
-    if (n >= 4) {
+    if (n >= 4)
+    {
         CHECK(toks[1].tok_type == TOK_SEMICOLON, "[1] ';' is SEMICOLON");
     }
     irx_tokn_free(NULL, toks, n);
 
-    toks = NULL; n = 0;
+    toks = NULL;
+    n = 0;
     rc = run("loop:\nsay 'x'", &toks, &n, &err);
     CHECK(rc == 0, "'loop:' label tokenizes");
-    if (n >= 2) {
+    if (n >= 2)
+    {
         CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "loop"),
               "[0] SYMBOL 'loop'");
         CHECK(toks[1].tok_type == TOK_SEMICOLON,
@@ -281,7 +305,8 @@ static void test_comments_and_lines(void)
 
     rc = run(src, &toks, &n, &err);
     CHECK(rc == 0, "tokenizer returns 0");
-    if (rc == 0) {
+    if (rc == 0)
+    {
         CHECK(toks[0].tok_type == TOK_SYMBOL && tok_text_eq(&toks[0], "say"),
               "[0] 'say' on line 2");
         CHECK(toks[0].tok_line == 2, "[0] tok_line == 2");
@@ -291,9 +316,11 @@ static void test_comments_and_lines(void)
         /* After EOC, we have x = 1 on line 3. */
         int i;
         int found_x = 0;
-        for (i = 0; i < n; i++) {
+        for (i = 0; i < n; i++)
+        {
             if (toks[i].tok_type == TOK_SYMBOL &&
-                tok_text_eq(&toks[i], "x")) {
+                tok_text_eq(&toks[i], "x"))
+            {
                 found_x = (toks[i].tok_line == 3);
                 break;
             }
@@ -318,12 +345,13 @@ static void test_continuation(void)
     /* Comma stays (argument separator), only EOC suppressed:
      * SYM STR COMMA STR EOC EOF = 6 */
     CHECK(n == 6, "6 tokens (comma kept, EOC suppressed)");
-    if (n >= 5) {
+    if (n >= 5)
+    {
         CHECK(toks[0].tok_type == TOK_SYMBOL, "[0] SYMBOL say");
         CHECK(toks[1].tok_type == TOK_STRING, "[1] STRING 'a'");
-        CHECK(toks[2].tok_type == TOK_COMMA,  "[2] COMMA (kept for parser)");
+        CHECK(toks[2].tok_type == TOK_COMMA, "[2] COMMA (kept for parser)");
         CHECK(toks[3].tok_type == TOK_STRING, "[3] STRING 'b'");
-        CHECK(toks[4].tok_type == TOK_EOC,    "[4] EOC");
+        CHECK(toks[4].tok_type == TOK_EOC, "[4] EOC");
     }
     irx_tokn_free(NULL, toks, n);
 }
@@ -338,7 +366,8 @@ static void test_numbers(void)
 
     run("42 3.14 1E5 1.5e-2 .5", &toks, &n, &err);
     CHECK(n == 7, "5 numbers + EOC + EOF");
-    if (n >= 5) {
+    if (n >= 5)
+    {
         CHECK(toks[0].tok_type == TOK_NUMBER && tok_text_eq(&toks[0], "42"),
               "42");
         CHECK(toks[1].tok_type == TOK_NUMBER && tok_text_eq(&toks[1], "3.14"),
@@ -374,20 +403,25 @@ static void test_stress_1000_lines(void)
 {
     /* Build "say 'line N'\n" 1000 times. */
     char *buf;
-    int   buf_len = 0;
-    int   buf_cap = 64 * 1024;
-    int   i;
+    int buf_len = 0;
+    int buf_cap = 64 * 1024;
+    int i;
     struct irx_token *toks = NULL;
-    int   n = 0;
+    int n = 0;
     struct irx_tokn_error err;
-    int   rc;
+    int rc;
 
     printf("\n--- Test: stress 1000 lines ---\n");
 
     buf = (char *)malloc((size_t)buf_cap);
-    if (buf == NULL) { CHECK(0, "malloc"); return; }
+    if (buf == NULL)
+    {
+        CHECK(0, "malloc");
+        return;
+    }
 
-    for (i = 1; i <= 1000; i++) {
+    for (i = 1; i <= 1000; i++)
+    {
         int written = sprintf(buf + buf_len, "say 'line %d'\n", i);
         buf_len += written;
     }
@@ -424,7 +458,10 @@ int main(void)
 
     printf("\n=== Results: %d/%d passed",
            tests_passed, tests_run);
-    if (tests_failed > 0) printf(", %d FAILED", tests_failed);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
     printf(" ===\n");
 
     return tests_failed > 0 ? 1 : 0;

--- a/test/test_vpool.c
+++ b/test/test_vpool.c
@@ -15,33 +15,37 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "lstring.h"
-#include "lstralloc.h"
 #include "irxvpool.h"
+#include "lstralloc.h"
+#include "lstring.h"
 
 #ifndef __MVS__
 void *_simulated_tcbuser = NULL;
 #endif
 
-static int tests_run    = 0;
+static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
 
-#define CHECK(cond, msg) \
-    do { \
-        tests_run++; \
-        if (cond) { \
-            tests_passed++; \
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
             printf("  PASS: %s\n", msg); \
-        } else { \
-            tests_failed++; \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
-        } \
+        }                                \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -56,7 +60,10 @@ static void set_lstr(struct lstr_alloc *a, Lstr *s, const char *cstr)
 static int lstr_eq_cstr(const Lstr *s, const char *cstr)
 {
     size_t n = strlen(cstr);
-    if (s->len != n) return 0;
+    if (s->len != n)
+    {
+        return 0;
+    }
     return memcmp(s->pstr, cstr, n) == 0;
 }
 
@@ -66,7 +73,8 @@ static int lstr_eq_cstr(const Lstr *s, const char *cstr)
 /*  injected callbacks).                                              */
 /* ------------------------------------------------------------------ */
 
-struct track {
+struct track
+{
     long alloc_calls;
     long dealloc_calls;
     long bytes_live;
@@ -76,7 +84,8 @@ static void *track_alloc(size_t size, void *ctx)
 {
     struct track *t = (struct track *)ctx;
     void *p = malloc(size);
-    if (p != NULL) {
+    if (p != NULL)
+    {
         t->alloc_calls++;
         t->bytes_live += (long)size;
     }
@@ -86,7 +95,8 @@ static void *track_alloc(size_t size, void *ctx)
 static void track_dealloc(void *ptr, size_t size, void *ctx)
 {
     struct track *t = (struct track *)ctx;
-    if (ptr != NULL) {
+    if (ptr != NULL)
+    {
         t->dealloc_calls++;
         t->bytes_live -= (long)size;
         free(ptr);
@@ -100,7 +110,7 @@ static void track_dealloc(void *ptr, size_t size, void *ctx)
 static void test_basic_set_get_drop(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool;
+    struct irx_vpool *pool;
     Lstr name, value, out;
 
     printf("\n--- Test: set/get/drop for simple variables ---\n");
@@ -108,7 +118,9 @@ static void test_basic_set_get_drop(void)
     pool = vpool_create(a, NULL);
     CHECK(pool != NULL, "vpool_create returns non-NULL");
 
-    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out);
     set_lstr(a, &name, "X");
     set_lstr(a, &value, "42");
 
@@ -132,7 +144,9 @@ static void test_basic_set_get_drop(void)
     CHECK(vpool_exists(pool, &name) == 0,
           "vpool_exists(X) after drop == 0");
 
-    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    Lfree(a, &name);
+    Lfree(a, &value);
+    Lfree(a, &out);
     vpool_destroy(pool);
 }
 
@@ -143,13 +157,15 @@ static void test_basic_set_get_drop(void)
 static void test_stem_default(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool;
+    struct irx_vpool *pool;
     Lstr name, value, out;
 
     printf("\n--- Test: stem-default lookup ---\n");
 
     pool = vpool_create(a, NULL);
-    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out);
 
     /* Set STEM. = 'default' */
     set_lstr(a, &name, "STEM.");
@@ -182,7 +198,9 @@ static void test_stem_default(void)
     CHECK(vpool_get(pool, &name, &out) == VPOOL_NOT_FOUND,
           "non-compound missing var -> NOT_FOUND");
 
-    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    Lfree(a, &name);
+    Lfree(a, &value);
+    Lfree(a, &out);
     vpool_destroy(pool);
 }
 
@@ -193,7 +211,7 @@ static void test_stem_default(void)
 static void test_resize(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool;
+    struct irx_vpool *pool;
     Lstr name, value, out;
     int i;
     int all_ok;
@@ -201,19 +219,24 @@ static void test_resize(void)
     printf("\n--- Test: dynamic resize with 5000 entries ---\n");
 
     pool = vpool_create(a, NULL);
-    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out);
 
     CHECK(pool->bucket_count == 67, "initial bucket count is 67");
 
     all_ok = 1;
-    for (i = 0; i < 5000; i++) {
+    for (i = 0; i < 5000; i++)
+    {
         char buf[16];
         sprintf(buf, "V%d", i);
         set_lstr(a, &name, buf);
         sprintf(buf, "val%d", i);
         set_lstr(a, &value, buf);
-        if (vpool_set(pool, &name, &value) != VPOOL_OK) {
-            all_ok = 0; break;
+        if (vpool_set(pool, &name, &value) != VPOOL_OK)
+        {
+            all_ok = 0;
+            break;
         }
     }
     CHECK(all_ok, "5000 inserts succeeded");
@@ -232,7 +255,9 @@ static void test_resize(void)
     vpool_get(pool, &name, &out);
     CHECK(lstr_eq_cstr(&out, "val4999"), "V4999 survives resizes");
 
-    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    Lfree(a, &name);
+    Lfree(a, &value);
+    Lfree(a, &out);
     vpool_destroy(pool);
 }
 
@@ -243,16 +268,18 @@ static void test_resize(void)
 static void test_large_load(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool;
+    struct irx_vpool *pool;
     Lstr name, value;
     int i;
 
     printf("\n--- Test: 10000 variables, load factor below 4 ---\n");
 
     pool = vpool_create(a, NULL);
-    Lzeroinit(&name); Lzeroinit(&value);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
 
-    for (i = 0; i < 10000; i++) {
+    for (i = 0; i < 10000; i++)
+    {
         char buf[16];
         sprintf(buf, "VAR%d", i);
         set_lstr(a, &name, buf);
@@ -266,7 +293,8 @@ static void test_large_load(void)
            load, pool->bucket_count);
     CHECK(load < 4.0, "load factor stays below 4");
 
-    Lfree(a, &name); Lfree(a, &value);
+    Lfree(a, &name);
+    Lfree(a, &value);
     vpool_destroy(pool);
 }
 
@@ -277,16 +305,18 @@ static void test_large_load(void)
 static void test_scope_isolation(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *parent;
-    struct irx_vpool  *child;
+    struct irx_vpool *parent;
+    struct irx_vpool *child;
     Lstr name, value, out;
 
     printf("\n--- Test: PROCEDURE scope isolation ---\n");
 
     parent = vpool_create(a, NULL);
-    child  = vpool_create(a, parent);
+    child = vpool_create(a, parent);
 
-    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out);
 
     set_lstr(a, &name, "PARENT_VAR");
     set_lstr(a, &value, "parent_val");
@@ -302,7 +332,9 @@ static void test_scope_isolation(void)
     CHECK(vpool_get(parent, &name, &out) == VPOOL_OK,
           "parent still sees PARENT_VAR");
 
-    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    Lfree(a, &name);
+    Lfree(a, &value);
+    Lfree(a, &out);
     vpool_destroy(child);
     vpool_destroy(parent);
 }
@@ -314,16 +346,18 @@ static void test_scope_isolation(void)
 static void test_expose_var(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *parent;
-    struct irx_vpool  *child;
+    struct irx_vpool *parent;
+    struct irx_vpool *child;
     Lstr name, value, out;
 
     printf("\n--- Test: EXPOSE single variable ---\n");
 
     parent = vpool_create(a, NULL);
-    child  = vpool_create(a, parent);
+    child = vpool_create(a, parent);
 
-    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out);
 
     /* Parent already has Y = 'parent_y' */
     set_lstr(a, &name, "Y");
@@ -369,7 +403,9 @@ static void test_expose_var(void)
     CHECK(lstr_eq_cstr(&out, "via_child"),
           "parent's Z has the child-written value");
 
-    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    Lfree(a, &name);
+    Lfree(a, &value);
+    Lfree(a, &out);
     vpool_destroy(child);
     vpool_destroy(parent);
 }
@@ -381,16 +417,18 @@ static void test_expose_var(void)
 static void test_expose_stem(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *parent;
-    struct irx_vpool  *child;
+    struct irx_vpool *parent;
+    struct irx_vpool *child;
     Lstr name, value, out;
 
     printf("\n--- Test: EXPOSE stem ---\n");
 
     parent = vpool_create(a, NULL);
-    child  = vpool_create(a, parent);
+    child = vpool_create(a, parent);
 
-    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out);
 
     /* Expose STEM. on child */
     set_lstr(a, &name, "STEM.");
@@ -416,7 +454,9 @@ static void test_expose_stem(void)
     CHECK(vpool_exists(parent, &name) == 0,
           "drop propagates to parent through stem EXPOSE");
 
-    Lfree(a, &name); Lfree(a, &value); Lfree(a, &out);
+    Lfree(a, &name);
+    Lfree(a, &value);
+    Lfree(a, &out);
     vpool_destroy(child);
     vpool_destroy(parent);
 }
@@ -428,21 +468,24 @@ static void test_expose_stem(void)
 static void test_iteration(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
-    struct irx_vpool  *pool;
+    struct irx_vpool *pool;
     Lstr name, value;
     Lstr out_name, out_value;
-    int  seen[10];
-    int  rc;
-    int  count;
-    int  i;
+    int seen[10];
+    int rc;
+    int count;
+    int i;
 
     printf("\n--- Test: vpool_next iteration ---\n");
 
     pool = vpool_create(a, NULL);
-    Lzeroinit(&name); Lzeroinit(&value);
-    Lzeroinit(&out_name); Lzeroinit(&out_value);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out_name);
+    Lzeroinit(&out_value);
 
-    for (i = 0; i < 10; i++) {
+    for (i = 0; i < 10; i++)
+    {
         char buf[8];
         sprintf(buf, "V%d", i);
         set_lstr(a, &name, buf);
@@ -454,17 +497,31 @@ static void test_iteration(void)
 
     vpool_next_reset(pool);
     count = 0;
-    while ((rc = vpool_next(pool, &out_name, &out_value)) == VPOOL_OK) {
+    while ((rc = vpool_next(pool, &out_name, &out_value)) == VPOOL_OK)
+    {
         /* out_name is "V<i>" -> index from "<i>" suffix */
         int idx = atoi((const char *)out_name.pstr + 1);
-        if (idx >= 0 && idx < 10 && !seen[idx]) seen[idx] = 1;
+        if (idx >= 0 && idx < 10 && !seen[idx])
+        {
+            seen[idx] = 1;
+        }
         count++;
-        if (count > 20) break;   /* safety cap */
+        if (count > 20)
+        {
+            break; /* safety cap */
+        }
     }
     CHECK(rc == VPOOL_LAST, "iteration ends with VPOOL_LAST");
     CHECK(count == 10, "iteration visited 10 entries");
     int all_seen = 1;
-    for (i = 0; i < 10; i++) if (!seen[i]) { all_seen = 0; break; }
+    for (i = 0; i < 10; i++)
+    {
+        if (!seen[i])
+        {
+            all_seen = 0;
+            break;
+        }
+    }
     CHECK(all_seen, "every entry visited exactly once");
 
     /* Empty pool: NOT_FOUND on first call. */
@@ -474,8 +531,10 @@ static void test_iteration(void)
           "empty pool -> NOT_FOUND");
     vpool_destroy(empty);
 
-    Lfree(a, &name);     Lfree(a, &value);
-    Lfree(a, &out_name); Lfree(a, &out_value);
+    Lfree(a, &name);
+    Lfree(a, &value);
+    Lfree(a, &out_name);
+    Lfree(a, &out_value);
     vpool_destroy(pool);
 }
 
@@ -485,26 +544,31 @@ static void test_iteration(void)
 
 static void test_allocator_injection(void)
 {
-    struct track       st;
-    struct lstr_alloc  tracking;
-    struct irx_vpool  *pool;
+    struct track st;
+    struct lstr_alloc tracking;
+    struct irx_vpool *pool;
     Lstr name, value, out;
     int i;
 
     printf("\n--- Test: allocator injection (no leaks) ---\n");
 
-    st.alloc_calls = 0; st.dealloc_calls = 0; st.bytes_live = 0;
-    tracking.alloc   = track_alloc;
+    st.alloc_calls = 0;
+    st.dealloc_calls = 0;
+    st.bytes_live = 0;
+    tracking.alloc = track_alloc;
     tracking.dealloc = track_dealloc;
-    tracking.ctx     = &st;
+    tracking.ctx = &st;
 
     pool = vpool_create(&tracking, NULL);
     CHECK(pool != NULL, "vpool_create with injected allocator");
     CHECK(st.bytes_live > 0, "allocator received alloc calls");
 
-    Lzeroinit(&name); Lzeroinit(&value); Lzeroinit(&out);
+    Lzeroinit(&name);
+    Lzeroinit(&value);
+    Lzeroinit(&out);
 
-    for (i = 0; i < 50; i++) {
+    for (i = 0; i < 50; i++)
+    {
         char buf[16];
         sprintf(buf, "K%d", i);
         set_lstr(&tracking, &name, buf);
@@ -512,7 +576,8 @@ static void test_allocator_injection(void)
         set_lstr(&tracking, &value, buf);
         vpool_set(pool, &name, &value);
     }
-    for (i = 0; i < 50; i++) {
+    for (i = 0; i < 50; i++)
+    {
         char buf[16];
         sprintf(buf, "K%d", i);
         set_lstr(&tracking, &name, buf);
@@ -550,7 +615,10 @@ int main(void)
 
     printf("\n=== Results: %d/%d passed",
            tests_passed, tests_run);
-    if (tests_failed > 0) printf(", %d FAILED", tests_failed);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
     printf(" ===\n");
 
     return tests_failed > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

Mechanical `clang-format -i src/*.c include/*.h test/*.c` sweep using the repo's `.clang-format` (Allman braces, 4-space indent, `InsertBraces`, 80-col limit). **No logic changes** — pure reformatting.

31 files changed, +4591 / −2621.

## Test plan

- [x] 401/401 Linux cross-compile tests pass
  - tokenizer 70, phase1 38, vpool 47, parser 38, say 27, control 62, hello 16, procedure 53, irxlstr 50
- [x] `make build` on MVS: all 13 modules RC=0

## Review note

Diff is large but mechanical — recommend reviewing with `git diff -w` (ignore whitespace) to confirm no logic changes slipped in.