### PR TITLE
feat(wp-16): PARSE instruction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,7 @@ gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' $LSTRING_SRC
 ./test/test_hello
 
-# PARSE instruction (WP-16) — 68/68
+# PARSE instruction (WP-16) — 74/74
 gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     -o test/test_parse test/test_parse.c \
     $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' $LSTRING_SRC

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,8 +359,8 @@ and acceptance criteria.
 
 Current status:
 - Phase 1 (WP-01 through WP-05): complete
-- Phase 2 (WP-10 through WP-16, WP-18): complete
-- Next: WP-17 (PROCEDURE EXPOSE)
+- Phase 2 (WP-10 through WP-18): complete
+- Next: WP-20 (Arithmetic engine)
 
 ## Knowledge sources
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,12 @@ gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     -o test/test_hello test/test_hello.c \
     $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' $LSTRING_SRC
 ./test/test_hello
+
+# PARSE instruction (WP-16) — 68/68
+gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
+    -o test/test_parse test/test_parse.c \
+    $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' $LSTRING_SRC
+./test/test_parse
 ```
 
 ## Work packages
@@ -353,8 +359,8 @@ and acceptance criteria.
 
 Current status:
 - Phase 1 (WP-01 through WP-05): complete
-- Phase 2 (WP-10 through WP-15, WP-18): complete
-- Next: WP-16 (PARSE instruction)
+- Phase 2 (WP-10 through WP-16, WP-18): complete
+- Next: WP-17 (PROCEDURE EXPOSE)
 
 ## Knowledge sources
 

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -22,8 +22,8 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-13 | Parser + evaluator (IRX#PARS) | 2 | DONE (38/38) — PR #8 |
 | WP-14 | SAY + basic I/O routine (IRX#IO) | 2 | DONE (27/27) — PR #10 |
 | WP-15 | DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL | 2 | DONE (62/62) — PR #12 |
-| WP-16 | PARSE instruction | 2 | DONE (68/68) — PR #21 |
-| WP-17 | PROCEDURE EXPOSE | 2 | OPEN |
+| WP-16 | PARSE instruction | 2 | DONE (68/68) — PR #22 |
+| WP-17 | PROCEDURE EXPOSE | 2 | DONE (53/53) — PR #16 |
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | OPEN |
 | WP-21 | Built-in string functions | 3 | OPEN |

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -22,7 +22,7 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-13 | Parser + evaluator (IRX#PARS) | 2 | DONE (38/38) — PR #8 |
 | WP-14 | SAY + basic I/O routine (IRX#IO) | 2 | DONE (27/27) — PR #10 |
 | WP-15 | DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL | 2 | DONE (62/62) — PR #12 |
-| WP-16 | PARSE instruction | 2 | DONE (68/68) — PR #22 |
+| WP-16 | PARSE instruction | 2 | DONE (74/74) — PR #22 |
 | WP-17 | PROCEDURE EXPOSE | 2 | DONE (53/53) — PR #16 |
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | OPEN |

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -22,7 +22,7 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-13 | Parser + evaluator (IRX#PARS) | 2 | DONE (38/38) — PR #8 |
 | WP-14 | SAY + basic I/O routine (IRX#IO) | 2 | DONE (27/27) — PR #10 |
 | WP-15 | DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL | 2 | DONE (62/62) — PR #12 |
-| WP-16 | PARSE instruction | 2 | OPEN |
+| WP-16 | PARSE instruction | 2 | DONE (68/68) — PR #21 |
 | WP-17 | PROCEDURE EXPOSE | 2 | OPEN |
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | OPEN |

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -2804,7 +2804,16 @@ static int parse_apply_template(struct irx_parser *p,
             continue;
         }
 
-        /* Absolute position: =n (identical retreat semantics to bare n) */
+        /* Absolute position: =n (identical retreat semantics to bare n)
+         *
+         * tok_is_op_char requires tok_length == 1, so a 2-char token
+         * (e.g. the second '=' of '==') would not match here.
+         * Additionally, the tokenizer emits one token per operator
+         * character (irx#tokn.c §scan_operator), so '==' always arrives
+         * as two separate 1-char TOK_COMPARISON tokens.  If the first '='
+         * matches but peek_tok(p,1) is not TOK_NUMBER (as it would be for
+         * the second '=' of '=='), the inner if fails and IRXPARS_SYNTAX
+         * is raised — '==5' cannot silently become '=5'.               */
         if (tok_is_op_char(t, TOK_COMPARISON, '='))
         {
             const struct irx_token *tnum = peek_tok(p, 1);

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -2771,7 +2771,12 @@ static int parse_apply_template(struct irx_parser *p,
             goto done;
         }
 
-        /* Absolute position: bare integer (TOK_NUMBER) */
+        /* Absolute position: bare integer (TOK_NUMBER)
+         *
+         * Ref: SC28-1883-0 §8 (PARSE instruction) — column positions are
+         * 1-based.  When n < scan_pos (backward), the pending variables
+         * receive an empty segment and the cursor retreats to n.  Same
+         * retreat rule applies to the =n form below.                    */
         if (t->tok_type == TOK_NUMBER)
         {
             long col    = parse_tok_num(t);
@@ -2782,6 +2787,8 @@ static int parse_apply_template(struct irx_parser *p,
             {
                 npos = srclen;
             }
+            /* When npos < scan_pos: seg_end == scan_pos → empty segment,
+             * cursor retreats.  When npos >= scan_pos: normal forward. */
             seg_end = (npos > scan_pos) ? npos : scan_pos;
 
             advance_tok(p);
@@ -2789,7 +2796,7 @@ static int parse_apply_template(struct irx_parser *p,
             rc = parse_assign_segment(p, src, scan_pos, seg_end,
                                      var_names, var_lens, var_dots, nvar);
             nvar     = 0;
-            scan_pos = npos;
+            scan_pos = npos; /* unconditional: handles both forward and retreat */
             if (rc != IRXPARS_OK)
             {
                 goto done;
@@ -2797,7 +2804,7 @@ static int parse_apply_template(struct irx_parser *p,
             continue;
         }
 
-        /* Absolute position: =n */
+        /* Absolute position: =n (identical retreat semantics to bare n) */
         if (tok_is_op_char(t, TOK_COMPARISON, '='))
         {
             const struct irx_token *tnum = peek_tok(p, 1);
@@ -2820,7 +2827,7 @@ static int parse_apply_template(struct irx_parser *p,
                 rc = parse_assign_segment(p, src, scan_pos, seg_end,
                                          var_names, var_lens, var_dots, nvar);
                 nvar     = 0;
-                scan_pos = npos;
+                scan_pos = npos; /* unconditional retreat/forward */
                 if (rc != IRXPARS_OK)
                 {
                     goto done;
@@ -2906,6 +2913,10 @@ static int parse_apply_template(struct irx_parser *p,
                     var_lens[nvar] = 0;
                     nvar++;
                 }
+                /* Phase 2 cap: PARSE_MAX_VARS (= IRX_MAX_ARGS = 16) template
+                 * items per segment.  IBM REXX has no such limit.  Items
+                 * beyond the cap are silently dropped.  A future improvement
+                 * should raise IRXPARS_SYNTAX instead of truncating. */
             }
             else if (!(t->tok_flags & TOKF_CONSTANT))
             {
@@ -2917,6 +2928,7 @@ static int parse_apply_template(struct irx_parser *p,
                     var_dots[nvar] = 0;
                     nvar++;
                 }
+                /* (same Phase 2 cap — see dot-placeholder note above) */
             }
             /* TOKF_CONSTANT symbols are data constants, not targets. Skip. */
             advance_tok(p);
@@ -3056,16 +3068,14 @@ static int kw_parse(struct irx_parser *p)
         }
 
         calltype = in_call ? "SUBROUTINE" : "COMMAND";
-        {
-            int off = 0;
-            memcpy(buf, "MVS ", 4);
-            off += 4;
-            memcpy(buf + off, calltype, strlen(calltype));
-            off += (int)strlen(calltype);
-            memcpy(buf + off, " ?", 2);
-            off += 2;
-            blen = off;
-        }
+        int off  = 0;
+        memcpy(buf, "MVS ", 4);
+        off += 4;
+        memcpy(buf + off, calltype, strlen(calltype));
+        off += (int)strlen(calltype);
+        memcpy(buf + off, " ?", 2);
+        off += 2;
+        blen = off;
         rc = lstr_set_bytes(p->alloc, &source_str, buf, (size_t)blen);
         if (rc != LSTR_OK)
         {

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -2372,6 +2372,862 @@ static int kw_signal(struct irx_parser *p)
 }
 
 /* ------------------------------------------------------------------ */
+/*  PARSE instruction (WP-16)                                         */
+/*                                                                    */
+/*  PARSE [UPPER] source [template [, template ...]]                  */
+/*                                                                    */
+/*  Sources handled in Phase 2:                                       */
+/*    ARG     — call_args[i], one per comma-separated template        */
+/*    VAR n   — current value of variable n                           */
+/*    VALUE expr WITH — evaluate expr, parse the result               */
+/*    SOURCE  — "MVS COMMAND ?" or "MVS SUBROUTINE ?"                 */
+/*    VERSION — REXX370 interpreter identification string              */
+/*    NUMERIC — current NUMERIC DIGITS / FUZZ / FORM settings         */
+/*  PULL / LINEIN / EXTERNAL → SYNTAX error (Phase 4).               */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 8 (PARSE instruction)                  */
+/* ------------------------------------------------------------------ */
+
+/* Version string returned by PARSE VERSION. */
+#define REXX370_PARSE_VERSION "REXX370 0.1.0 16 Apr 2026"
+
+/* Maximum template variables per segment (reuses IRX_MAX_ARGS). */
+#define PARSE_MAX_VARS IRX_MAX_ARGS
+
+/* Accessor for the i-th variable name slot in the flat name buffer. */
+#define PARSE_VAR(names, i) ((names) + (size_t)(i) * CTRL_NAME_MAX)
+
+/* Extract the integer value of a TOK_NUMBER token's text. */
+static long parse_tok_num(const struct irx_token *t)
+{
+    char buf[32];
+    size_t n = t->tok_length;
+
+    if (n >= sizeof(buf))
+    {
+        n = sizeof(buf) - 1;
+    }
+    memcpy(buf, t->tok_text, n);
+    buf[n] = '\0';
+    return strtol(buf, NULL, 10);
+}
+
+/* ------------------------------------------------------------------
+ * Assign a word-split segment src[spos..epos) to the pending variable
+ * list vars[0..nvar).
+ *
+ * The last non-dot item ("last_real") gets the raw remainder from the
+ * final whitespace-skip to epos (trailing blanks preserved).  All
+ * other non-dot items receive one whitespace-delimited word.  Dot
+ * placeholders consume one word silently.
+ *
+ * If epos <= spos, or src is NULL, every variable receives "".
+ * ------------------------------------------------------------------ */
+static int parse_assign_segment(struct irx_parser *p,
+                                const unsigned char *src,
+                                size_t spos, size_t epos,
+                                char *var_names, const int *var_lens,
+                                const int *var_dots, int nvar)
+{
+    size_t pos;
+    int i;
+    int last_real;
+
+    if (nvar == 0)
+    {
+        return IRXPARS_OK;
+    }
+
+    /* Clamp reversed or empty segments. */
+    if (src == NULL || epos < spos)
+    {
+        epos = spos;
+    }
+
+    pos = spos;
+
+    /* last_real: the last item is non-dot → it gets the raw remainder. */
+    last_real = (!var_dots[nvar - 1]) ? nvar - 1 : -1;
+
+    for (i = 0; i < nvar; i++)
+    {
+        Lstr val;
+        Lstr key;
+        size_t wstart;
+        size_t wend;
+        int rc;
+
+        Lzeroinit(&val);
+        Lzeroinit(&key);
+
+        /* Skip leading whitespace. */
+        while (pos < epos && isspace((unsigned char)src[pos]))
+        {
+            pos++;
+        }
+
+        if (var_dots[i])
+        {
+            /* Dot placeholder: skip one word, no assignment. */
+            while (pos < epos && !isspace((unsigned char)src[pos]))
+            {
+                pos++;
+            }
+            continue;
+        }
+
+        if (i == last_real)
+        {
+            /* Last real variable: raw rest to epos, trailing blanks kept. */
+            wstart = pos;
+            wend   = epos;
+            pos    = epos;
+        }
+        else
+        {
+            /* Non-last: one whitespace-delimited word. */
+            wstart = pos;
+            while (pos < epos && !isspace((unsigned char)src[pos]))
+            {
+                pos++;
+            }
+            wend = pos;
+        }
+
+        if (wend > wstart)
+        {
+            size_t vlen = wend - wstart;
+
+            if (Lfx(p->alloc, &val, vlen) != LSTR_OK)
+            {
+                return fail(p, IRXPARS_NOMEM);
+            }
+            memcpy(val.pstr, src + wstart, vlen);
+            val.len  = vlen;
+            val.type = LSTRING_TY;
+        }
+
+        rc = lstr_set_bytes(p->alloc, &key,
+                            PARSE_VAR(var_names, i),
+                            (size_t)var_lens[i]);
+        if (rc != LSTR_OK)
+        {
+            Lfree(p->alloc, &val);
+            return fail(p, IRXPARS_NOMEM);
+        }
+
+        vpool_set(p->vpool, &key, &val);
+        Lfree(p->alloc, &key);
+        Lfree(p->alloc, &val);
+    }
+
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------
+ * Scan from position `from` for the first standalone WITH token at
+ * paren depth 0 that is not an assignment target.
+ * Returns the token index, or -1 if not found before EOC/EOF.
+ * ------------------------------------------------------------------ */
+static int parse_find_with(struct irx_parser *p, int from)
+{
+    int depth = 0;
+    int i;
+
+    for (i = from; i < p->tok_count; i++)
+    {
+        const struct irx_token *t  = &p->tokens[i];
+        const struct irx_token *tn;
+        const struct irx_token *tn2;
+
+        if (tok_ends_clause(t))
+        {
+            break;
+        }
+        if (t->tok_type == TOK_LPAREN)
+        {
+            depth++;
+            continue;
+        }
+        if (t->tok_type == TOK_RPAREN)
+        {
+            if (depth > 0)
+            {
+                depth--;
+            }
+            continue;
+        }
+        if (depth != 0 || !sym_matches(t, "WITH"))
+        {
+            continue;
+        }
+        /* Exclude WITH = (but not WITH ==): that would be assignment. */
+        tn  = (i + 1 < p->tok_count) ? &p->tokens[i + 1] : NULL;
+        tn2 = (i + 2 < p->tok_count) ? &p->tokens[i + 2] : NULL;
+        if (tok_is_op_char(tn, TOK_COMPARISON, '=') &&
+            !tok_is_op_char(tn2, TOK_COMPARISON, '='))
+        {
+            continue;
+        }
+        return i;
+    }
+    return -1;
+}
+
+/* ------------------------------------------------------------------
+ * Apply one PARSE template against src[0..srclen).
+ *
+ * Processes tokens at p->tok_pos.  Stops at TOK_COMMA, EOC, or EOF.
+ * On return p->tok_pos is past all consumed template tokens.
+ * If a comma terminated the template, p->tok_pos is advanced past
+ * the comma and *hit_comma_out is 1.  Otherwise *hit_comma_out is 0.
+ *
+ * If src is NULL, all variables in the template receive "".
+ * ------------------------------------------------------------------ */
+static int parse_apply_template(struct irx_parser *p,
+                                const unsigned char *src, size_t srclen,
+                                int *hit_comma_out)
+{
+    size_t names_size = (size_t)PARSE_MAX_VARS * CTRL_NAME_MAX;
+    size_t lens_size  = (size_t)PARSE_MAX_VARS * sizeof(int);
+    size_t dots_size  = (size_t)PARSE_MAX_VARS * sizeof(int);
+    char *var_names   = (char *)p->alloc->alloc(names_size, p->alloc->ctx);
+    int *var_lens     = (int *)p->alloc->alloc(lens_size, p->alloc->ctx);
+    int *var_dots     = (int *)p->alloc->alloc(dots_size, p->alloc->ctx);
+    int nvar          = 0;
+    size_t scan_pos   = 0;
+    int rc            = IRXPARS_OK;
+
+    *hit_comma_out = 0;
+
+    if (var_names == NULL || var_lens == NULL || var_dots == NULL)
+    {
+        if (var_names != NULL)
+        {
+            p->alloc->dealloc(var_names, names_size, p->alloc->ctx);
+        }
+        if (var_lens != NULL)
+        {
+            p->alloc->dealloc(var_lens, lens_size, p->alloc->ctx);
+        }
+        if (var_dots != NULL)
+        {
+            p->alloc->dealloc(var_dots, dots_size, p->alloc->ctx);
+        }
+        return fail(p, IRXPARS_NOMEM);
+    }
+
+    while (!tok_ends_clause(cur_tok(p)))
+    {
+        const struct irx_token *t = cur_tok(p);
+
+        if (t == NULL)
+        {
+            break;
+        }
+
+        /* Comma: end of this template. */
+        if (t->tok_type == TOK_COMMA)
+        {
+            advance_tok(p);
+            *hit_comma_out = 1;
+            break;
+        }
+
+        /* Variable pattern: ( symbol ) */
+        if (t->tok_type == TOK_LPAREN)
+        {
+            const struct irx_token *tsym = peek_tok(p, 1);
+            const struct irx_token *trp  = peek_tok(p, 2);
+
+            if (tsym != NULL && tsym->tok_type == TOK_SYMBOL &&
+                !(tsym->tok_flags & TOKF_CONSTANT) &&
+                trp  != NULL && trp->tok_type == TOK_RPAREN)
+            {
+                Lstr pkey;
+                Lstr pval;
+                size_t plen;
+                int found;
+                size_t si;
+                size_t seg_end;
+                size_t new_scan;
+
+                Lzeroinit(&pkey);
+                Lzeroinit(&pval);
+
+                rc = set_upper_from_tok(p->alloc, &pkey, tsym);
+                if (rc != LSTR_OK)
+                {
+                    rc = fail(p, IRXPARS_NOMEM);
+                    goto done;
+                }
+
+                /* Fetch the variable's value; use as search pattern. */
+                if (vpool_get(p->vpool, &pkey, &pval) != VPOOL_OK)
+                {
+                    Lzeroinit(&pval); /* not found: empty pattern */
+                }
+                Lfree(p->alloc, &pkey);
+
+                advance_tok(p); /* ( */
+                advance_tok(p); /* sym */
+                advance_tok(p); /* ) */
+
+                plen = pval.len; /* save before possible Lfree */
+                if (plen == 0 || src == NULL)
+                {
+                    Lfree(p->alloc, &pval);
+                    /* Empty pattern: split at current position. */
+                    rc = parse_assign_segment(p, src, scan_pos, scan_pos,
+                                             var_names, var_lens, var_dots,
+                                             nvar);
+                    nvar = 0;
+                    if (rc != IRXPARS_OK)
+                    {
+                        goto done;
+                    }
+                    continue;
+                }
+
+                found = -1;
+                for (si = scan_pos; si + plen <= srclen; si++)
+                {
+                    if (memcmp(src + si, pval.pstr, plen) == 0)
+                    {
+                        found = (int)si;
+                        break;
+                    }
+                }
+                Lfree(p->alloc, &pval);
+
+                if (found >= 0)
+                {
+                    seg_end  = (size_t)found;
+                    new_scan = (size_t)found + plen;
+                }
+                else
+                {
+                    seg_end  = srclen;
+                    new_scan = srclen;
+                }
+
+                rc = parse_assign_segment(p, src, scan_pos, seg_end,
+                                         var_names, var_lens, var_dots, nvar);
+                nvar     = 0;
+                scan_pos = new_scan;
+                if (rc != IRXPARS_OK)
+                {
+                    goto done;
+                }
+                continue;
+            }
+            rc = fail(p, IRXPARS_SYNTAX);
+            goto done;
+        }
+
+        /* Relative position: +n or -n */
+        if (t->tok_type == TOK_OPERATOR && t->tok_length == 1 &&
+            (t->tok_text[0] == '+' || t->tok_text[0] == '-'))
+        {
+            const struct irx_token *tnum = peek_tok(p, 1);
+
+            if (tnum != NULL && tnum->tok_type == TOK_NUMBER)
+            {
+                long n = parse_tok_num(tnum);
+                size_t new_scan;
+                size_t seg_end;
+
+                if (t->tok_text[0] == '+')
+                {
+                    new_scan = scan_pos + (size_t)n;
+                    if (new_scan > srclen)
+                    {
+                        new_scan = srclen;
+                    }
+                    seg_end = new_scan;
+                }
+                else
+                {
+                    /* Backward: preceding vars get empty, cursor retreats. */
+                    new_scan = ((size_t)n <= scan_pos) ? scan_pos - (size_t)n
+                                                       : 0;
+                    seg_end  = scan_pos;
+                }
+
+                advance_tok(p); /* + or - */
+                advance_tok(p); /* number */
+
+                rc = parse_assign_segment(p, src, scan_pos, seg_end,
+                                         var_names, var_lens, var_dots, nvar);
+                nvar     = 0;
+                scan_pos = new_scan;
+                if (rc != IRXPARS_OK)
+                {
+                    goto done;
+                }
+                continue;
+            }
+            rc = fail(p, IRXPARS_SYNTAX);
+            goto done;
+        }
+
+        /* Absolute position: bare integer (TOK_NUMBER) */
+        if (t->tok_type == TOK_NUMBER)
+        {
+            long col    = parse_tok_num(t);
+            size_t npos = (col >= 1) ? (size_t)(col - 1) : 0;
+            size_t seg_end;
+
+            if (npos > srclen)
+            {
+                npos = srclen;
+            }
+            seg_end = (npos > scan_pos) ? npos : scan_pos;
+
+            advance_tok(p);
+
+            rc = parse_assign_segment(p, src, scan_pos, seg_end,
+                                     var_names, var_lens, var_dots, nvar);
+            nvar     = 0;
+            scan_pos = npos;
+            if (rc != IRXPARS_OK)
+            {
+                goto done;
+            }
+            continue;
+        }
+
+        /* Absolute position: =n */
+        if (tok_is_op_char(t, TOK_COMPARISON, '='))
+        {
+            const struct irx_token *tnum = peek_tok(p, 1);
+
+            if (tnum != NULL && tnum->tok_type == TOK_NUMBER)
+            {
+                long col    = parse_tok_num(tnum);
+                size_t npos = (col >= 1) ? (size_t)(col - 1) : 0;
+                size_t seg_end;
+
+                if (npos > srclen)
+                {
+                    npos = srclen;
+                }
+                seg_end = (npos > scan_pos) ? npos : scan_pos;
+
+                advance_tok(p); /* = */
+                advance_tok(p); /* number */
+
+                rc = parse_assign_segment(p, src, scan_pos, seg_end,
+                                         var_names, var_lens, var_dots, nvar);
+                nvar     = 0;
+                scan_pos = npos;
+                if (rc != IRXPARS_OK)
+                {
+                    goto done;
+                }
+                continue;
+            }
+            rc = fail(p, IRXPARS_SYNTAX);
+            goto done;
+        }
+
+        /* String literal pattern: TOK_STRING */
+        if (t->tok_type == TOK_STRING)
+        {
+            Lstr pat;
+            size_t plen;
+            int found;
+            size_t si;
+            size_t seg_end;
+            size_t new_scan;
+
+            Lzeroinit(&pat);
+            rc = lstr_set_bytes(p->alloc, &pat, t->tok_text, t->tok_length);
+            if (rc != LSTR_OK)
+            {
+                rc = fail(p, IRXPARS_NOMEM);
+                goto done;
+            }
+            if (t->tok_flags & TOKF_QUOTE_DBL)
+            {
+                dedouble_string(&pat);
+            }
+            advance_tok(p);
+
+            plen = pat.len; /* save before Lfree */
+            if (plen == 0 || src == NULL)
+            {
+                Lfree(p->alloc, &pat);
+                continue; /* empty pattern: no split */
+            }
+
+            found = -1;
+            for (si = scan_pos; si + plen <= srclen; si++)
+            {
+                if (memcmp(src + si, pat.pstr, plen) == 0)
+                {
+                    found = (int)si;
+                    break;
+                }
+            }
+            Lfree(p->alloc, &pat);
+
+            if (found >= 0)
+            {
+                seg_end  = (size_t)found;
+                new_scan = (size_t)found + plen;
+            }
+            else
+            {
+                seg_end  = srclen;
+                new_scan = srclen;
+            }
+
+            rc = parse_assign_segment(p, src, scan_pos, seg_end,
+                                     var_names, var_lens, var_dots, nvar);
+            nvar     = 0;
+            scan_pos = new_scan;
+            if (rc != IRXPARS_OK)
+            {
+                goto done;
+            }
+            continue;
+        }
+
+        /* Variable or dot placeholder: TOK_SYMBOL */
+        if (t->tok_type == TOK_SYMBOL)
+        {
+            if (t->tok_length == 1 && t->tok_text[0] == '.')
+            {
+                /* Dot placeholder (TOKF_CONSTANT is set for '.', that's OK). */
+                if (nvar < PARSE_MAX_VARS)
+                {
+                    var_dots[nvar] = 1;
+                    var_lens[nvar] = 0;
+                    nvar++;
+                }
+            }
+            else if (!(t->tok_flags & TOKF_CONSTANT))
+            {
+                /* Regular variable name (not digit/dot constant). */
+                if (nvar < PARSE_MAX_VARS)
+                {
+                    var_lens[nvar] = sym_to_upper(
+                        t, PARSE_VAR(var_names, nvar), CTRL_NAME_MAX);
+                    var_dots[nvar] = 0;
+                    nvar++;
+                }
+            }
+            /* TOKF_CONSTANT symbols are data constants, not targets. Skip. */
+            advance_tok(p);
+            continue;
+        }
+
+        /* Unrecognised token in template: syntax error. */
+        rc = fail(p, IRXPARS_SYNTAX);
+        goto done;
+    }
+
+    /* Final segment: remaining pending vars against [scan_pos, srclen). */
+    rc = parse_assign_segment(p, src, scan_pos, srclen,
+                             var_names, var_lens, var_dots, nvar);
+
+done:
+    p->alloc->dealloc(var_names, names_size, p->alloc->ctx);
+    p->alloc->dealloc(var_lens,  lens_size,  p->alloc->ctx);
+    p->alloc->dealloc(var_dots,  dots_size,  p->alloc->ctx);
+    return rc;
+}
+
+static int kw_parse(struct irx_parser *p)
+{
+    int upper     = 0;
+    int is_arg    = 0;
+    int arg_idx   = 0;
+    int hit_comma = 0;
+    int rc        = IRXPARS_OK;
+    Lstr source_str; /* built source for non-ARG sources   */
+    Lstr upper_copy; /* uppercase working copy when needed */
+    const struct irx_token *sk;
+
+    Lzeroinit(&source_str);
+    Lzeroinit(&upper_copy);
+
+    /* UPPER modifier. */
+    if (sym_matches(cur_tok(p), "UPPER"))
+    {
+        upper = 1;
+        advance_tok(p);
+    }
+
+    /* Source keyword. */
+    sk = cur_tok(p);
+    if (sk == NULL || sk->tok_type != TOK_SYMBOL)
+    {
+        skip_to_clause_end(p);
+        return fail(p, IRXPARS_SYNTAX);
+    }
+
+    if (sym_matches(sk, "ARG"))
+    {
+        is_arg = 1;
+        advance_tok(p);
+    }
+    else if (sym_matches(sk, "VAR"))
+    {
+        const struct irx_token *vn;
+        Lstr key;
+
+        advance_tok(p);
+        vn = cur_tok(p);
+        if (vn == NULL || vn->tok_type != TOK_SYMBOL ||
+            (vn->tok_flags & TOKF_CONSTANT))
+        {
+            skip_to_clause_end(p);
+            return fail(p, IRXPARS_SYNTAX);
+        }
+        Lzeroinit(&key);
+        rc = set_upper_from_tok(p->alloc, &key, vn);
+        advance_tok(p);
+        if (rc != LSTR_OK)
+        {
+            return fail(p, IRXPARS_NOMEM);
+        }
+        /* If the variable is not set, source_str stays empty. */
+        vpool_get(p->vpool, &key, &source_str);
+        Lfree(p->alloc, &key);
+        rc = IRXPARS_OK;
+    }
+    else if (sym_matches(sk, "VALUE"))
+    {
+        int with_pos;
+        int saved_count;
+
+        advance_tok(p);
+
+        with_pos = parse_find_with(p, p->tok_pos);
+        if (with_pos < 0)
+        {
+            skip_to_clause_end(p);
+            return fail(p, IRXPARS_SYNTAX);
+        }
+
+        if (p->tok_pos >= with_pos)
+        {
+            /* Empty expression: source is "". */
+            p->tok_pos = with_pos + 1;
+        }
+        else
+        {
+            saved_count  = p->tok_count;
+            p->tok_count = with_pos;
+            rc = irx_pars_eval_expr(p, &source_str);
+            p->tok_count = saved_count;
+            if (rc != IRXPARS_OK)
+            {
+                Lfree(p->alloc, &source_str);
+                return rc;
+            }
+            p->tok_pos = with_pos + 1;
+        }
+    }
+    else if (sym_matches(sk, "SOURCE"))
+    {
+        struct irx_exec_stack *es;
+        int in_call = 0;
+        const char *calltype;
+        char buf[32];
+        int blen;
+
+        advance_tok(p);
+
+        es = (struct irx_exec_stack *)p->exec_stack;
+        if (es != NULL)
+        {
+            int fi;
+            for (fi = es->top - 1; fi >= 0; fi--)
+            {
+                if (es->frames[fi].frame_type == FRAME_CALL)
+                {
+                    in_call = 1;
+                    break;
+                }
+            }
+        }
+
+        calltype = in_call ? "SUBROUTINE" : "COMMAND";
+        {
+            int off = 0;
+            memcpy(buf, "MVS ", 4);
+            off += 4;
+            memcpy(buf + off, calltype, strlen(calltype));
+            off += (int)strlen(calltype);
+            memcpy(buf + off, " ?", 2);
+            off += 2;
+            blen = off;
+        }
+        rc = lstr_set_bytes(p->alloc, &source_str, buf, (size_t)blen);
+        if (rc != LSTR_OK)
+        {
+            return fail(p, IRXPARS_NOMEM);
+        }
+        rc = IRXPARS_OK;
+    }
+    else if (sym_matches(sk, "VERSION"))
+    {
+        const char *vs = REXX370_PARSE_VERSION;
+
+        advance_tok(p);
+        rc = lstr_set_bytes(p->alloc, &source_str, vs, strlen(vs));
+        if (rc != LSTR_OK)
+        {
+            return fail(p, IRXPARS_NOMEM);
+        }
+        rc = IRXPARS_OK;
+    }
+    else if (sym_matches(sk, "NUMERIC"))
+    {
+        int digits = NUMERIC_DIGITS_DEFAULT;
+        int fuzz   = NUMERIC_FUZZ_DEFAULT;
+        int form   = NUMFORM_SCIENTIFIC;
+        char buf[64];
+        int blen;
+
+        advance_tok(p);
+
+        if (p->envblock != NULL &&
+            p->envblock->envblock_userfield != NULL)
+        {
+            struct irx_wkblk_int *wkbi =
+                (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+            digits = wkbi->wkbi_digits;
+            fuzz   = wkbi->wkbi_fuzz;
+            form   = wkbi->wkbi_form;
+        }
+
+        blen = sprintf(buf, "%d %d %s",
+                       digits, fuzz,
+                       (form == NUMFORM_ENGINEERING) ? "ENGINEERING"
+                                                     : "SCIENTIFIC");
+        if (blen < 0)
+        {
+            blen = 0;
+        }
+        rc = lstr_set_bytes(p->alloc, &source_str, buf, (size_t)blen);
+        if (rc != LSTR_OK)
+        {
+            return fail(p, IRXPARS_NOMEM);
+        }
+        rc = IRXPARS_OK;
+    }
+    else if (sym_matches(sk, "PULL")    ||
+             sym_matches(sk, "LINEIN")  ||
+             sym_matches(sk, "EXTERNAL"))
+    {
+        /* Phase 4: data stack / stream I/O not yet implemented. */
+        skip_to_clause_end(p);
+        return fail(p, IRXPARS_SYNTAX);
+    }
+    else
+    {
+        skip_to_clause_end(p);
+        return fail(p, IRXPARS_SYNTAX);
+    }
+
+    if (rc != IRXPARS_OK)
+    {
+        Lfree(p->alloc, &source_str);
+        return rc;
+    }
+
+    /* Uppercase the source once for non-ARG PARSE UPPER. */
+    if (!is_arg && upper && source_str.pstr != NULL && source_str.len > 0)
+    {
+        rc = Lfx(p->alloc, &upper_copy, source_str.len);
+        if (rc != LSTR_OK)
+        {
+            Lfree(p->alloc, &source_str);
+            return fail(p, IRXPARS_NOMEM);
+        }
+        memcpy(upper_copy.pstr, source_str.pstr, source_str.len);
+        upper_bytes(upper_copy.pstr, source_str.len);
+        upper_copy.len  = source_str.len;
+        upper_copy.type = LSTRING_TY;
+    }
+
+    /* Process comma-separated templates. */
+    do
+    {
+        const unsigned char *use_src = NULL;
+        size_t use_len               = 0;
+
+        if (is_arg)
+        {
+            const unsigned char *raw_src = NULL;
+            size_t raw_len               = 0;
+
+            if (arg_idx < p->call_argc &&
+                p->call_arg_exists != NULL &&
+                p->call_arg_exists[arg_idx] &&
+                p->call_args != NULL &&
+                p->call_args[arg_idx].pstr != NULL)
+            {
+                raw_src = p->call_args[arg_idx].pstr;
+                raw_len = p->call_args[arg_idx].len;
+            }
+            arg_idx++;
+
+            if (upper && raw_src != NULL && raw_len > 0)
+            {
+                /* Uppercase this argument for the current template only. */
+                Lfree(p->alloc, &upper_copy);
+                Lzeroinit(&upper_copy);
+                rc = Lfx(p->alloc, &upper_copy, raw_len);
+                if (rc != LSTR_OK)
+                {
+                    rc = fail(p, IRXPARS_NOMEM);
+                    break;
+                }
+                memcpy(upper_copy.pstr, raw_src, raw_len);
+                upper_bytes(upper_copy.pstr, raw_len);
+                upper_copy.len  = raw_len;
+                upper_copy.type = LSTRING_TY;
+                use_src = upper_copy.pstr;
+                use_len = upper_copy.len;
+            }
+            else
+            {
+                use_src = raw_src;
+                use_len = raw_len;
+            }
+        }
+        else
+        {
+            if (upper_copy.pstr != NULL)
+            {
+                use_src = upper_copy.pstr;
+                use_len = upper_copy.len;
+            }
+            else
+            {
+                use_src = source_str.pstr;
+                use_len = source_str.len;
+            }
+        }
+
+        rc = parse_apply_template(p, use_src, use_len, &hit_comma);
+        if (rc != IRXPARS_OK)
+        {
+            break;
+        }
+    } while (hit_comma);
+
+    Lfree(p->alloc, &source_str);
+    Lfree(p->alloc, &upper_copy);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Keyword table (WP-13 registers no handlers)                       */
 /*                                                                    */
 /*  WP-14 adds SAY. WP-15 adds DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL. */
@@ -2398,6 +3254,7 @@ static const struct irx_keyword g_keyword_table[] = {
     {"SIGNAL", kw_signal},
     {"PROCEDURE", kw_procedure},
     {"ARG", kw_arg},
+    {"PARSE", kw_parse},
     {NULL, NULL}};
 
 static const struct irx_keyword *find_keyword(const unsigned char *name,

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -714,8 +714,7 @@ static int tokenize(struct tok_ctx *ctx)
             continue;
         }
 
-        if (is_symbol_start(c) || isdigit(c) ||
-            (c == '.' && isdigit(peek(ctx, 1))))
+        if (is_symbol_start(c) || isdigit(c) || c == '.')
         {
             if (scan_symbol_or_number(ctx) != 0)
             {

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -1,0 +1,657 @@
+/* ------------------------------------------------------------------ */
+/*  test_parse.c - WP-16 PARSE instruction acceptance tests           */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_parse \               */
+/*        test/test_parse.c \                                          */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \       */
+/*        'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c' \       */
+/*        'src/irx#io.c'   'src/irx#lstr.c' 'src/irx#tokn.c' \       */
+/*        'src/irx#vpol.c' 'src/irx#pars.c' 'src/irx#ctrl.c' \       */
+/*        'src/irx#exec.c' \                                           */
+/*        ../lstring370/src/'lstr#cor.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run    = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Mock I/O                                                          */
+/* ------------------------------------------------------------------ */
+
+#define OUT_BUF_SIZE 4096
+
+static char g_out[OUT_BUF_SIZE];
+static int  g_out_len = 0;
+
+static void reset_output(void)
+{
+    g_out_len  = 0;
+    g_out[0]   = '\0';
+}
+
+static int output_contains(const char *line)
+{
+    int line_len = (int)strlen(line);
+    int i;
+    for (i = 0; i <= g_out_len - line_len; i++)
+    {
+        if (memcmp(g_out + i, line, (size_t)line_len) == 0)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int mock_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL &&
+        data->pstr != NULL && data->len > 0)
+    {
+        int n = (int)data->len;
+        if (g_out_len + n + 1 < OUT_BUF_SIZE)
+        {
+            memcpy(g_out + g_out_len, data->pstr, (size_t)n);
+            g_out_len += n;
+            g_out[g_out_len++] = '\n';
+            g_out[g_out_len]   = '\0';
+        }
+    }
+    return 0;
+}
+
+static void install_mock(struct envblock *env)
+{
+    struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+    {
+        exte->io_routine = (void *)mock_io;
+    }
+}
+
+static int run_src(const char *src, int *exit_rc_out)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    install_mock(env);
+    reset_output();
+
+    rc = irx_exec_run(src, (int)strlen(src), NULL, 0, exit_rc_out, env);
+
+    irxterm(env);
+    return rc;
+}
+
+static int run_src_with_args(const char *src, const char *args,
+                             int *exit_rc_out)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    install_mock(env);
+    reset_output();
+
+    rc = irx_exec_run(src, (int)strlen(src),
+                      args, (int)strlen(args),
+                      exit_rc_out, env);
+
+    irxterm(env);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#01: PARSE ARG first rest — word parsing                        */
+/* ------------------------------------------------------------------ */
+
+static void test_pa01_arg_word_parsing(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#01: PARSE ARG - first word / remainder ---\n");
+
+    rc = run_src_with_args(
+        "/* REXX */\n"
+        "parse arg first rest\n"
+        "say 'first=' || first\n"
+        "say 'rest=' || rest\n"
+        "exit 0\n",
+        "hello world foo",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("first=hello"), "first = 'hello'");
+    CHECK(output_contains("rest=world foo"), "rest = 'world foo'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#02: PARSE ARG a, b, c — multiple templates                     */
+/* ------------------------------------------------------------------ */
+
+static void test_pa02_arg_multiple_templates(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#02: PARSE ARG multiple templates (commas) ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "call mysub 'hello', 'world'\n"
+        "exit 0\n"
+        "mysub:\n"
+        "  parse arg a, b\n"
+        "  say 'a=' || a\n"
+        "  say 'b=' || b\n"
+        "  return\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("a=hello"), "a = 'hello'");
+    CHECK(output_contains("b=world"), "b = 'world'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#03: PARSE VAR line a ',' b ',' c — literal pattern splits      */
+/* ------------------------------------------------------------------ */
+
+static void test_pa03_var_literal_split(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#03: PARSE VAR with literal comma pattern ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "line = 'one,two,three'\n"
+        "parse var line a ',' b ',' c\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "say 'c=' || c\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("a=one"), "a = 'one'");
+    CHECK(output_contains("b=two"), "b = 'two'");
+    CHECK(output_contains("c=three"), "c = 'three'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#04: PARSE VAR x 1 a 5 b 10 c — absolute positional            */
+/* ------------------------------------------------------------------ */
+
+static void test_pa04_var_absolute_positions(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#04: PARSE VAR absolute positional ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 'ABCDEFGHIJ'\n"
+        "parse var x 1 a 5 b 10 c\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "say 'c=' || c\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    /* 1-based: a=[1..4]="ABCD", b=[5..9]="EFGHI", c=[10..]="J" */
+    CHECK(output_contains("a=ABCD"), "a = 'ABCD'");
+    CHECK(output_contains("b=EFGHI"), "b = 'EFGHI'");
+    CHECK(output_contains("c=J"), "c = 'J'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#05: PARSE VAR x a +3 b +3 c — relative forward                */
+/* ------------------------------------------------------------------ */
+
+static void test_pa05_var_relative_forward(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#05: PARSE VAR relative forward ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 'ABCDEFGHI'\n"
+        "parse var x a +3 b +3 c\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "say 'c=' || c\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    /* a=[0..2]="ABC", b=[3..5]="DEF", c=[6..]="GHI" */
+    CHECK(output_contains("a=ABC"), "a = 'ABC'");
+    CHECK(output_contains("b=DEF"), "b = 'DEF'");
+    CHECK(output_contains("c=GHI"), "c = 'GHI'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#06: PARSE VAR x a -3 b — relative backward                    */
+/* ------------------------------------------------------------------ */
+
+static void test_pa06_var_relative_backward(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#06: PARSE VAR relative backward ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 'ABCDEFGH'\n"
+        "parse var x 4 a -3 b\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    /* Absolute 4 sets scan=3 (0-based).
+     * a gets [3..2] = "" (empty: backward retreat means preceding var empty).
+     * After -3: scan retreats to max(0, 3-3)=0.
+     * b gets [0..end]="ABCDEFGH". */
+    CHECK(output_contains("a="), "a = '' (empty — backward move)");
+    CHECK(output_contains("b=ABCDEFGH"), "b = 'ABCDEFGH'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#07: PARSE VAR line a (delim) b — variable pattern              */
+/* ------------------------------------------------------------------ */
+
+static void test_pa07_var_variable_pattern(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#07: PARSE VAR variable pattern (delim) ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "line = 'hello:world'\n"
+        "delim = ':'\n"
+        "parse var line a (delim) b\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("a=hello"), "a = 'hello'");
+    CHECK(output_contains("b=world"), "b = 'world'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#08: PARSE ARG . name . — dot placeholders                      */
+/* ------------------------------------------------------------------ */
+
+static void test_pa08_dot_placeholder(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#08: PARSE ARG dot placeholders ---\n");
+
+    rc = run_src_with_args(
+        "/* REXX */\n"
+        "parse arg . name .\n"
+        "say 'name=' || name\n"
+        "exit 0\n",
+        "first middle last",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("name=middle"), "name = 'middle'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#09: PARSE UPPER ARG name — uppercases before parsing           */
+/* ------------------------------------------------------------------ */
+
+static void test_pa09_upper_arg(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#09: PARSE UPPER ARG ---\n");
+
+    rc = run_src_with_args(
+        "/* REXX */\n"
+        "parse upper arg name\n"
+        "say 'name=' || name\n"
+        "exit 0\n",
+        "hello world",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("name=HELLO WORLD"), "name = 'HELLO WORLD'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#10: PARSE SOURCE sys type name                                 */
+/* ------------------------------------------------------------------ */
+
+static void test_pa10_source(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#10: PARSE SOURCE ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "parse source sys calltype name\n"
+        "say 'sys=' || sys\n"
+        "say 'calltype=' || calltype\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("sys=MVS"), "sys = 'MVS'");
+    /* At top level (no CALL frame): COMMAND */
+    CHECK(output_contains("calltype=COMMAND"), "calltype = 'COMMAND'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#11: PARSE VERSION lang level date                              */
+/* ------------------------------------------------------------------ */
+
+static void test_pa11_version(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#11: PARSE VERSION ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "parse version lang level date\n"
+        "say 'lang=' || lang\n"
+        "say 'level=' || level\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("lang=REXX370"), "lang = 'REXX370'");
+    CHECK(output_contains("level=0.1.0"), "level = '0.1.0'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#12: PARSE NUMERIC digits fuzz form                             */
+/* ------------------------------------------------------------------ */
+
+static void test_pa12_numeric(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#12: PARSE NUMERIC ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "parse numeric digits fuzz form\n"
+        "say 'digits=' || digits\n"
+        "say 'fuzz=' || fuzz\n"
+        "say 'form=' || form\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("digits=9"), "digits = '9' (default)");
+    CHECK(output_contains("fuzz=0"), "fuzz = '0' (default)");
+    CHECK(output_contains("form=SCIENTIFIC"), "form = 'SCIENTIFIC' (default)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#13: PARSE VALUE expr WITH template                             */
+/* ------------------------------------------------------------------ */
+
+static void test_pa13_value_with(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#13: PARSE VALUE expr WITH template ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 'alpha beta gamma'\n"
+        "parse value x with a b c\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "say 'c=' || c\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("a=alpha"), "a = 'alpha'");
+    CHECK(output_contains("b=beta"), "b = 'beta'");
+    CHECK(output_contains("c=gamma"), "c = 'gamma'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#14: PARSE PULL → SYNTAX error                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_pa14_pull_syntax_error(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#14: PARSE PULL → SYNTAX error ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "parse pull x\n"
+        "exit 0\n",
+        &exit_rc);
+
+    /* Expect a non-zero rc (syntax error: PULL not yet implemented). */
+    CHECK(rc != 0, "irx_exec_run returns non-zero (SYNTAX)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#15: Last variable gets rest including trailing blanks          */
+/* ------------------------------------------------------------------ */
+
+static void test_pa15_last_var_trailing_blanks(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#15: last variable preserves trailing blanks ---\n");
+
+    /* When the last word in the string has trailing blanks, they are
+     * included in the last template variable's value.  Leading blanks
+     * between words are still stripped before each variable, but the
+     * trailing portion of the final word (including its trailing blanks)
+     * is preserved as-is. */
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 'hello world   '\n"
+        "parse var x a b\n"
+        "say 'a=[' || a || ']'\n"
+        "say 'b=[' || b || ']'\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    CHECK(output_contains("a=[hello]"), "a = 'hello'");
+    /* 'b' is the last variable: gets 'world   ' (trailing blanks kept). */
+    CHECK(output_contains("b=[world   ]"), "b = 'world   ' (trailing blanks preserved)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#16: Literal not found → preceding variable gets entire remainder */
+/* ------------------------------------------------------------------ */
+
+static void test_pa16_literal_not_found(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#16: literal not found - preceding var gets remainder ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "line = 'no semicolons here'\n"
+        "parse var line a ';' b\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    /* ';' not found: a gets entire string, b gets "". */
+    CHECK(output_contains("a=no semicolons here"), "a = entire string");
+    CHECK(output_contains("b="), "b = '' (empty)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  AC#17: No global state — two concurrent parses do not interfere   */
+/* ------------------------------------------------------------------ */
+
+static void test_pa17_no_global_state(void)
+{
+    int exit_rc1 = -1;
+    int exit_rc2 = -1;
+    int rc1;
+    int rc2;
+    char out1[OUT_BUF_SIZE];
+    char out2[OUT_BUF_SIZE];
+
+    printf("\n--- PA#17: no global state (two independent runs) ---\n");
+
+    rc1 = run_src_with_args(
+        "/* REXX */\n"
+        "parse arg first rest\n"
+        "say 'first=' || first\n"
+        "exit 0\n",
+        "hello world",
+        &exit_rc1);
+
+    /* Save first run output. */
+    memcpy(out1, g_out, (size_t)g_out_len);
+    out1[g_out_len] = '\0';
+
+    rc2 = run_src_with_args(
+        "/* REXX */\n"
+        "parse arg first rest\n"
+        "say 'first=' || first\n"
+        "exit 0\n",
+        "different args",
+        &exit_rc2);
+
+    memcpy(out2, g_out, (size_t)g_out_len);
+    out2[g_out_len] = '\0';
+
+    CHECK(rc1 == 0 && rc2 == 0, "both runs return 0");
+    CHECK(exit_rc1 == 0 && exit_rc2 == 0, "both exit with 0");
+    CHECK(strstr(out1, "first=hello") != NULL,
+          "first run: first = 'hello'");
+    CHECK(strstr(out2, "first=different") != NULL,
+          "second run: first = 'different'");
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("=== PARSE instruction tests (WP-16) ===\n");
+
+    test_pa01_arg_word_parsing();
+    test_pa02_arg_multiple_templates();
+    test_pa03_var_literal_split();
+    test_pa04_var_absolute_positions();
+    test_pa05_var_relative_forward();
+    test_pa06_var_relative_backward();
+    test_pa07_var_variable_pattern();
+    test_pa08_dot_placeholder();
+    test_pa09_upper_arg();
+    test_pa10_source();
+    test_pa11_version();
+    test_pa12_numeric();
+    test_pa13_value_with();
+    test_pa14_pull_syntax_error();
+    test_pa15_last_var_trailing_blanks();
+    test_pa16_literal_not_found();
+    test_pa17_no_global_state();
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -663,6 +663,34 @@ static void test_pa18_absolute_backward(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  AC#19: '==' in a template is not the =n absolute-position form    */
+/*                                                                     */
+/*  The tokenizer emits one token per operator character               */
+/*  (irx#tokn.c §scan_operator), so '==5' arrives as three tokens:    */
+/*  '=' '=' '5'.  tok_is_op_char requires tok_length == 1; the first  */
+/*  '=' matches but peek_tok(1) is another '=' (not TOK_NUMBER), so   */
+/*  IRXPARS_SYNTAX is raised rather than silently treating it as =5.  */
+/* ------------------------------------------------------------------ */
+
+static void test_pa19_eq_eq_not_absolute_position(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#19: '==' is not the =n absolute-position form ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 'ABCDEFGHIJ'\n"
+        "parse var x a ==5 b\n"
+        "exit 0\n",
+        &exit_rc);
+
+    /* '==5' must raise SYNTAX (cannot be treated as '=5'). */
+    CHECK(rc != 0, "'==5' in template raises SYNTAX, not treated as '=5'");
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -688,6 +716,7 @@ int main(void)
     test_pa16_literal_not_found();
     test_pa17_no_global_state();
     test_pa18_absolute_backward();
+    test_pa19_eq_eq_not_absolute_position();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);

--- a/test/test_parse.c
+++ b/test/test_parse.c
@@ -626,6 +626,43 @@ static void test_pa17_no_global_state(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  AC#18: absolute backward position retreats cursor                  */
+/*                                                                     */
+/*  Ref: SC28-1883-0 §8 — when n < current scan position the pending  */
+/*  variable receives an empty segment and the cursor retreats to n.  */
+/* ------------------------------------------------------------------ */
+
+static void test_pa18_absolute_backward(void)
+{
+    int exit_rc = -1;
+    int rc;
+
+    printf("\n--- PA#18: PARSE VAR absolute backward position ---\n");
+
+    rc = run_src(
+        "/* REXX */\n"
+        "x = 'ABCDEFGHIJKLMNOP'\n"
+        "parse var x a 10 b 5 c\n"
+        "say 'a=' || a\n"
+        "say 'b=' || b\n"
+        "say 'c=' || c\n"
+        "exit 0\n",
+        &exit_rc);
+
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit code 0");
+    /* 1-based positions, 0-based internally:
+     *   scan starts at 0.
+     *   '10' (forward): a = [0..9) = "ABCDEFGHI", scan -> 9.
+     *   '5'  (backward, 5-1=4 < 9): b = empty (seg_end = scan_pos),
+     *         scan retreats to 4.
+     *   c = remainder from 4 = "EFGHIJKLMNOP". */
+    CHECK(output_contains("a=ABCDEFGHI"), "a = 'ABCDEFGHI'");
+    CHECK(output_contains("b="), "b = '' (empty — backward retreat)");
+    CHECK(output_contains("c=EFGHIJKLMNOP"), "c = 'EFGHIJKLMNOP'");
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -650,6 +687,7 @@ int main(void)
     test_pa15_last_var_trailing_blanks();
     test_pa16_literal_not_found();
     test_pa17_no_global_state();
+    test_pa18_absolute_backward();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);


### PR DESCRIPTION
## Summary

- Implement the full PARSE instruction (WP-16) in `src/irx#pars.c`
- Fix tokenizer to accept standalone `.` as a valid symbol token (dot placeholder in templates)
- 74 acceptance tests covering all 19 criteria

### Sources supported
ARG · VAR · VALUE...WITH · SOURCE · VERSION · NUMERIC · UPPER modifier  
PULL/LINEIN/EXTERNAL return SYNTAX (Phase 4 placeholder)

### Template patterns supported
Word variable · dot placeholder · string literal · variable pattern `(sym)` · absolute column `n`/`=n` · relative column `+n`/`-n`

## Test plan

- [x] `./test/test_parse` — 74/74 pass (new)
- [x] `./test/test_tokenizer` — 70/70 pass (tokenizer fix regression check)
- [x] `./test/test_parser` — 38/38 pass
- [x] `./test/test_control` — 62/62 pass
- [x] `./test/test_procedure` — 53/53 pass
- [x] `./test/test_hello` — 16/16 pass

Fixes #21