### PR TITLE
feat(wp-21a): String Built-in Functions (IRXBIFSTR)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,9 @@ Tests: `test/test_name.c`
 | `src/irx#io.c`   | IRX#IO   | Default I/O routine IRXINOUT (WP-14) |
 | `src/irx#ctrl.c` | IRX#CTRL | Control flow: DO/IF/SELECT/CALL/SIGNAL (WP-15) |
 | `src/irx#exec.c` | IRX#EXEC | End-to-end execution pipeline irx_exec_run() (WP-18) |
+| `src/irx#cond.c` | IRX#COND | Condition raise helper (irx_cond_raise, WP-21a) |
+| `src/irx#bif.c`  | IRX#BIF  | BIF registry + argument-validation helpers (WP-21a) |
+| `src/irx#bifs.c` | IRX#BIFS | String BIFs (LENGTH, SUBSTR, WORD, ... WP-21a) |
 
 New source files follow the same pattern: `src/irx#xxxx.c` where
 `xxxx` is a 4-character identifier. Member names must be ≤ 8 chars.
@@ -292,7 +295,8 @@ The common dependency set for cross-compile tests is:
 LSTRING_SRC=../lstring370/src/'lstr#cor.c'
 LSTRING_INC=-I contrib/lstring370-0.1.0-dev/include
 PHASE1_SRC='src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \
-           'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c'
+           'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c' \
+           'src/irx#cond.c' 'src/irx#bif.c'  'src/irx#bifs.c'
 PHASE2_SRC='src/irx#io.c' 'src/irx#lstr.c' 'src/irx#tokn.c' \
            'src/irx#vpol.c' 'src/irx#pars.c' 'src/irx#ctrl.c'
 ```
@@ -355,6 +359,18 @@ gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     -o test/test_arith test/test_arith.c \
     $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' 'src/irx#arith.c' $LSTRING_SRC
 ./test/test_arith
+
+# BIF registry (WP-21a) — 29/29
+gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
+    -o test/test_bif test/test_bif.c \
+    $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' 'src/irx#arith.c' $LSTRING_SRC
+./test/test_bif
+
+# String BIFs end-to-end (WP-21a) — 87/87
+gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
+    -o test/test_bifs test/test_bifs.c \
+    $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' 'src/irx#arith.c' $LSTRING_SRC
+./test/test_bifs
 ```
 
 ## Work packages
@@ -366,7 +382,9 @@ and acceptance criteria.
 Current status:
 - Phase 1 (WP-01 through WP-05): complete
 - Phase 2 (WP-10 through WP-18): complete
-- Phase 3 in progress: WP-20 (Arithmetic engine — 128/128)
+- Phase 3 in progress:
+  - WP-20 (Arithmetic engine — 128/128)
+  - WP-21a (String BIFs — 29/29 + 87/87)
 
 ## Knowledge sources
 

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -26,7 +26,8 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-17 | PROCEDURE EXPOSE | 2 | DONE (53/53) — PR #16 |
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | DONE (128/128) — PR #24 |
-| WP-21 | Built-in string functions | 3 | OPEN |
+| WP-21a | String BIFs (IRXBIFSTR) | 3 | DONE (29/29 + 87/87) |
+| WP-21b | Misc BIFs | 3 | OPEN |
 | WP-22 | Built-in misc functions | 3 | OPEN |
 | WP-23 | INTERPRET instruction | 3 | OPEN |
 | WP-30 | EXECIO command | 4 | OPEN |

--- a/include/irxbif.h
+++ b/include/irxbif.h
@@ -1,0 +1,142 @@
+/* ------------------------------------------------------------------ */
+/*  irxbif.h - REXX/370 Built-in Function Registry                   */
+/*                                                                    */
+/*  Per-environment dynamic registry for built-in functions. The      */
+/*  parser calls irx_bif_find() during function-call dispatch; on     */
+/*  match it invokes the handler with argument validation already     */
+/*  performed.                                                        */
+/*                                                                    */
+/*  Registration is one-shot: irxinit() registers all core BIFs       */
+/*  (string, misc, arithmetic) after wkbi_bif_registry has been       */
+/*  allocated. irxterm() frees the registry. No globals.              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef IRXBIF_H
+#define IRXBIF_H
+
+#include "irx.h"
+#include "lstring.h"
+
+struct irx_parser; /* forward decl */
+
+/* ================================================================== */
+/*  Handler signature                                                 */
+/* ================================================================== */
+
+/* Maximum length of a BIF name (SAA REXX allows up to 250 chars in   */
+/* symbols, but real BIFs are well under 16).                         */
+#define IRX_BIF_NAME_MAX 16
+
+/* Return codes match IRXPARS_* so the parser can propagate directly. */
+typedef int (*irx_bif_handler_t)(struct irx_parser *p,
+                                 int argc, PLstr *argv, PLstr result);
+
+/* ================================================================== */
+/*  Registry entry                                                    */
+/* ================================================================== */
+
+struct irx_bif_entry
+{
+    char name[IRX_BIF_NAME_MAX]; /* upper-case BIF name (NUL-padded)   */
+    int min_args;
+    int max_args;
+    irx_bif_handler_t handler;
+};
+
+/* Opaque — full definition in irx#bif.c */
+struct irx_bif_registry;
+
+/* ================================================================== */
+/*  Return codes                                                      */
+/* ================================================================== */
+
+#define IRX_BIF_OK        0
+#define IRX_BIF_NOMEM     20
+#define IRX_BIF_NOTFOUND  21
+#define IRX_BIF_DUPLICATE 22
+#define IRX_BIF_BADARG    23
+
+/* ================================================================== */
+/*  Registry API                                                      */
+/*                                                                    */
+/*  asm() aliases are required because every entry point begins with  */
+/*  "irx_bif" — c2asm370 truncates identifiers to 8 characters and    */
+/*  they would collide otherwise.                                     */
+/* ================================================================== */
+
+/* Allocate a registry via irxstor. Returns IRX_BIF_OK on success. */
+int irx_bif_create(struct envblock *env,
+                   struct irx_bif_registry **out) asm("IRXBIFCR");
+
+/* Release every node and the registry itself. Safe on NULL. */
+void irx_bif_destroy(struct envblock *env,
+                     struct irx_bif_registry *reg) asm("IRXBIFDS");
+
+/* Add a single BIF to the registry. Name must be upper-case ASCII,
+ * length 1..15. Duplicate names are rejected. */
+int irx_bif_register(struct envblock *env,
+                     struct irx_bif_registry *reg,
+                     const char *name, int min_args, int max_args,
+                     irx_bif_handler_t handler) asm("IRXBIFRG");
+
+/* Find a BIF by its upper-case name (length-delimited, not
+ * NUL-terminated). Returns NULL if not registered. */
+const struct irx_bif_entry *
+irx_bif_find(const struct irx_bif_registry *reg,
+             const unsigned char *name, size_t len) asm("IRXBIFFN");
+
+/* Bulk-register every entry in a static table. Stops at the first
+ * entry whose name field is empty. */
+int irx_bif_register_table(struct envblock *env,
+                           struct irx_bif_registry *reg,
+                           const struct irx_bif_entry *table,
+                           int count) asm("IRXBIFRT");
+
+/* ================================================================== */
+/*  Argument-validation helpers                                       */
+/*                                                                    */
+/*  Each helper raises the appropriate SYNTAX 40.x condition via      */
+/*  irx_cond_raise() on failure and returns a non-zero code that the  */
+/*  handler should propagate. A zero return means "validated; use     */
+/*  *out".                                                            */
+/* ================================================================== */
+
+/* Require argv[idx] to be present (argc > idx && argv[idx] non-NULL). */
+int irx_bif_require_arg(struct irx_parser *p, int argc, PLstr *argv,
+                        int idx, const char *bif_name) asm("IRXBIFRA");
+
+/* Parse argv[idx] as a non-negative whole number into *out. */
+int irx_bif_whole_nonneg(struct irx_parser *p, PLstr *argv,
+                         int idx, const char *bif_name,
+                         long *out) asm("IRXBIFNN");
+
+/* Parse argv[idx] as a strictly-positive whole number into *out. */
+int irx_bif_whole_positive(struct irx_parser *p, PLstr *argv,
+                           int idx, const char *bif_name,
+                           long *out) asm("IRXBIFPO");
+
+/* Parse optional argv[idx] as a non-negative whole number.
+ * If omitted (argc <= idx or empty string), *out is set to default_val
+ * and 0 is returned. */
+int irx_bif_opt_whole(struct irx_parser *p, int argc, PLstr *argv,
+                      int idx, const char *bif_name,
+                      long default_val, long *out) asm("IRXBIFOW");
+
+/* Validate argv[idx] is exactly one character. If omitted, *out is
+ * set to default_char. */
+int irx_bif_opt_char(struct irx_parser *p, int argc, PLstr *argv,
+                     int idx, const char *bif_name,
+                     char default_char, char *out) asm("IRXBIFOC");
+
+/* Validate argv[idx] is exactly one character taken from the allowed
+ * set (EBCDIC-safe). The allowed set is an upper-case ASCII string of
+ * legal option letters. If omitted, *out = default_opt. The returned
+ * character is always upper-case. */
+int irx_bif_opt_option(struct irx_parser *p, int argc, PLstr *argv,
+                       int idx, const char *bif_name,
+                       const char *allowed, char default_opt,
+                       char *out) asm("IRXBIFOP");
+
+#endif /* IRXBIF_H */

--- a/include/irxbifstr.h
+++ b/include/irxbifstr.h
@@ -1,0 +1,21 @@
+/* ------------------------------------------------------------------ */
+/*  irxbifstr.h - REXX/370 String Built-in Functions                 */
+/*                                                                    */
+/*  Register the SC28-1883-0 §4 string BIFs into the per-environment */
+/*  BIF registry. Called once at the end of irxinit().                */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef IRXBIFSTR_H
+#define IRXBIFSTR_H
+
+struct envblock;
+struct irx_bif_registry;
+
+/* Register every built-in defined in src/irx#bifs.c.
+ * Returns IRX_BIF_OK on success or the first IRX_BIF_* error code. */
+int irx_bifstr_register(struct envblock *env,
+                        struct irx_bif_registry *reg) asm("IRXBSREG");
+
+#endif /* IRXBIFSTR_H */

--- a/include/irxcond.h
+++ b/include/irxcond.h
@@ -2,8 +2,8 @@
 /*  irxcond.h - REXX/370 Condition Information Block                  */
 /*                                                                    */
 /*  Tracks the last raised condition within a REXX environment.       */
-/*  Allocated lazily by the arithmetic engine on first error; freed   */
-/*  by irxterm().  Pointed to by irx_wkblk_int.wkbi_last_condition.  */
+/*  Allocated lazily on first error; freed by irxterm().              */
+/*  Pointed to by irx_wkblk_int.wkbi_last_condition.                  */
 /*                                                                    */
 /*  Ref: SC28-1883-0, Chapter 7 (SIGNAL ON / CALL ON), Appendix E    */
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
@@ -12,18 +12,61 @@
 #ifndef IRXCOND_H
 #define IRXCOND_H
 
-/* SYNTAX error subcodes (SC28-1883-0 Appendix E) */
-#define SYNTAX_BAD_OPERAND    24 /* arithmetic operand not a number  */
-#define SYNTAX_OVERFLOW       26 /* overflow / underflow             */
-#define SYNTAX_DIVZERO        42 /* divide by zero                   */
-#define SYNTAX_EXP_OVERFLOW   41 /* result exponent too large        */
+struct envblock; /* forward decl to avoid circular include */
+
+/* ================================================================== */
+/*  SYNTAX error primary codes (SC28-1883-0 Appendix E)               */
+/* ================================================================== */
+
+#define SYNTAX_BAD_OPERAND  24 /* arithmetic operand not a number  */
+#define SYNTAX_OVERFLOW     26 /* overflow / underflow             */
+#define SYNTAX_EXP_OVERFLOW 41 /* result exponent too large        */
+#define SYNTAX_DIVZERO      42 /* divide by zero                   */
+#define SYNTAX_BAD_CALL     40 /* incorrect call to routine        */
+
+/* ================================================================== */
+/*  SYNTAX 40.x subcodes — incorrect call to routine                  */
+/*  Raised by built-in functions when argument validation fails.      */
+/* ================================================================== */
+
+/* Subcodes listed in SC28-1883-0 Appendix E. Not every integer from  */
+/* 1..29 is defined by the spec; we expose only the documented ones.  */
+#define ERR40_TOO_FEW_ARGS    1  /* too few arguments                 */
+#define ERR40_TOO_MANY_ARGS   2  /* too many arguments                */
+#define ERR40_STRING_REQUIRED 3  /* argument N must be a string       */
+#define ERR40_ARG_LENGTH      4  /* argument N length out of range    */
+#define ERR40_WHOLE_NUMBER    5  /* argument N must be a whole number */
+#define ERR40_NONNEG_WHOLE    11 /* argument N must be ≥ 0 whole num  */
+#define ERR40_POSITIVE_WHOLE  12 /* argument N must be > 0 whole num  */
+#define ERR40_SINGLE_CHAR     14 /* argument N must be single char    */
+#define ERR40_NUMBER_REQUIRED 21 /* argument N must be a number       */
+#define ERR40_OPTION_INVALID  23 /* argument N option not in allowed  */
+#define ERR40_PAIRED_LENGTH   29 /* translate table lengths mismatch  */
+
+/* ================================================================== */
+/*  Condition Information block                                       */
+/* ================================================================== */
+
+#define IRX_COND_DESC_LEN 80
 
 struct irx_condition_info
 {
-    int  valid;      /* non-zero if this block contains a raised condition */
-    int  code;       /* primary REXX error number (e.g. 24)                */
-    int  subcode;    /* secondary error code (0 if none)                   */
-    char desc[80];   /* human-readable description (null-terminated)       */
+    int valid;                    /* non-zero if this block contains a raised condition */
+    int code;                     /* primary REXX error number (e.g. 24)                */
+    int subcode;                  /* secondary error code (0 if none)                   */
+    char desc[IRX_COND_DESC_LEN]; /* human-readable description (null-terminated) */
 };
+
+/* ================================================================== */
+/*  Public condition-raising helper                                   */
+/*                                                                    */
+/*  Populates wkbi_last_condition on the given environment. Lazily    */
+/*  allocates the condition block on first use. Safe to call when     */
+/*  env == NULL or the work block is missing (then it silently        */
+/*  returns without error).                                           */
+/* ================================================================== */
+
+void irx_cond_raise(struct envblock *env, int code, int subcode,
+                    const char *desc) asm("IRXCRAIS");
 
 #endif /* IRXCOND_H */

--- a/include/irxcond.h
+++ b/include/irxcond.h
@@ -31,17 +31,19 @@ struct envblock; /* forward decl to avoid circular include */
 
 /* Subcodes listed in SC28-1883-0 Appendix E. Not every integer from  */
 /* 1..29 is defined by the spec; we expose only the documented ones.  */
-#define ERR40_TOO_FEW_ARGS    1  /* too few arguments                 */
-#define ERR40_TOO_MANY_ARGS   2  /* too many arguments                */
-#define ERR40_STRING_REQUIRED 3  /* argument N must be a string       */
-#define ERR40_ARG_LENGTH      4  /* argument N length out of range    */
+#define ERR40_TOO_FEW_ARGS    1 /* too few arguments                 */
+#define ERR40_TOO_MANY_ARGS   2 /* too many arguments                */
+#define ERR40_STRING_REQUIRED 3 /* argument N must be a string       */
+#define ERR40_ARG_LENGTH      4 /* argument N length out of range    */
+/* reserved for WP-21b misc BIFs (raised by e.g. DATATYPE / FORMAT) */
 #define ERR40_WHOLE_NUMBER    5  /* argument N must be a whole number */
 #define ERR40_NONNEG_WHOLE    11 /* argument N must be ≥ 0 whole num  */
 #define ERR40_POSITIVE_WHOLE  12 /* argument N must be > 0 whole num  */
 #define ERR40_SINGLE_CHAR     14 /* argument N must be single char    */
 #define ERR40_NUMBER_REQUIRED 21 /* argument N must be a number       */
 #define ERR40_OPTION_INVALID  23 /* argument N option not in allowed  */
-#define ERR40_PAIRED_LENGTH   29 /* translate table lengths mismatch  */
+/* reserved for WP-21b misc BIFs (raised by TRANSLATE-style table check) */
+#define ERR40_PAIRED_LENGTH 29 /* translate table lengths mismatch  */
 
 /* ================================================================== */
 /*  Condition Information block                                       */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -145,4 +145,11 @@ int irx_pars_run(struct irx_parser *p) asm("IRXPARRN");
 int irx_pars_eval_expr(struct irx_parser *p,
                        PLstr out) asm("IRXPAREV");
 
+/* Register parser-owned BIFs (ARG) into the per-environment registry.
+ * Called from irxinit() after the registry is created. */
+struct irx_bif_registry; /* forward */
+int irx_pars_register_core_bifs(struct envblock *env,
+                                struct irx_bif_registry *reg)
+    asm("IRXPARBF");
+
 #endif /* IRXPARS_H */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -154,7 +154,11 @@ struct irx_wkblk_int
      * environment creation. See <irxbif.h>.                          */
     void *wkbi_bif_registry;
 
-    int _reserved[1]; /* reserved for future use        */
+    /* Originally 2 reserved word-slots; WP-21a consumed one for
+     * wkbi_bif_registry (above). One slot remaining for future use;
+     * enlarge the array (and re-check any layout-sensitive callers)
+     * when a new WP needs another slot.                              */
+    int _reserved[1];
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -148,7 +148,13 @@ struct irx_wkblk_int
     /* --- Condition tracking (WP-20) --- */
     struct irx_condition_info *wkbi_last_condition; /* last raised condition */
 
-    int _reserved[2]; /* reserved for future use        */
+    /* --- BIF registry (WP-21a) ------------------------------------- */
+    /* Opaque pointer to struct irx_bif_registry, allocated by irxinit
+     * and released by irxterm. Populated with all core built-ins at
+     * environment creation. See <irxbif.h>.                          */
+    void *wkbi_bif_registry;
+
+    int _reserved[1]; /* reserved for future use        */
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/project.toml
+++ b/project.toml
@@ -66,6 +66,9 @@ include = [
   "IRX#RAB",
   "IRX#UID",
   "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
   "IRX#IO",
   "IRX#LSTR",
   "IRX#TOKN",
@@ -90,5 +93,6 @@ version_files = ["VERSION"]
 
 [artifacts]
 headers = true
-header_files = ["irx.h", "irxrab.h", "irxwkblk.h", "irxfunc.h"]
+header_files = ["irx.h", "irxrab.h", "irxwkblk.h", "irxfunc.h",
+                "irxbif.h", "irxbifstr.h", "irxcond.h"]
 loads = true

--- a/src/irx#arith.c
+++ b/src/irx#arith.c
@@ -112,53 +112,6 @@ static void get_numeric(struct envblock *env,
 }
 
 /* ------------------------------------------------------------------ */
-/*  Raise a SYNTAX condition via wkbi_last_condition.                 */
-/* ------------------------------------------------------------------ */
-
-static void irx_arith_raise(struct envblock *env, int code, int subcode,
-                            const char *desc)
-{
-    struct irx_wkblk_int *wk;
-    struct irx_condition_info *ci;
-
-    if (env == NULL || env->envblock_userfield == NULL)
-    {
-        return;
-    }
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
-    ci = wk->wkbi_last_condition;
-    if (ci == NULL)
-    {
-        void *p = NULL;
-        if (irxstor(RXSMGET, (int)sizeof(struct irx_condition_info),
-                    &p, env) != 0)
-        {
-            return;
-        }
-        ci = (struct irx_condition_info *)p;
-        memset(ci, 0, sizeof(*ci));
-        wk->wkbi_last_condition = ci;
-    }
-    ci->valid = 1;
-    ci->code = code;
-    ci->subcode = subcode;
-    if (desc != NULL)
-    {
-        int dlen = (int)strlen(desc);
-        if (dlen >= (int)sizeof(ci->desc))
-        {
-            dlen = (int)sizeof(ci->desc) - 1;
-        }
-        memcpy(ci->desc, desc, (size_t)dlen);
-        ci->desc[dlen] = '\0';
-    }
-    else
-    {
-        ci->desc[0] = '\0';
-    }
-}
-
-/* ------------------------------------------------------------------ */
 /*  Normalization helpers                                             */
 /* ------------------------------------------------------------------ */
 
@@ -1377,8 +1330,8 @@ int irx_arith_op(struct envblock *env,
             /* SC28-1883-0 §9.5.4: |exponent| × DIGITS ≤ 9,999,999 */
             if (overflow || labs(exp_val) > 9999999 / digits)
             {
-                irx_arith_raise(env, SYNTAX_OVERFLOW, 0,
-                                "power exponent overflow");
+                irx_cond_raise(env, SYNTAX_OVERFLOW, 0,
+                               "power exponent overflow");
                 num_free(env, &na);
                 num_free(env, &nb);
                 return IRXPARS_SYNTAX;

--- a/src/irx#bif.c
+++ b/src/irx#bif.c
@@ -1,0 +1,407 @@
+/* ------------------------------------------------------------------ */
+/*  irx#bif.c - REXX/370 BIF registry and argument-validation helpers */
+/*                                                                    */
+/*  Linear list of registered built-in functions. One list per        */
+/*  environment, anchored at wkbi_bif_registry. Lookup is case-       */
+/*  sensitive on the registered (upper-case) name.                    */
+/*                                                                    */
+/*  Allocation goes through irxstor; no malloc/free direct calls.     */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbif.h"
+#include "irxcond.h"
+#include "irxfunc.h"
+#include "irxpars.h"
+#include "irxwkblk.h"
+#include "lstring.h"
+
+/* ------------------------------------------------------------------ */
+/*  Registry layout                                                   */
+/* ------------------------------------------------------------------ */
+
+#define BIF_EYECATCHER     "IRBR"
+#define BIF_EYECATCHER_LEN 4
+
+/* Scratch buffer size for assembling "BIFNAME: <detail>" messages.   */
+#define BIF_DESC_BUF 96
+
+/* Error return propagated to the parser when a validation helper      */
+/* raises a condition. Matches IRXPARS_SYNTAX.                         */
+#define BIF_FAIL 20
+
+/* Decimal radix for whole-number parsing.                             */
+#define BIF_RADIX 10
+
+struct bif_node
+{
+    struct bif_node *next;
+    struct irx_bif_entry entry;
+};
+
+struct irx_bif_registry
+{
+    unsigned char id[BIF_EYECATCHER_LEN]; /* eye-catcher "IRBR"        */
+    struct bif_node *head;
+    int count;
+};
+
+/* ------------------------------------------------------------------ */
+/*  Internal helpers                                                  */
+/* ------------------------------------------------------------------ */
+
+static int name_len(const char *name)
+{
+    int n = 0;
+    while (n < IRX_BIF_NAME_MAX && name[n] != '\0')
+    {
+        n++;
+    }
+    return n;
+}
+
+static int ebcdic_eq(const char *a, const unsigned char *b, size_t len)
+{
+    size_t i;
+    for (i = 0; i < len; i++)
+    {
+        if ((unsigned char)a[i] != b[i])
+        {
+            return 0;
+        }
+    }
+    return a[len] == '\0';
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public registry API                                               */
+/* ------------------------------------------------------------------ */
+
+int irx_bif_create(struct envblock *env, struct irx_bif_registry **out)
+{
+    if (out == NULL)
+    {
+        return IRX_BIF_BADARG;
+    }
+    *out = NULL;
+
+    void *p = NULL;
+    if (irxstor(RXSMGET, (int)sizeof(struct irx_bif_registry),
+                &p, env) != 0)
+    {
+        return IRX_BIF_NOMEM;
+    }
+
+    struct irx_bif_registry *reg = (struct irx_bif_registry *)p;
+    memcpy(reg->id, BIF_EYECATCHER, BIF_EYECATCHER_LEN);
+    reg->head = NULL;
+    reg->count = 0;
+
+    *out = reg;
+    return IRX_BIF_OK;
+}
+
+void irx_bif_destroy(struct envblock *env, struct irx_bif_registry *reg)
+{
+    if (reg == NULL)
+    {
+        return;
+    }
+
+    struct bif_node *node = reg->head;
+    while (node != NULL)
+    {
+        struct bif_node *next = node->next;
+        void *p = node;
+        irxstor(RXSMFRE, 0, &p, env);
+        node = next;
+    }
+
+    void *p = reg;
+    irxstor(RXSMFRE, 0, &p, env);
+}
+
+int irx_bif_register(struct envblock *env, struct irx_bif_registry *reg,
+                     const char *name, int min_args, int max_args,
+                     irx_bif_handler_t handler)
+{
+    if (reg == NULL || name == NULL || handler == NULL ||
+        min_args < 0 || max_args < min_args)
+    {
+        return IRX_BIF_BADARG;
+    }
+
+    int nlen = name_len(name);
+    if (nlen == 0 || nlen >= IRX_BIF_NAME_MAX)
+    {
+        return IRX_BIF_BADARG;
+    }
+
+    /* Reject duplicates. */
+    struct bif_node *cursor = reg->head;
+    while (cursor != NULL)
+    {
+        if (strcmp(cursor->entry.name, name) == 0)
+        {
+            return IRX_BIF_DUPLICATE;
+        }
+        cursor = cursor->next;
+    }
+
+    void *p = NULL;
+    if (irxstor(RXSMGET, (int)sizeof(struct bif_node), &p, env) != 0)
+    {
+        return IRX_BIF_NOMEM;
+    }
+    struct bif_node *node = (struct bif_node *)p;
+
+    memset(node->entry.name, 0, sizeof(node->entry.name));
+    memcpy(node->entry.name, name, (size_t)nlen);
+    node->entry.min_args = min_args;
+    node->entry.max_args = max_args;
+    node->entry.handler = handler;
+
+    node->next = reg->head;
+    reg->head = node;
+    reg->count++;
+    return IRX_BIF_OK;
+}
+
+int irx_bif_register_table(struct envblock *env,
+                           struct irx_bif_registry *reg,
+                           const struct irx_bif_entry *table, int count)
+{
+    if (reg == NULL || table == NULL || count < 0)
+    {
+        return IRX_BIF_BADARG;
+    }
+
+    int i;
+    for (i = 0; i < count; i++)
+    {
+        const struct irx_bif_entry *e = &table[i];
+        if (e->name[0] == '\0')
+        {
+            break;
+        }
+        int rc = irx_bif_register(env, reg, e->name,
+                                  e->min_args, e->max_args, e->handler);
+        if (rc != IRX_BIF_OK)
+        {
+            return rc;
+        }
+    }
+    return IRX_BIF_OK;
+}
+
+const struct irx_bif_entry *
+irx_bif_find(const struct irx_bif_registry *reg,
+             const unsigned char *name, size_t len)
+{
+    if (reg == NULL || name == NULL || len == 0 ||
+        len >= IRX_BIF_NAME_MAX)
+    {
+        return NULL;
+    }
+
+    struct bif_node *node = reg->head;
+    while (node != NULL)
+    {
+        if (ebcdic_eq(node->entry.name, name, len))
+        {
+            return &node->entry;
+        }
+        node = node->next;
+    }
+    return NULL;
+}
+
+/* ================================================================== */
+/*  Argument-validation helpers                                       */
+/* ================================================================== */
+
+/* Build "BIFNAME: detail" into desc_buf. Returns desc_buf for          */
+/* convenience.                                                         */
+static const char *mkdesc(char *buf, size_t cap, const char *bif_name,
+                          const char *detail)
+{
+    size_t nlen = strlen(bif_name);
+    size_t dlen = strlen(detail);
+    size_t off = 0;
+
+    if (nlen + 2 + dlen >= cap)
+    {
+        if (nlen >= cap)
+        {
+            nlen = cap - 1;
+        }
+        memcpy(buf, bif_name, nlen);
+        buf[nlen] = '\0';
+        return buf;
+    }
+
+    memcpy(buf, bif_name, nlen);
+    off += nlen;
+    buf[off++] = ':';
+    buf[off++] = ' ';
+    memcpy(buf + off, detail, dlen);
+    off += dlen;
+    buf[off] = '\0';
+    return buf;
+}
+
+int irx_bif_require_arg(struct irx_parser *p, int argc, PLstr *argv,
+                        int idx, const char *bif_name)
+{
+    char desc[BIF_DESC_BUF];
+    if (idx < argc && argv != NULL && argv[idx] != NULL)
+    {
+        return 0;
+    }
+    irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_TOO_FEW_ARGS,
+                   mkdesc(desc, sizeof(desc), bif_name,
+                          "required argument missing"));
+    return BIF_FAIL;
+}
+
+static int parse_whole(PLstr s, long *out)
+{
+    if (s == NULL || s->len == 0)
+    {
+        return -1;
+    }
+    size_t i = 0;
+    int neg = 0;
+    if (i < s->len && (s->pstr[i] == '+' || s->pstr[i] == '-'))
+    {
+        neg = (s->pstr[i] == '-');
+        i++;
+    }
+    if (i >= s->len)
+    {
+        return -1;
+    }
+    long v = 0;
+    for (; i < s->len; i++)
+    {
+        unsigned char c = s->pstr[i];
+        if (c < '0' || c > '9')
+        {
+            return -1;
+        }
+        v = v * BIF_RADIX + (long)(c - '0');
+    }
+    *out = neg ? -v : v;
+    return 0;
+}
+
+int irx_bif_whole_nonneg(struct irx_parser *p, PLstr *argv,
+                         int idx, const char *bif_name, long *out)
+{
+    char desc[BIF_DESC_BUF];
+    long v = 0;
+    if (parse_whole(argv[idx], &v) != 0 || v < 0)
+    {
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE,
+                       mkdesc(desc, sizeof(desc), bif_name,
+                              "argument must be a non-negative whole number"));
+        return BIF_FAIL;
+    }
+    *out = v;
+    return 0;
+}
+
+int irx_bif_whole_positive(struct irx_parser *p, PLstr *argv,
+                           int idx, const char *bif_name, long *out)
+{
+    char desc[BIF_DESC_BUF];
+    long v = 0;
+    if (parse_whole(argv[idx], &v) != 0 || v <= 0)
+    {
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_POSITIVE_WHOLE,
+                       mkdesc(desc, sizeof(desc), bif_name,
+                              "argument must be a positive whole number"));
+        return BIF_FAIL;
+    }
+    *out = v;
+    return 0;
+}
+
+int irx_bif_opt_whole(struct irx_parser *p, int argc, PLstr *argv,
+                      int idx, const char *bif_name,
+                      long default_val, long *out)
+{
+    if (idx >= argc || argv[idx] == NULL || argv[idx]->len == 0)
+    {
+        *out = default_val;
+        return 0;
+    }
+    return irx_bif_whole_nonneg(p, argv, idx, bif_name, out);
+}
+
+int irx_bif_opt_char(struct irx_parser *p, int argc, PLstr *argv,
+                     int idx, const char *bif_name,
+                     char default_char, char *out)
+{
+    char desc[BIF_DESC_BUF];
+    if (idx >= argc || argv[idx] == NULL || argv[idx]->len == 0)
+    {
+        *out = default_char;
+        return 0;
+    }
+    if (argv[idx]->len != 1)
+    {
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_SINGLE_CHAR,
+                       mkdesc(desc, sizeof(desc), bif_name,
+                              "argument must be a single character"));
+        return BIF_FAIL;
+    }
+    *out = (char)argv[idx]->pstr[0];
+    return 0;
+}
+
+int irx_bif_opt_option(struct irx_parser *p, int argc, PLstr *argv,
+                       int idx, const char *bif_name,
+                       const char *allowed, char default_opt, char *out)
+{
+    char desc[BIF_DESC_BUF];
+    if (idx >= argc || argv[idx] == NULL || argv[idx]->len == 0)
+    {
+        *out = default_opt;
+        return 0;
+    }
+    if (argv[idx]->len < 1)
+    {
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_OPTION_INVALID,
+                       mkdesc(desc, sizeof(desc), bif_name,
+                              "option argument empty"));
+        return BIF_FAIL;
+    }
+
+    unsigned char c = argv[idx]->pstr[0];
+    if (islower(c))
+    {
+        c = (unsigned char)toupper(c);
+    }
+    const char *s;
+    for (s = allowed; *s != '\0'; s++)
+    {
+        if ((unsigned char)*s == c)
+        {
+            *out = (char)c;
+            return 0;
+        }
+    }
+    irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_OPTION_INVALID,
+                   mkdesc(desc, sizeof(desc), bif_name,
+                          "option value not recognised"));
+    return BIF_FAIL;
+}

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -1,0 +1,1053 @@
+/* ------------------------------------------------------------------ */
+/*  irx#bifs.c - REXX/370 String Built-in Functions (WP-21a)         */
+/*                                                                    */
+/*  Implements the ~29 SC28-1883-0 §4 string BIFs as thin wrappers    */
+/*  around lstring370 primitives. Argument parsing and validation     */
+/*  goes through the helpers in irx#bif.c, which surface SYNTAX 40.x  */
+/*  conditions on failure.                                            */
+/*                                                                    */
+/*  All state is per-environment; no globals, no statics holding      */
+/*  mutable data. Registration is one-shot via irx_bifstr_register(). */
+/*                                                                    */
+/*  Note on the filename: SC28-1883-0 naming wants IRXBIFSTR but the  */
+/*  MVS PDS member limit is 8 characters; mbt truncates upper-cased   */
+/*  basenames, so this file is named irx#bifs.c → IRX#BIFS.           */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbif.h"
+#include "irxbifstr.h"
+#include "irxcond.h"
+#include "irxlstr.h"
+#include "irxpars.h"
+#include "irxwkblk.h"
+#include "lstralloc.h"
+#include "lstring.h"
+
+/* ================================================================== */
+/*  Scratch / conversion helpers                                      */
+/* ================================================================== */
+
+#define LTOA_BUF 32
+
+static int long_to_lstr(struct lstr_alloc *a, PLstr dst, long v)
+{
+    char buf[LTOA_BUF];
+    int n = sprintf(buf, "%ld", v);
+    if (n < 0)
+    {
+        return LSTR_ERR_NOMEM;
+    }
+    int rc = Lfx(a, dst, (size_t)n);
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
+    if (n > 0)
+    {
+        memcpy(dst->pstr, buf, (size_t)n);
+    }
+    dst->len = (size_t)n;
+    dst->type = LSTRING_TY;
+    return LSTR_OK;
+}
+
+static int translate_lstr_rc(int rc)
+{
+    if (rc == LSTR_OK)
+    {
+        return IRXPARS_OK;
+    }
+    if (rc == LSTR_ERR_NOMEM)
+    {
+        return IRXPARS_NOMEM;
+    }
+    return IRXPARS_SYNTAX;
+}
+
+static int set_empty(struct lstr_alloc *a, PLstr s)
+{
+    int rc = Lfx(a, s, 0);
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
+    s->len = 0;
+    s->type = LSTRING_TY;
+    return LSTR_OK;
+}
+
+static int set_one(struct lstr_alloc *a, PLstr s, unsigned char c)
+{
+    int rc = Lfx(a, s, 1);
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
+    s->pstr[0] = c;
+    s->len = 1;
+    s->type = LSTRING_TY;
+    return LSTR_OK;
+}
+
+/* ================================================================== */
+/*  Phase B — Substring & position                                    */
+/* ================================================================== */
+
+static int bif_length(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    (void)argc;
+    return translate_lstr_rc(
+        long_to_lstr(p->alloc, result, (long)argv[0]->len));
+}
+
+static int bif_left(struct irx_parser *p, int argc, PLstr *argv,
+                    PLstr result)
+{
+    long n = 0;
+    char pad = ' ';
+    int rc = irx_bif_whole_nonneg(p, argv, 1, "LEFT", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_char(p, argc, argv, 2, "LEFT", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return translate_lstr_rc(
+        Lleft(p->alloc, result, argv[0], (size_t)n, pad));
+}
+
+static int bif_right(struct irx_parser *p, int argc, PLstr *argv,
+                     PLstr result)
+{
+    long n = 0;
+    char pad = ' ';
+    int rc = irx_bif_whole_nonneg(p, argv, 1, "RIGHT", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_char(p, argc, argv, 2, "RIGHT", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return translate_lstr_rc(
+        Lright(p->alloc, result, argv[0], (size_t)n, pad));
+}
+
+static int bif_substr(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    long start = 0;
+    long len = 0;
+    char pad = ' ';
+    int rc = irx_bif_whole_positive(p, argv, 1, "SUBSTR", &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    size_t used_len = LSTR_REST;
+    if (argc >= 3 && argv[2] != NULL && argv[2]->len > 0)
+    {
+        rc = irx_bif_whole_nonneg(p, argv, 2, "SUBSTR", &len);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        used_len = (size_t)len;
+    }
+
+    rc = irx_bif_opt_char(p, argc, argv, 3, "SUBSTR", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    return translate_lstr_rc(
+        Lsubstr(p->alloc, result, argv[0], (size_t)start, used_len, pad));
+}
+
+static int bif_pos(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    long start = 1;
+    int rc = irx_bif_opt_whole(p, argc, argv, 2, "POS", 1, &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    size_t pos = Lpos(argv[0], argv[1], (size_t)start);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)pos));
+}
+
+static int bif_index(struct irx_parser *p, int argc, PLstr *argv,
+                     PLstr result)
+{
+    /* INDEX(haystack, needle [,start]) — haystack/needle reversed vs POS. */
+    long start = 1;
+    int rc = irx_bif_opt_whole(p, argc, argv, 2, "INDEX", 1, &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    size_t pos = Lindex(argv[1], argv[0], (size_t)start);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)pos));
+}
+
+static int bif_lastpos(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    long start = 0;
+    int rc = irx_bif_opt_whole(p, argc, argv, 2, "LASTPOS", 0, &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    size_t pos = Llastpos(argv[0], argv[1], (size_t)start);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)pos));
+}
+
+/* ================================================================== */
+/*  Phase C — Word operations                                         */
+/* ================================================================== */
+
+static int bif_words(struct irx_parser *p, int argc, PLstr *argv,
+                     PLstr result)
+{
+    (void)argc;
+    size_t n = Lwords(argv[0]);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)n));
+}
+
+static int bif_word(struct irx_parser *p, int argc, PLstr *argv,
+                    PLstr result)
+{
+    (void)argc;
+    long n = 0;
+    int rc = irx_bif_whole_positive(p, argv, 1, "WORD", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return translate_lstr_rc(Lword(p->alloc, result, argv[0], (size_t)n));
+}
+
+static int bif_wordindex(struct irx_parser *p, int argc, PLstr *argv,
+                         PLstr result)
+{
+    (void)argc;
+    long n = 0;
+    int rc = irx_bif_whole_positive(p, argv, 1, "WORDINDEX", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    size_t idx = Lwordindex(argv[0], (size_t)n);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)idx));
+}
+
+static int bif_wordlength(struct irx_parser *p, int argc, PLstr *argv,
+                          PLstr result)
+{
+    (void)argc;
+    long n = 0;
+    int rc = irx_bif_whole_positive(p, argv, 1, "WORDLENGTH", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    size_t len = Lwordlength(argv[0], (size_t)n);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)len));
+}
+
+static int bif_subword(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    long n = 0;
+    long count = 0;
+    int rc = irx_bif_whole_positive(p, argv, 1, "SUBWORD", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    size_t used_count = LSTR_REST;
+    if (argc >= 3 && argv[2] != NULL && argv[2]->len > 0)
+    {
+        rc = irx_bif_whole_nonneg(p, argv, 2, "SUBWORD", &count);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        used_count = (size_t)count;
+    }
+
+    return translate_lstr_rc(
+        Lsubword(p->alloc, result, argv[0], (size_t)n, used_count));
+}
+
+static int bif_wordpos(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    long start = 1;
+    int rc = irx_bif_opt_whole(p, argc, argv, 2, "WORDPOS", 1, &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    size_t pos = Lwordpos(argv[0], argv[1], (size_t)start);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)pos));
+}
+
+/* ================================================================== */
+/*  Phase D — Padding, stripping, formatting                          */
+/* ================================================================== */
+
+static int bif_center(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    long n = 0;
+    char pad = ' ';
+    int rc = irx_bif_whole_nonneg(p, argv, 1, "CENTER", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_char(p, argc, argv, 2, "CENTER", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return translate_lstr_rc(
+        Lcenter(p->alloc, result, argv[0], (size_t)n, pad));
+}
+
+static int bif_strip(struct irx_parser *p, int argc, PLstr *argv,
+                     PLstr result)
+{
+    char opt = LSTRIP_BOTH;
+    char sc = ' ';
+    int rc = irx_bif_opt_option(p, argc, argv, 1, "STRIP",
+                                "BLT", LSTRIP_BOTH, &opt);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_char(p, argc, argv, 2, "STRIP", ' ', &sc);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return translate_lstr_rc(
+        Lstrip(p->alloc, result, argv[0], opt, sc));
+}
+
+static int bif_space(struct irx_parser *p, int argc, PLstr *argv,
+                     PLstr result)
+{
+    long n = 1;
+    char pad = ' ';
+    int rc = irx_bif_opt_whole(p, argc, argv, 1, "SPACE", 1, &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_char(p, argc, argv, 2, "SPACE", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return translate_lstr_rc(
+        Lspace(p->alloc, result, argv[0], (size_t)n, pad));
+}
+
+static int bif_copies(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    (void)argc;
+    long n = 0;
+    int rc = irx_bif_whole_nonneg(p, argv, 1, "COPIES", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    return translate_lstr_rc(
+        Lcopies(p->alloc, result, argv[0], (size_t)n));
+}
+
+static int bif_reverse(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    (void)argc;
+    return translate_lstr_rc(Lreverse(p->alloc, result, argv[0]));
+}
+
+/* ------------------------------------------------------------------ */
+/*  JUSTIFY(str, n [,pad])                                            */
+/*                                                                    */
+/*  Normalise whitespace in str (SPACE style), then distribute extra  */
+/*  pad characters evenly between word gaps to fill to exactly n.     */
+/*  Extra pad characters are spread right-to-left so leftmost gaps    */
+/*  get padded first.                                                 */
+/* ------------------------------------------------------------------ */
+
+static int bif_justify(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    long n = 0;
+    char pad = ' ';
+    int rc = irx_bif_whole_nonneg(p, argv, 1, "JUSTIFY", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_char(p, argc, argv, 2, "JUSTIFY", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    Lstr spaced;
+    Lzeroinit(&spaced);
+    rc = Lspace(p->alloc, &spaced, argv[0], 1, pad);
+    if (rc != LSTR_OK)
+    {
+        Lfree(p->alloc, &spaced);
+        return translate_lstr_rc(rc);
+    }
+
+    size_t width = (size_t)n;
+
+    /* Empty source or zero width → just pad-or-truncate to width. */
+    if (spaced.len == 0 || width == 0)
+    {
+        int rc2 = Lfx(p->alloc, result, width);
+        if (rc2 != LSTR_OK)
+        {
+            Lfree(p->alloc, &spaced);
+            return translate_lstr_rc(rc2);
+        }
+        if (width > 0)
+        {
+            memset(result->pstr, (unsigned char)pad, width);
+        }
+        result->len = width;
+        result->type = LSTRING_TY;
+        Lfree(p->alloc, &spaced);
+        return IRXPARS_OK;
+    }
+
+    if (width <= spaced.len)
+    {
+        int rc2 = Lfx(p->alloc, result, width);
+        if (rc2 != LSTR_OK)
+        {
+            Lfree(p->alloc, &spaced);
+            return translate_lstr_rc(rc2);
+        }
+        memcpy(result->pstr, spaced.pstr, width);
+        result->len = width;
+        result->type = LSTRING_TY;
+        Lfree(p->alloc, &spaced);
+        return IRXPARS_OK;
+    }
+
+    /* Count word gaps (single pad chars between words). */
+    size_t gaps = 0;
+    size_t i;
+    for (i = 0; i < spaced.len; i++)
+    {
+        if ((char)spaced.pstr[i] == pad)
+        {
+            gaps++;
+        }
+    }
+
+    size_t extra = width - spaced.len;
+
+    int rc2 = Lfx(p->alloc, result, width);
+    if (rc2 != LSTR_OK)
+    {
+        Lfree(p->alloc, &spaced);
+        return translate_lstr_rc(rc2);
+    }
+
+    if (gaps == 0)
+    {
+        /* Single word — pad on the right. */
+        memcpy(result->pstr, spaced.pstr, spaced.len);
+        memset(result->pstr + spaced.len, (unsigned char)pad, extra);
+        result->len = width;
+        result->type = LSTRING_TY;
+        Lfree(p->alloc, &spaced);
+        return IRXPARS_OK;
+    }
+
+    size_t base = extra / gaps;
+    size_t rem = extra % gaps;
+
+    size_t src_idx = 0;
+    size_t dst_idx = 0;
+    for (src_idx = 0; src_idx < spaced.len; src_idx++)
+    {
+        unsigned char c = spaced.pstr[src_idx];
+        result->pstr[dst_idx++] = c;
+        if ((char)c == pad)
+        {
+            size_t extra_here = base + (rem > 0 ? 1 : 0);
+            if (rem > 0)
+            {
+                rem--;
+            }
+            size_t k;
+            for (k = 0; k < extra_here; k++)
+            {
+                result->pstr[dst_idx++] = (unsigned char)pad;
+            }
+        }
+    }
+
+    result->len = width;
+    result->type = LSTRING_TY;
+    Lfree(p->alloc, &spaced);
+    return IRXPARS_OK;
+}
+
+/* ================================================================== */
+/*  Phase E — Insert, delete, overlay                                 */
+/* ================================================================== */
+
+static int bif_insert(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    long pos = 0;
+    long len = 0;
+    char pad = ' ';
+    int rc = irx_bif_opt_whole(p, argc, argv, 2, "INSERT", 0, &pos);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    size_t used_len = LSTR_REST;
+    if (argc >= 4 && argv[3] != NULL && argv[3]->len > 0)
+    {
+        rc = irx_bif_whole_nonneg(p, argv, 3, "INSERT", &len);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        used_len = (size_t)len;
+    }
+
+    rc = irx_bif_opt_char(p, argc, argv, 4, "INSERT", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    /* Linsert may not accept LSTR_REST as length; fall back to ins->len. */
+    Lstr ins_trim;
+    Lzeroinit(&ins_trim);
+    const PLstr ins = argv[0];
+    size_t actual_len = (used_len == LSTR_REST) ? ins->len : used_len;
+
+    /* If actual_len > ins->len, pad ins on the right with `pad`. */
+    if (actual_len > ins->len)
+    {
+        rc = Lfx(p->alloc, &ins_trim, actual_len);
+        if (rc != LSTR_OK)
+        {
+            Lfree(p->alloc, &ins_trim);
+            return translate_lstr_rc(rc);
+        }
+        memcpy(ins_trim.pstr, ins->pstr, ins->len);
+        memset(ins_trim.pstr + ins->len, (unsigned char)pad,
+               actual_len - ins->len);
+        ins_trim.len = actual_len;
+        ins_trim.type = LSTRING_TY;
+    }
+    else if (actual_len < ins->len)
+    {
+        rc = Lfx(p->alloc, &ins_trim, actual_len);
+        if (rc != LSTR_OK)
+        {
+            Lfree(p->alloc, &ins_trim);
+            return translate_lstr_rc(rc);
+        }
+        memcpy(ins_trim.pstr, ins->pstr, actual_len);
+        ins_trim.len = actual_len;
+        ins_trim.type = LSTRING_TY;
+    }
+    else
+    {
+        rc = Lstrcpy(p->alloc, &ins_trim, ins);
+        if (rc != LSTR_OK)
+        {
+            Lfree(p->alloc, &ins_trim);
+            return translate_lstr_rc(rc);
+        }
+    }
+
+    rc = Linsert(p->alloc, result, &ins_trim, argv[1],
+                 (size_t)pos, pad);
+    Lfree(p->alloc, &ins_trim);
+    return translate_lstr_rc(rc);
+}
+
+static int bif_overlay(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    long pos = 1;
+    long len = 0;
+    char pad = ' ';
+    int rc = irx_bif_opt_whole(p, argc, argv, 2, "OVERLAY", 1, &pos);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    if (pos < 1)
+    {
+        pos = 1;
+    }
+
+    size_t used_len = LSTR_REST;
+    if (argc >= 4 && argv[3] != NULL && argv[3]->len > 0)
+    {
+        rc = irx_bif_whole_nonneg(p, argv, 3, "OVERLAY", &len);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        used_len = (size_t)len;
+    }
+
+    rc = irx_bif_opt_char(p, argc, argv, 4, "OVERLAY", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    /* Same trim/pad dance as INSERT. */
+    Lstr ins_trim;
+    Lzeroinit(&ins_trim);
+    const PLstr ins = argv[0];
+    size_t actual_len = (used_len == LSTR_REST) ? ins->len : used_len;
+
+    if (actual_len != ins->len)
+    {
+        rc = Lfx(p->alloc, &ins_trim, actual_len);
+        if (rc != LSTR_OK)
+        {
+            Lfree(p->alloc, &ins_trim);
+            return translate_lstr_rc(rc);
+        }
+        size_t copy = ins->len < actual_len ? ins->len : actual_len;
+        memcpy(ins_trim.pstr, ins->pstr, copy);
+        if (copy < actual_len)
+        {
+            memset(ins_trim.pstr + copy, (unsigned char)pad,
+                   actual_len - copy);
+        }
+        ins_trim.len = actual_len;
+        ins_trim.type = LSTRING_TY;
+    }
+    else
+    {
+        rc = Lstrcpy(p->alloc, &ins_trim, ins);
+        if (rc != LSTR_OK)
+        {
+            Lfree(p->alloc, &ins_trim);
+            return translate_lstr_rc(rc);
+        }
+    }
+
+    rc = Loverlay(p->alloc, result, &ins_trim, argv[1],
+                  (size_t)pos, pad);
+    Lfree(p->alloc, &ins_trim);
+    return translate_lstr_rc(rc);
+}
+
+static int bif_delstr(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    long start = 0;
+    long len = 0;
+    int rc = irx_bif_whole_positive(p, argv, 1, "DELSTR", &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    size_t used_len = LSTR_REST;
+    if (argc >= 3 && argv[2] != NULL && argv[2]->len > 0)
+    {
+        rc = irx_bif_whole_nonneg(p, argv, 2, "DELSTR", &len);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        used_len = (size_t)len;
+    }
+
+    return translate_lstr_rc(
+        Ldelstr(p->alloc, result, argv[0], (size_t)start, used_len));
+}
+
+static int bif_delword(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    long start = 0;
+    long count = 0;
+    int rc = irx_bif_whole_positive(p, argv, 1, "DELWORD", &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    size_t used_count = LSTR_REST;
+    if (argc >= 3 && argv[2] != NULL && argv[2]->len > 0)
+    {
+        rc = irx_bif_whole_nonneg(p, argv, 2, "DELWORD", &count);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        used_count = (size_t)count;
+    }
+
+    return translate_lstr_rc(
+        Ldelword(p->alloc, result, argv[0], (size_t)start, used_count));
+}
+
+/* ================================================================== */
+/*  Phase F — Translation & verification                              */
+/* ================================================================== */
+
+static int bif_translate(struct irx_parser *p, int argc, PLstr *argv,
+                         PLstr result)
+{
+    char pad = ' ';
+    int rc = irx_bif_opt_char(p, argc, argv, 3, "TRANSLATE", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    PLstr tableo = NULL;
+    PLstr tablei = NULL;
+    if (argc >= 2 && argv[1] != NULL && argv[1]->len > 0)
+    {
+        tableo = argv[1];
+    }
+    if (argc >= 3 && argv[2] != NULL && argv[2]->len > 0)
+    {
+        tablei = argv[2];
+    }
+
+    return translate_lstr_rc(
+        Ltranslate(p->alloc, result, argv[0], tableo, tablei, pad));
+}
+
+static int bif_verify(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    char opt = 'N';
+    int mode = LVERIFY_NOMATCH;
+    long start = 1;
+    int rc = irx_bif_opt_option(p, argc, argv, 2, "VERIFY",
+                                "MN", 'N', &opt);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    mode = (opt == 'M') ? LVERIFY_MATCH : LVERIFY_NOMATCH;
+
+    rc = irx_bif_opt_whole(p, argc, argv, 3, "VERIFY", 1, &start);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    size_t pos = Lverify(argv[0], argv[1], mode, (size_t)start);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)pos));
+}
+
+static int bif_compare(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    char pad = ' ';
+    int rc = irx_bif_opt_char(p, argc, argv, 2, "COMPARE", ' ', &pad);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    size_t pos = Lcompare(argv[0], argv[1], pad);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, (long)pos));
+}
+
+static int bif_abbrev(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    long min = 0;
+    int rc = irx_bif_opt_whole(p, argc, argv, 2, "ABBREV", 0, &min);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    int ok = Labbrev(argv[0], argv[1], (size_t)min);
+    return translate_lstr_rc(set_one(p->alloc, result,
+                                     ok ? (unsigned char)'1'
+                                        : (unsigned char)'0'));
+}
+
+/* ------------------------------------------------------------------ */
+/*  XRANGE([start] [,end])                                            */
+/*                                                                    */
+/*  Returns the characters with byte values start..end inclusive.     */
+/*  Defaults: start=0x00, end=0xFF. If end < start, the range wraps   */
+/*  through 0xFF/0x00 (i.e. XRANGE('FE'x,'01'x) yields 'FEFF0001'x).  */
+/* ------------------------------------------------------------------ */
+
+static int bif_xrange(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    unsigned char lo = 0x00;
+    unsigned char hi = 0xFF;
+    char desc[96];
+
+    if (argc >= 1 && argv[0] != NULL && argv[0]->len > 0)
+    {
+        if (argv[0]->len != 1)
+        {
+            memcpy(desc, "XRANGE: argument must be a single character",
+                   sizeof("XRANGE: argument must be a single character"));
+            irx_cond_raise(p->envblock, SYNTAX_BAD_CALL,
+                           ERR40_SINGLE_CHAR, desc);
+            return IRXPARS_SYNTAX;
+        }
+        lo = argv[0]->pstr[0];
+    }
+    if (argc >= 2 && argv[1] != NULL && argv[1]->len > 0)
+    {
+        if (argv[1]->len != 1)
+        {
+            memcpy(desc, "XRANGE: argument must be a single character",
+                   sizeof("XRANGE: argument must be a single character"));
+            irx_cond_raise(p->envblock, SYNTAX_BAD_CALL,
+                           ERR40_SINGLE_CHAR, desc);
+            return IRXPARS_SYNTAX;
+        }
+        hi = argv[1]->pstr[0];
+    }
+
+    size_t n;
+    if (hi >= lo)
+    {
+        n = (size_t)(hi - lo) + 1;
+    }
+    else
+    {
+        n = (size_t)(0x100 - (int)lo + (int)hi + 1);
+    }
+
+    int rc = Lfx(p->alloc, result, n);
+    if (rc != LSTR_OK)
+    {
+        return translate_lstr_rc(rc);
+    }
+    size_t i;
+    unsigned int c = lo;
+    for (i = 0; i < n; i++)
+    {
+        result->pstr[i] = (unsigned char)(c & 0xFF);
+        c++;
+    }
+    result->len = n;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  FIND(str, phrase)                                                 */
+/*                                                                    */
+/*  Returns the word position in str at which phrase appears as a     */
+/*  contiguous word sequence, or 0 if not found. Whitespace in phrase */
+/*  matches any whitespace run in str. Both arguments are compared    */
+/*  word-by-word; leading/trailing whitespace is irrelevant.          */
+/* ------------------------------------------------------------------ */
+
+static size_t next_word_span(const PLstr s, size_t *cursor,
+                             size_t *word_start, size_t *word_len)
+{
+    while (*cursor < s->len && isspace(s->pstr[*cursor]))
+    {
+        (*cursor)++;
+    }
+    if (*cursor >= s->len)
+    {
+        return 0;
+    }
+    *word_start = *cursor;
+    while (*cursor < s->len && !isspace(s->pstr[*cursor]))
+    {
+        (*cursor)++;
+    }
+    *word_len = *cursor - *word_start;
+    return 1;
+}
+
+static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
+                    PLstr result)
+{
+    (void)argc;
+    const PLstr str = argv[0];
+    const PLstr phrase = argv[1];
+
+    /* Count words in phrase and stash (offset,len) pairs in a small
+     * temporary buffer. REXX FIND has no stated cap on phrase words;
+     * 64 words is well beyond typical usage. */
+#define FIND_MAX_WORDS 64
+    size_t ph_off[FIND_MAX_WORDS];
+    size_t ph_len[FIND_MAX_WORDS];
+    size_t ph_count = 0;
+    size_t cursor = 0;
+    size_t wstart = 0;
+    size_t wlen = 0;
+    while (next_word_span(phrase, &cursor, &wstart, &wlen))
+    {
+        if (ph_count >= FIND_MAX_WORDS)
+        {
+            return translate_lstr_rc(long_to_lstr(p->alloc, result, 0));
+        }
+        ph_off[ph_count] = wstart;
+        ph_len[ph_count] = wlen;
+        ph_count++;
+    }
+
+    if (ph_count == 0)
+    {
+        return translate_lstr_rc(long_to_lstr(p->alloc, result, 0));
+    }
+
+    /* Scan str word-by-word. */
+    size_t pos = 0; /* 1-based running word number in str  */
+    size_t s_cursor = 0;
+    while (s_cursor < str->len)
+    {
+        /* Advance to start of next word in str. */
+        size_t save_cursor = s_cursor;
+        size_t s_start = 0;
+        size_t s_len = 0;
+        if (!next_word_span(str, &s_cursor, &s_start, &s_len))
+        {
+            break;
+        }
+        pos++;
+
+        /* Compare against the phrase: first word must match at the
+         * current position; remaining ph_count-1 words must follow. */
+        if (s_len == ph_len[0] &&
+            memcmp(str->pstr + s_start, phrase->pstr + ph_off[0],
+                   s_len) == 0)
+        {
+            size_t look_cursor = s_cursor;
+            size_t all_match = 1;
+            size_t i;
+            for (i = 1; i < ph_count; i++)
+            {
+                size_t w_start = 0;
+                size_t w_len = 0;
+                if (!next_word_span(str, &look_cursor, &w_start, &w_len))
+                {
+                    all_match = 0;
+                    break;
+                }
+                if (w_len != ph_len[i] ||
+                    memcmp(str->pstr + w_start,
+                           phrase->pstr + ph_off[i], w_len) != 0)
+                {
+                    all_match = 0;
+                    break;
+                }
+            }
+            if (all_match)
+            {
+                return translate_lstr_rc(
+                    long_to_lstr(p->alloc, result, (long)pos));
+            }
+        }
+
+        (void)save_cursor; /* silence unused-var in release builds */
+    }
+
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, 0));
+#undef FIND_MAX_WORDS
+}
+
+/* ================================================================== */
+/*  Registration                                                      */
+/* ================================================================== */
+
+static const struct irx_bif_entry g_bifstr_table[] = {
+    /* Phase B */
+    {"LENGTH", 1, 1, bif_length},
+    {"LEFT", 2, 3, bif_left},
+    {"RIGHT", 2, 3, bif_right},
+    {"SUBSTR", 2, 4, bif_substr},
+    {"POS", 2, 3, bif_pos},
+    {"INDEX", 2, 3, bif_index},
+    {"LASTPOS", 2, 3, bif_lastpos},
+    /* Phase C */
+    {"WORDS", 1, 1, bif_words},
+    {"WORD", 2, 2, bif_word},
+    {"WORDINDEX", 2, 2, bif_wordindex},
+    {"WORDLENGTH", 2, 2, bif_wordlength},
+    {"SUBWORD", 2, 3, bif_subword},
+    {"WORDPOS", 2, 3, bif_wordpos},
+    /* Phase D */
+    {"CENTER", 2, 3, bif_center},
+    {"CENTRE", 2, 3, bif_center},
+    {"STRIP", 1, 3, bif_strip},
+    {"SPACE", 1, 3, bif_space},
+    {"JUSTIFY", 2, 3, bif_justify},
+    {"COPIES", 2, 2, bif_copies},
+    {"REVERSE", 1, 1, bif_reverse},
+    /* Phase E */
+    {"INSERT", 2, 5, bif_insert},
+    {"OVERLAY", 2, 5, bif_overlay},
+    {"DELSTR", 2, 3, bif_delstr},
+    {"DELWORD", 2, 3, bif_delword},
+    /* Phase F */
+    {"TRANSLATE", 1, 4, bif_translate},
+    {"VERIFY", 2, 4, bif_verify},
+    {"COMPARE", 2, 3, bif_compare},
+    {"ABBREV", 2, 3, bif_abbrev},
+    {"XRANGE", 0, 2, bif_xrange},
+    {"FIND", 2, 2, bif_find},
+    /* Sentinel */
+    {"", 0, 0, NULL}};
+
+#define BIFSTR_COUNT \
+    ((int)(sizeof(g_bifstr_table) / sizeof(g_bifstr_table[0])))
+
+int irx_bifstr_register(struct envblock *env, struct irx_bif_registry *reg)
+{
+    (void)set_empty; /* kept for future use */
+    return irx_bif_register_table(env, reg, g_bifstr_table,
+                                  BIFSTR_COUNT);
+}

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -73,18 +73,6 @@ static int translate_lstr_rc(int rc)
     return IRXPARS_SYNTAX;
 }
 
-static int set_empty(struct lstr_alloc *a, PLstr s)
-{
-    int rc = Lfx(a, s, 0);
-    if (rc != LSTR_OK)
-    {
-        return rc;
-    }
-    s->len = 0;
-    s->type = LSTRING_TY;
-    return LSTR_OK;
-}
-
 static int set_one(struct lstr_alloc *a, PLstr s, unsigned char c)
 {
     int rc = Lfx(a, s, 1);
@@ -911,6 +899,13 @@ static size_t next_word_span(const PLstr s, size_t *cursor,
     return 1;
 }
 
+/* Implementation cap on the phrase argument. SC28-1883-0 §4 does not
+ * define a limit, but real REXX programs never approach this value —
+ * 1024 words would be 6+ KB of prose. Exceeding the cap raises
+ * SYNTAX 40.ERR40_ARG_LENGTH so the caller learns immediately that
+ * the argument is out of range, rather than silently getting 0. */
+#define FIND_MAX_WORDS 1024
+
 static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
                     PLstr result)
 {
@@ -918,10 +913,6 @@ static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
     const PLstr str = argv[0];
     const PLstr phrase = argv[1];
 
-    /* Count words in phrase and stash (offset,len) pairs in a small
-     * temporary buffer. REXX FIND has no stated cap on phrase words;
-     * 64 words is well beyond typical usage. */
-#define FIND_MAX_WORDS 64
     size_t ph_off[FIND_MAX_WORDS];
     size_t ph_len[FIND_MAX_WORDS];
     size_t ph_count = 0;
@@ -932,7 +923,11 @@ static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
     {
         if (ph_count >= FIND_MAX_WORDS)
         {
-            return translate_lstr_rc(long_to_lstr(p->alloc, result, 0));
+            char desc[64];
+            sprintf(desc, "FIND: phrase exceeds %d words", FIND_MAX_WORDS);
+            irx_cond_raise(p->envblock, SYNTAX_BAD_CALL,
+                           ERR40_ARG_LENGTH, desc);
+            return IRXPARS_SYNTAX;
         }
         ph_off[ph_count] = wstart;
         ph_len[ph_count] = wlen;
@@ -996,7 +991,6 @@ static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
     }
 
     return translate_lstr_rc(long_to_lstr(p->alloc, result, 0));
-#undef FIND_MAX_WORDS
 }
 
 /* ================================================================== */
@@ -1047,7 +1041,6 @@ static const struct irx_bif_entry g_bifstr_table[] = {
 
 int irx_bifstr_register(struct envblock *env, struct irx_bif_registry *reg)
 {
-    (void)set_empty; /* kept for future use */
     return irx_bif_register_table(env, reg, g_bifstr_table,
                                   BIFSTR_COUNT);
 }

--- a/src/irx#cond.c
+++ b/src/irx#cond.c
@@ -1,0 +1,65 @@
+/* ------------------------------------------------------------------ */
+/*  irx#cond.c - REXX/370 Condition helper                           */
+/*                                                                    */
+/*  Raises a SYNTAX / ERROR condition by populating                  */
+/*  wkbi_last_condition on the given environment. Called by the      */
+/*  arithmetic engine, the BIF registry, and other modules that      */
+/*  need to surface a diagnostic to the REXX program.                 */
+/*                                                                    */
+/*  No globals; state lives exclusively on the ENVBLOCK.              */
+/*                                                                    */
+/*  Ref: SC28-1883-0, Chapter 7 / Appendix E                         */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <string.h>
+
+#include "irx.h"
+#include "irxcond.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+void irx_cond_raise(struct envblock *env, int code, int subcode,
+                    const char *desc)
+{
+    if (env == NULL || env->envblock_userfield == NULL)
+    {
+        return;
+    }
+
+    struct irx_wkblk_int *wk =
+        (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_condition_info *ci = wk->wkbi_last_condition;
+
+    if (ci == NULL)
+    {
+        void *p = NULL;
+        if (irxstor(RXSMGET, (int)sizeof(struct irx_condition_info),
+                    &p, env) != 0)
+        {
+            return;
+        }
+        ci = (struct irx_condition_info *)p;
+        memset(ci, 0, sizeof(*ci));
+        wk->wkbi_last_condition = ci;
+    }
+
+    ci->valid = 1;
+    ci->code = code;
+    ci->subcode = subcode;
+
+    if (desc != NULL)
+    {
+        size_t dlen = strlen(desc);
+        if (dlen >= sizeof(ci->desc))
+        {
+            dlen = sizeof(ci->desc) - 1;
+        }
+        memcpy(ci->desc, desc, dlen);
+        ci->desc[dlen] = '\0';
+    }
+    else
+    {
+        ci->desc[0] = '\0';
+    }
+}

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -15,8 +15,11 @@
 #include <string.h>
 
 #include "irx.h"
+#include "irxbif.h"
+#include "irxbifstr.h"
 #include "irxfunc.h"
 #include "irxio.h"
+#include "irxpars.h"
 #include "irxrab.h"
 #include "irxwkblk.h"
 
@@ -339,6 +342,28 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
 
     /* Link internal work block via envblock_userfield */
     envblk->envblock_userfield = wkbi;
+
+    /* 7a. BIF registry and core registrations */
+    {
+        struct irx_bif_registry *reg = NULL;
+        rc = irx_bif_create(envblk, &reg);
+        if (rc != 0)
+        {
+            goto cleanup;
+        }
+        wkbi->wkbi_bif_registry = reg;
+
+        rc = irx_pars_register_core_bifs(envblk, reg);
+        if (rc != 0)
+        {
+            goto cleanup;
+        }
+        rc = irx_bifstr_register(envblk, reg);
+        if (rc != 0)
+        {
+            goto cleanup;
+        }
+    }
 
     /* 8. Create env_node and register in RAB */
     {

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -21,6 +21,7 @@
 
 #include "irx.h"
 #include "irxarith.h"
+#include "irxbif.h"
 #include "irxctrl.h"
 #include "irxlstr.h"
 #include "irxpars.h"
@@ -391,18 +392,10 @@ static int compare_normal(struct envblock *env, PLstr a, PLstr b)
 }
 
 /* ------------------------------------------------------------------ */
-/*  Built-in functions                                                */
-/* ------------------------------------------------------------------ */
-
-static int bif_length(struct irx_parser *p, int argc, PLstr *argv,
-                      PLstr result)
-{
-    (void)argc;
-    return long_to_lstr(p->alloc, result, (long)argv[0]->len);
-}
-
-/* ------------------------------------------------------------------ */
 /*  ARG([n[,option]]) - argument count / value / existence (WP-17)   */
+/*                                                                    */
+/*  Stays in the parser because it reads p->call_args / call_argc     */
+/*  directly; other BIFs (LENGTH, SUBSTR, ...) live in irx#bifs.c.    */
 /* ------------------------------------------------------------------ */
 
 static int bif_arg(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
@@ -488,25 +481,33 @@ static int bif_arg(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
                : fail(p, IRXPARS_NOMEM);
 }
 
-static const struct irx_bif g_bif_table[] = {
-    {"LENGTH", 1, 1, bif_length},
-    {"ARG", 0, 2, bif_arg}};
-static const int g_bif_count = (int)(sizeof(g_bif_table) /
-                                     sizeof(g_bif_table[0]));
+/* ------------------------------------------------------------------ */
+/*  Registry wiring                                                   */
+/*                                                                    */
+/*  irx_pars_register_core_bifs() is called from irxinit() once the   */
+/*  per-environment BIF registry has been allocated. It adds the      */
+/*  parser-internal built-ins; everything else (string BIFs, ...)     */
+/*  registers from its own module.                                    */
+/* ------------------------------------------------------------------ */
 
-static const struct irx_bif *find_bif(const unsigned char *name, size_t len)
+int irx_pars_register_core_bifs(struct envblock *env,
+                                struct irx_bif_registry *reg)
 {
-    int i;
-    for (i = 0; i < g_bif_count; i++)
+    return irx_bif_register(env, reg, "ARG", 0, 2, bif_arg);
+}
+
+/* Fetch the registry hanging off the parser's environment. */
+static struct irx_bif_registry *get_bif_registry(struct irx_parser *p)
+{
+    struct irx_wkblk_int *wk;
+
+    if (p == NULL || p->envblock == NULL ||
+        p->envblock->envblock_userfield == NULL)
     {
-        const char *bn = g_bif_table[i].bif_name;
-        size_t bl = strlen(bn);
-        if (bl == len && memcmp(bn, name, len) == 0)
-        {
-            return &g_bif_table[i];
-        }
+        return NULL;
     }
-    return NULL;
+    wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+    return (struct irx_bif_registry *)wk->wkbi_bif_registry;
 }
 
 /* ------------------------------------------------------------------ */
@@ -3625,7 +3626,8 @@ static int parse_function_call(struct irx_parser *p,
     int argc = 0;
     int i;
     int rc;
-    const struct irx_bif *bif;
+    const struct irx_bif_entry *bif;
+    struct irx_bif_registry *registry;
     Lstr upname;
 
     for (i = 0; i < IRX_MAX_ARGS; i++)
@@ -3680,19 +3682,20 @@ static int parse_function_call(struct irx_parser *p,
         goto done;
     }
 
-    bif = find_bif(upname.pstr, upname.len);
+    registry = get_bif_registry(p);
+    bif = irx_bif_find(registry, upname.pstr, upname.len);
     if (bif == NULL)
     {
         rc = fail(p, IRXPARS_BADFUNC);
         goto done;
     }
-    if (argc < bif->bif_min_args || argc > bif->bif_max_args)
+    if (argc < bif->min_args || argc > bif->max_args)
     {
         rc = fail(p, IRXPARS_SYNTAX);
         goto done;
     }
 
-    rc = bif->bif_handler(p, argc, argptrs, out);
+    rc = bif->handler(p, argc, argptrs, out);
 
 done:
     Lfree(p->alloc, &upname);

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include "irx.h"
+#include "irxbif.h"
 #include "irxfunc.h"
 #include "irxrab.h"
 #include "irxwkblk.h"
@@ -75,6 +76,15 @@ int irxterm(struct envblock *envblk)
         if (wkbi->wkbi_lstr_alloc != NULL)
         {
             stor_free(&wkbi->wkbi_lstr_alloc, envblk);
+        }
+
+        /* Free the BIF registry (WP-21a). */
+        if (wkbi->wkbi_bif_registry != NULL)
+        {
+            irx_bif_destroy(
+                envblk,
+                (struct irx_bif_registry *)wkbi->wkbi_bif_registry);
+            wkbi->wkbi_bif_registry = NULL;
         }
 
         envblk->envblock_userfield = NULL;

--- a/test/test_bif.c
+++ b/test/test_bif.c
@@ -1,0 +1,246 @@
+/* ------------------------------------------------------------------ */
+/*  test_bif.c - WP-21a BIF registry unit tests                       */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_bif \                 */
+/*        test/test_bif.c \                                            */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \        */
+/*        'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c' \        */
+/*        'src/irx#cond.c' 'src/irx#bif.c'  'src/irx#bifs.c' \        */
+/*        'src/irx#io.c'   'src/irx#lstr.c' 'src/irx#tokn.c' \        */
+/*        'src/irx#vpol.c' 'src/irx#pars.c' 'src/irx#ctrl.c' \        */
+/*        'src/irx#arith.c' 'src/irx#exec.c' \                         */
+/*        ../lstring370/src/lstr#*.c                                   */
+/*                                                                    */
+/*  Verifies: add/lookup/not-found/duplicate handling; correct         */
+/*  min/max arg enforcement; lifecycle via irxinit/irxterm.            */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbif.h"
+#include "irxcond.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* Dummy handler — never invoked by these tests. */
+static int dummy_handler(struct irx_parser *p, int argc, PLstr *argv,
+                         PLstr result)
+{
+    (void)p;
+    (void)argc;
+    (void)argv;
+    (void)result;
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+
+static void test_create_destroy(void)
+{
+    struct envblock *env = NULL;
+    struct irx_bif_registry *reg = NULL;
+
+    printf("\n--- BIF#1: create + destroy ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(irx_bif_create(env, &reg) == IRX_BIF_OK, "create returned OK");
+    CHECK(reg != NULL, "registry allocated");
+    irx_bif_destroy(env, reg);
+    irxterm(env);
+}
+
+static void test_register_and_lookup(void)
+{
+    struct envblock *env = NULL;
+    struct irx_bif_registry *reg = NULL;
+    const struct irx_bif_entry *e;
+    const unsigned char foo[] = {'F', 'O', 'O'};
+
+    printf("\n--- BIF#2: register + lookup ---\n");
+    irxinit(NULL, &env);
+    irx_bif_create(env, &reg);
+
+    CHECK(irx_bif_register(env, reg, "FOO", 1, 3, dummy_handler) ==
+              IRX_BIF_OK,
+          "register FOO");
+
+    e = irx_bif_find(reg, foo, 3);
+    CHECK(e != NULL, "find FOO");
+    CHECK(e != NULL && strcmp(e->name, "FOO") == 0, "name matches");
+    CHECK(e != NULL && e->min_args == 1, "min_args = 1");
+    CHECK(e != NULL && e->max_args == 3, "max_args = 3");
+    CHECK(e != NULL && e->handler == dummy_handler, "handler pointer");
+
+    irx_bif_destroy(env, reg);
+    irxterm(env);
+}
+
+static void test_not_found(void)
+{
+    struct envblock *env = NULL;
+    struct irx_bif_registry *reg = NULL;
+    const unsigned char bar[] = {'B', 'A', 'R'};
+
+    printf("\n--- BIF#3: not found ---\n");
+    irxinit(NULL, &env);
+    irx_bif_create(env, &reg);
+
+    CHECK(irx_bif_find(reg, bar, 3) == NULL, "find BAR returns NULL");
+
+    irx_bif_destroy(env, reg);
+    irxterm(env);
+}
+
+static void test_duplicate(void)
+{
+    struct envblock *env = NULL;
+    struct irx_bif_registry *reg = NULL;
+
+    printf("\n--- BIF#4: duplicate rejection ---\n");
+    irxinit(NULL, &env);
+    irx_bif_create(env, &reg);
+
+    CHECK(irx_bif_register(env, reg, "DUP", 0, 0, dummy_handler) ==
+              IRX_BIF_OK,
+          "register DUP");
+    CHECK(irx_bif_register(env, reg, "DUP", 0, 0, dummy_handler) ==
+              IRX_BIF_DUPLICATE,
+          "second register returns DUPLICATE");
+
+    irx_bif_destroy(env, reg);
+    irxterm(env);
+}
+
+static void test_bad_args(void)
+{
+    struct envblock *env = NULL;
+    struct irx_bif_registry *reg = NULL;
+
+    printf("\n--- BIF#5: bad arguments ---\n");
+    irxinit(NULL, &env);
+    irx_bif_create(env, &reg);
+
+    CHECK(irx_bif_register(env, reg, NULL, 0, 0, dummy_handler) ==
+              IRX_BIF_BADARG,
+          "NULL name rejected");
+    CHECK(irx_bif_register(env, reg, "", 0, 0, dummy_handler) ==
+              IRX_BIF_BADARG,
+          "empty name rejected");
+    CHECK(irx_bif_register(env, reg, "X", 2, 1, dummy_handler) ==
+              IRX_BIF_BADARG,
+          "max < min rejected");
+    CHECK(irx_bif_register(env, reg, "X", -1, 0, dummy_handler) ==
+              IRX_BIF_BADARG,
+          "negative min rejected");
+    CHECK(irx_bif_register(env, reg, "X", 0, 0, NULL) ==
+              IRX_BIF_BADARG,
+          "NULL handler rejected");
+    CHECK(irx_bif_find(reg, NULL, 1) == NULL, "NULL name lookup");
+    CHECK(irx_bif_find(reg, (const unsigned char *)"X", 0) == NULL,
+          "zero-length lookup");
+
+    irx_bif_destroy(env, reg);
+    irxterm(env);
+}
+
+static void test_table_registration(void)
+{
+    struct envblock *env = NULL;
+    struct irx_bif_registry *reg = NULL;
+    const struct irx_bif_entry table[] = {
+        {"A", 0, 0, dummy_handler},
+        {"B", 1, 2, dummy_handler},
+        {"C", 0, 3, dummy_handler},
+        {"", 0, 0, NULL},
+    };
+    const int count = (int)(sizeof(table) / sizeof(table[0]));
+
+    printf("\n--- BIF#6: bulk register via table ---\n");
+    irxinit(NULL, &env);
+    irx_bif_create(env, &reg);
+
+    CHECK(irx_bif_register_table(env, reg, table, count) == IRX_BIF_OK,
+          "bulk register OK");
+    CHECK(irx_bif_find(reg, (const unsigned char *)"A", 1) != NULL,
+          "A registered");
+    CHECK(irx_bif_find(reg, (const unsigned char *)"B", 1) != NULL,
+          "B registered");
+    CHECK(irx_bif_find(reg, (const unsigned char *)"C", 1) != NULL,
+          "C registered");
+
+    irx_bif_destroy(env, reg);
+    irxterm(env);
+}
+
+static void test_core_bifs_registered(void)
+{
+    /* After irxinit, LENGTH, ARG, and the full string-BIF set should
+     * be reachable through the per-environment registry. */
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    struct irx_bif_registry *reg;
+
+    printf("\n--- BIF#7: irxinit registers core BIFs ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    CHECK(wk != NULL && wk->wkbi_bif_registry != NULL,
+          "wkbi_bif_registry populated");
+    reg = (struct irx_bif_registry *)wk->wkbi_bif_registry;
+    CHECK(irx_bif_find(reg, (const unsigned char *)"LENGTH", 6) != NULL,
+          "LENGTH is registered");
+    CHECK(irx_bif_find(reg, (const unsigned char *)"ARG", 3) != NULL,
+          "ARG is registered");
+    CHECK(irx_bif_find(reg, (const unsigned char *)"SUBSTR", 6) != NULL,
+          "SUBSTR is registered");
+    CHECK(irx_bif_find(reg, (const unsigned char *)"XRANGE", 6) != NULL,
+          "XRANGE is registered");
+    irxterm(env);
+}
+
+int main(void)
+{
+    printf("=== WP-21a: BIF registry tests ===\n");
+
+    test_create_destroy();
+    test_register_and_lookup();
+    test_not_found();
+    test_duplicate();
+    test_bad_args();
+    test_table_registration();
+    test_core_bifs_registered();
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -1,0 +1,429 @@
+/* ------------------------------------------------------------------ */
+/*  test_bifs.c - WP-21a string BIF unit tests                        */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_bifs \                 */
+/*        test/test_bifs.c \                                           */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \        */
+/*        'src/irx#rab.c'  'src/irx#uid.c'  'src/irx#msid.c' \        */
+/*        'src/irx#cond.c' 'src/irx#bif.c'  'src/irx#bifs.c' \        */
+/*        'src/irx#io.c'   'src/irx#lstr.c' 'src/irx#tokn.c' \        */
+/*        'src/irx#vpol.c' 'src/irx#pars.c' 'src/irx#ctrl.c' \        */
+/*        'src/irx#arith.c' 'src/irx#exec.c' \                         */
+/*        ../lstring370/src/lstr#*.c                                   */
+/*                                                                    */
+/*  Drives each BIF through the parser end-to-end and checks that     */
+/*  the resulting variable matches expectation. Also covers the       */
+/*  SYNTAX 40.x error paths.                                          */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbif.h"
+#include "irxcond.h"
+#include "irxfunc.h"
+#include "irxpars.h"
+#include "irxtokn.h"
+#include "irxvpool.h"
+#include "irxwkblk.h"
+#include "lstralloc.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Fixture: irxinit + fresh vpool per test; run REXX source, fetch X */
+/* ------------------------------------------------------------------ */
+
+struct fixture
+{
+    struct envblock *env;
+    struct lstr_alloc *alloc;
+    struct irx_vpool *pool;
+};
+
+static int fixture_open(struct fixture *f)
+{
+    memset(f, 0, sizeof(*f));
+    if (irxinit(NULL, &f->env) != 0)
+    {
+        return -1;
+    }
+    f->alloc = lstr_default_alloc();
+    f->pool = vpool_create(f->alloc, NULL);
+    return (f->pool != NULL) ? 0 : -1;
+}
+
+static void fixture_close(struct fixture *f)
+{
+    if (f->pool != NULL)
+    {
+        vpool_destroy(f->pool);
+    }
+    if (f->env != NULL)
+    {
+        irxterm(f->env);
+    }
+    memset(f, 0, sizeof(*f));
+}
+
+static int run_src(struct fixture *f, const char *src)
+{
+    struct irx_token *tokens = NULL;
+    int count = 0;
+    struct irx_tokn_error tok_err;
+    struct irx_parser parser;
+    int rc;
+
+    rc = irx_tokn_run(NULL, src, (int)strlen(src), &tokens, &count,
+                      &tok_err);
+    if (rc != 0)
+    {
+        return -1;
+    }
+    rc = irx_pars_init(&parser, tokens, count, f->pool, f->alloc, f->env);
+    if (rc != IRXPARS_OK)
+    {
+        irx_tokn_free(NULL, tokens, count);
+        return rc;
+    }
+    rc = irx_pars_run(&parser);
+    irx_pars_cleanup(&parser);
+    irx_tokn_free(NULL, tokens, count);
+    return rc;
+}
+
+static int var_eq(struct fixture *f, const char *name, const char *want)
+{
+    Lstr key;
+    Lstr val;
+    int rc;
+    int eq;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    rc = vpool_get(f->pool, &key, &val);
+    if (rc != VPOOL_OK)
+    {
+        Lfree(f->alloc, &key);
+        Lfree(f->alloc, &val);
+        return 0;
+    }
+
+    size_t wl = strlen(want);
+    eq = (val.len == wl) && (memcmp(val.pstr, want, wl) == 0);
+    if (!eq)
+    {
+        printf("    %s = '%.*s' (expected '%s')\n",
+               name, (int)val.len, (const char *)val.pstr, want);
+    }
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return eq;
+}
+
+/* Expect the parser to succeed and X to equal want. */
+#define EXPECT_OK(src, want, msg)                \
+    do                                           \
+    {                                            \
+        struct fixture fx;                       \
+        if (fixture_open(&fx) != 0)              \
+        {                                        \
+            CHECK(0, "fixture_open " msg);       \
+            break;                               \
+        }                                        \
+        int _rc = run_src(&fx, "x = " src "\n"); \
+        if (_rc != IRXPARS_OK)                   \
+        {                                        \
+            printf("    parser rc=%d\n", _rc);   \
+            CHECK(0, msg);                       \
+        }                                        \
+        else                                     \
+        {                                        \
+            CHECK(var_eq(&fx, "X", want), msg);  \
+        }                                        \
+        fixture_close(&fx);                      \
+    } while (0)
+
+/* ================================================================== */
+/*  Phase B — LENGTH, LEFT, RIGHT, SUBSTR, POS, LASTPOS, INDEX        */
+/* ================================================================== */
+
+static void test_phase_b(void)
+{
+    printf("\n--- Phase B: substring & position ---\n");
+    EXPECT_OK("LENGTH('hello')", "5", "LENGTH basic");
+    EXPECT_OK("LENGTH('')", "0", "LENGTH empty");
+    EXPECT_OK("LEFT('abcdef',3)", "abc", "LEFT basic");
+    EXPECT_OK("LEFT('ab',5)", "ab   ", "LEFT pad default");
+    EXPECT_OK("LEFT('ab',5,'.')", "ab...", "LEFT pad explicit");
+    EXPECT_OK("LEFT('abcdef',0)", "", "LEFT zero");
+    EXPECT_OK("RIGHT('abcdef',3)", "def", "RIGHT basic");
+    EXPECT_OK("RIGHT('ab',5,'.')", "...ab", "RIGHT pad");
+    EXPECT_OK("SUBSTR('abcdef',3)", "cdef", "SUBSTR from pos");
+    EXPECT_OK("SUBSTR('abcdef',3,2)", "cd", "SUBSTR fixed length");
+    EXPECT_OK("SUBSTR('ab',1,5)", "ab   ", "SUBSTR pad");
+    EXPECT_OK("SUBSTR('ab',1,5,'*')", "ab***", "SUBSTR explicit pad");
+    EXPECT_OK("POS('cd','abcdef')", "3", "POS found");
+    EXPECT_OK("POS('x','abcdef')", "0", "POS not found");
+    EXPECT_OK("POS('ab','abcabc',2)", "4", "POS with start");
+    EXPECT_OK("INDEX('abcdef','cd')", "3", "INDEX found (args flipped)");
+    EXPECT_OK("INDEX('abcdef','x')", "0", "INDEX not found");
+    EXPECT_OK("LASTPOS('ab','ababab')", "5", "LASTPOS basic");
+    EXPECT_OK("LASTPOS('x','abcdef')", "0", "LASTPOS not found");
+}
+
+/* ================================================================== */
+/*  Phase C — word ops                                                 */
+/* ================================================================== */
+
+static void test_phase_c(void)
+{
+    printf("\n--- Phase C: word operations ---\n");
+    EXPECT_OK("WORDS('foo bar baz')", "3", "WORDS 3");
+    EXPECT_OK("WORDS('')", "0", "WORDS empty");
+    EXPECT_OK("WORDS('   one   ')", "1", "WORDS trim");
+    EXPECT_OK("WORD('foo bar baz',2)", "bar", "WORD 2");
+    EXPECT_OK("WORD('foo bar',5)", "", "WORD out of range");
+    EXPECT_OK("WORDINDEX('foo bar baz',2)", "5", "WORDINDEX 2");
+    EXPECT_OK("WORDINDEX('foo bar',5)", "0", "WORDINDEX out of range");
+    EXPECT_OK("WORDLENGTH('foo bar',2)", "3", "WORDLENGTH 2");
+    EXPECT_OK("WORDLENGTH('foo bar',5)", "0", "WORDLENGTH oob");
+    EXPECT_OK("SUBWORD('a b c d e',2,2)", "b c", "SUBWORD 2..3");
+    EXPECT_OK("SUBWORD('a b c d e',3)", "c d e", "SUBWORD rest");
+    EXPECT_OK("WORDPOS('bar baz','foo bar baz qux')", "2", "WORDPOS found");
+    EXPECT_OK("WORDPOS('xx','foo bar')", "0", "WORDPOS not found");
+}
+
+/* ================================================================== */
+/*  Phase D — padding/stripping/formatting                             */
+/* ================================================================== */
+
+static void test_phase_d(void)
+{
+    printf("\n--- Phase D: padding & formatting ---\n");
+    EXPECT_OK("CENTER('abc',7)", "  abc  ", "CENTER default");
+    EXPECT_OK("CENTRE('abc',7,'-')", "--abc--", "CENTRE alias + pad");
+    EXPECT_OK("CENTER('abc',2)", "ab", "CENTER truncates (odd remainder from end)");
+    EXPECT_OK("STRIP('   abc   ')", "abc", "STRIP both");
+    EXPECT_OK("STRIP('   abc   ','L')", "abc   ", "STRIP leading");
+    EXPECT_OK("STRIP('   abc   ','T')", "   abc", "STRIP trailing");
+    EXPECT_OK("STRIP('xxxabcxxx','B','x')", "abc", "STRIP char");
+    EXPECT_OK("SPACE('  foo   bar   baz  ')", "foo bar baz", "SPACE default");
+    EXPECT_OK("SPACE('foo   bar',2)", "foo  bar", "SPACE n=2");
+    EXPECT_OK("SPACE('foo   bar',1,'.')", "foo.bar", "SPACE pad");
+    EXPECT_OK("COPIES('ab',3)", "ababab", "COPIES 3");
+    EXPECT_OK("COPIES('ab',0)", "", "COPIES 0");
+    EXPECT_OK("REVERSE('abc')", "cba", "REVERSE");
+    EXPECT_OK("REVERSE('')", "", "REVERSE empty");
+    EXPECT_OK("JUSTIFY('foo bar baz',15)", "foo   bar   baz", "JUSTIFY 15");
+    EXPECT_OK("JUSTIFY('foo bar',7)", "foo bar", "JUSTIFY exact");
+    EXPECT_OK("JUSTIFY('foo bar',3)", "foo", "JUSTIFY truncate");
+    EXPECT_OK("JUSTIFY('hello',8,'-')", "hello---", "JUSTIFY single word");
+}
+
+/* ================================================================== */
+/*  Phase E — insert/delete/overlay                                   */
+/* ================================================================== */
+
+static void test_phase_e(void)
+{
+    printf("\n--- Phase E: insert / delete / overlay ---\n");
+    EXPECT_OK("INSERT('XY','abcdef',3)", "abcXYdef", "INSERT at 3");
+    EXPECT_OK("INSERT('XY','abc',0)", "XYabc", "INSERT at 0 (prepend)");
+    EXPECT_OK("INSERT('XY','abc',5)", "abc  XY", "INSERT pad");
+    EXPECT_OK("INSERT('XY','abc',3,5)", "abcXY   ", "INSERT pad length");
+    EXPECT_OK("INSERT('XY','abc',3,5,'.')", "abcXY...", "INSERT pad char");
+    EXPECT_OK("OVERLAY('XY','abcdef',3)", "abXYef", "OVERLAY at 3");
+    EXPECT_OK("OVERLAY('XY','abc',5)", "abc XY", "OVERLAY past end");
+    EXPECT_OK("OVERLAY('XY','abcdef',3,4,'.')", "abXY..", "OVERLAY len+pad");
+    EXPECT_OK("DELSTR('abcdef',3)", "ab", "DELSTR from 3");
+    EXPECT_OK("DELSTR('abcdef',3,2)", "abef", "DELSTR 3,2");
+    EXPECT_OK("DELWORD('a b c d e',3)", "a b", "DELWORD from 3");
+    EXPECT_OK("DELWORD('a b c d e',2,2)", "a d e", "DELWORD 2,2");
+}
+
+/* ================================================================== */
+/*  Phase F — translation, verification, compare, abbrev, xrange, find*/
+/* ================================================================== */
+
+static void test_phase_f(void)
+{
+    printf("\n--- Phase F: translate / verify / compare / abbrev ---\n");
+    EXPECT_OK("TRANSLATE('abc')", "ABC", "TRANSLATE uppercase");
+    EXPECT_OK("TRANSLATE('abc','xyz','abc')", "xyz", "TRANSLATE map");
+    EXPECT_OK("TRANSLATE('abc','XY','ab')", "XYc", "TRANSLATE partial");
+    EXPECT_OK("TRANSLATE('abcd','*','bc','.')", "a*.d", "TRANSLATE short-output uses pad");
+    EXPECT_OK("VERIFY('abc123','abcdefghijklmnopqrstuvwxyz')", "4",
+              "VERIFY finds digit at 4");
+    EXPECT_OK("VERIFY('abc','abc')", "0", "VERIFY all match");
+    EXPECT_OK("VERIFY('abc123','0123456789','M')", "4", "VERIFY match mode");
+    EXPECT_OK("COMPARE('abc','abc')", "0", "COMPARE equal");
+    EXPECT_OK("COMPARE('abc','abd')", "3", "COMPARE diff pos");
+    EXPECT_OK("COMPARE('ab  ','ab')", "0", "COMPARE blank-pad");
+    EXPECT_OK("ABBREV('program','prog')", "1", "ABBREV prefix");
+    EXPECT_OK("ABBREV('program','prog',5)", "0", "ABBREV too short");
+    EXPECT_OK("ABBREV('program','xx')", "0", "ABBREV no");
+    EXPECT_OK("FIND('foo bar baz','bar')", "2", "FIND single word");
+    EXPECT_OK("FIND('a b c d e','c d')", "3", "FIND multi-word");
+    EXPECT_OK("FIND('a b c','x')", "0", "FIND not found");
+    EXPECT_OK("LENGTH(XRANGE('A','Z'))", "26", "XRANGE length 26");
+    EXPECT_OK("LENGTH(XRANGE())", "256", "XRANGE default 256");
+}
+
+/* ================================================================== */
+/*  Error paths — SYNTAX 40.x                                         */
+/* ================================================================== */
+
+static int run_expect_fail(const char *src, int want_code,
+                           int want_subcode, const char *msg)
+{
+    struct fixture fx;
+    int rc;
+    int code = 0;
+    int subcode = 0;
+
+    if (fixture_open(&fx) != 0)
+    {
+        return 0;
+    }
+    rc = run_src(&fx, src);
+
+    struct irx_wkblk_int *wk =
+        (struct irx_wkblk_int *)fx.env->envblock_userfield;
+    if (wk != NULL && wk->wkbi_last_condition != NULL &&
+        wk->wkbi_last_condition->valid)
+    {
+        code = wk->wkbi_last_condition->code;
+        subcode = wk->wkbi_last_condition->subcode;
+    }
+
+    int ok = (rc != IRXPARS_OK) && (code == want_code) &&
+             (want_subcode == 0 || subcode == want_subcode);
+    if (!ok)
+    {
+        printf("    rc=%d code=%d subcode=%d (want rc!=0 code=%d subcode=%d)\n",
+               rc, code, subcode, want_code, want_subcode);
+    }
+    CHECK(ok, msg);
+    fixture_close(&fx);
+    return ok;
+}
+
+static void test_error_paths(void)
+{
+    /* Every BIF that has a validation branch gets at least one       */
+    /* error-path test here (SC28-1883-0 Appendix E, SYNTAX 40.x).    */
+    /* BIFs whose only arg is a string (LENGTH, WORDS, REVERSE, FIND) */
+    /* have no 40.x validation and are exercised only positively.     */
+    printf("\n--- Error paths (SYNTAX 40.x) ---\n");
+
+    /* Non-negative whole required */
+    run_expect_fail("x = LEFT('hello','abc')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "LEFT non-numeric");
+    run_expect_fail("x = LEFT('hello',-1)\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "LEFT negative");
+    run_expect_fail("x = RIGHT('hello','abc')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "RIGHT non-numeric");
+    run_expect_fail("x = CENTER('abc','oops')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "CENTER bad width");
+    run_expect_fail("x = COPIES('ab','bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "COPIES bad count");
+    run_expect_fail("x = JUSTIFY('a b','no')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "JUSTIFY bad width");
+
+    /* Positive whole required */
+    run_expect_fail("x = SUBSTR('abc',0)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE, "SUBSTR zero start");
+    run_expect_fail("x = WORD('a b c',0)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE, "WORD zero index");
+    run_expect_fail("x = WORDINDEX('a b',0)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE, "WORDINDEX zero");
+    run_expect_fail("x = WORDLENGTH('a b',-2)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE, "WORDLENGTH negative");
+    run_expect_fail("x = SUBWORD('a b c',0)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE, "SUBWORD zero");
+    run_expect_fail("x = DELSTR('abc',0)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE, "DELSTR zero");
+    run_expect_fail("x = DELWORD('a b c',0)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE, "DELWORD zero");
+
+    /* Optional-whole validation path */
+    run_expect_fail("x = POS('a','abc','bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "POS bad start");
+    run_expect_fail("x = LASTPOS('a','abc','x')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "LASTPOS bad start");
+    run_expect_fail("x = INDEX('abc','a','bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "INDEX bad start");
+    run_expect_fail("x = WORDPOS('a','a b','bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "WORDPOS bad start");
+    run_expect_fail("x = INSERT('X','abc','bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "INSERT bad pos");
+    run_expect_fail("x = OVERLAY('X','abc','bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "OVERLAY bad pos");
+    run_expect_fail("x = ABBREV('program','prog','bad')\n",
+                    SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE,
+                    "ABBREV bad min");
+
+    /* Single-char validation (pad args) */
+    run_expect_fail("x = SPACE('a b',1,'ab')\n", SYNTAX_BAD_CALL,
+                    ERR40_SINGLE_CHAR, "SPACE bad pad");
+    run_expect_fail("x = TRANSLATE('abc','x','y','ab')\n",
+                    SYNTAX_BAD_CALL, ERR40_SINGLE_CHAR,
+                    "TRANSLATE bad pad");
+    run_expect_fail("x = COMPARE('a','b','ab')\n", SYNTAX_BAD_CALL,
+                    ERR40_SINGLE_CHAR, "COMPARE bad pad");
+    run_expect_fail("x = XRANGE('ab')\n", SYNTAX_BAD_CALL,
+                    ERR40_SINGLE_CHAR, "XRANGE multi-char");
+
+    /* Option validation */
+    run_expect_fail("x = STRIP('abc','X')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID, "STRIP bad option");
+    run_expect_fail("x = VERIFY('abc','abc','X')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID, "VERIFY bad option");
+}
+
+int main(void)
+{
+    printf("=== WP-21a: String BIFs ===\n");
+    test_phase_b();
+    test_phase_c();
+    test_phase_d();
+    test_phase_e();
+    test_phase_f();
+    test_error_paths();
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -413,6 +413,61 @@ static void test_error_paths(void)
                     ERR40_OPTION_INVALID, "VERIFY bad option");
 }
 
+/* FIND has a hard implementation cap on the phrase argument. Exceeding
+ * it must raise SYNTAX 40.4 (ERR40_ARG_LENGTH) rather than silently
+ * returning 0 (which would look like a legitimate "not found"). */
+static void test_find_phrase_cap(void)
+{
+    printf("\n--- FIND phrase-length cap ---\n");
+
+    /* Build a REXX expression of the form
+     *    x = FIND('a', 'w1 w2 w3 ... wN')
+     * where N = 1050 > FIND_MAX_WORDS (1024). 5-byte tokens at most,
+     * so a ~7 KB source buffer is sufficient. */
+    const int num_words = 1050;
+    size_t buflen = 64 + (size_t)num_words * 6;
+    char *buf = (char *)malloc(buflen);
+    if (buf == NULL)
+    {
+        CHECK(0, "malloc for FIND cap source");
+        return;
+    }
+    size_t off = 0;
+    off += (size_t)sprintf(buf + off, "x = FIND('a','");
+    for (int i = 0; i < num_words; i++)
+    {
+        off += (size_t)sprintf(buf + off, "%sw%d",
+                               (i == 0) ? "" : " ", i);
+    }
+    off += (size_t)sprintf(buf + off, "')\n");
+
+    struct fixture fx;
+    if (fixture_open(&fx) != 0)
+    {
+        free(buf);
+        CHECK(0, "fixture_open FIND cap");
+        return;
+    }
+    int rc = run_src(&fx, buf);
+    struct irx_wkblk_int *wk =
+        (struct irx_wkblk_int *)fx.env->envblock_userfield;
+    int code = 0;
+    int subcode = 0;
+    if (wk != NULL && wk->wkbi_last_condition != NULL &&
+        wk->wkbi_last_condition->valid)
+    {
+        code = wk->wkbi_last_condition->code;
+        subcode = wk->wkbi_last_condition->subcode;
+    }
+    CHECK(rc != IRXPARS_OK, "FIND >cap: parser reports error");
+    CHECK(code == SYNTAX_BAD_CALL,
+          "FIND >cap: condition code is SYNTAX 40");
+    CHECK(subcode == ERR40_ARG_LENGTH,
+          "FIND >cap: subcode is ERR40_ARG_LENGTH (40.4)");
+    fixture_close(&fx);
+    free(buf);
+}
+
 int main(void)
 {
     printf("=== WP-21a: String BIFs ===\n");
@@ -422,6 +477,7 @@ int main(void)
     test_phase_e();
     test_phase_f();
     test_error_paths();
+    test_find_phrase_cap();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);

--- a/test/test_parser.c
+++ b/test/test_parser.c
@@ -21,6 +21,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "irx.h"
+#include "irxfunc.h"
 #include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
@@ -70,11 +72,11 @@ static void set_lstr(struct lstr_alloc *a, PLstr s, const char *c)
     Lscpy(a, s, c);
 }
 
-/* Run a complete REXX source through tokenizer + parser, using the
- * provided (optional) pre-populated variable pool. Returns the final
- * parser return code (IRXPARS_*). */
-static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
-                      const char *src)
+/* Run a complete REXX source through tokenizer + parser, optionally
+ * tied to an ENVBLOCK so BIF dispatch can reach the per-env registry.
+ * Returns the final parser return code (IRXPARS_*). */
+static int run_source_env(struct lstr_alloc *a, struct irx_vpool *pool,
+                          const char *src, struct envblock *env)
 {
     struct irx_token *tokens = NULL;
     int count = 0;
@@ -92,7 +94,7 @@ static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
         return -1;
     }
 
-    rc = irx_pars_init(&parser, tokens, count, pool, a, NULL);
+    rc = irx_pars_init(&parser, tokens, count, pool, a, env);
     if (rc != IRXPARS_OK)
     {
         irx_tokn_free(NULL, tokens, count);
@@ -110,6 +112,12 @@ static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
     irx_pars_cleanup(&parser);
     irx_tokn_free(NULL, tokens, count);
     return rc;
+}
+
+static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
+                      const char *src)
+{
+    return run_source_env(a, pool, src, NULL);
 }
 
 /* Convenience: run_source then vpool_get("X") and compare. */
@@ -256,10 +264,18 @@ static void test_ac8_function_length(void)
 {
     struct lstr_alloc *a = lstr_default_alloc();
     struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+
     printf("\n--- AC#8: x = LENGTH('hello') ---\n");
-    CHECK(run_source(a, pool, "x = LENGTH('hello')\n") == IRXPARS_OK,
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(run_source_env(a, pool, "x = LENGTH('hello')\n", env) ==
+              IRXPARS_OK,
           "parser OK");
     CHECK(get_var_eq(a, pool, "X", "5"), "X = '5'");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
     vpool_destroy(pool);
 }
 


### PR DESCRIPTION
Fixes #25

## Overview

Implements WP-21a end-to-end: the 29 SC28-1883-0 §4 string BIFs plus
the shared BIF registry infrastructure that WP-21b and WP-50 will also
build on.

## What's in this PR

**Phase A — Foundation** (commit 5059d95)
- Rename `irx_arith_raise` → `irx_cond_raise` and extract it into a
  new `src/irx#cond.c` / `include/irxcond.h` pair so other modules can
  raise SYNTAX/ERROR conditions.
- Add SC28-1883-0 Appendix E SYNTAX 40.x subcodes.
- Per-environment BIF registry (`include/irxbif.h`, `src/irx#bif.c`)
  with create / destroy / register / find / register_table plus
  argument-validation helpers.
- `wkbi_bif_registry` slot in the work block; registry allocated in
  `irxinit`, freed in `irxterm`.
- Parser now dispatches function calls through the registry instead
  of a file-static table. `LENGTH` moves to `src/irx#bifs.c`; `ARG`
  stays in the parser (reads `call_args` / `call_argc`) but registers
  itself via `irx_pars_register_core_bifs()`.

**Phase B–F — String BIFs** (commit d22f30e)

| Phase | Functions |
|-------|-----------|
| B | LENGTH, LEFT, RIGHT, SUBSTR, POS, LASTPOS, INDEX |
| C | WORDS, WORD, WORDINDEX, WORDLENGTH, SUBWORD, WORDPOS |
| D | CENTER/CENTRE, STRIP, SPACE, JUSTIFY, COPIES, REVERSE |
| E | INSERT, OVERLAY, DELSTR, DELWORD |
| F | TRANSLATE, VERIFY, COMPARE, ABBREV, XRANGE, FIND |

Most BIFs delegate to existing lstring370 primitives. `JUSTIFY`,
`XRANGE`, and `FIND` are implemented locally.

**Phase G — Tests & docs** (commit 54085d3)
- `test/test_bif.c`: 29 registry unit tests.
- `test/test_bifs.c`: 106 tests — positive outputs plus SYNTAX 40.x
  error paths for every validating BIF.
- `project.toml` updated to include IRX#COND / IRX#BIF / IRX#BIFS in
  the IRXJCL link and the new headers in release artifacts.
- CLAUDE.md and docs/workpackages.md updated.

## Filename note — irx#bifs.c

The issue body uses `src/irx#bifstr.c`, which would be a 10-char PDS
member name. MVS member names are capped at 8; mbt silently truncates
`stem.upper()[:8]`, so `irx#bifstr` would become `IRX#BIFS` anyway. I
named the file `irx#bifs.c` directly so the member mapping is explicit.
Header filenames (`irxbifstr.h`, `irxbif.h`, `irxcond.h`) are unchanged
because they live only on the host side.

## Test results

All 12 test suites on this branch pass — 701 / 701.

```
tokenizer 70   vpool     47   parser   39   say      27
irxlstr   50   control   62   hello    16   parse    74
arith    128   procedure 53   bif      29   bifs    106
```

## Acceptance criteria (from issue #25)

- ✅ `irx_cond_raise()` is the only condition-reporting function name
- ✅ Registry add / lookup / not-found unit tests pass
- ✅ Every validating BIF has at least one positive + one error-path
  test (non-validating BIFs — LENGTH, WORDS, REVERSE, FIND — have
  positive-only tests as their only arg is a string)
- ✅ Full prior test suite still green, no regressions
- ✅ Cross-compile build succeeds with `-Wall -Wextra -std=gnu99`