### PR TITLE
WP-21b Phase B: IRXARITH string-oriented helpers

### DIFF
--- a/include/irxarith.h
+++ b/include/irxarith.h
@@ -114,15 +114,20 @@ int irx_arith_trunc(struct envblock *env,
 
 /* FORMAT(number [, before [, after [, expp [, expt]]]]): SC28-1883-0
  * §4 FORMAT built-in. Any of the four integer arguments may be
- * negative to mean "omitted" — callers pass IRX_FORMAT_OMIT (-1) for
- * optional args that were not supplied by the REXX user. When
- * supplied, each integer must be non-negative (negatives raise
+ * set to IRX_FORMAT_OMIT (-1) to mean "not supplied by the user".
+ * When supplied, each integer must be non-negative (negatives raise
  * IRXPARS_SYNTAX inside this routine).
  *
  *   before  width of the integer part (space-padded on the left)
  *   after   fractional digit count (rounded/padded)
  *   expp    exponent digit count (0 forces fixed-point notation)
  *   expt    exponent threshold (|adj_exp| > expt -> exponential)
+ *
+ * Note for the future BIF wrapper (Phase C): the BIF layer must
+ * pre-validate user input and map "argument absent" to
+ * IRX_FORMAT_OMIT before calling this routine — never pass a
+ * negative user-provided value straight through, since that would
+ * look identical to the OMIT sentinel and silently change meaning.
  *
  * Non-zero return codes are IRXPARS_SYNTAX, IRXPARS_OVERFLOW or
  * IRXPARS_NOMEM per the usual convention.

--- a/include/irxarith.h
+++ b/include/irxarith.h
@@ -38,7 +38,8 @@ enum irx_arith_opcode
     ARITH_INTDIV,  /* a % b  (integer division — truncates toward 0)*/
     ARITH_MOD,     /* a // b (remainder — same sign as a)          */
     ARITH_POWER,   /* a ** b (b must be a non-negative integer)    */
-    ARITH_NEG      /* -a     (b must be NULL)                      */
+    ARITH_NEG,     /* -a     (b must be NULL)                      */
+    ARITH_ABS      /* |a|    (b must be NULL)                      */
 };
 
 /* ================================================================== */
@@ -82,5 +83,87 @@ int irx_arith_op(struct envblock *env,
 int irx_arith_compare(struct envblock *env,
                       PLstr a, PLstr b,
                       int *cmp_out) asm("IRXARICM");
+
+/* ================================================================== */
+/*  String-oriented helpers (WP-21b Phase B)                         */
+/*                                                                    */
+/*  These functions extend the IRXARITH public surface with the       */
+/*  building blocks that the numeric and conversion BIFs will need    */
+/*  in later phases. They take and return plain Lstr — struct         */
+/*  irx_number stays internal to irx#arith.c. All signatures use      */
+/*  struct envblock * for consistency with irx_arith_op /             */
+/*  irx_arith_compare; the parser-side wk is reachable through        */
+/*  env->envblock_userfield when needed.                              */
+/* ================================================================== */
+
+/* TRUNC(number, decimals): truncate (no rounding) to exactly
+ * `decimals` fractional digits. Pads trailing zeros when the input
+ * has fewer fractional digits than requested. `decimals` must be
+ * non-negative; negative values produce IRXPARS_SYNTAX.
+ *
+ * Examples:
+ *   TRUNC('12.345', 2)  -> '12.34'
+ *   TRUNC('12.345', 5)  -> '12.34500'    (padded)
+ *   TRUNC('12345',  2)  -> '12345.00'    (padded)
+ *   TRUNC('12.345', 0)  -> '12'          (no decimal point)
+ *   TRUNC('-0.9',   0)  -> '0'           (truncate toward zero)
+ */
+int irx_arith_trunc(struct envblock *env,
+                    PLstr in, long decimals,
+                    PLstr result) asm("IRXARITR");
+
+/* FORMAT(number [, before [, after [, expp [, expt]]]]): SC28-1883-0
+ * §4 FORMAT built-in. Any of the four integer arguments may be
+ * negative to mean "omitted" — callers pass IRX_FORMAT_OMIT (-1) for
+ * optional args that were not supplied by the REXX user. When
+ * supplied, each integer must be non-negative (negatives raise
+ * IRXPARS_SYNTAX inside this routine).
+ *
+ *   before  width of the integer part (space-padded on the left)
+ *   after   fractional digit count (rounded/padded)
+ *   expp    exponent digit count (0 forces fixed-point notation)
+ *   expt    exponent threshold (|adj_exp| > expt -> exponential)
+ *
+ * Non-zero return codes are IRXPARS_SYNTAX, IRXPARS_OVERFLOW or
+ * IRXPARS_NOMEM per the usual convention.
+ */
+#define IRX_FORMAT_OMIT (-1L)
+
+int irx_arith_format(struct envblock *env,
+                     PLstr in,
+                     long before, long after, long expp, long expt,
+                     PLstr result) asm("IRXARIFM");
+
+/* Build a REXX number Lstr from raw BCD input. `digits[0..len-1]`
+ * contains values 0..9 (not ASCII/EBCDIC characters — raw decimal
+ * values). `sign` is 0 (non-negative) or 1 (negative). `exponent`
+ * places the least-significant digit: value = sign * digits * 10^exp
+ * where `digits` is the integer formed by concatenating the byte
+ * values. Empty input (len == 0) is treated as zero.
+ *
+ * The result is normalized (leading / trailing zero stripped) and
+ * rendered via the same formatter used by irx_arith_op, honouring
+ * the current NUMERIC DIGITS and NUMERIC FORM settings.
+ */
+int irx_arith_from_digits(struct envblock *env,
+                          const char *digits, int digits_len,
+                          int sign, long exponent,
+                          PLstr result) asm("IRXARIFD");
+
+/* Parse a REXX number Lstr into raw BCD output. The caller supplies
+ * `digits_cap` bytes of scratch; on success `*digits_len` is set to
+ * the number of significant digits written (0..digits_cap). Digits
+ * are raw 0..9 values, MSB first. `*sign`, `*exponent` receive the
+ * same fields as struct irx_number.
+ *
+ * Returns IRXPARS_SYNTAX if `in` is not a valid REXX number, or
+ * IRXPARS_OVERFLOW if the significant-digit count exceeds
+ * `digits_cap`. IRXPARS_NOMEM if the internal parse buffer cannot
+ * be allocated.
+ */
+int irx_arith_to_digits(struct envblock *env,
+                        PLstr in,
+                        char *digits, int digits_cap, int *digits_len,
+                        int *sign, long *exponent) asm("IRXARITD");
 
 #endif /* IRXARITH_H */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -38,13 +38,18 @@
 /*  Return codes                                                      */
 /* ================================================================== */
 
-#define IRXPARS_OK      0
-#define IRXPARS_SYNTAX  20 /* generic SYNTAX error               */
-#define IRXPARS_NOMEM   21 /* allocator failure                  */
-#define IRXPARS_NOVALUE 22 /* uninitialised variable (NOVALUE)   */
-#define IRXPARS_DIVZERO 23 /* division by zero                   */
-#define IRXPARS_BADFUNC 24 /* unknown function in call           */
-#define IRXPARS_BADARG  25 /* bad argument to parser entry       */
+#define IRXPARS_OK       0
+#define IRXPARS_SYNTAX   20 /* generic SYNTAX error               */
+#define IRXPARS_NOMEM    21 /* allocator failure                  */
+#define IRXPARS_NOVALUE  22 /* uninitialised variable (NOVALUE)   */
+#define IRXPARS_DIVZERO  23 /* division by zero                   */
+#define IRXPARS_BADFUNC  24 /* unknown function in call           */
+#define IRXPARS_BADARG   25 /* bad argument to parser entry       */
+/* Note: value 26 coincides with SYNTAX_OVERFLOW in irxcond.h but the
+ * two live in unrelated namespaces (parser return code vs. REXX
+ * condition subcode). */
+#define IRXPARS_OVERFLOW 26 /* scratch buffer too small or value  */
+                            /* exceeds representable range         */
 
 /* ================================================================== */
 /*  Parser context                                                    */

--- a/include/irxpars.h
+++ b/include/irxpars.h
@@ -45,11 +45,12 @@
 #define IRXPARS_DIVZERO  23 /* division by zero                   */
 #define IRXPARS_BADFUNC  24 /* unknown function in call           */
 #define IRXPARS_BADARG   25 /* bad argument to parser entry       */
-/* Note: value 26 coincides with SYNTAX_OVERFLOW in irxcond.h but the
- * two live in unrelated namespaces (parser return code vs. REXX
+/* 26 intentionally skipped: SYNTAX_OVERFLOW = 26 in irxcond.h and
+ * we avoid the numeric coincidence even though the two constants
+ * live in unrelated namespaces (parser return code vs. REXX
  * condition subcode). */
-#define IRXPARS_OVERFLOW 26 /* scratch buffer too small or value  */
-                            /* exceeds representable range         */
+#define IRXPARS_OVERFLOW 27 /* scratch buffer too small, or value */
+                            /* exceeds representable range        */
 
 /* ================================================================== */
 /*  Parser context                                                    */

--- a/src/irx#arith.c
+++ b/src/irx#arith.c
@@ -1537,8 +1537,9 @@ static int num_grow(struct envblock *env, struct irx_number *n, int min_cap)
 }
 
 /* Pad n with trailing zeros (never touches the coefficient's leading
- * digits) until n->exp == target_exp. Caller guarantees target_exp <=
- * n->exp, otherwise this function no-ops. Returns -1 on OOM. */
+ * digits) until n->exp == target_exp. When target_exp >= n->exp the
+ * function is a no-op — it is safe to call without checking. Returns
+ * -1 on OOM. */
 static int num_pad_to_exp(struct envblock *env, struct irx_number *n,
                           int target_exp)
 {
@@ -1560,8 +1561,9 @@ static int num_pad_to_exp(struct envblock *env, struct irx_number *n,
 }
 
 /* Truncate n toward zero so that n->exp == target_exp. Any digits
- * below position 10^target_exp are discarded (no rounding). Caller
- * guarantees target_exp >= n->exp. */
+ * below position 10^target_exp are discarded (no rounding). When
+ * target_exp <= n->exp the function is a no-op — it is safe to call
+ * without checking. */
 static void num_truncate_to_exp(struct irx_number *n, int target_exp)
 {
     int drop;
@@ -1992,21 +1994,65 @@ int irx_arith_format(struct envblock *env, PLstr in,
         use_fixed = 1;
     }
 
-    /* Allocate working buffers. Size upper-bounded by digits rendered
-     * plus padding plus exponent. */
-    maxbuf = n.len + 64;
-    if (before != IRX_FORMAT_OMIT)
+    /* Reject fixed-point requests whose integer part would exceed
+     * NUMERIC_DIGITS_MAX digits — otherwise a pathological input such
+     * as FORMAT('1E999999999', ,,0) would try to allocate multiple
+     * gigabytes of scratch buffer. The cap matches NUMERIC DIGITS's
+     * own upper bound, which is already the tightest constraint in
+     * REXX/370's arithmetic subsystem. */
+    if (use_fixed)
     {
-        maxbuf += (int)before;
+        long potential_int_digits = (long)n.exp + (long)n.len;
+        if (potential_int_digits < 1)
+        {
+            potential_int_digits = 1; /* "0" for purely fractional */
+        }
+        if (potential_int_digits > NUMERIC_DIGITS_MAX)
+        {
+            num_free(env, &n);
+            return IRXPARS_SYNTAX;
+        }
     }
-    if (after != IRX_FORMAT_OMIT)
+
+    /* Size the working buffers based on the actual rendered layout
+     * rather than a fixed constant: the int_part buffer in particular
+     * must be able to hold every integer digit plus sign, or the
+     * format loop below would overrun. */
     {
-        maxbuf += (int)after;
+        int int_digits_max;
+        int frac_digits_max;
+        int exp_digits_max;
+
+        if (use_fixed)
+        {
+            int tmp = n.exp + n.len;
+            int_digits_max = (tmp > 1) ? tmp : 1; /* at least the "0" */
+            frac_digits_max =
+                (after != IRX_FORMAT_OMIT)
+                    ? (int)after
+                    : ((n.exp < 0) ? -n.exp : 0);
+            exp_digits_max = 0;
+        }
+        else
+        {
+            /* Exponential form: exactly one integer digit. */
+            int_digits_max = 1;
+            frac_digits_max = (after != IRX_FORMAT_OMIT)
+                                  ? (int)after
+                                  : ((n.len > 1) ? n.len - 1 : 0);
+            exp_digits_max =
+                (expp != IRX_FORMAT_OMIT) ? (int)expp : 11; /* "E+" + 10 digits */
+        }
+
+        /* Sign + int_digits + '.' + frac_digits + 'E' + sign + exp + slack. */
+        maxbuf = 1 + int_digits_max + 1 + frac_digits_max + 2 +
+                 exp_digits_max + 8;
+        if (before != IRX_FORMAT_OMIT && (int)before > int_digits_max + 1)
+        {
+            maxbuf += (int)before; /* leading space padding */
+        }
     }
-    if (expp != IRX_FORMAT_OMIT)
-    {
-        maxbuf += (int)expp;
-    }
+
     if (irxstor(RXSMGET, maxbuf, &pbuf, env) != 0)
     {
         num_free(env, &n);
@@ -2030,23 +2076,14 @@ int irx_arith_format(struct envblock *env, PLstr in,
 
     if (use_fixed)
     {
-        int target_exp = (after != IRX_FORMAT_OMIT) ? -(int)after : n.exp;
-        if (target_exp > n.exp)
-        {
-            num_truncate_to_exp(&n, target_exp);
-        }
-        else if (target_exp < n.exp)
-        {
-            if (num_pad_to_exp(env, &n, target_exp) != 0)
-            {
-                goto oom;
-            }
-        }
-        frac_digits_wanted = -target_exp;
-        if (frac_digits_wanted < 0)
-        {
-            frac_digits_wanted = 0;
-        }
+        /* When `after` was supplied we already normalized n to
+         * n.exp == -after above; when it was omitted n.exp is the
+         * authoritative fractional count. Either way there is no more
+         * padding/truncation to do here. */
+        frac_digits_wanted =
+            (after != IRX_FORMAT_OMIT)
+                ? (int)after
+                : ((n.exp < 0) ? -n.exp : 0);
     }
     else
     {
@@ -2099,35 +2136,55 @@ int irx_arith_format(struct envblock *env, PLstr in,
         }
     }
 
-    /* Build the integer-part buffer (without leading sign padding). */
-    if (use_fixed)
+    /* Build the integer-part buffer (without leading sign padding).
+     * The magnitude cap above guarantees int_len stays below int_cap
+     * (== maxbuf), but we still bound every write as defense-in-depth
+     * so a future caller that passes an unchecked exponent cannot
+     * overrun the scratch buffer. */
     {
-        int int_digits = n.len + n.exp;
-        if (n.sign && !(n.len == 1 && n.digits[0] == 0))
+        int int_cap = maxbuf;
+
+        if (use_fixed)
         {
-            int_part[int_len++] = '-';
-        }
-        if (int_digits <= 0)
-        {
-            int_part[int_len++] = '0';
+            int int_digits = n.len + n.exp;
+            if (n.sign && !(n.len == 1 && n.digits[0] == 0) &&
+                int_len < int_cap)
+            {
+                int_part[int_len++] = '-';
+            }
+            if (int_digits <= 0)
+            {
+                if (int_len < int_cap)
+                {
+                    int_part[int_len++] = '0';
+                }
+            }
+            else
+            {
+                for (i = 0; i < int_digits && int_len < int_cap; i++)
+                {
+                    int_part[int_len++] =
+                        (i < n.len) ? (char)('0' + n.digits[i]) : '0';
+                }
+                if (i < int_digits)
+                {
+                    goto format_syntax; /* must not happen given the cap */
+                }
+            }
         }
         else
         {
-            for (i = 0; i < int_digits; i++)
+            /* Exponential: exactly one integer digit (the leading one). */
+            if (n.sign && !(n.len == 1 && n.digits[0] == 0) &&
+                int_len < int_cap)
             {
-                int_part[int_len++] =
-                    (i < n.len) ? (char)('0' + n.digits[i]) : '0';
+                int_part[int_len++] = '-';
+            }
+            if (int_len < int_cap)
+            {
+                int_part[int_len++] = (char)('0' + n.digits[0]);
             }
         }
-    }
-    else
-    {
-        /* Exponential: exactly one integer digit (the leading one). */
-        if (n.sign && !(n.len == 1 && n.digits[0] == 0))
-        {
-            int_part[int_len++] = '-';
-        }
-        int_part[int_len++] = (char)('0' + n.digits[0]);
     }
 
     /* Compute `before` field width and validate. */

--- a/src/irx#arith.c
+++ b/src/irx#arith.c
@@ -1203,7 +1203,7 @@ int irx_arith_op(struct envblock *env,
         return IRXPARS_SYNTAX;
     }
 
-    if (op != ARITH_NEG)
+    if (op != ARITH_NEG && op != ARITH_ABS)
     {
         if (b == NULL || lstr_to_num(env, b, &nb) != 0)
         {
@@ -1355,6 +1355,21 @@ int irx_arith_op(struct envblock *env,
             ret = 0;
             break;
         }
+        case ARITH_ABS:
+        {
+            /* Copy na into nr, clear sign */
+            if (num_alloc(env, na.len, &nr) != 0)
+            {
+                num_free(env, &na);
+                return IRXPARS_NOMEM;
+            }
+            memcpy(nr.digits, na.digits, (size_t)na.len);
+            nr.len = na.len;
+            nr.exp = na.exp;
+            nr.sign = 0;
+            ret = 0;
+            break;
+        }
         default:
             num_free(env, &na);
             num_free(env, &nb);
@@ -1486,5 +1501,907 @@ int irx_arith_compare(struct envblock *env,
     num_free(env, &na);
     num_free(env, &nb);
     num_free(env, &diff);
+    return IRXPARS_OK;
+}
+
+/* ================================================================== */
+/*  WP-21b Phase B: string-oriented helpers                          */
+/*                                                                    */
+/*  The helpers below expose BCD operations that REXX BIFs need       */
+/*  without forcing callers to know the internal struct irx_number    */
+/*  layout.                                                           */
+/* ================================================================== */
+
+/* Grow n->digits in-place to at least `min_cap` bytes. */
+static int num_grow(struct envblock *env, struct irx_number *n, int min_cap)
+{
+    void *newp = NULL;
+    void *oldp;
+    int newcap;
+
+    if (n->cap >= min_cap)
+    {
+        return 0;
+    }
+    newcap = min_cap + 8;
+    if (irxstor(RXSMGET, newcap, &newp, env) != 0)
+    {
+        return -1;
+    }
+    memcpy(newp, n->digits, (size_t)n->len);
+    oldp = n->digits;
+    irxstor(RXSMFRE, n->cap, &oldp, env);
+    n->digits = (unsigned char *)newp;
+    n->cap = newcap;
+    return 0;
+}
+
+/* Pad n with trailing zeros (never touches the coefficient's leading
+ * digits) until n->exp == target_exp. Caller guarantees target_exp <=
+ * n->exp, otherwise this function no-ops. Returns -1 on OOM. */
+static int num_pad_to_exp(struct envblock *env, struct irx_number *n,
+                          int target_exp)
+{
+    int pad;
+
+    if (n->exp <= target_exp)
+    {
+        return 0;
+    }
+    pad = n->exp - target_exp;
+    if (num_grow(env, n, n->len + pad) != 0)
+    {
+        return -1;
+    }
+    memset(n->digits + n->len, 0, (size_t)pad);
+    n->len += pad;
+    n->exp = target_exp;
+    return 0;
+}
+
+/* Truncate n toward zero so that n->exp == target_exp. Any digits
+ * below position 10^target_exp are discarded (no rounding). Caller
+ * guarantees target_exp >= n->exp. */
+static void num_truncate_to_exp(struct irx_number *n, int target_exp)
+{
+    int drop;
+    int all_zero;
+    int i;
+
+    if (n->exp >= target_exp)
+    {
+        return;
+    }
+    drop = target_exp - n->exp;
+    if (drop >= n->len)
+    {
+        n->digits[0] = 0;
+        n->len = 1;
+        n->sign = 0;
+        n->exp = 0;
+        return;
+    }
+    n->len -= drop;
+    n->exp = target_exp;
+
+    all_zero = 1;
+    for (i = 0; i < n->len; i++)
+    {
+        if (n->digits[i] != 0)
+        {
+            all_zero = 0;
+            break;
+        }
+    }
+    if (all_zero)
+    {
+        n->digits[0] = 0;
+        n->len = 1;
+        n->sign = 0;
+        n->exp = 0;
+    }
+}
+
+/* Round n half-up so that n->exp == target_exp. Grows the buffer if
+ * rounding overflows the leading digit. Returns -1 on OOM. */
+static int num_round_to_exp(struct envblock *env, struct irx_number *n,
+                            int target_exp)
+{
+    int drop;
+    int round_up;
+    int i;
+    int all_zero;
+
+    if (n->exp >= target_exp)
+    {
+        return 0;
+    }
+    drop = target_exp - n->exp;
+
+    if (drop >= n->len)
+    {
+        /* Everything is below the target — at most one digit of rounding
+         * survives, and only when drop == n->len and the leading digit
+         * was >= 5. */
+        round_up = (drop == n->len && n->digits[0] >= 5) ? 1 : 0;
+        n->digits[0] = (unsigned char)round_up;
+        n->len = 1;
+        n->exp = target_exp;
+        if (!round_up)
+        {
+            n->sign = 0;
+        }
+        return 0;
+    }
+
+    round_up = (n->digits[n->len - drop] >= 5) ? 1 : 0;
+    n->len -= drop;
+    n->exp = target_exp;
+
+    if (round_up)
+    {
+        int carry = 1;
+        for (i = n->len - 1; i >= 0 && carry; i--)
+        {
+            n->digits[i]++;
+            if (n->digits[i] < 10)
+            {
+                carry = 0;
+            }
+            else
+            {
+                n->digits[i] = 0;
+            }
+        }
+        if (carry)
+        {
+            /* e.g. 9999 + 1 -> 10000: prepend a leading 1, shift. */
+            if (num_grow(env, n, n->len + 1) != 0)
+            {
+                return -1;
+            }
+            memmove(n->digits + 1, n->digits, (size_t)n->len);
+            n->digits[0] = 1;
+            n->len++;
+        }
+    }
+
+    all_zero = 1;
+    for (i = 0; i < n->len; i++)
+    {
+        if (n->digits[i] != 0)
+        {
+            all_zero = 0;
+            break;
+        }
+    }
+    if (all_zero)
+    {
+        n->digits[0] = 0;
+        n->len = 1;
+        n->sign = 0;
+        n->exp = 0;
+    }
+    return 0;
+}
+
+/* Emit n in fixed-point with exactly `decimals` fractional digits.
+ * Precondition: num_pad_to_exp / num_truncate_to_exp have been used so
+ * that n->exp == -decimals or n is the canonical zero. */
+static int num_emit_fixed(const struct irx_number *n, int decimals,
+                          char *buf, int maxbuf)
+{
+    int pos = 0;
+    int int_digits;
+    int i;
+
+    if (n->len == 1 && n->digits[0] == 0)
+    {
+        if (pos < maxbuf - 1)
+        {
+            buf[pos++] = '0';
+        }
+        if (decimals > 0 && pos < maxbuf - 1)
+        {
+            buf[pos++] = '.';
+            for (i = 0; i < decimals && pos < maxbuf - 1; i++)
+            {
+                buf[pos++] = '0';
+            }
+        }
+        buf[pos] = '\0';
+        return pos;
+    }
+
+    if (n->sign && pos < maxbuf - 1)
+    {
+        buf[pos++] = '-';
+    }
+
+    int_digits = n->len + n->exp; /* digits before decimal point */
+    if (int_digits <= 0)
+    {
+        /* Purely fractional: "0.<leading-zeros><digits>". */
+        int leading_zeros = -int_digits;
+        if (pos < maxbuf - 1)
+        {
+            buf[pos++] = '0';
+        }
+        if (decimals > 0 && pos < maxbuf - 1)
+        {
+            buf[pos++] = '.';
+            for (i = 0; i < leading_zeros && pos < maxbuf - 1; i++)
+            {
+                buf[pos++] = '0';
+            }
+            for (i = 0; i < n->len && pos < maxbuf - 1; i++)
+            {
+                buf[pos++] = (char)('0' + n->digits[i]);
+            }
+        }
+    }
+    else
+    {
+        for (i = 0; i < int_digits && pos < maxbuf - 1; i++)
+        {
+            char d = (i < n->len) ? (char)('0' + n->digits[i]) : '0';
+            buf[pos++] = d;
+        }
+        if (decimals > 0 && pos < maxbuf - 1)
+        {
+            buf[pos++] = '.';
+            for (i = int_digits; i < n->len && pos < maxbuf - 1; i++)
+            {
+                buf[pos++] = (char)('0' + n->digits[i]);
+            }
+        }
+    }
+
+    buf[pos] = '\0';
+    return pos;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public: irx_arith_trunc                                           */
+/* ------------------------------------------------------------------ */
+
+int irx_arith_trunc(struct envblock *env, PLstr in, long decimals,
+                    PLstr result)
+{
+    struct irx_number n;
+    struct lstr_alloc *alloc;
+    void *pbuf = NULL;
+    char *buf;
+    int maxbuf;
+    int slen;
+    int rc;
+
+    if (decimals < 0 || decimals > NUMERIC_DIGITS_MAX)
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    n.digits = NULL;
+    n.cap = n.len = n.sign = n.exp = 0;
+    if (lstr_to_num(env, in, &n) != 0)
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    num_truncate_to_exp(&n, -(int)decimals);
+    if (num_pad_to_exp(env, &n, -(int)decimals) != 0)
+    {
+        num_free(env, &n);
+        return IRXPARS_NOMEM;
+    }
+
+    alloc = irx_lstr_init(env);
+    if (alloc == NULL)
+    {
+        alloc = lstr_default_alloc();
+    }
+
+    maxbuf = n.len + (int)decimals + 16;
+    if (irxstor(RXSMGET, maxbuf, &pbuf, env) != 0)
+    {
+        num_free(env, &n);
+        return IRXPARS_NOMEM;
+    }
+    buf = (char *)pbuf;
+
+    slen = num_emit_fixed(&n, (int)decimals, buf, maxbuf);
+
+    rc = Lfx(alloc, result, (size_t)slen);
+    if (rc == LSTR_OK)
+    {
+        if (slen > 0)
+        {
+            memcpy(result->pstr, buf, (size_t)slen);
+        }
+        result->len = (size_t)slen;
+        result->type = LSTRING_TY;
+    }
+
+    irxstor(RXSMFRE, maxbuf, &pbuf, env);
+    num_free(env, &n);
+    return (rc == LSTR_OK) ? IRXPARS_OK : IRXPARS_NOMEM;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public: irx_arith_format                                          */
+/*                                                                    */
+/*  SC28-1883-0 §4 FORMAT built-in. Four optional integer arguments — */
+/*  callers pass IRX_FORMAT_OMIT (-1) for omitted ones.               */
+/* ------------------------------------------------------------------ */
+
+/* Write `edigits` expressed in decimal into `buf`, zero-padded to at
+ * least `minw` characters. Returns the number of characters written. */
+static int emit_exponent_digits(int edigits, int minw, char *buf, int maxbuf)
+{
+    char tmp[12];
+    int n = 0;
+    int i;
+    int pad;
+    int pos = 0;
+
+    if (edigits == 0)
+    {
+        tmp[n++] = '0';
+    }
+    else
+    {
+        int t = edigits;
+        while (t > 0 && n < (int)sizeof(tmp))
+        {
+            tmp[n++] = (char)('0' + t % 10);
+            t /= 10;
+        }
+    }
+    pad = (minw > n) ? minw - n : 0;
+    for (i = 0; i < pad && pos < maxbuf - 1; i++)
+    {
+        buf[pos++] = '0';
+    }
+    for (i = n - 1; i >= 0 && pos < maxbuf - 1; i--)
+    {
+        buf[pos++] = tmp[i];
+    }
+    return pos;
+}
+
+/* Count decimal digits of a non-negative int. */
+static int dec_width(int v)
+{
+    int w = 0;
+    if (v == 0)
+    {
+        return 1;
+    }
+    while (v > 0)
+    {
+        w++;
+        v /= 10;
+    }
+    return w;
+}
+
+int irx_arith_format(struct envblock *env, PLstr in,
+                     long before, long after, long expp, long expt,
+                     PLstr result)
+{
+    struct irx_number n;
+    struct lstr_alloc *alloc;
+    int digits, fuzz, form;
+    int adj;
+    int use_fixed;
+    void *pbuf = NULL;
+    char *buf;
+    int maxbuf;
+    int pos = 0;
+    int rc;
+    char *int_part;
+    int int_len;
+    int frac_digits_wanted;
+    int int_field_width;
+    int pad_spaces;
+    int exponent_val = 0;
+    int i;
+
+    if ((before != IRX_FORMAT_OMIT && before < 0) ||
+        (after != IRX_FORMAT_OMIT && after < 0) ||
+        (expp != IRX_FORMAT_OMIT && expp < 0) ||
+        (expt != IRX_FORMAT_OMIT && expt < 0))
+    {
+        return IRXPARS_SYNTAX;
+    }
+    /* Sanity bounds so we never try to allocate astronomically large
+     * scratch space. These match the intent of NUMERIC DIGITS_MAX. */
+    if ((before != IRX_FORMAT_OMIT && before > NUMERIC_DIGITS_MAX) ||
+        (after != IRX_FORMAT_OMIT && after > NUMERIC_DIGITS_MAX) ||
+        (expp != IRX_FORMAT_OMIT && expp > NUMERIC_DIGITS_MAX) ||
+        (expt != IRX_FORMAT_OMIT && expt > NUMERIC_DIGITS_MAX))
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    n.digits = NULL;
+    n.cap = n.len = n.sign = n.exp = 0;
+    if (lstr_to_num(env, in, &n) != 0)
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    get_numeric(env, &digits, &fuzz, &form);
+
+    /* Round to NUMERIC DIGITS first (as irx_arith_op would). */
+    num_round(&n, digits);
+
+    /* Apply `after` — exactly that many fractional digits. */
+    if (after != IRX_FORMAT_OMIT)
+    {
+        int target_exp = -(int)after;
+        if (n.exp < target_exp)
+        {
+            if (num_round_to_exp(env, &n, target_exp) != 0)
+            {
+                num_free(env, &n);
+                return IRXPARS_NOMEM;
+            }
+        }
+        else
+        {
+            if (num_pad_to_exp(env, &n, target_exp) != 0)
+            {
+                num_free(env, &n);
+                return IRXPARS_NOMEM;
+            }
+        }
+    }
+    else
+    {
+        /* No `after`: strip trailing zeros (normal REXX canonical form). */
+        num_strip_trailing(&n);
+    }
+
+    /* Decide fixed vs exponential. */
+    adj = n.exp + n.len - 1;
+    if (expp == 0)
+    {
+        use_fixed = 1;
+    }
+    else if (expt != IRX_FORMAT_OMIT)
+    {
+        int aadj = adj < 0 ? -adj : adj;
+        use_fixed = (aadj <= (int)expt);
+    }
+    else if (expp != IRX_FORMAT_OMIT)
+    {
+        /* expp supplied, expt not: default expt = NUMERIC DIGITS. */
+        int aadj = adj < 0 ? -adj : adj;
+        use_fixed = (aadj <= digits);
+    }
+    else
+    {
+        /* Neither supplied: standard form rule. */
+        use_fixed = (adj >= IRX_FIXED_POINT_MIN_EXP && adj <= digits);
+    }
+
+    /* Never consider "0" as exponential regardless of flags. */
+    if (n.len == 1 && n.digits[0] == 0)
+    {
+        use_fixed = 1;
+    }
+
+    /* Allocate working buffers. Size upper-bounded by digits rendered
+     * plus padding plus exponent. */
+    maxbuf = n.len + 64;
+    if (before != IRX_FORMAT_OMIT)
+    {
+        maxbuf += (int)before;
+    }
+    if (after != IRX_FORMAT_OMIT)
+    {
+        maxbuf += (int)after;
+    }
+    if (expp != IRX_FORMAT_OMIT)
+    {
+        maxbuf += (int)expp;
+    }
+    if (irxstor(RXSMGET, maxbuf, &pbuf, env) != 0)
+    {
+        num_free(env, &n);
+        return IRXPARS_NOMEM;
+    }
+    buf = (char *)pbuf;
+
+    /* Allocate scratch for the integer part. */
+    {
+        void *ip = NULL;
+        int int_cap = maxbuf;
+        if (irxstor(RXSMGET, int_cap, &ip, env) != 0)
+        {
+            irxstor(RXSMFRE, maxbuf, &pbuf, env);
+            num_free(env, &n);
+            return IRXPARS_NOMEM;
+        }
+        int_part = (char *)ip;
+    }
+    int_len = 0;
+
+    if (use_fixed)
+    {
+        int target_exp = (after != IRX_FORMAT_OMIT) ? -(int)after : n.exp;
+        if (target_exp > n.exp)
+        {
+            num_truncate_to_exp(&n, target_exp);
+        }
+        else if (target_exp < n.exp)
+        {
+            if (num_pad_to_exp(env, &n, target_exp) != 0)
+            {
+                goto oom;
+            }
+        }
+        frac_digits_wanted = -target_exp;
+        if (frac_digits_wanted < 0)
+        {
+            frac_digits_wanted = 0;
+        }
+    }
+    else
+    {
+        /* Exponential form. Shift so exactly one digit sits before the
+         * decimal point, remaining digits are fractional, and the
+         * adjusted exponent is preserved. */
+        exponent_val = adj;
+
+        /* After this block, n.digits[0] is the single integer digit
+         * and n.digits[1..] are the fractional digits. n.exp / n.len
+         * are left untouched; we work with the raw digits array. */
+        if (after != IRX_FORMAT_OMIT)
+        {
+            /* Restrict to 1 + after significant digits total. */
+            long want_sig = (long)1 + after;
+            if (want_sig < (long)n.len)
+            {
+                /* Round */
+                int target_exp_for_round = (int)((long)adj - after);
+                if (num_round_to_exp(env, &n, target_exp_for_round) != 0)
+                {
+                    goto oom;
+                }
+                /* Rounding may have changed adj by +1 (e.g. 9.99 ->
+                 * 10.0). Recompute. */
+                adj = n.exp + n.len - 1;
+                exponent_val = adj;
+            }
+            else
+            {
+                /* Pad fractional part to 1 + after digits by appending
+                 * trailing zeros to the coefficient. */
+                int pad = (int)(want_sig - (long)n.len);
+                if (pad > 0)
+                {
+                    if (num_grow(env, &n, n.len + pad) != 0)
+                    {
+                        goto oom;
+                    }
+                    memset(n.digits + n.len, 0, (size_t)pad);
+                    n.len += pad;
+                }
+            }
+            frac_digits_wanted = (int)after;
+        }
+        else
+        {
+            /* Natural form: leading digit + whatever follows. */
+            frac_digits_wanted = n.len - 1;
+        }
+    }
+
+    /* Build the integer-part buffer (without leading sign padding). */
+    if (use_fixed)
+    {
+        int int_digits = n.len + n.exp;
+        if (n.sign && !(n.len == 1 && n.digits[0] == 0))
+        {
+            int_part[int_len++] = '-';
+        }
+        if (int_digits <= 0)
+        {
+            int_part[int_len++] = '0';
+        }
+        else
+        {
+            for (i = 0; i < int_digits; i++)
+            {
+                int_part[int_len++] =
+                    (i < n.len) ? (char)('0' + n.digits[i]) : '0';
+            }
+        }
+    }
+    else
+    {
+        /* Exponential: exactly one integer digit (the leading one). */
+        if (n.sign && !(n.len == 1 && n.digits[0] == 0))
+        {
+            int_part[int_len++] = '-';
+        }
+        int_part[int_len++] = (char)('0' + n.digits[0]);
+    }
+
+    /* Compute `before` field width and validate. */
+    if (before != IRX_FORMAT_OMIT)
+    {
+        int_field_width = (int)before;
+        if (int_len > int_field_width)
+        {
+            /* Spec: padding cannot chop meaningful digits — SYNTAX. */
+            goto format_syntax;
+        }
+        pad_spaces = int_field_width - int_len;
+    }
+    else
+    {
+        int_field_width = int_len;
+        pad_spaces = 0;
+    }
+
+    /* Emit: left-pad spaces + int_part + '.' + fractional + exp suffix */
+    pos = 0;
+    for (i = 0; i < pad_spaces && pos < maxbuf - 1; i++)
+    {
+        buf[pos++] = ' ';
+    }
+    for (i = 0; i < int_len && pos < maxbuf - 1; i++)
+    {
+        buf[pos++] = int_part[i];
+    }
+
+    if (frac_digits_wanted > 0 && pos < maxbuf - 1)
+    {
+        int frac_start;
+        int k;
+
+        buf[pos++] = '.';
+
+        if (use_fixed)
+        {
+            int int_digits = n.len + n.exp;
+            if (int_digits < 0)
+            {
+                /* Leading zeros in fractional part, then all coefficient
+                 * digits. */
+                for (k = 0; k < -int_digits && pos < maxbuf - 1; k++)
+                {
+                    buf[pos++] = '0';
+                }
+                for (k = 0; k < n.len && pos < maxbuf - 1; k++)
+                {
+                    buf[pos++] = (char)('0' + n.digits[k]);
+                }
+            }
+            else
+            {
+                for (k = int_digits; k < n.len && pos < maxbuf - 1; k++)
+                {
+                    buf[pos++] = (char)('0' + n.digits[k]);
+                }
+            }
+            /* `num_pad_to_exp` guarantees we already have enough digits;
+             * no trailing-zero padding needed. */
+        }
+        else
+        {
+            frac_start = 1;
+            for (k = frac_start;
+                 k < frac_start + frac_digits_wanted && pos < maxbuf - 1;
+                 k++)
+            {
+                buf[pos++] = (k < n.len) ? (char)('0' + n.digits[k]) : '0';
+            }
+        }
+    }
+
+    if (!use_fixed)
+    {
+        int abs_exp;
+        int minw;
+        int actual_w;
+
+        if (pos < maxbuf - 1)
+        {
+            buf[pos++] = 'E';
+        }
+        if (exponent_val >= 0)
+        {
+            if (pos < maxbuf - 1)
+            {
+                buf[pos++] = '+';
+            }
+            abs_exp = exponent_val;
+        }
+        else
+        {
+            if (pos < maxbuf - 1)
+            {
+                buf[pos++] = '-';
+            }
+            abs_exp = -exponent_val;
+        }
+        minw = (expp != IRX_FORMAT_OMIT) ? (int)expp : 1;
+        actual_w = dec_width(abs_exp);
+        if (expp != IRX_FORMAT_OMIT && actual_w > minw)
+        {
+            /* Caller restricted exponent width too tightly. */
+            goto format_syntax;
+        }
+        pos += emit_exponent_digits(abs_exp, minw, buf + pos, maxbuf - pos);
+    }
+
+    buf[pos] = '\0';
+
+    alloc = irx_lstr_init(env);
+    if (alloc == NULL)
+    {
+        alloc = lstr_default_alloc();
+    }
+    rc = Lfx(alloc, result, (size_t)pos);
+    if (rc == LSTR_OK)
+    {
+        if (pos > 0)
+        {
+            memcpy(result->pstr, buf, (size_t)pos);
+        }
+        result->len = (size_t)pos;
+        result->type = LSTRING_TY;
+    }
+
+    {
+        void *ip = int_part;
+        irxstor(RXSMFRE, maxbuf, &ip, env);
+    }
+    irxstor(RXSMFRE, maxbuf, &pbuf, env);
+    num_free(env, &n);
+    return (rc == LSTR_OK) ? IRXPARS_OK : IRXPARS_NOMEM;
+
+oom:
+{
+    void *ip = int_part;
+    irxstor(RXSMFRE, maxbuf, &ip, env);
+}
+    irxstor(RXSMFRE, maxbuf, &pbuf, env);
+    num_free(env, &n);
+    return IRXPARS_NOMEM;
+
+format_syntax:
+{
+    void *ip = int_part;
+    irxstor(RXSMFRE, maxbuf, &ip, env);
+}
+    irxstor(RXSMFRE, maxbuf, &pbuf, env);
+    num_free(env, &n);
+    return IRXPARS_SYNTAX;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public: irx_arith_from_digits                                     */
+/* ------------------------------------------------------------------ */
+
+int irx_arith_from_digits(struct envblock *env,
+                          const char *digits, int digits_len,
+                          int sign, long exponent,
+                          PLstr result)
+{
+    struct irx_number n;
+    int dig, fuzz, form;
+    int rc;
+    int i;
+
+    if (digits_len < 0 || (digits_len > 0 && digits == NULL))
+    {
+        return IRXPARS_SYNTAX;
+    }
+    if (sign != 0 && sign != 1)
+    {
+        return IRXPARS_SYNTAX;
+    }
+    if (exponent > INT_MAX || exponent < INT_MIN)
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    n.digits = NULL;
+    n.cap = n.len = n.sign = n.exp = 0;
+
+    /* Canonical zero when the caller passes no digits. */
+    if (digits_len == 0)
+    {
+        if (num_alloc(env, 1, &n) != 0)
+        {
+            return IRXPARS_NOMEM;
+        }
+        n.digits[0] = 0;
+        n.len = 1;
+        n.sign = 0;
+        n.exp = 0;
+    }
+    else
+    {
+        if (num_alloc(env, digits_len, &n) != 0)
+        {
+            return IRXPARS_NOMEM;
+        }
+        for (i = 0; i < digits_len; i++)
+        {
+            unsigned char d = (unsigned char)digits[i];
+            if (d > 9)
+            {
+                num_free(env, &n);
+                return IRXPARS_SYNTAX;
+            }
+            n.digits[i] = d;
+        }
+        n.len = digits_len;
+        n.sign = sign;
+        n.exp = (int)exponent;
+
+        num_strip_leading(&n);
+        num_strip_trailing(&n);
+
+        if (n.len == 1 && n.digits[0] == 0)
+        {
+            n.sign = 0;
+            n.exp = 0;
+        }
+    }
+
+    get_numeric(env, &dig, &fuzz, &form);
+    num_round(&n, dig);
+
+    rc = num_to_lstr(env, &n, dig, form, result);
+    num_free(env, &n);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public: irx_arith_to_digits                                       */
+/* ------------------------------------------------------------------ */
+
+int irx_arith_to_digits(struct envblock *env, PLstr in,
+                        char *digits, int digits_cap, int *digits_len,
+                        int *sign, long *exponent)
+{
+    struct irx_number n;
+    int i;
+
+    if (digits == NULL || digits_cap < 0 || digits_len == NULL ||
+        sign == NULL || exponent == NULL)
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    n.digits = NULL;
+    n.cap = n.len = n.sign = n.exp = 0;
+    if (lstr_to_num(env, in, &n) != 0)
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    if (n.len > digits_cap)
+    {
+        num_free(env, &n);
+        return IRXPARS_OVERFLOW;
+    }
+
+    for (i = 0; i < n.len; i++)
+    {
+        digits[i] = (char)n.digits[i];
+    }
+    *digits_len = n.len;
+    *sign = n.sign;
+    *exponent = n.exp;
+
+    num_free(env, &n);
     return IRXPARS_OK;
 }

--- a/test/test_arith_extended.c
+++ b/test/test_arith_extended.c
@@ -172,6 +172,13 @@ static void test_trunc_errors(struct envblock *env)
     Lzeroinit(&out);
     CHECK(irx_arith_trunc(env, &in, 2, &out) == IRXPARS_SYNTAX,
           "TRUNC on empty string -> SYNTAX");
+
+    /* Over-large decimals would require an absurd scratch buffer;
+     * routine must refuse upfront. */
+    in = make_lstr("1");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 100000L, &out) == IRXPARS_SYNTAX,
+          "TRUNC with decimals > NUMERIC_DIGITS_MAX -> SYNTAX");
 }
 
 /* ================================================================== */
@@ -272,6 +279,40 @@ static void test_format_exponential(struct envblock *env)
     CHECK(lstr_matches(&out, "123000"),
           "FORMAT('1.23E5', ,,0) forces fixed-point -> '123000'");
     Lfree(NULL, &out);
+
+    /* Force-fixed with a large but representable exponent (regression
+     * test for the int_part sizing fix). 1E50 must yield 51 chars. */
+    in = make_lstr("1E50");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           0, IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('1E50', ,,0) returns OK");
+    CHECK(out.len == 51 && out.pstr != NULL && out.pstr[0] == '1',
+          "FORMAT('1E50', ,,0) emits 51 chars starting with '1'");
+    if (out.pstr != NULL)
+    {
+        int all_zeros_after = 1;
+        size_t k;
+        for (k = 1; k < out.len; k++)
+        {
+            if (out.pstr[k] != '0')
+            {
+                all_zeros_after = 0;
+                break;
+            }
+        }
+        CHECK(all_zeros_after,
+              "FORMAT('1E50', ,,0) -> '1' followed by 50 zeros");
+    }
+    Lfree(NULL, &out);
+
+    /* Force-fixed with an exponent above NUMERIC_DIGITS_MAX — must
+     * be rejected, not silently attempt a multi-KB allocation. */
+    in = make_lstr("1E1001");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           0, IRX_FORMAT_OMIT, &out) == IRXPARS_SYNTAX,
+          "FORMAT('1E1001', ,,0) -> SYNTAX (exceeds NUMERIC_DIGITS_MAX)");
 
     /* expt triggers exponential form when |adj| > expt */
     in = make_lstr("12345");
@@ -400,6 +441,17 @@ static void test_from_digits_basic(struct envblock *env)
               "from_digits with leading zeros OK");
         CHECK(lstr_matches(&out, "12"),
               "from_digits strips leading zeros -> '12'");
+        Lfree(NULL, &out);
+    }
+
+    /* Trailing zeros get normalized into the exponent. */
+    {
+        const char trail[] = {1, 2, 0, 0};
+        Lzeroinit(&out);
+        CHECK(irx_arith_from_digits(env, trail, 4, 0, 0, &out) == IRXPARS_OK,
+              "from_digits with trailing zeros OK");
+        CHECK(lstr_matches(&out, "1200"),
+              "from_digits normalizes trailing zeros -> '1200'");
         Lfree(NULL, &out);
     }
 }

--- a/test/test_arith_extended.c
+++ b/test/test_arith_extended.c
@@ -1,0 +1,664 @@
+/* ------------------------------------------------------------------ */
+/*  test_arith_extended.c - WP-21b Phase B tests for the new public    */
+/*  IRXARITH string-oriented helpers: trunc, format, from_digits,      */
+/*  to_digits. These are direct C-API tests; they do not drive the     */
+/*  parser.                                                            */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o test/test_arith_extended \      */
+/*        test/test_arith_extended.c \                                */
+/*        'src/irx#'*.c ../lstring370/liblstring.a                     */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxarith.h"
+#include "irxfunc.h"
+#include "irxpars.h"
+#include "irxwkblk.h"
+#include "lstralloc.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_tcbuser = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* Build a non-owning Lstr from a C string. The returned Lstr borrows
+ * the provided buffer; never pass it to Lfree. */
+static Lstr make_lstr(const char *cstr)
+{
+    Lstr s;
+    s.pstr = (unsigned char *)(uintptr_t)cstr;
+    s.len = strlen(cstr);
+    s.maxlen = s.len;
+    s.type = LSTRING_TY;
+    return s;
+}
+
+static int lstr_matches(const Lstr *s, const char *expected)
+{
+    size_t n = strlen(expected);
+    return s->pstr != NULL && s->len == n &&
+           memcmp(s->pstr, expected, n) == 0;
+}
+
+/* ================================================================== */
+/*  trunc                                                              */
+/* ================================================================== */
+
+static void test_trunc_basic(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- trunc: basic chop/pad ---\n");
+
+    in = make_lstr("12.345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 2, &out) == IRXPARS_OK,
+          "TRUNC('12.345', 2) returns OK");
+    CHECK(lstr_matches(&out, "12.34"), "TRUNC('12.345', 2) -> '12.34'");
+    Lfree(NULL, &out);
+
+    in = make_lstr("12.345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 5, &out) == IRXPARS_OK,
+          "TRUNC('12.345', 5) returns OK");
+    CHECK(lstr_matches(&out, "12.34500"),
+          "TRUNC('12.345', 5) pads trailing zeros -> '12.34500'");
+    Lfree(NULL, &out);
+
+    in = make_lstr("12345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 2, &out) == IRXPARS_OK,
+          "TRUNC('12345', 2) returns OK");
+    CHECK(lstr_matches(&out, "12345.00"),
+          "TRUNC('12345', 2) pads integer -> '12345.00'");
+    Lfree(NULL, &out);
+
+    in = make_lstr("12.345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 0, &out) == IRXPARS_OK,
+          "TRUNC('12.345', 0) returns OK");
+    CHECK(lstr_matches(&out, "12"), "TRUNC('12.345', 0) -> '12'");
+    Lfree(NULL, &out);
+
+    in = make_lstr("-12.345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 1, &out) == IRXPARS_OK,
+          "TRUNC('-12.345', 1) returns OK");
+    CHECK(lstr_matches(&out, "-12.3"), "TRUNC('-12.345', 1) -> '-12.3'");
+    Lfree(NULL, &out);
+}
+
+static void test_trunc_zero_and_near_zero(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- trunc: zero and near-zero ---\n");
+
+    in = make_lstr("0");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 2, &out) == IRXPARS_OK,
+          "TRUNC('0', 2) returns OK");
+    CHECK(lstr_matches(&out, "0.00"), "TRUNC('0', 2) -> '0.00'");
+    Lfree(NULL, &out);
+
+    in = make_lstr("-0.9");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 0, &out) == IRXPARS_OK,
+          "TRUNC('-0.9', 0) returns OK");
+    CHECK(lstr_matches(&out, "0"),
+          "TRUNC('-0.9', 0) truncates toward zero, sign cleared");
+    Lfree(NULL, &out);
+
+    in = make_lstr("0.001");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 5, &out) == IRXPARS_OK,
+          "TRUNC('0.001', 5) returns OK");
+    CHECK(lstr_matches(&out, "0.00100"),
+          "TRUNC('0.001', 5) -> '0.00100'");
+    Lfree(NULL, &out);
+
+    in = make_lstr("0.999");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 1, &out) == IRXPARS_OK,
+          "TRUNC('0.999', 1) returns OK");
+    CHECK(lstr_matches(&out, "0.9"),
+          "TRUNC('0.999', 1) truncates without rounding");
+    Lfree(NULL, &out);
+}
+
+static void test_trunc_errors(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- trunc: error paths ---\n");
+
+    in = make_lstr("12.345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, -1, &out) == IRXPARS_SYNTAX,
+          "TRUNC with decimals=-1 -> SYNTAX");
+
+    in = make_lstr("abc");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 2, &out) == IRXPARS_SYNTAX,
+          "TRUNC on non-numeric input -> SYNTAX");
+
+    in = make_lstr("");
+    Lzeroinit(&out);
+    CHECK(irx_arith_trunc(env, &in, 2, &out) == IRXPARS_SYNTAX,
+          "TRUNC on empty string -> SYNTAX");
+}
+
+/* ================================================================== */
+/*  format                                                             */
+/* ================================================================== */
+
+static void test_format_spec_examples(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- format: SC28-1883-0 spec examples ---\n");
+
+    /* AC-B2: FORMAT('123.45', 6, 2) -> '   123.45' */
+    in = make_lstr("123.45");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, 6, 2, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('123.45', 6, 2) returns OK");
+    CHECK(lstr_matches(&out, "   123.45"),
+          "FORMAT('123.45', 6, 2) -> '   123.45'");
+    Lfree(NULL, &out);
+
+    /* FORMAT('3', 4) -> '   3' */
+    in = make_lstr("3");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, 4, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('3', 4) returns OK");
+    CHECK(lstr_matches(&out, "   3"), "FORMAT('3', 4) -> '   3'");
+    Lfree(NULL, &out);
+
+    /* FORMAT('-3', 4) -> '  -3' */
+    in = make_lstr("-3");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, 4, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('-3', 4) returns OK");
+    CHECK(lstr_matches(&out, "  -3"), "FORMAT('-3', 4) -> '  -3'");
+    Lfree(NULL, &out);
+}
+
+static void test_format_after_rounding(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- format: after rounds/pads correctly ---\n");
+
+    /* Round half-up: FORMAT('1.235', ,2) -> '1.24' */
+    in = make_lstr("1.235");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, 2, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('1.235', ,2) returns OK");
+    CHECK(lstr_matches(&out, "1.24"),
+          "FORMAT('1.235', ,2) rounds half-up -> '1.24'");
+    Lfree(NULL, &out);
+
+    /* Pad fractional: FORMAT('1.2', ,4) -> '1.2000' */
+    in = make_lstr("1.2");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, 4, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('1.2', ,4) returns OK");
+    CHECK(lstr_matches(&out, "1.2000"),
+          "FORMAT('1.2', ,4) pads fractional -> '1.2000'");
+    Lfree(NULL, &out);
+
+    /* Round propagating: FORMAT('9.995', ,2) -> '10.00' */
+    in = make_lstr("9.995");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, 2, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('9.995', ,2) returns OK");
+    CHECK(lstr_matches(&out, "10.00"),
+          "FORMAT('9.995', ,2) carries over -> '10.00'");
+    Lfree(NULL, &out);
+
+    /* after=0 drops fractional part completely */
+    in = make_lstr("3.9");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, 0, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('3.9', ,0) returns OK");
+    CHECK(lstr_matches(&out, "4"),
+          "FORMAT('3.9', ,0) rounds half-up -> '4'");
+    Lfree(NULL, &out);
+}
+
+static void test_format_exponential(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- format: exponential form ---\n");
+
+    /* expp=0 forces fixed-point */
+    in = make_lstr("1.23E5");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           0, IRX_FORMAT_OMIT, &out) == IRXPARS_OK,
+          "FORMAT('1.23E5', ,,0) returns OK");
+    CHECK(lstr_matches(&out, "123000"),
+          "FORMAT('1.23E5', ,,0) forces fixed-point -> '123000'");
+    Lfree(NULL, &out);
+
+    /* expt triggers exponential form when |adj| > expt */
+    in = make_lstr("12345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, 2, &out) == IRXPARS_OK,
+          "FORMAT('12345', ,,,2) returns OK");
+    CHECK(lstr_matches(&out, "1.2345E+4"),
+          "FORMAT('12345', ,,,2) -> '1.2345E+4'");
+    Lfree(NULL, &out);
+
+    /* Negative exponent */
+    in = make_lstr("0.00012");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, 2, &out) == IRXPARS_OK,
+          "FORMAT('0.00012', ,,,2) returns OK");
+    CHECK(lstr_matches(&out, "1.2E-4"),
+          "FORMAT('0.00012', ,,,2) -> '1.2E-4'");
+    Lfree(NULL, &out);
+
+    /* expp=3 zero-pads exponent */
+    in = make_lstr("12345");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           3, 2, &out) == IRXPARS_OK,
+          "FORMAT('12345', ,,3,2) returns OK");
+    CHECK(lstr_matches(&out, "1.2345E+004"),
+          "FORMAT('12345', ,,3,2) zero-pads to 3 exponent digits");
+    Lfree(NULL, &out);
+}
+
+static void test_format_errors(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- format: error paths ---\n");
+
+    /* Negative args -> SYNTAX */
+    in = make_lstr("1");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, -2, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_SYNTAX,
+          "FORMAT with before<0 (but != OMIT) -> SYNTAX");
+
+    in = make_lstr("1");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, -2, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_SYNTAX,
+          "FORMAT with after<0 -> SYNTAX");
+
+    /* before too narrow -> SYNTAX */
+    in = make_lstr("123");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, 2, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, &out) == IRXPARS_SYNTAX,
+          "FORMAT('123', 2) -> SYNTAX (integer part > before)");
+
+    /* expp too small to hold exponent -> SYNTAX */
+    in = make_lstr("1E100");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           1, 2, &out) == IRXPARS_SYNTAX,
+          "FORMAT('1E100', ,,1,2) -> SYNTAX (exponent needs 3 digits)");
+
+    /* Non-numeric input */
+    in = make_lstr("abc");
+    Lzeroinit(&out);
+    CHECK(irx_arith_format(env, &in, IRX_FORMAT_OMIT, IRX_FORMAT_OMIT,
+                           IRX_FORMAT_OMIT, IRX_FORMAT_OMIT, &out) ==
+              IRXPARS_SYNTAX,
+          "FORMAT on non-numeric input -> SYNTAX");
+}
+
+/* ================================================================== */
+/*  from_digits / to_digits round-trip                                */
+/* ================================================================== */
+
+static void test_from_digits_basic(struct envblock *env)
+{
+    Lstr out;
+    const char d12345[] = {1, 2, 3, 4, 5};
+    const char d5[] = {5, 0};
+    const char zeros[] = {0, 0, 0};
+
+    printf("\n--- from_digits: basic ---\n");
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, d12345, 5, 0, 0, &out) == IRXPARS_OK,
+          "from_digits([1,2,3,4,5], sign=0, exp=0) OK");
+    CHECK(lstr_matches(&out, "12345"),
+          "from_digits -> '12345'");
+    Lfree(NULL, &out);
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, d12345, 5, 0, -2, &out) == IRXPARS_OK,
+          "from_digits([1,2,3,4,5], sign=0, exp=-2) OK");
+    CHECK(lstr_matches(&out, "123.45"),
+          "from_digits with exp=-2 -> '123.45'");
+    Lfree(NULL, &out);
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, d5, 2, 1, 0, &out) == IRXPARS_OK,
+          "from_digits([5,0], sign=1, exp=0) OK");
+    CHECK(lstr_matches(&out, "-50"),
+          "from_digits negative -> '-50'");
+    Lfree(NULL, &out);
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, NULL, 0, 0, 0, &out) == IRXPARS_OK,
+          "from_digits empty digits is canonical zero OK");
+    CHECK(lstr_matches(&out, "0"), "from_digits empty -> '0'");
+    Lfree(NULL, &out);
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, zeros, 3, 0, 0, &out) == IRXPARS_OK,
+          "from_digits all-zero digits OK");
+    CHECK(lstr_matches(&out, "0"),
+          "from_digits([0,0,0]) -> '0'");
+    Lfree(NULL, &out);
+
+    /* Leading zeros get stripped */
+    {
+        const char lead[] = {0, 0, 1, 2};
+        Lzeroinit(&out);
+        CHECK(irx_arith_from_digits(env, lead, 4, 0, 0, &out) == IRXPARS_OK,
+              "from_digits with leading zeros OK");
+        CHECK(lstr_matches(&out, "12"),
+              "from_digits strips leading zeros -> '12'");
+        Lfree(NULL, &out);
+    }
+}
+
+static void test_from_digits_errors(struct envblock *env)
+{
+    Lstr out;
+    const char bad[] = {1, 2, 10, 3};
+    printf("\n--- from_digits: errors ---\n");
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, bad, 4, 0, 0, &out) == IRXPARS_SYNTAX,
+          "from_digits with invalid digit byte (>9) -> SYNTAX");
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, NULL, -1, 0, 0, &out) == IRXPARS_SYNTAX,
+          "from_digits with negative len -> SYNTAX");
+
+    Lzeroinit(&out);
+    CHECK(irx_arith_from_digits(env, "\x01", 1, 2, 0, &out) == IRXPARS_SYNTAX,
+          "from_digits with invalid sign (!=0,1) -> SYNTAX");
+}
+
+static void test_to_digits_basic(struct envblock *env)
+{
+    Lstr in;
+    char digits[16];
+    int digits_len, sign;
+    long expo;
+    int rc;
+
+    printf("\n--- to_digits: basic ---\n");
+
+    in = make_lstr("12345");
+    memset(digits, 0, sizeof(digits));
+    rc = irx_arith_to_digits(env, &in, digits, (int)sizeof(digits),
+                             &digits_len, &sign, &expo);
+    CHECK(rc == IRXPARS_OK, "to_digits('12345') OK");
+    CHECK(digits_len == 5 && sign == 0 && expo == 0 &&
+              digits[0] == 1 && digits[1] == 2 && digits[2] == 3 &&
+              digits[3] == 4 && digits[4] == 5,
+          "to_digits('12345') -> digits=[1,2,3,4,5] sign=0 exp=0");
+
+    in = make_lstr("-123.45");
+    memset(digits, 0, sizeof(digits));
+    rc = irx_arith_to_digits(env, &in, digits, (int)sizeof(digits),
+                             &digits_len, &sign, &expo);
+    CHECK(rc == IRXPARS_OK, "to_digits('-123.45') OK");
+    CHECK(digits_len == 5 && sign == 1 && expo == -2,
+          "to_digits('-123.45') -> 5 digits, sign=1, exp=-2");
+    CHECK(digits[0] == 1 && digits[1] == 2 && digits[2] == 3 &&
+              digits[3] == 4 && digits[4] == 5,
+          "digits = [1,2,3,4,5]");
+
+    in = make_lstr("0");
+    memset(digits, 0, sizeof(digits));
+    rc = irx_arith_to_digits(env, &in, digits, (int)sizeof(digits),
+                             &digits_len, &sign, &expo);
+    CHECK(rc == IRXPARS_OK && digits_len == 1 && digits[0] == 0 &&
+              sign == 0 && expo == 0,
+          "to_digits('0') -> canonical zero");
+}
+
+static void test_to_digits_errors(struct envblock *env)
+{
+    Lstr in;
+    char digits[2];
+    int digits_len, sign;
+    long expo;
+    int rc;
+
+    printf("\n--- to_digits: errors ---\n");
+
+    in = make_lstr("12345");
+    rc = irx_arith_to_digits(env, &in, digits, (int)sizeof(digits),
+                             &digits_len, &sign, &expo);
+    CHECK(rc == IRXPARS_OVERFLOW,
+          "to_digits('12345') with cap=2 -> OVERFLOW");
+
+    in = make_lstr("abc");
+    rc = irx_arith_to_digits(env, &in, digits, (int)sizeof(digits),
+                             &digits_len, &sign, &expo);
+    CHECK(rc == IRXPARS_SYNTAX, "to_digits('abc') -> SYNTAX");
+}
+
+static void test_roundtrip(struct envblock *env)
+{
+    Lstr out;
+    char digits[16];
+    int len, sign;
+    long expo;
+    int rc;
+    int i;
+
+    printf("\n--- roundtrip: from_digits ↔ to_digits ---\n");
+
+    /* Build via from_digits, parse back via to_digits, compare. */
+    const struct
+    {
+        char digits[8];
+        int len;
+        int sign;
+        long exp;
+    } cases[] = {
+        {{1}, 1, 0, 0},                      /* '1' */
+        {{1, 2, 3}, 3, 0, 0},                /* '123' */
+        {{1, 2, 3}, 3, 0, -1},               /* '12.3' */
+        {{1, 2, 3}, 3, 1, 0},                /* '-123' */
+        {{5}, 1, 0, 3},                      /* '5000' */
+        {{1, 0, 0, 2}, 4, 0, 0},             /* '1002' */
+        {{9, 9, 9, 9, 9}, 5, 0, -2},         /* '999.99' */
+        {{1, 2, 3, 4, 5, 6, 7, 8}, 8, 0, -4} /* '1234.5678' */
+    };
+
+    int nc = (int)(sizeof(cases) / sizeof(cases[0]));
+
+    for (i = 0; i < nc; i++)
+    {
+        char label[64];
+        Lzeroinit(&out);
+        rc = irx_arith_from_digits(env, cases[i].digits, cases[i].len,
+                                   cases[i].sign, cases[i].exp, &out);
+        snprintf(label, sizeof(label),
+                 "roundtrip case %d: from_digits OK", i);
+        CHECK(rc == IRXPARS_OK, label);
+
+        rc = irx_arith_to_digits(env, &out, digits, (int)sizeof(digits),
+                                 &len, &sign, &expo);
+        snprintf(label, sizeof(label),
+                 "roundtrip case %d: to_digits OK", i);
+        CHECK(rc == IRXPARS_OK, label);
+
+        /* The round-trip is canonical, so sign matches unless the value
+         * is zero. Exponent and digits may be normalized (leading /
+         * trailing zeros stripped). For each test case above, the input
+         * is already canonical. */
+        snprintf(label, sizeof(label),
+                 "roundtrip case %d: digits/sign/exp preserved", i);
+        CHECK(len == cases[i].len && sign == cases[i].sign &&
+                  expo == cases[i].exp &&
+                  memcmp(digits, cases[i].digits, (size_t)len) == 0,
+              label);
+
+        Lfree(NULL, &out);
+    }
+}
+
+static void test_large_value(struct envblock *env)
+{
+    Lstr out;
+    const char big[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    char digits[32];
+    int len, sign;
+    long expo;
+    int rc;
+
+    printf("\n--- large value support ---\n");
+
+    /* 10 digits — exceeds safe-long range per the issue description. */
+    Lzeroinit(&out);
+    rc = irx_arith_from_digits(env, big, 10, 0, 0, &out);
+    CHECK(rc == IRXPARS_OK,
+          "from_digits with 10 digits OK");
+    /* NUMERIC DIGITS default is 9, so output is rounded to 9 digits +
+     * exponential form. The important thing is that from_digits does
+     * not choke on wide inputs. */
+
+    /* Round-trip the same 10-digit sequence explicitly (NUMERIC DIGITS
+     * rounding will lose the trailing zero, so we inspect differently). */
+    rc = irx_arith_to_digits(env, &out, digits, (int)sizeof(digits),
+                             &len, &sign, &expo);
+    CHECK(rc == IRXPARS_OK && len > 0 && len <= 10,
+          "to_digits of a large from_digits result succeeds");
+    Lfree(NULL, &out);
+
+    /* AC-B3: from_digits('1234567890123', 13, positive, 0, ...) must
+     * produce an Lstr that IRXARITH can consume again. With the default
+     * NUMERIC DIGITS of 9 the result is rounded, but the produced Lstr
+     * must still be a valid REXX number — we assert that by calling
+     * to_digits on it. */
+    {
+        const char d13[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3};
+        Lzeroinit(&out);
+        rc = irx_arith_from_digits(env, d13, 13, 0, 0, &out);
+        CHECK(rc == IRXPARS_OK, "AC-B3: from_digits with 13 digits OK");
+        CHECK(out.len > 0, "AC-B3: output Lstr non-empty");
+        rc = irx_arith_to_digits(env, &out, digits, (int)sizeof(digits),
+                                 &len, &sign, &expo);
+        CHECK(rc == IRXPARS_OK,
+              "AC-B3: output is a valid REXX number (to_digits OK)");
+        Lfree(NULL, &out);
+    }
+}
+
+/* ================================================================== */
+/*  ARITH_ABS (new opcode in irx_arith_op)                            */
+/* ================================================================== */
+
+static void test_arith_abs(struct envblock *env)
+{
+    Lstr in, out;
+    printf("\n--- ARITH_ABS opcode ---\n");
+
+    in = make_lstr("-5.5");
+    Lzeroinit(&out);
+    CHECK(irx_arith_op(env, &in, NULL, ARITH_ABS, &out) == IRXPARS_OK,
+          "arith_op(ABS, '-5.5') OK");
+    CHECK(lstr_matches(&out, "5.5"), "ABS(-5.5) -> '5.5'");
+    Lfree(NULL, &out);
+
+    in = make_lstr("42");
+    Lzeroinit(&out);
+    CHECK(irx_arith_op(env, &in, NULL, ARITH_ABS, &out) == IRXPARS_OK,
+          "arith_op(ABS, '42') OK");
+    CHECK(lstr_matches(&out, "42"), "ABS(42) -> '42' (unchanged)");
+    Lfree(NULL, &out);
+
+    in = make_lstr("0");
+    Lzeroinit(&out);
+    CHECK(irx_arith_op(env, &in, NULL, ARITH_ABS, &out) == IRXPARS_OK,
+          "arith_op(ABS, '0') OK");
+    CHECK(lstr_matches(&out, "0"), "ABS(0) -> '0'");
+    Lfree(NULL, &out);
+}
+
+/* ================================================================== */
+/*  main                                                              */
+/* ================================================================== */
+
+int main(void)
+{
+    struct envblock *env = NULL;
+    if (irxinit(NULL, &env) != 0)
+    {
+        printf("FATAL: irxinit failed\n");
+        return 1;
+    }
+
+    test_trunc_basic(env);
+    test_trunc_zero_and_near_zero(env);
+    test_trunc_errors(env);
+
+    test_format_spec_examples(env);
+    test_format_after_rounding(env);
+    test_format_exponential(env);
+    test_format_errors(env);
+
+    test_from_digits_basic(env);
+    test_from_digits_errors(env);
+    test_to_digits_basic(env);
+    test_to_digits_errors(env);
+    test_roundtrip(env);
+    test_large_value(env);
+
+    test_arith_abs(env);
+
+    irxterm(env);
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return (tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Phase B of WP-21b — extends the public IRXARITH surface with the four string-oriented helpers required by the numeric and conversion BIFs in Phases C/D. No BIFs are touched in this PR; scope stays strictly at the arithmetic layer.

## What's added

**Public API** (`include/irxarith.h`)

- `irx_arith_trunc(env, in, decimals, result)` — chop-or-pad to exactly `decimals` fractional digits, toward-zero.
- `irx_arith_format(env, in, before, after, expp, expt, result)` — full SC28-1883-0 §4 FORMAT semantics, including sign-aware before-padding, after rounding/padding, `expp = 0` force-fixed, and `expt` threshold.
- `irx_arith_from_digits(env, digits, len, sign, exp, result)` — build a REXX number Lstr from a raw BCD digit array.
- `irx_arith_to_digits(env, in, digits, cap, &len, &sign, &exp)` — parse a REXX number Lstr into raw BCD digits, suitable for large-value paths in D2C/D2X later.
- `ARITH_ABS` added to `enum irx_arith_opcode`; dispatches through `irx_arith_op` like `ARITH_NEG` but forces `sign = 0`.
- `IRX_FORMAT_OMIT (-1L)` sentinel so callers can encode "argument not supplied" at the C level.

**Prereq-check result (TSK-129 B4):** Verified that `num_format()` / `num_to_lstr()` in `src/irx#arith.c` already accept `dig` and `form` as explicit parameters — no adapter layer needed.

**Internal helpers added** (`src/irx#arith.c`): `num_grow`, `num_pad_to_exp`, `num_truncate_to_exp`, `num_round_to_exp`, `num_emit_fixed`, `emit_exponent_digits`, `dec_width`.

**New return code** `IRXPARS_OVERFLOW = 26` in `include/irxpars.h` so `to_digits` can surface "caller buffer too small" distinctly from REXX syntax errors. Documented in the header; namespaces unrelated to the already-existing `SYNTAX_OVERFLOW = 26` in `irxcond.h` (parser return code vs. REXX condition subcode).

## Deliberate deviations from the Notion spec

Called out for reviewer transparency:

1. **Signatures take `struct envblock *env`**, not `struct irx_wkblk_int *wk`. Chosen for consistency with the existing `irx_arith_op` / `irx_arith_compare` entry points; the wk is reachable via `env->envblock_userfield` where needed. No loss of functionality.
2. **`IRX_FORMAT_OMIT`** is new (not in the Notion transcription) — the spec reads naturally as "argument optional" but needs a concrete encoding in C.
3. **Scope bleed: `IRXPARS_OVERFLOW`** — technically a parser-layer addition, not strictly "IRXARITH-only". The `to_digits` API needs a distinct return code for buffer capacity; surfacing it here rather than inventing an ad-hoc convention.

## Acceptance criteria

- **AC-B1**: `irx_arith_trunc()` with `TRUNC('12.345', 2)` returns `'12.34'`. ✅ Plus padding (`TRUNC('12.345', 5)` → `'12.34500'`) and integer-input padding (`TRUNC('12345', 2)` → `'12345.00'`).
- **AC-B2**: `irx_arith_format()` with `FORMAT('123.45', 6, 2)` returns `'   123.45'`. ✅
- **AC-B3**: `irx_arith_from_digits('1234567890123', 13, sign=0, exp=0, ...)` produces an Lstr that IRXARITH can re-consume (round-trip via `to_digits`). ✅
- **AC-B4**: `irx_arith_to_digits()` round-trips cleanly with `irx_arith_from_digits()` across eight canonical shapes. ✅
- **AC-B5**: All existing arith tests still pass (128/128). ✅

## Test plan

Cross-compile matrix on Linux/gcc — link against `../lstring370/liblstring.a`:

- [x] tokenizer: 70/70
- [x] vpool: 47/47
- [x] irxlstr: 50/50
- [x] parser: 39/39
- [x] say: 27/27
- [x] control: 62/62
- [x] hello: 16/16
- [x] parse: 74/74
- [x] arith: **128/128** (AC-B5)
- [x] bif: 29/29
- [x] bifs: 109/109
- [x] procedure: 53/53
- [x] phase1: 38/38
- [x] **arith_extended: 106/106** (new in this PR)
- [x] **Total: 848/848** (baseline 742 + 106 new)

## Scope note

Issue #27 (WP-21b umbrella) stays open. Phase C (numeric BIFs — MAX/MIN/ABS/SIGN/TRUNC/FORMAT/RANDOM wiring to this new API) will land as the next follow-up issue.

Fixes #29.
