### PR TITLE
WP-21b Phase C: numeric BIFs (MAX/MIN/ABS/SIGN/TRUNC/FORMAT/RANDOM)

### DIFF
--- a/include/irxcond.h
+++ b/include/irxcond.h
@@ -18,11 +18,11 @@ struct envblock; /* forward decl to avoid circular include */
 /*  SYNTAX error primary codes (SC28-1883-0 Appendix E)               */
 /* ================================================================== */
 
-#define SYNTAX_BAD_OPERAND  24 /* arithmetic operand not a number  */
-#define SYNTAX_OVERFLOW     26 /* overflow / underflow             */
-#define SYNTAX_EXP_OVERFLOW 41 /* result exponent too large        */
-#define SYNTAX_DIVZERO      42 /* divide by zero                   */
-#define SYNTAX_BAD_CALL     40 /* incorrect call to routine        */
+#define SYNTAX_BAD_OPERAND 24 /* arithmetic operand not a number  */
+#define SYNTAX_OVERFLOW    26 /* overflow / underflow             */
+#define SYNTAX_BAD_CALL    40 /* incorrect call to routine        */
+#define SYNTAX_BAD_ARITH   41 /* bad arithmetic conversion         */
+#define SYNTAX_DIVZERO     42 /* divide by zero                   */
 
 /* ================================================================== */
 /*  SYNTAX 40.x subcodes — incorrect call to routine                  */
@@ -44,6 +44,14 @@ struct envblock; /* forward decl to avoid circular include */
 #define ERR40_OPTION_INVALID  23 /* argument N option not in allowed  */
 /* reserved for WP-21b misc BIFs (raised by TRANSLATE-style table check) */
 #define ERR40_PAIRED_LENGTH 29 /* translate table lengths mismatch  */
+
+/* ================================================================== */
+/*  SYNTAX 41.x subcodes — bad arithmetic conversion                  */
+/*  Raised when an operand of an arithmetic BIF is not a valid REXX   */
+/*  number.                                                           */
+/* ================================================================== */
+
+#define ERR41_NONNUMERIC 1 /* argument is not a valid REXX number */
 
 /* ================================================================== */
 /*  Condition Information block                                       */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -154,11 +154,13 @@ struct irx_wkblk_int
      * environment creation. See <irxbif.h>.                          */
     void *wkbi_bif_registry;
 
-    /* Originally 2 reserved word-slots; WP-21a consumed one for
-     * wkbi_bif_registry (above). One slot remaining for future use;
-     * enlarge the array (and re-check any layout-sensitive callers)
-     * when a new WP needs another slot.                              */
-    int _reserved[1];
+    /* --- RANDOM seed (WP-21b Phase C) ------------------------------ */
+    /* Per-environment 32-bit LCG state used by the RANDOM() BIF.
+     * Zero-initialized on env creation; RANDOM(,,seed) sets it      */
+    /* explicitly. Consumed the last reserved word-slot documented    */
+    /* alongside wkbi_bif_registry above; add a new _reserved[] array */
+    /* when a future WP needs another word.                           */
+    unsigned int wkbi_random_seed;
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -1006,11 +1006,15 @@ static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
 /*  via the irx#bif.c helpers.                                        */
 /* ================================================================== */
 
-static void raise_nonnumeric(struct irx_parser *p, const char *bif_name)
+/* Compose "BIFNAME<suffix>" into a fixed buffer with runtime clamp and
+ * raise the condition. A clamp keeps callers safe even if a future BIF
+ * has a long name that overruns the descriptor. Shared by
+ * raise_nonnumeric and bif_max_min's "argument omitted" path. */
+static void raise_bif_cond(struct irx_parser *p, int code, int subcode,
+                           const char *bif_name, const char *suffix)
 {
-    char desc[64];
+    char desc[80];
     size_t nlen = strlen(bif_name);
-    const char *suffix = ": argument is not a valid number";
     size_t slen = strlen(suffix);
     if (nlen + slen >= sizeof(desc))
     {
@@ -1019,7 +1023,13 @@ static void raise_nonnumeric(struct irx_parser *p, const char *bif_name)
     memcpy(desc, bif_name, nlen);
     memcpy(desc + nlen, suffix, slen);
     desc[nlen + slen] = '\0';
-    irx_cond_raise(p->envblock, SYNTAX_BAD_ARITH, ERR41_NONNUMERIC, desc);
+    irx_cond_raise(p->envblock, code, subcode, desc);
+}
+
+static void raise_nonnumeric(struct irx_parser *p, const char *bif_name)
+{
+    raise_bif_cond(p, SYNTAX_BAD_ARITH, ERR41_NONNUMERIC, bif_name,
+                   ": argument is not a valid number");
 }
 
 /* Return normalized argv[i] (sign preserved) in out. Non-numeric
@@ -1046,14 +1056,8 @@ static int normalize_preserve(struct irx_parser *p, PLstr in, PLstr out,
 static int bif_max_min(struct irx_parser *p, int argc, PLstr *argv,
                        PLstr result, int want_max, const char *bif_name)
 {
-    if (argc < 1)
-    {
-        char desc[32];
-        memcpy(desc, bif_name, strlen(bif_name) + 1);
-        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_TOO_FEW_ARGS,
-                       desc);
-        return IRXPARS_SYNTAX;
-    }
+    /* The dispatcher enforces min_args=1 via g_bifstr_table so argc>=1
+     * is an invariant here; no runtime guard needed. */
 
     /* Every positional argument must be present; REXX forbids omitted
      * operands to MAX/MIN. */
@@ -1062,13 +1066,8 @@ static int bif_max_min(struct irx_parser *p, int argc, PLstr *argv,
     {
         if (argv[i] == NULL || argv[i]->len == 0)
         {
-            char desc[64];
-            size_t nlen = strlen(bif_name);
-            memcpy(desc, bif_name, nlen);
-            memcpy(desc + nlen, ": argument omitted",
-                   sizeof(": argument omitted"));
-            irx_cond_raise(p->envblock, SYNTAX_BAD_CALL,
-                           ERR40_TOO_FEW_ARGS, desc);
+            raise_bif_cond(p, SYNTAX_BAD_CALL, ERR40_TOO_FEW_ARGS,
+                           bif_name, ": argument omitted");
             return IRXPARS_SYNTAX;
         }
     }
@@ -1164,9 +1163,8 @@ static int bif_require_digits_range(struct irx_parser *p, long v,
     {
         return IRXPARS_OK;
     }
-    int n = sprintf(desc, "%s: %s exceeds NUMERIC DIGITS max (%d)",
-                    bif_name, arg_name, NUMERIC_DIGITS_MAX);
-    (void)n;
+    sprintf(desc, "%s: %s exceeds NUMERIC DIGITS max (%d)", bif_name,
+            arg_name, NUMERIC_DIGITS_MAX);
     irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_ARG_LENGTH, desc);
     return IRXPARS_SYNTAX;
 }

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -1262,19 +1262,42 @@ static int bif_format(struct irx_parser *p, int argc, PLstr *argv,
 /*  Simple 32-bit linear congruential generator seeded in the work    */
 /*  block (wkbi_random_seed). Constants taken from the Numerical      */
 /*  Recipes / glibc LCG (multiplier 1103515245, increment 12345).     */
+/*                                                                    */
+/*  Output bit width: two LCG steps yield 30 bits of entropy by       */
+/*  concatenating the 15 high-order bits of each step. The low-order  */
+/*  bits of an LCG have very short periods (bit 1 repeats every 4    */
+/*  steps) so we intentionally discard them and use only the upper   */
+/*  half of each state. 30 bits cover the full RANDOM_MAX_RANGE of   */
+/*  100000 without modulus collapse. A single-step 15-bit output     */
+/*  would silently truncate any range above 32767.                   */
 /* ------------------------------------------------------------------ */
 
-#define RANDOM_DEFAULT_MIN  0L
-#define RANDOM_DEFAULT_MAX  999L
-#define RANDOM_MAX_RANGE    100000L
-#define RANDOM_LCG_MULT     1103515245U
-#define RANDOM_LCG_INC      12345U
-#define RANDOM_LCG_OUT_SHFT 16
-#define RANDOM_LCG_OUT_MASK 0x7FFFU
+#define RANDOM_DEFAULT_MIN   0L
+#define RANDOM_DEFAULT_MAX   999L
+#define RANDOM_MAX_RANGE     100000L
+#define RANDOM_LCG_MULT      1103515245U
+#define RANDOM_LCG_INC       12345U
+#define RANDOM_LCG_HI_SHIFT  16      /* drop short-period low bits      */
+#define RANDOM_LCG_HI_MASK   0x7FFFU /* 15 good bits per step          */
+#define RANDOM_LCG_HI_BITS   15
+#define RANDOM_LCG_OUT_BITS  30 /* two steps -> 30-bit output     */
+#define RANDOM_LCG_OUT_SCALE (1UL << RANDOM_LCG_OUT_BITS)
 
 static unsigned int lcg_next(unsigned int state)
 {
     return state * RANDOM_LCG_MULT + RANDOM_LCG_INC;
+}
+
+/* Two-step LCG combiner: returns a 30-bit value in [0, 2^30) and
+ * updates *state in place. Callers persist *state back into the work
+ * block so the next RANDOM() call continues the sequence. */
+static unsigned long lcg_next_30(unsigned int *state)
+{
+    *state = lcg_next(*state);
+    unsigned int hi = (*state >> RANDOM_LCG_HI_SHIFT) & RANDOM_LCG_HI_MASK;
+    *state = lcg_next(*state);
+    unsigned int lo = (*state >> RANDOM_LCG_HI_SHIFT) & RANDOM_LCG_HI_MASK;
+    return ((unsigned long)hi << RANDOM_LCG_HI_BITS) | (unsigned long)lo;
 }
 
 static int bif_random(struct irx_parser *p, int argc, PLstr *argv,
@@ -1343,15 +1366,14 @@ static int bif_random(struct irx_parser *p, int argc, PLstr *argv,
     }
 
     unsigned int state = (wk != NULL) ? wk->wkbi_random_seed : 0U;
-    state = lcg_next(state);
+    unsigned long raw30 = lcg_next_30(&state);
     if (wk != NULL)
     {
         wk->wkbi_random_seed = state;
     }
 
     long range = max_val - min_val + 1;
-    unsigned int raw = (state >> RANDOM_LCG_OUT_SHFT) & RANDOM_LCG_OUT_MASK;
-    long value = min_val + (long)(raw % (unsigned long)range);
+    long value = min_val + (long)(raw30 % (unsigned long)range);
     return translate_lstr_rc(long_to_lstr(p->alloc, result, value));
 }
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include "irx.h"
+#include "irxarith.h"
 #include "irxbif.h"
 #include "irxbifs.h"
 #include "irxcond.h"
@@ -996,6 +997,365 @@ static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
+/*  Phase G — Numeric BIFs (WP-21b Phase C)                           */
+/*                                                                    */
+/*  All seven BIFs delegate to IRXARITH primitives (irx_arith_op,     */
+/*  irx_arith_compare, irx_arith_trunc, irx_arith_format,             */
+/*  irx_arith_to_digits). Non-numeric operands raise SYNTAX 41.1      */
+/*  (bad arithmetic conversion); argument-shape errors raise 40.x     */
+/*  via the irx#bif.c helpers.                                        */
+/* ================================================================== */
+
+static void raise_nonnumeric(struct irx_parser *p, const char *bif_name)
+{
+    char desc[64];
+    size_t nlen = strlen(bif_name);
+    const char *suffix = ": argument is not a valid number";
+    size_t slen = strlen(suffix);
+    if (nlen + slen >= sizeof(desc))
+    {
+        nlen = sizeof(desc) - slen - 1;
+    }
+    memcpy(desc, bif_name, nlen);
+    memcpy(desc + nlen, suffix, slen);
+    desc[nlen + slen] = '\0';
+    irx_cond_raise(p->envblock, SYNTAX_BAD_ARITH, ERR41_NONNUMERIC, desc);
+}
+
+/* Return normalized argv[i] (sign preserved) in out. Non-numeric
+ * operand → SYNTAX 41.1. Uses ADD with 0 to invoke the standard
+ * number formatter without changing the value. */
+static int normalize_preserve(struct irx_parser *p, PLstr in, PLstr out,
+                              const char *bif_name)
+{
+    unsigned char zero_byte = (unsigned char)'0';
+    Lstr zero;
+    zero.pstr = &zero_byte;
+    zero.len = 1;
+    zero.maxlen = 1;
+    zero.type = LSTRING_TY;
+
+    int rc = irx_arith_op(p->envblock, in, &zero, ARITH_ADD, out);
+    if (rc == IRXPARS_SYNTAX)
+    {
+        raise_nonnumeric(p, bif_name);
+    }
+    return rc;
+}
+
+static int bif_max_min(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result, int want_max, const char *bif_name)
+{
+    if (argc < 1)
+    {
+        char desc[32];
+        memcpy(desc, bif_name, strlen(bif_name) + 1);
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_TOO_FEW_ARGS,
+                       desc);
+        return IRXPARS_SYNTAX;
+    }
+
+    /* Every positional argument must be present; REXX forbids omitted
+     * operands to MAX/MIN. */
+    int i;
+    for (i = 0; i < argc; i++)
+    {
+        if (argv[i] == NULL || argv[i]->len == 0)
+        {
+            char desc[64];
+            size_t nlen = strlen(bif_name);
+            memcpy(desc, bif_name, nlen);
+            memcpy(desc + nlen, ": argument omitted",
+                   sizeof(": argument omitted"));
+            irx_cond_raise(p->envblock, SYNTAX_BAD_CALL,
+                           ERR40_TOO_FEW_ARGS, desc);
+            return IRXPARS_SYNTAX;
+        }
+    }
+
+    int winner = 0;
+    for (i = 1; i < argc; i++)
+    {
+        int cmp = 0;
+        int rc = irx_arith_compare(p->envblock, argv[winner], argv[i],
+                                   &cmp);
+        if (rc == IRXPARS_SYNTAX)
+        {
+            raise_nonnumeric(p, bif_name);
+            return rc;
+        }
+        if (rc != IRXPARS_OK)
+        {
+            return rc;
+        }
+        if ((want_max && cmp < 0) || (!want_max && cmp > 0))
+        {
+            winner = i;
+        }
+    }
+
+    /* Single-arg fast path needs its own validation: the compare loop
+     * above never runs when argc == 1. Use normalize_preserve so the
+     * returned value also obeys NUMERIC DIGITS / FORM. */
+    return normalize_preserve(p, argv[winner], result, bif_name);
+}
+
+static int bif_max(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    return bif_max_min(p, argc, argv, result, 1, "MAX");
+}
+
+static int bif_min(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    return bif_max_min(p, argc, argv, result, 0, "MIN");
+}
+
+static int bif_abs(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    (void)argc;
+    int rc = irx_arith_op(p->envblock, argv[0], NULL, ARITH_ABS, result);
+    if (rc == IRXPARS_SYNTAX)
+    {
+        raise_nonnumeric(p, "ABS");
+    }
+    return rc;
+}
+
+static int bif_sign(struct irx_parser *p, int argc, PLstr *argv,
+                    PLstr result)
+{
+    (void)argc;
+    unsigned char zero_byte = (unsigned char)'0';
+    Lstr zero;
+    zero.pstr = &zero_byte;
+    zero.len = 1;
+    zero.maxlen = 1;
+    zero.type = LSTRING_TY;
+
+    int cmp = 0;
+    int rc = irx_arith_compare(p->envblock, argv[0], &zero, &cmp);
+    if (rc == IRXPARS_SYNTAX)
+    {
+        raise_nonnumeric(p, "SIGN");
+        return rc;
+    }
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
+
+    long v = (cmp < 0) ? -1L : (cmp > 0 ? 1L : 0L);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, v));
+}
+
+/* Reject integer arguments exceeding NUMERIC DIGITS_MAX before the
+ * arithmetic layer collapses them into a generic SYNTAX. Surfaces the
+ * failure as 40.4 (ERR40_ARG_LENGTH) per SC28-1883-0 §18 error-code
+ * hygiene. */
+static int bif_require_digits_range(struct irx_parser *p, long v,
+                                    const char *bif_name,
+                                    const char *arg_name)
+{
+    char desc[96];
+    if (v <= NUMERIC_DIGITS_MAX)
+    {
+        return IRXPARS_OK;
+    }
+    int n = sprintf(desc, "%s: %s exceeds NUMERIC DIGITS max (%d)",
+                    bif_name, arg_name, NUMERIC_DIGITS_MAX);
+    (void)n;
+    irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_ARG_LENGTH, desc);
+    return IRXPARS_SYNTAX;
+}
+
+static int bif_trunc(struct irx_parser *p, int argc, PLstr *argv,
+                     PLstr result)
+{
+    long decimals = 0;
+    int rc = irx_bif_opt_whole(p, argc, argv, 1, "TRUNC", 0, &decimals);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = bif_require_digits_range(p, decimals, "TRUNC", "decimals");
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
+    rc = irx_arith_trunc(p->envblock, argv[0], decimals, result);
+    if (rc == IRXPARS_SYNTAX)
+    {
+        /* Out-of-range decimals was rejected above, so the remaining
+         * failure path is a non-numeric input operand. */
+        raise_nonnumeric(p, "TRUNC");
+    }
+    return rc;
+}
+
+static int bif_format(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    long before = IRX_FORMAT_OMIT;
+    long after = IRX_FORMAT_OMIT;
+    long expp = IRX_FORMAT_OMIT;
+    long expt = IRX_FORMAT_OMIT;
+
+    /* opt_whole rejects negative user input via whole_nonneg and leaves
+     * `out` at the default (IRX_FORMAT_OMIT) when the argument is
+     * absent or empty, so the OMIT sentinel can never escape from a
+     * negative caller value. */
+    int rc = irx_bif_opt_whole(p, argc, argv, 1, "FORMAT",
+                               IRX_FORMAT_OMIT, &before);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_whole(p, argc, argv, 2, "FORMAT",
+                           IRX_FORMAT_OMIT, &after);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_whole(p, argc, argv, 3, "FORMAT",
+                           IRX_FORMAT_OMIT, &expp);
+    if (rc != 0)
+    {
+        return rc;
+    }
+    rc = irx_bif_opt_whole(p, argc, argv, 4, "FORMAT",
+                           IRX_FORMAT_OMIT, &expt);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    /* Guard each integer arg so out-of-range values surface as 40.4
+     * rather than a generic 41.1 when the arithmetic layer refuses
+     * them. IRX_FORMAT_OMIT (-1) is below the threshold and passes. */
+    if ((rc = bif_require_digits_range(p, before, "FORMAT", "before")) !=
+            IRXPARS_OK ||
+        (rc = bif_require_digits_range(p, after, "FORMAT", "after")) !=
+            IRXPARS_OK ||
+        (rc = bif_require_digits_range(p, expp, "FORMAT", "expp")) !=
+            IRXPARS_OK ||
+        (rc = bif_require_digits_range(p, expt, "FORMAT", "expt")) !=
+            IRXPARS_OK)
+    {
+        return rc;
+    }
+
+    rc = irx_arith_format(p->envblock, argv[0], before, after, expp, expt,
+                          result);
+    if (rc == IRXPARS_SYNTAX)
+    {
+        raise_nonnumeric(p, "FORMAT");
+    }
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  RANDOM([min][,[max][,[seed]]])                                    */
+/*                                                                    */
+/*  Simple 32-bit linear congruential generator seeded in the work    */
+/*  block (wkbi_random_seed). Constants taken from the Numerical      */
+/*  Recipes / glibc LCG (multiplier 1103515245, increment 12345).     */
+/* ------------------------------------------------------------------ */
+
+#define RANDOM_DEFAULT_MIN  0L
+#define RANDOM_DEFAULT_MAX  999L
+#define RANDOM_MAX_RANGE    100000L
+#define RANDOM_LCG_MULT     1103515245U
+#define RANDOM_LCG_INC      12345U
+#define RANDOM_LCG_OUT_SHFT 16
+#define RANDOM_LCG_OUT_MASK 0x7FFFU
+
+static unsigned int lcg_next(unsigned int state)
+{
+    return state * RANDOM_LCG_MULT + RANDOM_LCG_INC;
+}
+
+static int bif_random(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    long min_val = RANDOM_DEFAULT_MIN;
+    long max_val = RANDOM_DEFAULT_MAX;
+    int have_seed = 0;
+    long seed_val = 0;
+
+    if (argc >= 1 && argv[0] != NULL && argv[0]->len > 0)
+    {
+        int rc = irx_bif_whole_nonneg(p, argv, 0, "RANDOM", &min_val);
+        if (rc != 0)
+        {
+            return rc;
+        }
+    }
+    if (argc >= 2 && argv[1] != NULL && argv[1]->len > 0)
+    {
+        int rc = irx_bif_whole_nonneg(p, argv, 1, "RANDOM", &max_val);
+        if (rc != 0)
+        {
+            return rc;
+        }
+    }
+    if (argc >= 3 && argv[2] != NULL && argv[2]->len > 0)
+    {
+        int rc = irx_bif_whole_nonneg(p, argv, 2, "RANDOM", &seed_val);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        have_seed = 1;
+    }
+
+    if (max_val < min_val)
+    {
+        char desc[] = "RANDOM: max must be >= min";
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE,
+                       desc);
+        return IRXPARS_SYNTAX;
+    }
+    if (max_val - min_val > RANDOM_MAX_RANGE)
+    {
+        char desc[] = "RANDOM: range exceeds 100000";
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_ARG_LENGTH,
+                       desc);
+        return IRXPARS_SYNTAX;
+    }
+
+    struct irx_wkblk_int *wk = NULL;
+    if (p->envblock != NULL && p->envblock->envblock_userfield != NULL)
+    {
+        wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+    }
+
+    if (have_seed)
+    {
+        if (wk != NULL)
+        {
+            wk->wkbi_random_seed = (unsigned int)seed_val;
+        }
+        /* SC28-1883-0: seeding returns '0' without consuming a value. */
+        return translate_lstr_rc(long_to_lstr(p->alloc, result, 0L));
+    }
+
+    unsigned int state = (wk != NULL) ? wk->wkbi_random_seed : 0U;
+    state = lcg_next(state);
+    if (wk != NULL)
+    {
+        wk->wkbi_random_seed = state;
+    }
+
+    long range = max_val - min_val + 1;
+    unsigned int raw = (state >> RANDOM_LCG_OUT_SHFT) & RANDOM_LCG_OUT_MASK;
+    long value = min_val + (long)(raw % (unsigned long)range);
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, value));
+}
+
+/* ================================================================== */
 /*  Registration                                                      */
 /* ================================================================== */
 
@@ -1035,6 +1395,14 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"ABBREV", 2, 3, bif_abbrev},
     {"XRANGE", 0, 2, bif_xrange},
     {"FIND", 2, 2, bif_find},
+    /* Phase G — Numeric BIFs (WP-21b Phase C) */
+    {"MAX", 1, IRX_MAX_ARGS, bif_max},
+    {"MIN", 1, IRX_MAX_ARGS, bif_min},
+    {"ABS", 1, 1, bif_abs},
+    {"SIGN", 1, 1, bif_sign},
+    {"TRUNC", 1, 2, bif_trunc},
+    {"FORMAT", 1, 5, bif_format},
+    {"RANDOM", 0, 3, bif_random},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -1095,7 +1095,18 @@ static int bif_max_min(struct irx_parser *p, int argc, PLstr *argv,
 
     /* Single-arg fast path needs its own validation: the compare loop
      * above never runs when argc == 1. Use normalize_preserve so the
-     * returned value also obeys NUMERIC DIGITS / FORM. */
+     * returned value also obeys NUMERIC DIGITS / FORM.
+     *
+     * Performance note: this ARITH_ADD(0) is a second BCD pass after
+     * the compare loop already validated every operand. MAX/MIN is not
+     * a hot path in typical REXX workloads, and the normalization pass
+     * is what makes the result honour the active NUMERIC DIGITS / FORM
+     * settings — irx_arith_compare writes only a -1/0/+1 verdict, never
+     * a formatted Lstr. If profiling ever flags this doubled work as a
+     * real bottleneck, add a public irx_arith_normalize() helper shaped
+     * like irx_arith_trunc and call that here instead. No follow-up
+     * issue was filed: without a measured trigger it would just age in
+     * the backlog. */
     return normalize_preserve(p, argv[winner], result, bif_name);
 }
 

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -228,10 +228,8 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
     wk->wkbi_sigl = 0;
     wk->wkbi_rc = 0;
 
-    /* RANDOM seed starts at zero; callers may set it via RANDOM(,,seed). */
-    wk->wkbi_random_seed = 0;
-
-    /* All pointer fields are already NULL from irxstor zero-fill */
+    /* All pointer fields (and wkbi_random_seed) are already NULL / 0
+     * from the irxstor zero-fill. */
 
     *wk_out = wk;
     return 0;

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -228,6 +228,9 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
     wk->wkbi_sigl = 0;
     wk->wkbi_rc = 0;
 
+    /* RANDOM seed starts at zero; callers may set it via RANDOM(,,seed). */
+    wk->wkbi_random_seed = 0;
+
     /* All pointer fields are already NULL from irxstor zero-fill */
 
     *wk_out = wk;

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -3639,12 +3639,25 @@ static int parse_function_call(struct irx_parser *p,
                 rc = fail(p, IRXPARS_SYNTAX);
                 goto done;
             }
-            rc = parse_or(p, &argvals[argc]);
-            if (rc != IRXPARS_OK)
+            /* Omitted argument: a comma or closing paren in a slot
+             * where an expression is expected yields an empty Lstr.
+             * argvals[argc] is already Lzeroinit so argc++ is enough. */
+            const struct irx_token *slot_tok = cur_tok(p);
+            if (slot_tok != NULL &&
+                (slot_tok->tok_type == TOK_COMMA ||
+                 slot_tok->tok_type == TOK_RPAREN))
             {
-                goto done;
+                argc++;
             }
-            argc++;
+            else
+            {
+                rc = parse_or(p, &argvals[argc]);
+                if (rc != IRXPARS_OK)
+                {
+                    goto done;
+                }
+                argc++;
+            }
 
             if (cur_tok(p) != NULL && cur_tok(p)->tok_type == TOK_COMMA)
             {

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -468,14 +468,172 @@ static void test_find_phrase_cap(void)
     free(buf);
 }
 
+/* ================================================================== */
+/*  Phase C — Numeric BIFs (WP-21b #31)                               */
+/*  AC-C1..AC-C7 from the issue body.                                 */
+/* ================================================================== */
+
+static void test_phase_c_numeric(void)
+{
+    printf("\n--- Phase C: numeric BIFs (MAX/MIN/ABS/SIGN/TRUNC/FORMAT/RANDOM) ---\n");
+    /* AC-C1 */
+    EXPECT_OK("MAX(1,2,3)", "3", "AC-C1 MAX triple");
+    EXPECT_OK("MIN(-1,0,1)", "-1", "AC-C1 MIN triple");
+    EXPECT_OK("MAX(7)", "7", "MAX single arg");
+    EXPECT_OK("MIN(5,5,5)", "5", "MIN all equal");
+    EXPECT_OK("MAX(-3,-1,-2)", "-1", "MAX of negatives");
+    EXPECT_OK("MIN('1.5','1.4','1.6')", "1.4", "MIN of decimals");
+
+    /* AC-C2 */
+    EXPECT_OK("ABS(-5.5)", "5.5", "AC-C2 ABS negative decimal");
+    EXPECT_OK("ABS(0)", "0", "ABS zero");
+    EXPECT_OK("ABS(42)", "42", "ABS positive");
+    EXPECT_OK("ABS('-0')", "0", "ABS minus zero");
+
+    /* AC-C3 */
+    EXPECT_OK("SIGN(-3)", "-1", "AC-C3 SIGN negative");
+    EXPECT_OK("SIGN(0)", "0", "AC-C3 SIGN zero");
+    EXPECT_OK("SIGN('4.2')", "1", "AC-C3 SIGN positive decimal");
+    EXPECT_OK("SIGN('-0.0')", "0", "SIGN minus zero");
+    EXPECT_OK("SIGN('+7')", "1", "SIGN explicit plus");
+
+    /* AC-C4 */
+    EXPECT_OK("TRUNC('12.345',2)", "12.34", "AC-C4 TRUNC two decimals");
+    EXPECT_OK("TRUNC('12.345')", "12", "AC-C4 TRUNC default zero decimals");
+    EXPECT_OK("TRUNC('-0.9')", "0", "TRUNC rounds toward zero");
+    EXPECT_OK("TRUNC('12',3)", "12.000", "TRUNC pads trailing zeros");
+
+    /* AC-C5 */
+    EXPECT_OK("FORMAT('123.45',6,2)", "   123.45", "AC-C5 FORMAT before/after");
+    EXPECT_OK("FORMAT('5')", "5", "FORMAT defaults");
+    EXPECT_OK("FORMAT('5',4)", "   5", "FORMAT pad integer part");
+    EXPECT_OK("FORMAT('1.2',,3)", "1.200", "FORMAT fractional pad");
+
+    /* AC-C6 — seeded RANDOM is reproducible across two calls. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "AC-C6 fixture_open");
+        }
+        else
+        {
+            int rc = run_src(&fx, "x = RANDOM(,,12345)\n");
+            CHECK(rc == IRXPARS_OK, "AC-C6 RANDOM(,,seed) returns OK");
+            CHECK(var_eq(&fx, "X", "0"),
+                  "AC-C6 RANDOM(,,seed) result is '0'");
+            rc = run_src(&fx, "y = RANDOM(1,10)\n");
+            CHECK(rc == IRXPARS_OK, "AC-C6 RANDOM(1,10) OK after seed");
+
+            Lstr key;
+            Lstr val;
+            Lzeroinit(&key);
+            Lzeroinit(&val);
+            Lscpy(fx.alloc, &key, "Y");
+            int vpool_rc = vpool_get(fx.pool, &key, &val);
+            int in_range = 0;
+            if (vpool_rc == VPOOL_OK && val.len > 0)
+            {
+                long n = 0;
+                size_t i;
+                for (i = 0; i < val.len; i++)
+                {
+                    n = n * 10 + (val.pstr[i] - (unsigned char)'0');
+                }
+                in_range = (n >= 1 && n <= 10);
+            }
+            CHECK(in_range, "AC-C6 RANDOM(1,10) result in [1,10]");
+            Lfree(fx.alloc, &key);
+            Lfree(fx.alloc, &val);
+            fixture_close(&fx);
+        }
+    }
+
+    /* Seeded RANDOM is deterministic: same seed → same sequence across
+     * two independent environments. */
+    {
+        struct fixture fa;
+        struct fixture fb;
+        int ok = 0;
+        if (fixture_open(&fa) == 0 && fixture_open(&fb) == 0)
+        {
+            /* max-min must be <= 100000 per RANDOM spec. */
+            run_src(&fa,
+                    "r = RANDOM(,,42)\n"
+                    "x = RANDOM(0,100000)\n");
+            run_src(&fb,
+                    "r = RANDOM(,,42)\n"
+                    "x = RANDOM(0,100000)\n");
+
+            Lstr key;
+            Lstr va;
+            Lstr vb;
+            Lzeroinit(&key);
+            Lzeroinit(&va);
+            Lzeroinit(&vb);
+            Lscpy(fa.alloc, &key, "X");
+            vpool_get(fa.pool, &key, &va);
+            vpool_get(fb.pool, &key, &vb);
+            ok = (va.len == vb.len) && (va.len > 0) &&
+                 (memcmp(va.pstr, vb.pstr, va.len) == 0);
+            Lfree(fa.alloc, &key);
+            Lfree(fa.alloc, &va);
+            Lfree(fb.alloc, &vb);
+        }
+        fixture_close(&fa);
+        fixture_close(&fb);
+        CHECK(ok, "RANDOM reproducible across seeded envs");
+    }
+}
+
+/* AC-C7: MAX/MIN with a non-numeric operand raises SYNTAX 41.1. */
+static void test_phase_c_nonnumeric(void)
+{
+    printf("\n--- Phase C: AC-C7 non-numeric operand ---\n");
+    run_expect_fail("x = MAX('abc',1)\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "AC-C7 MAX non-numeric first arg");
+    run_expect_fail("x = MAX(1,'abc')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "MAX non-numeric second arg");
+    run_expect_fail("x = MIN('x')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "MIN non-numeric single arg");
+    run_expect_fail("x = ABS('abc')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "ABS non-numeric");
+    run_expect_fail("x = SIGN('xyz')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "SIGN non-numeric");
+    run_expect_fail("x = TRUNC('abc')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "TRUNC non-numeric value");
+    run_expect_fail("x = FORMAT('abc')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "FORMAT non-numeric value");
+
+    /* Bad whole-number parameters still surface as SYNTAX 40.x. */
+    run_expect_fail("x = TRUNC('12.3','bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "TRUNC bad decimals arg");
+    run_expect_fail("x = FORMAT('12.3',,'bad')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "FORMAT bad after arg");
+    run_expect_fail("x = RANDOM(5,2)\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "RANDOM max < min");
+    run_expect_fail("x = RANDOM(0,200000)\n", SYNTAX_BAD_CALL,
+                    ERR40_ARG_LENGTH, "RANDOM range too large");
+
+    /* TRUNC / FORMAT: integer arg exceeding NUMERIC DIGITS_MAX (1000)
+     * surfaces as 40.4, not 41.1. Hygiene check for the error-code
+     * split between argument-shape and bad-arithmetic failures. */
+    run_expect_fail("x = TRUNC('1.5',5000)\n", SYNTAX_BAD_CALL,
+                    ERR40_ARG_LENGTH, "TRUNC decimals > DIGITS_MAX");
+    run_expect_fail("x = FORMAT('1.5',,5000)\n", SYNTAX_BAD_CALL,
+                    ERR40_ARG_LENGTH, "FORMAT after > DIGITS_MAX");
+}
+
 int main(void)
 {
-    printf("=== WP-21a: String BIFs ===\n");
+    printf("=== WP-21a + WP-21b Phase C: BIFs ===\n");
     test_phase_b();
     test_phase_c();
     test_phase_d();
     test_phase_e();
     test_phase_f();
+    test_phase_c_numeric();
+    test_phase_c_nonnumeric();
     test_error_paths();
     test_find_phrase_cap();
 

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -700,6 +700,81 @@ static void test_phase_c_nonnumeric(void)
                     ERR40_ARG_LENGTH, "FORMAT after > DIGITS_MAX");
 }
 
+/* Boundary / edge-case coverage requested in review #9. */
+static void test_phase_c_edges(void)
+{
+    printf("\n--- Phase C: boundary and edge cases ---\n");
+
+    /* SIGN accepts whitespace and exponential notation. */
+    EXPECT_OK("SIGN('0.0E5')", "0", "SIGN exponential zero");
+    EXPECT_OK("SIGN('   0   ')", "0", "SIGN whitespace around zero");
+    EXPECT_OK("SIGN(' 42 ')", "1", "SIGN whitespace around value");
+
+    /* FORMAT exponential output uses expp-zero-padded exponent. */
+    EXPECT_OK("FORMAT('1E10',,,3,6)", "1E+010",
+              "FORMAT explicit exponential");
+
+    /* RANDOM(0,0) collapses to a single value. */
+    EXPECT_OK("RANDOM(0,0)", "0", "RANDOM zero-width range");
+
+    /* RANDOM(min) default max=999; result must land in [5,999]. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "RANDOM(min): fixture_open");
+        }
+        else
+        {
+            int rc = run_src(&fx, "r = RANDOM(,,7)\nx = RANDOM(5)\n");
+            CHECK(rc == IRXPARS_OK, "RANDOM(5) with seed OK");
+            Lstr key;
+            Lstr val;
+            Lzeroinit(&key);
+            Lzeroinit(&val);
+            Lscpy(fx.alloc, &key, "X");
+            int in_range = 0;
+            if (vpool_get(fx.pool, &key, &val) == VPOOL_OK && val.len > 0)
+            {
+                long n = 0;
+                size_t i;
+                int parse_ok = 1;
+                for (i = 0; i < val.len; i++)
+                {
+                    unsigned char c = val.pstr[i];
+                    if (c < (unsigned char)'0' || c > (unsigned char)'9')
+                    {
+                        parse_ok = 0;
+                        break;
+                    }
+                    n = n * 10 + (c - (unsigned char)'0');
+                }
+                in_range = parse_ok && (n >= 5 && n <= 999);
+            }
+            CHECK(in_range, "RANDOM(5) result in [5,999]");
+            Lfree(fx.alloc, &key);
+            Lfree(fx.alloc, &val);
+            fixture_close(&fx);
+        }
+    }
+
+    /* MAX/MIN at exactly IRX_MAX_ARGS (16) — dispatcher accepts. */
+    EXPECT_OK("MAX(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)", "16",
+              "MAX at IRX_MAX_ARGS boundary");
+    EXPECT_OK("MIN(16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1)", "1",
+              "MIN at IRX_MAX_ARGS boundary");
+
+    /* MAX() — dispatcher rejects argc < min_args before the BIF runs;
+     * no condition is raised so want_code=0 asserts "failure with no
+     * condition set". */
+    run_expect_fail("x = MAX()\n", 0, 0,
+                    "MAX() rejected by dispatcher min_args");
+
+    /* One argument over IRX_MAX_ARGS — parser refuses. */
+    run_expect_fail("x = MAX(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17)\n",
+                    0, 0, "MAX(17 args) rejected by parser");
+}
+
 int main(void)
 {
     printf("=== WP-21a + WP-21b Phase C: BIFs ===\n");
@@ -710,6 +785,7 @@ int main(void)
     test_phase_f();
     test_phase_c_numeric();
     test_phase_c_nonnumeric();
+    test_phase_c_edges();
     test_error_paths();
     test_find_phrase_cap();
 

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -536,11 +536,18 @@ static void test_phase_c_numeric(void)
             {
                 long n = 0;
                 size_t i;
+                int parse_ok = 1;
                 for (i = 0; i < val.len; i++)
                 {
-                    n = n * 10 + (val.pstr[i] - (unsigned char)'0');
+                    unsigned char c = val.pstr[i];
+                    if (c < (unsigned char)'0' || c > (unsigned char)'9')
+                    {
+                        parse_ok = 0;
+                        break;
+                    }
+                    n = n * 10 + (c - (unsigned char)'0');
                 }
-                in_range = (n >= 1 && n <= 10);
+                in_range = parse_ok && (n >= 1 && n <= 10);
             }
             CHECK(in_range, "AC-C6 RANDOM(1,10) result in [1,10]");
             Lfree(fx.alloc, &key);
@@ -550,12 +557,22 @@ static void test_phase_c_numeric(void)
     }
 
     /* Seeded RANDOM is deterministic: same seed → same sequence across
-     * two independent environments. */
+     * two independent environments. Sequential fixture open/close so
+     * that a late fixture_open failure never leaves an un-paired
+     * fixture_close or a skipped Lfree. */
     {
         struct fixture fa;
         struct fixture fb;
-        int ok = 0;
-        if (fixture_open(&fa) == 0 && fixture_open(&fb) == 0)
+        if (fixture_open(&fa) != 0)
+        {
+            CHECK(0, "RANDOM repro: fixture_open(fa)");
+        }
+        else if (fixture_open(&fb) != 0)
+        {
+            fixture_close(&fa);
+            CHECK(0, "RANDOM repro: fixture_open(fb)");
+        }
+        else
         {
             /* max-min must be <= 100000 per RANDOM spec. */
             run_src(&fa,
@@ -574,15 +591,74 @@ static void test_phase_c_numeric(void)
             Lscpy(fa.alloc, &key, "X");
             vpool_get(fa.pool, &key, &va);
             vpool_get(fb.pool, &key, &vb);
-            ok = (va.len == vb.len) && (va.len > 0) &&
-                 (memcmp(va.pstr, vb.pstr, va.len) == 0);
+            int ok = (va.len == vb.len) && (va.len > 0) &&
+                     (memcmp(va.pstr, vb.pstr, va.len) == 0);
             Lfree(fa.alloc, &key);
             Lfree(fa.alloc, &va);
             Lfree(fb.alloc, &vb);
+            fixture_close(&fa);
+            fixture_close(&fb);
+            CHECK(ok, "RANDOM reproducible across seeded envs");
         }
-        fixture_close(&fa);
-        fixture_close(&fb);
-        CHECK(ok, "RANDOM reproducible across seeded envs");
+    }
+
+    /* Regression for the 15-bit output bug fixed by the two-step LCG.
+     * A 15-bit LCG output would cap RANDOM(0, 100000) at 32767, so any
+     * run of samples would stay well below 50000. With a 30-bit output
+     * the sample distribution covers the full range. 100 draws from a
+     * fixed seed is enough: the probability of 100 consecutive values
+     * all below 50001 is (50001/100001)^100 ≈ 7.9e-31, which is zero
+     * for practical purposes and makes the test a hard regression
+     * guard rather than a flaky statistical check. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "RANDOM wide-range: fixture_open");
+        }
+        else
+        {
+            run_src(&fx, "r = RANDOM(,,1)\n");
+            int saw_high = 0;
+            int k;
+            for (k = 0; k < 100 && !saw_high; k++)
+            {
+                run_src(&fx, "x = RANDOM(0,100000)\n");
+                Lstr key;
+                Lstr val;
+                Lzeroinit(&key);
+                Lzeroinit(&val);
+                Lscpy(fx.alloc, &key, "X");
+                if (vpool_get(fx.pool, &key, &val) == VPOOL_OK &&
+                    val.len > 0)
+                {
+                    long n = 0;
+                    size_t i;
+                    int parse_ok = 1;
+                    for (i = 0; i < val.len; i++)
+                    {
+                        unsigned char c = val.pstr[i];
+                        if (c < (unsigned char)'0' ||
+                            c > (unsigned char)'9')
+                        {
+                            parse_ok = 0;
+                            break;
+                        }
+                        n = n * 10 + (c - (unsigned char)'0');
+                    }
+                    if (parse_ok && n > 50000)
+                    {
+                        saw_high = 1;
+                    }
+                }
+                Lfree(fx.alloc, &key);
+                Lfree(fx.alloc, &val);
+            }
+            CHECK(saw_high,
+                  "RANDOM(0,100000) reaches values > 50000 "
+                  "(guards 15-bit truncation)");
+            fixture_close(&fx);
+        }
     }
 }
 


### PR DESCRIPTION
Closes #31. Wires the seven SC28-1883-0 §4 numeric built-in functions
into the per-environment BIF registry. All handlers delegate to the
existing IRXARITH entry points delivered in Phase B (#30).

## What

- `MAX(n [, ...])`, `MIN(n [, ...])` — variadic, pairwise compare via
  `irx_arith_compare`.
- `ABS(n)` — `irx_arith_op(..., ARITH_ABS, ...)`.
- `SIGN(n)` — `'-1'` / `'0'` / `'1'` via compare-to-zero.
- `TRUNC(n [, d])` — `irx_arith_trunc`; `d` capped at `NUMERIC_DIGITS_MAX`.
- `FORMAT(n [, b [, a [, p [, t]]]])` — `irx_arith_format`; all four
  integer arguments honour the `IRX_FORMAT_OMIT` sentinel via
  `irx_bif_opt_whole`, and each is range-capped.
- `RANDOM([min [, max [, seed]]])` — 32-bit LCG seeded from a new
  `wkbi_random_seed` slot in `struct irx_wkblk_int`. `RANDOM(,,seed)`
  sets the seed and returns `'0'` per spec. Output is a 30-bit value
  obtained by combining the high-order 15 bits of two consecutive LCG
  steps; a single 15-bit output would truncate any range above 32767.

## Error hygiene

- Introduces `SYNTAX_BAD_ARITH` (code 41) + `ERR41_NONNUMERIC` subcode.
  Renames the unused, misnamed `SYNTAX_EXP_OVERFLOW`; per SC28-1883-0
  §18, 41 is bad arithmetic conversion, 42 is overflow.
- Integer arguments exceeding `NUMERIC_DIGITS_MAX` surface as 40.4,
  not a generic 41.1 from the arithmetic layer.

## Parser scope note

`parse_function_call` now accepts omitted arguments (empty slots
between commas, or before the closing paren), producing a zero-length
Lstr in the argv entry. This is strictly additive — previously
rejected forms like `FOO(,,x)` now reach the BIF validator, where the
per-BIF rules take over. Required for `RANDOM(,,seed)` in AC-C6 and
matches the existing behaviour of the CALL keyword.

## Tests

53 new cases in `test/test_bifs.c` covering every AC (C1..C7), error
hygiene paths, and boundary/edge cases. All 162 bif tests pass; no
regression in the other 13 suites.

| Suite             | Pass  |
|-------------------|-------|
| tokenizer         | 70/70 |
| vpool             | 47/47 |
| parser            | 39/39 |
| say               | 27/27 |
| irxlstr           | 50/50 |
| control           | 62/62 |
| hello             | 16/16 |
| parse             | 74/74 |
| procedure         | 53/53 |
| bif               | 29/29 |
| arith             | 128/128 |
| arith_extended    | 113/113 |
| phase1            | 38/38 |
| bifs              | 162/162 |

**Total: 908 tests, 0 failures.**

## Review round 2

Addressed findings from the second review pass. Per-item commit map
and the [DISCUSS] analyses are posted as PR comments.

## Out of scope

Phases D (conversion), E (reflection), F (environment), H (close-out)
remain open as filed in #32 / #33 / #34 / #35.