### PR TITLE
WP-21b Phase D: conversion BIFs (C2X/X2C/B2X/X2B/C2D/X2D/D2C/D2X)

### DIFF
--- a/include/irxcond.h
+++ b/include/irxcond.h
@@ -42,6 +42,8 @@ struct envblock; /* forward decl to avoid circular include */
 #define ERR40_SINGLE_CHAR     14 /* argument N must be single char    */
 #define ERR40_NUMBER_REQUIRED 21 /* argument N must be a number       */
 #define ERR40_OPTION_INVALID  23 /* argument N option not in allowed  */
+#define ERR40_BAD_BINARY      24 /* argument 1 must be a binary string (B2X) */
+#define ERR40_BAD_HEX         25 /* argument 1 must be a hex string (X2C/X2D/X2B) */
 /* reserved for WP-21b misc BIFs (raised by TRANSLATE-style table check) */
 #define ERR40_PAIRED_LENGTH 29 /* translate table lengths mismatch  */
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -1646,6 +1646,13 @@ static int bif_x2b(struct irx_parser *p, int argc, PLstr *argv,
 /* Returns the new length or -1 if the buffer is too small to hold the */
 /* result. At most three digits can be prepended per call (carry ≤ 255 */
 /* times residual ≤ ~2304, which rolls up to at most three decimals).  */
+/*                                                                      */
+/* Performance note: the prepend loop uses memmove per new digit, so a  */
+/* k-byte input costs O(k²) bytes of movement worst case (~7.5 MB for   */
+/* k=1000). A "prepend counter + single final shift" variant would      */
+/* reduce this to O(k). Left as-is until profiling against a real       */
+/* hotpath justifies the change — C2D inputs of that magnitude are      */
+/* pathological in practice.                                            */
 static int bcd_mul256_add(char *digits, int len, int cap, int byte_val)
 {
     int i;
@@ -1771,6 +1778,8 @@ static int compute_c2d(struct irx_parser *p,
 
     /* BCD path. Scratch: digits upper bound is byte_len * 3 (each byte  */
     /* contributes ≤ 2.41 decimal digits; round up to 3 for slack).      */
+    /* The (int) cast is safe in practice: byte_len is bounded by the    */
+    /* input Lstr length which is well under INT_MAX/3 on 24-bit MVS.    */
     int digits_cap = (int)byte_len * 3 + 4;
     void *tmp = NULL;
     int arc = irxstor(RXSMGET, digits_cap, &tmp, p->envblock);
@@ -2092,19 +2101,19 @@ static int d2_parse_whole(struct irx_parser *p, PLstr in,
     return IRXPARS_OK;
 }
 
-/* Pull out bytes LSB-first from a digit array, into a reversed        */
-/* (caller-provided) buffer. Returns the number of bytes actually      */
-/* written before the value was exhausted.                             */
-static int digits_to_bytes_lsb_collect(char *digits, int digits_len,
-                                       unsigned char *lsb_out, int cap)
-{
-    return bcd_to_bytes_lsb(digits, digits_len, lsb_out, cap);
-}
-
 /* Core for D2C and the byte-backing of D2X. Writes `out_bytes_len`    */
 /* bytes MSB-first into `out_bytes`. Handles sign, length padding,     */
-/* truncation, and two's-complement negation. `*all_zero_out` is 1 iff */
-/* the absolute value of the input is zero.                            */
+/* truncation, and two's-complement negation. `*all_zero_out` reflects */
+/* the PRE-NEGATION magnitude (1 iff |n| == 0 after length truncation) */
+/* — callers only use it in the sign==0 / length-omitted path where    */
+/* the distinction doesn't matter. If a future refactor consults       */
+/* `all_zero` on a post-negation buffer, re-check this semantics.      */
+/*                                                                     */
+/* Performance note: two scratch buffers are allocated per call        */
+/* (`digits`, DIGITS_CAP bytes ≈ 2000; `lsb`, lsb_cap bytes ≤ ~505).    */
+/* Consolidating into one allocation with offset pointers would save   */
+/* ~2.5 KB on the MVS heap per invocation — deferred until a concrete  */
+/* hotpath motivates it.                                               */
 static int d2_core_write_bytes(struct irx_parser *p, PLstr in,
                                const char *bif_name,
                                int length_given,
@@ -2171,9 +2180,7 @@ static int d2_core_write_bytes(struct irx_parser *p, PLstr in,
     }
     memset(lsb, 0, (size_t)lsb_cap);
 
-    int actual = digits_to_bytes_lsb_collect(digits, digits_len, lsb,
-                                             lsb_cap);
-    (void)actual;
+    (void)bcd_to_bytes_lsb(digits, digits_len, lsb, lsb_cap);
 
     /* Reverse LSB-first into MSB-first in out_bytes, right-aligned. */
     memset(out_bytes, 0, (size_t)out_bytes_len);

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -29,6 +29,7 @@
 #include "irxbif.h"
 #include "irxbifs.h"
 #include "irxcond.h"
+#include "irxfunc.h"
 #include "irxlstr.h"
 #include "irxpars.h"
 #include "irxwkblk.h"
@@ -1387,6 +1388,1099 @@ static int bif_random(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
+/*  Phase H — Conversion BIFs (WP-21b Phase D)                        */
+/*                                                                    */
+/*  C2X / X2C / B2X / X2B are pure byte-level conversions; they       */
+/*  neither inspect nor produce REXX numbers. C2D / X2D / D2C / D2X   */
+/*  bridge bytes and decimal numbers. Small inputs go through direct  */
+/*  long arithmetic; larger values route through                      */
+/*  irx_arith_from_digits / irx_arith_to_digits (WP-21b Phase B).     */
+/*                                                                    */
+/*  Charset note: the conversion BIFs operate on raw byte values, not */
+/*  on characters as symbols. On EBCDIC MVS, D2C(193) produces the    */
+/*  byte 0xC1 which happens to render as 'A'; on ASCII Linux,         */
+/*  D2C(65) produces 0x41 which also renders as 'A'. The interpreter  */
+/*  is byte-identical across platforms — only the rendering differs.  */
+/* ================================================================== */
+
+/* Hex-digit lookup. Returns 0..15 for the three legal digit ranges,  */
+/* -1 for any other character. The contiguous-range checks hold on    */
+/* both ASCII and EBCDIC because '0'..'9', 'A'..'F', and 'a'..'f' are */
+/* each a single contiguous code-point block in both encodings.       */
+static int hex_val(unsigned char c)
+{
+    if (c >= (unsigned char)'0' && c <= (unsigned char)'9')
+    {
+        return (int)(c - (unsigned char)'0');
+    }
+    if (c >= (unsigned char)'A' && c <= (unsigned char)'F')
+    {
+        return (int)(c - (unsigned char)'A') + 10;
+    }
+    if (c >= (unsigned char)'a' && c <= (unsigned char)'f')
+    {
+        return (int)(c - (unsigned char)'a') + 10;
+    }
+    return -1;
+}
+
+/* Produce an upper-case hex digit for nibble value 0..15. */
+static unsigned char hex_char(int v)
+{
+    if (v < 10)
+    {
+        return (unsigned char)((int)'0' + v);
+    }
+    return (unsigned char)((int)'A' + (v - 10));
+}
+
+/* SC28-1883-0 treats only blank as whitespace inside hex/binary       */
+/* literals. Tab, newline, etc. are not skipped.                       */
+static int is_blank(unsigned char c)
+{
+    return c == (unsigned char)' ';
+}
+
+static void raise_bad_hex(struct irx_parser *p, const char *bif_name)
+{
+    raise_bif_cond(p, SYNTAX_BAD_CALL, ERR40_BAD_HEX, bif_name,
+                   ": argument 1 must be a hexadecimal string");
+}
+
+static void raise_bad_binary(struct irx_parser *p, const char *bif_name)
+{
+    raise_bif_cond(p, SYNTAX_BAD_CALL, ERR40_BAD_BINARY, bif_name,
+                   ": argument 1 must be a binary string");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Byte-based conversions (no IRXARITH involvement)                  */
+/* ------------------------------------------------------------------ */
+
+static int bif_c2x(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    (void)argc;
+    PLstr in = argv[0];
+    size_t in_len = in->len;
+    size_t out_len = in_len * 2;
+    int rc = Lfx(p->alloc, result, out_len);
+    if (rc != LSTR_OK)
+    {
+        return translate_lstr_rc(rc);
+    }
+    size_t i;
+    for (i = 0; i < in_len; i++)
+    {
+        unsigned char b = in->pstr[i];
+        result->pstr[2 * i]     = hex_char((b >> 4) & 0x0F);
+        result->pstr[2 * i + 1] = hex_char(b & 0x0F);
+    }
+    result->len = out_len;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+static int bif_x2c(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    (void)argc;
+    PLstr in = argv[0];
+    size_t count = 0;
+    size_t i;
+    for (i = 0; i < in->len; i++)
+    {
+        unsigned char c = in->pstr[i];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        if (hex_val(c) < 0)
+        {
+            raise_bad_hex(p, "X2C");
+            return IRXPARS_SYNTAX;
+        }
+        count++;
+    }
+
+    size_t out_len = (count + 1) / 2;
+    int rc = Lfx(p->alloc, result, out_len);
+    if (rc != LSTR_OK)
+    {
+        return translate_lstr_rc(rc);
+    }
+    /* Odd total count pads a leading '0' nibble; the very first input  */
+    /* digit becomes the LOW nibble of byte[0].                         */
+    int nibble_count = (int)(count & 1);
+    int cur = 0;
+    size_t out_idx = 0;
+    for (i = 0; i < in->len; i++)
+    {
+        unsigned char c = in->pstr[i];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        cur = (cur << 4) | hex_val(c);
+        nibble_count++;
+        if (nibble_count == 2)
+        {
+            result->pstr[out_idx++] = (unsigned char)cur;
+            cur = 0;
+            nibble_count = 0;
+        }
+    }
+    result->len = out_len;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+static int bif_b2x(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    (void)argc;
+    PLstr in = argv[0];
+    size_t count = 0;
+    size_t i;
+    for (i = 0; i < in->len; i++)
+    {
+        unsigned char c = in->pstr[i];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        if (c != (unsigned char)'0' && c != (unsigned char)'1')
+        {
+            raise_bad_binary(p, "B2X");
+            return IRXPARS_SYNTAX;
+        }
+        count++;
+    }
+
+    size_t out_len = (count + 3) / 4;
+    int rc = Lfx(p->alloc, result, out_len);
+    if (rc != LSTR_OK)
+    {
+        return translate_lstr_rc(rc);
+    }
+    /* Left-pad zero bits so 4-bit groups align from the right. */
+    int pad = (int)((4 - (count & 3)) & 3);
+    int bit_count = pad;
+    int cur = 0;
+    size_t out_idx = 0;
+    for (i = 0; i < in->len; i++)
+    {
+        unsigned char c = in->pstr[i];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        cur = (cur << 1) | (int)(c - (unsigned char)'0');
+        bit_count++;
+        if (bit_count == 4)
+        {
+            result->pstr[out_idx++] = hex_char(cur);
+            cur = 0;
+            bit_count = 0;
+        }
+    }
+    result->len = out_len;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+static int bif_x2b(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    (void)argc;
+    PLstr in = argv[0];
+    size_t count = 0;
+    size_t i;
+    for (i = 0; i < in->len; i++)
+    {
+        unsigned char c = in->pstr[i];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        if (hex_val(c) < 0)
+        {
+            raise_bad_hex(p, "X2B");
+            return IRXPARS_SYNTAX;
+        }
+        count++;
+    }
+
+    size_t out_len = count * 4;
+    int rc = Lfx(p->alloc, result, out_len);
+    if (rc != LSTR_OK)
+    {
+        return translate_lstr_rc(rc);
+    }
+    size_t out_idx = 0;
+    for (i = 0; i < in->len; i++)
+    {
+        unsigned char c = in->pstr[i];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        int v = hex_val(c);
+        int b;
+        for (b = 3; b >= 0; b--)
+        {
+            result->pstr[out_idx++] =
+                (unsigned char)((int)'0' + ((v >> b) & 1));
+        }
+    }
+    result->len = out_len;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  BCD helpers for the large-value paths                             */
+/* ------------------------------------------------------------------ */
+
+/* Multiply the BCD digit array (MSB first) by 256 and add `byte_val`. */
+/* Returns the new length or -1 if the buffer is too small to hold the */
+/* result. At most three digits can be prepended per call (carry ≤ 255 */
+/* times residual ≤ ~2304, which rolls up to at most three decimals).  */
+static int bcd_mul256_add(char *digits, int len, int cap, int byte_val)
+{
+    int i;
+    int carry = byte_val;
+    for (i = len - 1; i >= 0; i--)
+    {
+        int v = (int)(unsigned char)digits[i] * 256 + carry;
+        digits[i] = (char)(v % 10);
+        carry = v / 10;
+    }
+    int new_len = len;
+    while (carry > 0)
+    {
+        if (new_len >= cap)
+        {
+            return -1;
+        }
+        memmove(digits + 1, digits, (size_t)new_len);
+        digits[0] = (char)(carry % 10);
+        carry /= 10;
+        new_len++;
+    }
+    return new_len;
+}
+
+/* Given a BCD digit array (MSB first) representing |value|, extract   */
+/* bytes LSB-first via repeated division by 256. Up to `max_bytes` are */
+/* written into `bytes_out`. The digit array is consumed. Returns the  */
+/* count written.                                                      */
+/*                                                                     */
+/* Loop invariant for the inner division: each `cur = rem*10 + d[i]`   */
+/* is < 256*10 + 9 = 2569, so `cur/256 ∈ 0..9` — every iteration emits */
+/* a legitimate single decimal digit, no normalization needed.         */
+static int bcd_to_bytes_lsb(char *digits, int digits_len,
+                            unsigned char *bytes_out, int max_bytes)
+{
+    int count = 0;
+    int len = digits_len;
+    while (count < max_bytes && len > 0)
+    {
+        int all_zero = 1;
+        int i;
+        for (i = 0; i < len; i++)
+        {
+            if (digits[i] != 0)
+            {
+                all_zero = 0;
+                break;
+            }
+        }
+        if (all_zero)
+        {
+            break;
+        }
+        int rem = 0;
+        int first_nz = -1;
+        for (i = 0; i < len; i++)
+        {
+            int cur = rem * 10 + (int)(unsigned char)digits[i];
+            digits[i] = (char)(cur / 256);
+            rem = cur % 256;
+            if (first_nz < 0 && digits[i] != 0)
+            {
+                first_nz = i;
+            }
+        }
+        bytes_out[count++] = (unsigned char)rem;
+        if (first_nz < 0)
+        {
+            len = 0;
+        }
+        else if (first_nz > 0)
+        {
+            memmove(digits, digits + first_nz,
+                    (size_t)(len - first_nz));
+            len -= first_nz;
+        }
+    }
+    return count;
+}
+
+/* ------------------------------------------------------------------ */
+/*  C2D / X2D core                                                    */
+/* ------------------------------------------------------------------ */
+
+/* Emit a signed decimal REXX number from a magnitude byte array (MSB   */
+/* first, already the absolute value — no two's-complement logic here). */
+/* `sign` is 0 for non-negative, 1 for negative.                        */
+/*                                                                       */
+/* Small path: byte_len ≤ 3 always fits signed long — uval ≤ 2^24-1,    */
+/* sval ∈ [-2^24+1, 2^24-1]. Four-byte and larger magnitudes route       */
+/* through the BCD path; keeping the small-path threshold at 3 sidesteps */
+/* platform-specific `long` widths (32 bit on MVS, 64 on the Linux       */
+/* cross-compile host).                                                  */
+static int compute_c2d(struct irx_parser *p,
+                       const unsigned char *mag, size_t byte_len,
+                       int sign, PLstr result)
+{
+    /* Strip leading zero bytes so the small-path check sees the true    */
+    /* magnitude width. */
+    while (byte_len > 0 && mag[0] == 0)
+    {
+        mag++;
+        byte_len--;
+    }
+
+    if (byte_len == 0)
+    {
+        return translate_lstr_rc(long_to_lstr(p->alloc, result, 0L));
+    }
+
+    if (byte_len <= 3)
+    {
+        unsigned long uval = 0;
+        size_t i;
+        for (i = 0; i < byte_len; i++)
+        {
+            uval = (uval << 8) | mag[i];
+        }
+        long sval = sign ? -(long)uval : (long)uval;
+        return translate_lstr_rc(long_to_lstr(p->alloc, result, sval));
+    }
+
+    /* BCD path. Scratch: digits upper bound is byte_len * 3 (each byte  */
+    /* contributes ≤ 2.41 decimal digits; round up to 3 for slack).      */
+    int digits_cap = (int)byte_len * 3 + 4;
+    void *tmp = NULL;
+    int arc = irxstor(RXSMGET, digits_cap, &tmp, p->envblock);
+    if (arc != 0)
+    {
+        return IRXPARS_NOMEM;
+    }
+    char *digits = (char *)tmp;
+
+    int digits_len = 0;
+    size_t i;
+    for (i = 0; i < byte_len; i++)
+    {
+        digits_len = bcd_mul256_add(digits, digits_len, digits_cap,
+                                    (int)mag[i]);
+        if (digits_len < 0)
+        {
+            void *p1 = digits;
+            irxstor(RXSMFRE, 0, &p1, p->envblock);
+            return IRXPARS_NOMEM;
+        }
+    }
+
+    int rc = irx_arith_from_digits(p->envblock, digits, digits_len,
+                                   sign ? 1 : 0, 0L, result);
+
+    void *p1 = digits;
+    irxstor(RXSMFRE, 0, &p1, p->envblock);
+    return rc;
+}
+
+/* Negate a bit-width-bounded byte array in place (two's complement)     */
+/* and return the resulting magnitude (low `byte_len` bytes). When       */
+/* `pad_odd_nibble` is non-zero, byte[0]'s high nibble is masked before  */
+/* and after the flip so the eff_hex-nibble-wide semantics are honored.  */
+static void twos_complement_bytes(unsigned char *bytes, size_t byte_len,
+                                  int pad_odd_nibble)
+{
+    if (byte_len == 0)
+    {
+        return;
+    }
+    if (pad_odd_nibble)
+    {
+        bytes[0] &= 0x0F;
+    }
+    size_t i;
+    for (i = 0; i < byte_len; i++)
+    {
+        bytes[i] = (unsigned char)(~bytes[i]);
+    }
+    int carry = 1;
+    size_t j;
+    for (j = byte_len; j > 0 && carry != 0; )
+    {
+        j--;
+        int s = (int)bytes[j] + carry;
+        bytes[j] = (unsigned char)(s & 0xFF);
+        carry = (s >> 8) & 1;
+    }
+    if (pad_odd_nibble)
+    {
+        bytes[0] &= 0x0F;
+    }
+}
+
+static int bif_c2d(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    PLstr in = argv[0];
+    long n = 0;
+    int n_given = 0;
+
+    if (argc >= 2 && argv[1] != NULL && argv[1]->len > 0)
+    {
+        int rc = irx_bif_whole_nonneg(p, argv, 1, "C2D", &n);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        n_given = 1;
+    }
+
+    const unsigned char *bytes = in->pstr;
+    size_t byte_len = in->len;
+    unsigned char *work = NULL;
+
+    if (n_given)
+    {
+        if (n == 0)
+        {
+            return translate_lstr_rc(long_to_lstr(p->alloc, result, 0L));
+        }
+        if (byte_len > (size_t)n)
+        {
+            /* Keep the rightmost n bytes, drop the rest. */
+            bytes += byte_len - (size_t)n;
+            byte_len = (size_t)n;
+        }
+        else if (byte_len < (size_t)n)
+        {
+            /* Left-pad with 0x00 to exactly n bytes. */
+            void *tmp = NULL;
+            int arc = irxstor(RXSMGET, (int)n, &tmp, p->envblock);
+            if (arc != 0)
+            {
+                return IRXPARS_NOMEM;
+            }
+            work = (unsigned char *)tmp;
+            size_t pad = (size_t)n - byte_len;
+            memset(work, 0, pad);
+            if (byte_len > 0)
+            {
+                memcpy(work + pad, bytes, byte_len);
+            }
+            bytes = work;
+            byte_len = (size_t)n;
+        }
+    }
+
+    /* Determine sign. For n_given with MSB of byte[0] set, compute the  */
+    /* magnitude (two's complement) in a scratch buffer and hand that to */
+    /* compute_c2d with sign=1. Otherwise treat as positive.             */
+    int sign = 0;
+    if (n_given && byte_len > 0 && (bytes[0] & 0x80U) != 0)
+    {
+        sign = 1;
+        if (work == NULL)
+        {
+            /* Copy into a mutable scratch buffer — we mustn't modify the */
+            /* original argv[0] payload. */
+            void *tmp = NULL;
+            int arc = irxstor(RXSMGET, (int)byte_len, &tmp, p->envblock);
+            if (arc != 0)
+            {
+                return IRXPARS_NOMEM;
+            }
+            work = (unsigned char *)tmp;
+            memcpy(work, bytes, byte_len);
+            bytes = work;
+        }
+        twos_complement_bytes(work, byte_len, 0);
+    }
+
+    int rc = compute_c2d(p, bytes, byte_len, sign, result);
+
+    if (work != NULL)
+    {
+        void *p1 = work;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+    return rc;
+}
+
+static int bif_x2d(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    PLstr in = argv[0];
+    long n_arg = 0;
+    int n_given = 0;
+
+    if (argc >= 2 && argv[1] != NULL && argv[1]->len > 0)
+    {
+        int rc = irx_bif_whole_nonneg(p, argv, 1, "X2D", &n_arg);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        n_given = 1;
+    }
+
+    size_t hex_count = 0;
+    size_t i;
+    for (i = 0; i < in->len; i++)
+    {
+        unsigned char c = in->pstr[i];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        if (hex_val(c) < 0)
+        {
+            raise_bad_hex(p, "X2D");
+            return IRXPARS_SYNTAX;
+        }
+        hex_count++;
+    }
+
+    size_t eff_hex = n_given ? (size_t)n_arg : hex_count;
+    if (eff_hex == 0)
+    {
+        return translate_lstr_rc(long_to_lstr(p->alloc, result, 0L));
+    }
+
+    size_t byte_len = (eff_hex + 1) / 2;
+    int pad_odd = (int)(eff_hex & 1);
+
+    void *tmp = NULL;
+    int arc = irxstor(RXSMGET, (int)byte_len, &tmp, p->envblock);
+    if (arc != 0)
+    {
+        return IRXPARS_NOMEM;
+    }
+    unsigned char *bytes = (unsigned char *)tmp;
+    memset(bytes, 0, byte_len);
+
+    /* Pack up to min(eff_hex, hex_count) nibbles into the rightmost     */
+    /* slots. When the input has fewer than eff_hex digits, the leading  */
+    /* slots stay zero — that's the implicit left-pad.                   */
+    size_t need = (eff_hex < hex_count) ? eff_hex : hex_count;
+    size_t total_slots = byte_len * 2;
+    size_t slot = total_slots;
+    size_t taken = 0;
+    size_t j;
+    for (j = in->len; j > 0 && taken < need; )
+    {
+        j--;
+        unsigned char c = in->pstr[j];
+        if (is_blank(c))
+        {
+            continue;
+        }
+        int v = hex_val(c);
+        slot--;
+        size_t byte_idx = slot / 2;
+        int is_high = ((slot & 1) == 0);
+        if (is_high)
+        {
+            bytes[byte_idx] |= (unsigned char)((v & 0x0F) << 4);
+        }
+        else
+        {
+            bytes[byte_idx] |= (unsigned char)(v & 0x0F);
+        }
+        taken++;
+    }
+
+    /* Two's-complement sign = bit 3 of the leftmost real hex digit.     */
+    /* For odd eff_hex, slot 0 is a pad '0' nibble and the first real    */
+    /* digit lives at slot 1. Mask byte[0]'s high nibble for odd eff_hex */
+    /* so the magnitude arithmetic stays within the effective bit width. */
+    if (pad_odd && byte_len > 0)
+    {
+        bytes[0] &= 0x0F;
+    }
+
+    int sign = 0;
+    if (n_given && byte_len > 0)
+    {
+        unsigned char msn = pad_odd
+            ? (unsigned char)(bytes[0] & 0x0F)
+            : (unsigned char)((bytes[0] >> 4) & 0x0F);
+        if ((msn & 0x08U) != 0)
+        {
+            sign = 1;
+            twos_complement_bytes(bytes, byte_len, pad_odd);
+        }
+    }
+
+    int rc = compute_c2d(p, bytes, byte_len, sign, result);
+
+    {
+        void *p1 = bytes;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+    return rc;
+}
+
+/* ------------------------------------------------------------------ */
+/*  D2C / D2X core                                                    */
+/* ------------------------------------------------------------------ */
+
+/* Parse argv[0] as a REXX whole number via irx_arith_to_digits.       */
+/* Expands the digit array by any positive exponent (trailing zeros).  */
+/* Sets condition and returns IRXPARS_SYNTAX on non-numeric or         */
+/* fractional inputs.                                                  */
+static int d2_parse_whole(struct irx_parser *p, PLstr in,
+                          const char *bif_name,
+                          char *digits, int digits_cap,
+                          int *digits_len_out, int *sign_out)
+{
+    int digits_len = 0;
+    int sign = 0;
+    long exponent = 0;
+    int rc = irx_arith_to_digits(p->envblock, in, digits, digits_cap,
+                                 &digits_len, &sign, &exponent);
+    if (rc == IRXPARS_SYNTAX)
+    {
+        raise_nonnumeric(p, bif_name);
+        return rc;
+    }
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
+    if (exponent < 0)
+    {
+        raise_bif_cond(p, SYNTAX_BAD_CALL, ERR40_WHOLE_NUMBER, bif_name,
+                       ": argument 1 must be a whole number");
+        return IRXPARS_SYNTAX;
+    }
+    if (exponent > 0)
+    {
+        if ((long)digits_len + exponent > (long)digits_cap)
+        {
+            raise_bif_cond(p, SYNTAX_BAD_CALL, ERR40_ARG_LENGTH, bif_name,
+                           ": argument 1 magnitude too large");
+            return IRXPARS_SYNTAX;
+        }
+        int e;
+        for (e = 0; e < (int)exponent; e++)
+        {
+            digits[digits_len + e] = 0;
+        }
+        digits_len += (int)exponent;
+    }
+    *digits_len_out = digits_len;
+    *sign_out = sign;
+    return IRXPARS_OK;
+}
+
+/* Pull out bytes LSB-first from a digit array, into a reversed        */
+/* (caller-provided) buffer. Returns the number of bytes actually      */
+/* written before the value was exhausted.                             */
+static int digits_to_bytes_lsb_collect(char *digits, int digits_len,
+                                       unsigned char *lsb_out, int cap)
+{
+    return bcd_to_bytes_lsb(digits, digits_len, lsb_out, cap);
+}
+
+/* Core for D2C and the byte-backing of D2X. Writes `out_bytes_len`    */
+/* bytes MSB-first into `out_bytes`. Handles sign, length padding,     */
+/* truncation, and two's-complement negation. `*all_zero_out` is 1 iff */
+/* the absolute value of the input is zero.                            */
+static int d2_core_write_bytes(struct irx_parser *p, PLstr in,
+                               const char *bif_name,
+                               int length_given,
+                               int out_bytes_len,
+                               unsigned char *out_bytes,
+                               int *sign_out, int *all_zero_out,
+                               int twos_mask_high_nibble)
+{
+    /* digits_cap sized to hold NUMERIC DIGITS max plus a generous       */
+    /* exponent expansion. 2 * NUMERIC_DIGITS_MAX covers every number    */
+    /* that fits the engine — if that overflows, d2_parse_whole raises  */
+    /* a condition.                                                     */
+    enum { DIGITS_CAP = NUMERIC_DIGITS_MAX * 2 };
+    char *digits = NULL;
+    int rc = IRXPARS_OK;
+    int digits_len = 0;
+    int sign = 0;
+
+    {
+        void *tmp = NULL;
+        int arc = irxstor(RXSMGET, DIGITS_CAP, &tmp, p->envblock);
+        if (arc != 0)
+        {
+            return IRXPARS_NOMEM;
+        }
+        digits = (char *)tmp;
+    }
+
+    rc = d2_parse_whole(p, in, bif_name, digits, DIGITS_CAP,
+                        &digits_len, &sign);
+    if (rc != IRXPARS_OK)
+    {
+        goto cleanup;
+    }
+
+    *sign_out = sign;
+
+    /* Negative without length → SYNTAX 40.11. Must come before byte    */
+    /* extraction so the error wins over an empty output.               */
+    if (sign == 1 && !length_given)
+    {
+        raise_bif_cond(p, SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE, bif_name,
+                       ": argument 1 must be non-negative when length omitted");
+        rc = IRXPARS_SYNTAX;
+        goto cleanup;
+    }
+
+    /* Extract low bytes into a temporary LSB-first buffer. We need at  */
+    /* most out_bytes_len + 1 bytes to detect overflow for the length-  */
+    /* omitted case (the extra byte lets us see a non-zero after our    */
+    /* window ends). For D2C/D2X with length given, out_bytes_len is    */
+    /* enough and overflow truncates silently per spec.                 */
+    int lsb_cap = out_bytes_len + 1;
+    unsigned char *lsb = NULL;
+    {
+        void *tmp = NULL;
+        int arc = irxstor(RXSMGET, lsb_cap, &tmp, p->envblock);
+        if (arc != 0)
+        {
+            rc = IRXPARS_NOMEM;
+            goto cleanup;
+        }
+        lsb = (unsigned char *)tmp;
+    }
+    memset(lsb, 0, (size_t)lsb_cap);
+
+    int actual = digits_to_bytes_lsb_collect(digits, digits_len, lsb,
+                                             lsb_cap);
+    (void)actual;
+
+    /* Reverse LSB-first into MSB-first in out_bytes, right-aligned. */
+    memset(out_bytes, 0, (size_t)out_bytes_len);
+    int k;
+    for (k = 0; k < out_bytes_len; k++)
+    {
+        out_bytes[out_bytes_len - 1 - k] = lsb[k];
+    }
+
+    *all_zero_out = 1;
+    {
+        int m;
+        for (m = 0; m < out_bytes_len; m++)
+        {
+            if (out_bytes[m] != 0)
+            {
+                *all_zero_out = 0;
+                break;
+            }
+        }
+    }
+
+    /* For D2X with odd hex-digit length, the caller sets                */
+    /* twos_mask_high_nibble = 1 to mask out the stray high nibble of    */
+    /* byte[0] before negation (and after, to restore the invariant).   */
+    if (twos_mask_high_nibble && out_bytes_len > 0)
+    {
+        out_bytes[0] &= 0x0F;
+    }
+
+    if (sign == 1 && length_given && out_bytes_len > 0)
+    {
+        /* Flip all bits, add 1 with carry. */
+        int m;
+        for (m = 0; m < out_bytes_len; m++)
+        {
+            out_bytes[m] = (unsigned char)(~out_bytes[m]);
+        }
+        int carry = 1;
+        for (m = out_bytes_len; m > 0 && carry != 0; )
+        {
+            m--;
+            int s = (int)out_bytes[m] + carry;
+            out_bytes[m] = (unsigned char)(s & 0xFF);
+            carry = (s >> 8) & 1;
+        }
+        if (twos_mask_high_nibble)
+        {
+            out_bytes[0] &= 0x0F;
+        }
+    }
+
+    {
+        void *p1 = lsb;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+    rc = IRXPARS_OK;
+
+cleanup:
+    {
+        void *p1 = digits;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+    return rc;
+}
+
+static int bif_d2c(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    long length = 0;
+    int length_given = 0;
+
+    if (argc >= 2 && argv[1] != NULL && argv[1]->len > 0)
+    {
+        int rc = irx_bif_whole_nonneg(p, argv, 1, "D2C", &length);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        length_given = 1;
+    }
+
+    /* length == 0 → empty result regardless of value. */
+    if (length_given && length == 0)
+    {
+        int lrc = Lfx(p->alloc, result, 0);
+        if (lrc == LSTR_OK)
+        {
+            result->len = 0;
+            result->type = LSTRING_TY;
+        }
+        return translate_lstr_rc(lrc);
+    }
+
+    int out_len;
+    if (length_given)
+    {
+        out_len = (int)length;
+    }
+    else
+    {
+        /* Upper bound for the unsigned case. Each decimal digit needs   */
+        /* ≤ log2(10)/8 ≈ 0.415 bytes, so digits/2 + 2 is safe. We       */
+        /* actually ask d2_core_write_bytes for this many slots; if the  */
+        /* magnitude is smaller we trim the leading zero bytes afterward.*/
+        out_len = NUMERIC_DIGITS_MAX / 2 + 4;
+    }
+
+    void *tmp = NULL;
+    int arc = irxstor(RXSMGET, out_len, &tmp, p->envblock);
+    if (arc != 0)
+    {
+        return IRXPARS_NOMEM;
+    }
+    unsigned char *buf = (unsigned char *)tmp;
+
+    int sign = 0;
+    int all_zero = 0;
+    int rc = d2_core_write_bytes(p, argv[0], "D2C", length_given, out_len,
+                                 buf, &sign, &all_zero, 0);
+    if (rc != IRXPARS_OK)
+    {
+        void *p1 = buf;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+        return rc;
+    }
+
+    int emit_len = out_len;
+    int emit_start = 0;
+    if (!length_given)
+    {
+        /* Strip leading zero bytes; zero value → empty. */
+        if (all_zero)
+        {
+            emit_len = 0;
+        }
+        else
+        {
+            while (emit_start < out_len && buf[emit_start] == 0)
+            {
+                emit_start++;
+            }
+            emit_len = out_len - emit_start;
+        }
+    }
+
+    int lrc = Lfx(p->alloc, result, (size_t)emit_len);
+    if (lrc != LSTR_OK)
+    {
+        void *p1 = buf;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+        return translate_lstr_rc(lrc);
+    }
+    if (emit_len > 0)
+    {
+        memcpy(result->pstr, buf + emit_start, (size_t)emit_len);
+    }
+    result->len = (size_t)emit_len;
+    result->type = LSTRING_TY;
+
+    {
+        void *p1 = buf;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+    return IRXPARS_OK;
+}
+
+static int bif_d2x(struct irx_parser *p, int argc, PLstr *argv,
+                   PLstr result)
+{
+    long length = 0;
+    int length_given = 0;
+
+    if (argc >= 2 && argv[1] != NULL && argv[1]->len > 0)
+    {
+        int rc = irx_bif_whole_nonneg(p, argv, 1, "D2X", &length);
+        if (rc != 0)
+        {
+            return rc;
+        }
+        length_given = 1;
+    }
+
+    if (length_given && length == 0)
+    {
+        int lrc = Lfx(p->alloc, result, 0);
+        if (lrc == LSTR_OK)
+        {
+            result->len = 0;
+            result->type = LSTRING_TY;
+        }
+        return translate_lstr_rc(lrc);
+    }
+
+    int byte_len;
+    int pad_odd = 0;
+    if (length_given)
+    {
+        byte_len = (int)((length + 1) / 2);
+        pad_odd = (int)(length & 1);
+    }
+    else
+    {
+        byte_len = NUMERIC_DIGITS_MAX / 2 + 4;
+    }
+
+    void *tmp = NULL;
+    int arc = irxstor(RXSMGET, byte_len, &tmp, p->envblock);
+    if (arc != 0)
+    {
+        return IRXPARS_NOMEM;
+    }
+    unsigned char *buf = (unsigned char *)tmp;
+
+    int sign = 0;
+    int all_zero = 0;
+    int rc = d2_core_write_bytes(p, argv[0], "D2X", length_given, byte_len,
+                                 buf, &sign, &all_zero, pad_odd);
+    if (rc != IRXPARS_OK)
+    {
+        void *p1 = buf;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+        return rc;
+    }
+
+    /* Emit hex. For length_given: exactly `length` hex digits,          */
+    /* starting at nibble position (pad_odd): if pad_odd, the high       */
+    /* nibble of byte[0] is the pad and is skipped. For length omitted:  */
+    /* emit all nibbles of the un-trimmed buffer, then strip leading '0' */
+    /* characters (leaving a single '0' if the value is zero).           */
+    int out_hex;
+    if (length_given)
+    {
+        out_hex = (int)length;
+    }
+    else
+    {
+        out_hex = byte_len * 2;
+    }
+
+    /* Worst case scratch = byte_len * 2. */
+    void *tmp2 = NULL;
+    int arc2 = irxstor(RXSMGET, byte_len * 2, &tmp2, p->envblock);
+    if (arc2 != 0)
+    {
+        void *p1 = buf;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+        return IRXPARS_NOMEM;
+    }
+    unsigned char *hex_buf = (unsigned char *)tmp2;
+    int k;
+    for (k = 0; k < byte_len; k++)
+    {
+        hex_buf[2 * k]     = hex_char((buf[k] >> 4) & 0x0F);
+        hex_buf[2 * k + 1] = hex_char(buf[k] & 0x0F);
+    }
+
+    int emit_start;
+    int emit_len;
+    if (length_given)
+    {
+        emit_start = pad_odd ? 1 : 0;
+        emit_len = out_hex;
+    }
+    else
+    {
+        if (all_zero)
+        {
+            /* D2X(0) → "0". */
+            emit_start = byte_len * 2 - 1;
+            emit_len = 1;
+        }
+        else
+        {
+            emit_start = 0;
+            while (emit_start < byte_len * 2 - 1
+                   && hex_buf[emit_start] == (unsigned char)'0')
+            {
+                emit_start++;
+            }
+            emit_len = byte_len * 2 - emit_start;
+        }
+    }
+
+    int lrc = Lfx(p->alloc, result, (size_t)emit_len);
+    if (lrc == LSTR_OK)
+    {
+        if (emit_len > 0)
+        {
+            memcpy(result->pstr, hex_buf + emit_start, (size_t)emit_len);
+        }
+        result->len = (size_t)emit_len;
+        result->type = LSTRING_TY;
+    }
+
+    {
+        void *p1 = hex_buf;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+    {
+        void *p1 = buf;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+    return translate_lstr_rc(lrc);
+}
+
+/* ================================================================== */
 /*  Registration                                                      */
 /* ================================================================== */
 
@@ -1434,6 +2528,15 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"TRUNC", 1, 2, bif_trunc},
     {"FORMAT", 1, 5, bif_format},
     {"RANDOM", 0, 3, bif_random},
+    /* Phase H — Conversion BIFs (WP-21b Phase D) */
+    {"C2X", 1, 1, bif_c2x},
+    {"X2C", 1, 1, bif_x2c},
+    {"B2X", 1, 1, bif_b2x},
+    {"X2B", 1, 1, bif_x2b},
+    {"C2D", 1, 2, bif_c2d},
+    {"X2D", 1, 2, bif_x2d},
+    {"D2C", 1, 2, bif_d2c},
+    {"D2X", 1, 2, bif_d2x},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -908,6 +908,18 @@ static void test_phase_d_c2d_x2d(void)
     EXPECT_OK("X2D('FFF',3)", "-1", "X2D FFF n=3 (12-bit -1)");
     EXPECT_OK("X2D('800',3)", "-2048", "X2D 800 n=3 (12-bit min)");
     EXPECT_OK("X2D('7FF',3)", "2047", "X2D 7FF n=3 (12-bit max)");
+
+    /* Odd-nibble TRUNCATION: hex_count > n, retains rightmost n nibbles. */
+    /* Expected values verified on TSO/E REXX (SC28-1883-0 reference — see */
+    /* PR #38 thread for the verification run). The leading 'A' gets       */
+    /* dropped, MSN = 'B' has bit 3 set, so the 12-bit two's-complement    */
+    /* value is 0x0BCD - 2^12 = -1075.                                     */
+    EXPECT_OK("X2D('ABCD',3)", "-1075",
+              "X2D ABCD n=3 truncates → BCD (neg, TSO/E-verified)");
+    EXPECT_OK("X2D('A7CD',3)", "1997",
+              "X2D A7CD n=3 truncates → 7CD (pos, non-negation path)");
+    EXPECT_OK("X2D('A00D',3)", "13",
+              "X2D A00D n=3 truncates → 00D (pos, small value)");
 }
 
 static void test_phase_d_d2c_d2x(void)
@@ -1052,6 +1064,12 @@ static void test_phase_d_errors(void)
                     "AC-D7 X2D non-hex → 40.25");
     run_expect_fail("x = X2B('GG')\n", SYNTAX_BAD_CALL, ERR40_BAD_HEX,
                     "X2B non-hex → 40.25");
+    /* Non-hex character surrounded by legitimate blanks — the blank-   */
+    /* skipping loop must NOT suppress the non-hex detection.           */
+    run_expect_fail("x = X2D('F G F')\n", SYNTAX_BAD_CALL, ERR40_BAD_HEX,
+                    "X2D non-hex between blanks");
+    run_expect_fail("x = X2C('A G B')\n", SYNTAX_BAD_CALL, ERR40_BAD_HEX,
+                    "X2C non-hex between blanks");
 
     /* B2X non-binary → SYNTAX 40.24. */
     run_expect_fail("x = B2X('12')\n", SYNTAX_BAD_CALL, ERR40_BAD_BINARY,
@@ -1070,6 +1088,12 @@ static void test_phase_d_errors(void)
                     ERR40_WHOLE_NUMBER, "D2C fractional");
     run_expect_fail("x = D2X('3.14')\n", SYNTAX_BAD_CALL,
                     ERR40_WHOLE_NUMBER, "D2X fractional");
+    /* Scientific notation with negative exponent parses as a number but  */
+    /* has fractional digits after NUMERIC normalization — whole check    */
+    /* must reject it. TSO/E REXX raises SYNTAX 40 (verified, see PR #38  */
+    /* thread).                                                           */
+    run_expect_fail("x = D2C('1E-5')\n", SYNTAX_BAD_CALL,
+                    ERR40_WHOLE_NUMBER, "D2C negative-exponent fractional");
 
     /* D2C / D2X non-numeric → 41.1. */
     run_expect_fail("x = D2C('abc')\n", SYNTAX_BAD_ARITH,

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -775,9 +775,324 @@ static void test_phase_c_edges(void)
                     0, 0, "MAX(17 args) rejected by parser");
 }
 
+/* ================================================================== */
+/*  Phase D — Conversion BIFs (WP-21b #32)                            */
+/*  AC-D1..AC-D11. Charset-sensitive expected values are wrapped with */
+/*  C2X(...) on the REXX side so assertions remain byte-exact on both */
+/*  ASCII (cross-compile) and EBCDIC (future MVS build).              */
+/*                                                                    */
+/*  Bytes for test inputs are built via X2C('...'). REXX '41'x hex    */
+/*  literal syntax is tokenized but not yet decoded by the parser     */
+/*  (see irx#pars.c:3743 — deferred from WP-13), so '41'x currently   */
+/*  surfaces as the raw 2-char string "41". Tests that want a byte    */
+/*  value of 0x41 must go through X2C('41') instead.                  */
+/* ================================================================== */
+
+/* Like EXPECT_OK, but wraps the source with `numeric digits 20` so    */
+/* results longer than the 9-digit default don't get rounded. Used for */
+/* BCD-path tests whose expected value has 10+ decimal digits.         */
+#define EXPECT_OK_BIG(src, want, msg)                                  \
+    do                                                                 \
+    {                                                                  \
+        struct fixture fx;                                             \
+        if (fixture_open(&fx) != 0)                                    \
+        {                                                              \
+            CHECK(0, "fixture_open " msg);                             \
+            break;                                                     \
+        }                                                              \
+        int _rc = run_src(&fx, "numeric digits 20\nx = " src "\n");    \
+        if (_rc != IRXPARS_OK)                                         \
+        {                                                              \
+            printf("    parser rc=%d\n", _rc);                         \
+            CHECK(0, msg);                                             \
+        }                                                              \
+        else                                                           \
+        {                                                              \
+            CHECK(var_eq(&fx, "X", want), msg);                        \
+        }                                                              \
+        fixture_close(&fx);                                            \
+    } while (0)
+
+static void test_phase_d_byte_conv(void)
+{
+    printf("\n--- Phase D: byte-based conversions (C2X/X2C/B2X/X2B) ---\n");
+
+    /* C2X — pure byte → hex. Uppercase always. */
+    EXPECT_OK("C2X('')", "", "C2X empty");
+    EXPECT_OK("C2X(X2C('41'))", "41", "C2X single byte");
+    EXPECT_OK("C2X(X2C('4142'))", "4142", "C2X two bytes");
+    EXPECT_OK("C2X(X2C('ff'))", "FF", "AC-D2 C2X uppercase output");
+    EXPECT_OK("C2X(X2C('00'))", "00", "C2X NUL byte");
+
+    /* X2C — hex → bytes. Verified via C2X wrapper (charset-neutral). */
+    EXPECT_OK("C2X(X2C(''))", "", "X2C empty round-trip");
+    EXPECT_OK("C2X(X2C('41'))", "41", "X2C basic");
+    EXPECT_OK("C2X(X2C('fF'))", "FF", "X2C mixed-case input");
+    EXPECT_OK("C2X(X2C('4 1 4 2'))", "4142", "X2C strips blanks");
+    EXPECT_OK("C2X(X2C('F'))", "0F", "X2C odd length left-pads '0'");
+    EXPECT_OK("C2X(X2C('ABC'))", "0ABC", "X2C 3 digits → 4 digits padded");
+
+    /* B2X — binary → hex. */
+    EXPECT_OK("B2X('')", "", "B2X empty");
+    EXPECT_OK("B2X('11111111')", "FF", "AC-D5 B2X byte FF");
+    EXPECT_OK("B2X('10101010')", "AA", "B2X byte AA");
+    EXPECT_OK("B2X('1')", "1", "B2X single bit pads left");
+    EXPECT_OK("B2X('1010')", "A", "B2X nibble");
+    EXPECT_OK("B2X('1 1010 0101')", "1A5", "B2X blanks + 9 bits");
+
+    /* X2B — hex → binary. */
+    EXPECT_OK("X2B('')", "", "X2B empty");
+    EXPECT_OK("X2B('FF')", "11111111", "AC-D5 X2B FF");
+    EXPECT_OK("X2B('AA')", "10101010", "X2B AA");
+    EXPECT_OK("X2B('0')", "0000", "X2B single 0 digit");
+    EXPECT_OK("X2B('a b')", "10101011", "X2B blanks + lowercase");
+    EXPECT_OK("X2B('DEADBEEF')", "11011110101011011011111011101111",
+              "X2B 8 digits");
+
+    /* Byte-conversion round-trips. */
+    EXPECT_OK("X2B(B2X('10101010'))", "10101010", "RT X2B(B2X) 8 bits");
+    EXPECT_OK("X2B(B2X('1'))", "0001", "RT X2B(B2X) left-pads to 4");
+    EXPECT_OK("X2B(B2X('101'))", "0101", "RT X2B(B2X) 3 bits → 0101");
+    EXPECT_OK("C2X(X2C('deadbeef'))", "DEADBEEF",
+              "RT C2X(X2C) uppercases");
+    EXPECT_OK("C2X(X2C('00112233'))", "00112233",
+              "RT C2X(X2C) preserves zeros");
+}
+
+static void test_phase_d_c2d_x2d(void)
+{
+    printf("\n--- Phase D: C2D / X2D ---\n");
+
+    /* AC-D1 — C2D without n: unsigned big-endian interpretation. */
+    EXPECT_OK("C2D('')", "0", "C2D empty → 0");
+    EXPECT_OK("C2D(X2C('00'))", "0", "C2D one zero byte");
+    EXPECT_OK("C2D(X2C('01'))", "1", "C2D single byte 01");
+    EXPECT_OK("C2D(X2C('FF'))", "255", "C2D single byte FF");
+    EXPECT_OK("C2D(X2C('FFFF'))", "65535", "C2D 2 bytes unsigned");
+    EXPECT_OK("C2D(X2C('FFFFFF'))", "16777215", "C2D 3 bytes unsigned");
+    EXPECT_OK("C2D(X2C('01000000'))", "16777216", "C2D 4 bytes = 2^24");
+
+    /* C2D with n — two's complement. */
+    EXPECT_OK("C2D('',0)", "0", "C2D empty n=0");
+    EXPECT_OK("C2D(X2C('FF'),0)", "0", "C2D nonempty n=0 → 0");
+    EXPECT_OK("C2D(X2C('81'),1)", "-127", "AC-D10 C2D 81 n=1 → -127");
+    EXPECT_OK("C2D(X2C('81'),2)", "129", "C2D 81 n=2 (pad left) → 129");
+    EXPECT_OK("C2D(X2C('FF'),1)", "-1", "C2D FF n=1 → -1");
+    EXPECT_OK("C2D(X2C('FF'),2)", "255", "C2D FF n=2 → 255 (pad)");
+    EXPECT_OK("C2D(X2C('7F'),1)", "127", "AC-D10 MSB-off boundary");
+    EXPECT_OK("C2D(X2C('80'),1)", "-128", "AC-D10 MSB-on boundary");
+    EXPECT_OK("C2D(X2C('FFFF'),1)", "-1", "C2D FFFF n=1 truncates left");
+    EXPECT_OK("C2D(X2C('00FF'),4)", "255", "C2D 00FF n=4 pads left");
+
+    /* X2D without n. */
+    EXPECT_OK("X2D('')", "0", "X2D empty → 0");
+    EXPECT_OK("X2D('0')", "0", "X2D single '0'");
+    EXPECT_OK("X2D('FF')", "255", "X2D FF unsigned");
+    EXPECT_OK("X2D('ff')", "255", "X2D lowercase");
+    EXPECT_OK("X2D('F F')", "255", "AC-D8 X2D blanks tolerated");
+    EXPECT_OK("X2D('100')", "256", "X2D 100 → 256");
+
+    /* X2D with n — n counts HEX DIGITS, not bytes. */
+    EXPECT_OK("X2D('81',2)", "-127", "X2D 81 n=2 → -127");
+    EXPECT_OK("X2D('81',3)", "129", "X2D 81 n=3 pad → 129");
+    EXPECT_OK("X2D('81',4)", "129", "X2D 81 n=4 pad → 129");
+    EXPECT_OK("X2D('7F',2)", "127", "X2D 7F n=2 MSB off");
+    EXPECT_OK("X2D('80',2)", "-128", "X2D 80 n=2 MSB on");
+    EXPECT_OK("X2D('F',1)", "-1", "X2D F n=1 single-nibble signed");
+    EXPECT_OK("X2D('7',1)", "7", "X2D 7 n=1 single-nibble positive");
+    EXPECT_OK("X2D('8',1)", "-8", "X2D 8 n=1 → -8");
+    EXPECT_OK("X2D('FFFF',2)", "-1", "X2D truncated to n=2 → -1");
+    EXPECT_OK("X2D('0080',3)", "128", "X2D 0080 n=3 truncates → 080 = 128");
+
+    /* Odd-nibble two's-complement round-trip sanity. */
+    EXPECT_OK("X2D('FFF',3)", "-1", "X2D FFF n=3 (12-bit -1)");
+    EXPECT_OK("X2D('800',3)", "-2048", "X2D 800 n=3 (12-bit min)");
+    EXPECT_OK("X2D('7FF',3)", "2047", "X2D 7FF n=3 (12-bit max)");
+}
+
+static void test_phase_d_d2c_d2x(void)
+{
+    printf("\n--- Phase D: D2C / D2X ---\n");
+
+    /* AC-D3 charset-independent byte checks via C2X wrapper. */
+    EXPECT_OK("D2C(0)", "", "D2C(0) → empty");
+    EXPECT_OK("C2X(D2C(0,0))", "", "D2C(0,0) → empty");
+    EXPECT_OK("C2X(D2C(0,1))", "00", "D2C(0,1) → 00x");
+    EXPECT_OK("C2X(D2C(1))", "01", "D2C(1) → 01x");
+    EXPECT_OK("C2X(D2C(255))", "FF", "D2C(255) → FFx");
+    EXPECT_OK("C2X(D2C(256))", "0100", "D2C(256) → 0100x");
+    EXPECT_OK("C2X(D2C(65))", "41", "AC-D3 D2C(65) → 0x41 byte");
+    EXPECT_OK("C2X(D2C(193))", "C1", "AC-D3 D2C(193) → 0xC1 byte");
+
+    /* D2C with length — padding and truncation. */
+    EXPECT_OK("C2X(D2C(1,4))", "00000001", "D2C(1,4) left-pads 00s");
+    EXPECT_OK("C2X(D2C(256,1))", "00", "D2C(256,1) truncates to low byte");
+    EXPECT_OK("C2X(D2C(256,2))", "0100", "D2C(256,2) fits exactly");
+
+    /* D2C negative — two's complement. */
+    EXPECT_OK("C2X(D2C(-1,1))", "FF", "D2C(-1,1) → FFx");
+    EXPECT_OK("C2X(D2C(-1,2))", "FFFF", "D2C(-1,2) → FFFFx");
+    EXPECT_OK("C2X(D2C(-1,4))", "FFFFFFFF", "D2C(-1,4) → FFFFFFFFx");
+    EXPECT_OK("C2X(D2C(-128,1))", "80", "D2C(-128,1) → 80x");
+    EXPECT_OK("C2X(D2C(-256,2))", "FF00", "D2C(-256,2) → FF00x");
+    EXPECT_OK("C2X(D2C(-257,2))", "FEFF", "D2C(-257,2) → FEFFx");
+
+    /* AC-D4 — D2X / X2D basic. */
+    EXPECT_OK("D2X(0)", "0", "AC-D4 D2X(0) → '0'");
+    EXPECT_OK("D2X(0,0)", "", "D2X(0,0) → empty");
+    EXPECT_OK("D2X(0,4)", "0000", "D2X(0,4) → 0000");
+    EXPECT_OK("D2X(1)", "1", "D2X(1) no leading zero");
+    EXPECT_OK("D2X(15)", "F", "D2X(15) single digit");
+    EXPECT_OK("D2X(16)", "10", "D2X(16) → 10");
+    EXPECT_OK("D2X(255)", "FF", "AC-D4 D2X(255) → FF");
+    EXPECT_OK("D2X(256)", "100", "D2X(256) → 100");
+    EXPECT_OK("D2X(255,4)", "00FF", "D2X(255,4) pad");
+    EXPECT_OK("D2X(-1,2)", "FF", "D2X(-1,2) → FF");
+    EXPECT_OK("D2X(-1,3)", "FFF", "D2X(-1,3) → FFF (odd length)");
+    EXPECT_OK("D2X(-1,4)", "FFFF", "D2X(-1,4) → FFFF");
+    EXPECT_OK("D2X(-256,3)", "F00", "D2X(-256,3) → F00 (odd, MSB nibble)");
+
+    /* Whole-number inputs expressed as decimals/scientific still work. */
+    EXPECT_OK("C2X(D2C('1E2'))", "64", "D2C scientific → 100 → 0x64");
+    EXPECT_OK("C2X(D2C('1.0'))", "01", "D2C '1.0' whole");
+}
+
+static void test_phase_d_roundtrips(void)
+{
+    printf("\n--- Phase D: round-trips (AC-D4/D10) ---\n");
+
+    /* X2D(D2X(n)) = n for a spectrum of values including BCD-path ones. */
+    EXPECT_OK("X2D(D2X(0))", "0", "RT X2D∘D2X 0");
+    EXPECT_OK("X2D(D2X(1))", "1", "RT X2D∘D2X 1");
+    EXPECT_OK("X2D(D2X(127))", "127", "RT X2D∘D2X 127");
+    EXPECT_OK("X2D(D2X(128))", "128", "RT X2D∘D2X 128");
+    EXPECT_OK("X2D(D2X(255))", "255", "RT X2D∘D2X 255");
+    EXPECT_OK("X2D(D2X(256))", "256", "RT X2D∘D2X 256");
+    EXPECT_OK("X2D(D2X(65535))", "65535", "RT X2D∘D2X 65535");
+    EXPECT_OK_BIG("X2D(D2X(1073741824))", "1073741824", "RT X2D∘D2X 2^30");
+
+    /* Two's-complement C2D(D2C(n,k),k) = n. */
+    EXPECT_OK("C2D(D2C(-1,1),1)", "-1", "RT 2c -1 @1B");
+    EXPECT_OK("C2D(D2C(1,1),1)", "1", "RT 2c 1 @1B");
+    EXPECT_OK("C2D(D2C(127,1),1)", "127", "RT 2c 127 @1B");
+    EXPECT_OK("C2D(D2C(-128,1),1)", "-128", "RT 2c -128 @1B");
+    EXPECT_OK("C2D(D2C(-1,2),2)", "-1", "RT 2c -1 @2B");
+    EXPECT_OK("C2D(D2C(-32768,2),2)", "-32768", "RT 2c int16 min");
+    EXPECT_OK("C2D(D2C(32767,2),2)", "32767", "RT 2c int16 max");
+    EXPECT_OK("C2D(D2C(-1,4),4)", "-1", "RT 2c -1 @4B");
+    EXPECT_OK_BIG("C2D(D2C(2147483647,4),4)", "2147483647",
+                  "RT 2c int32 max");
+    EXPECT_OK_BIG("C2D(D2C(-2147483648,4),4)", "-2147483648",
+                  "RT 2c int32 min");
+}
+
+static void test_phase_d_bcd_path(void)
+{
+    printf("\n--- Phase D: BCD path (AC-D9) ---\n");
+
+    /* Values produced here exceed the default 9-digit NUMERIC DIGITS, so */
+    /* every assertion uses EXPECT_OK_BIG which sets DIGITS 20 up-front.  */
+
+    /* C2D with 5-byte input routes through irx_arith_from_digits.      */
+    /* Construct input via X2C so the test is byte-exact regardless of */
+    /* host code page.                                                 */
+    EXPECT_OK_BIG("C2D(X2C('0100000000'))", "4294967296",
+                  "AC-D9 C2D 5 bytes → 2^32");
+    EXPECT_OK_BIG("C2D(X2C('FF00000000'))", "1095216660480",
+                  "AC-D9 C2D 5 bytes 0xFF00000000");
+
+    /* Unsigned 4-byte with MSB set: signed `long` on MVS overflows;   */
+    /* the 4-byte BCD path covers this too.                            */
+    EXPECT_OK_BIG("C2D(X2C('FFFFFFFF'))", "4294967295",
+                  "AC-D9 C2D 4 bytes FFFFFFFF (unsigned overflow) → BCD");
+    EXPECT_OK_BIG("C2D(X2C('80000000'))", "2147483648",
+                  "C2D 4 bytes 0x80000000 unsigned → BCD");
+
+    /* X2D 9+ hex digits exceeds 32-bit unsigned — BCD path. */
+    EXPECT_OK_BIG("X2D('100000000')", "4294967296",
+                  "AC-D9 X2D 9 digits → 2^32");
+    EXPECT_OK_BIG("X2D('FFFFFFFF')", "4294967295",
+                  "X2D 8 digits FFFFFFFF unsigned overflow → BCD");
+    EXPECT_OK_BIG("X2D('1234567890')", "78187493520",
+                  "AC-D9 X2D 10 digits");
+
+    /* D2C(2^32) → 5-byte output via BCD (irx_arith_to_digits path). */
+    EXPECT_OK_BIG("C2X(D2C(4294967296))", "0100000000",
+                  "AC-D9 D2C(2^32) → 0100000000x");
+    EXPECT_OK_BIG("C2X(D2C(4294967296,5))", "0100000000",
+                  "D2C(2^32,5) BCD fixed-width");
+    EXPECT_OK_BIG("C2X(D2C(4294967296,4))", "00000000",
+                  "D2C(2^32,4) truncates to 0");
+
+    /* Two's-complement in BCD width. */
+    EXPECT_OK_BIG("C2X(D2C(-1,5))", "FFFFFFFFFF",
+                  "D2C(-1,5) BCD two's complement");
+
+    /* D2C/C2D symmetric BCD round-trip. */
+    EXPECT_OK_BIG("C2D(D2C(4294967296,5),5)", "4294967296",
+                  "RT BCD 5-byte 2^32");
+    EXPECT_OK_BIG("C2D(D2C(-4294967296,5),5)", "-4294967296",
+                  "RT BCD 5-byte negative 2^32");
+
+    /* D2X BCD. */
+    EXPECT_OK_BIG("D2X(4294967296)", "100000000",
+                  "D2X(2^32) BCD → 9 digits");
+    EXPECT_OK_BIG("D2X(4294967296,12)", "000100000000",
+                  "D2X(2^32,12) left-pads");
+}
+
+static void test_phase_d_errors(void)
+{
+    printf("\n--- Phase D: error paths ---\n");
+
+    /* AC-D7 — X2C / X2D / X2B non-hex → SYNTAX 40.25. */
+    run_expect_fail("x = X2C('GG')\n", SYNTAX_BAD_CALL, ERR40_BAD_HEX,
+                    "X2C non-hex → 40.25");
+    run_expect_fail("x = X2D('GG')\n", SYNTAX_BAD_CALL, ERR40_BAD_HEX,
+                    "AC-D7 X2D non-hex → 40.25");
+    run_expect_fail("x = X2B('GG')\n", SYNTAX_BAD_CALL, ERR40_BAD_HEX,
+                    "X2B non-hex → 40.25");
+
+    /* B2X non-binary → SYNTAX 40.24. */
+    run_expect_fail("x = B2X('12')\n", SYNTAX_BAD_CALL, ERR40_BAD_BINARY,
+                    "B2X contains '2' → 40.24");
+    run_expect_fail("x = B2X('10102')\n", SYNTAX_BAD_CALL,
+                    ERR40_BAD_BINARY, "B2X bad digit mid-string");
+
+    /* D2C / D2X negative without length → 40.11. */
+    run_expect_fail("x = D2C(-1)\n", SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE,
+                    "D2C(-1) no length");
+    run_expect_fail("x = D2X(-1)\n", SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE,
+                    "D2X(-1) no length");
+
+    /* D2C / D2X fractional → 40.5 (whole-number required). */
+    run_expect_fail("x = D2C('1.5')\n", SYNTAX_BAD_CALL,
+                    ERR40_WHOLE_NUMBER, "D2C fractional");
+    run_expect_fail("x = D2X('3.14')\n", SYNTAX_BAD_CALL,
+                    ERR40_WHOLE_NUMBER, "D2X fractional");
+
+    /* D2C / D2X non-numeric → 41.1. */
+    run_expect_fail("x = D2C('abc')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "D2C non-numeric");
+    run_expect_fail("x = D2X('xy')\n", SYNTAX_BAD_ARITH,
+                    ERR41_NONNUMERIC, "D2X non-numeric");
+
+    /* C2D / X2D negative n → 40.11 from irx_bif_whole_nonneg. */
+    run_expect_fail("x = C2D('abc',-1)\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "C2D negative n");
+    run_expect_fail("x = X2D('41',-1)\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE, "X2D negative n");
+
+    /* D2C / D2X negative length → 40.11. */
+    run_expect_fail("x = D2C(5,-1)\n", SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE,
+                    "D2C negative length");
+    run_expect_fail("x = D2X(5,-2)\n", SYNTAX_BAD_CALL, ERR40_NONNEG_WHOLE,
+                    "D2X negative length");
+}
+
 int main(void)
 {
-    printf("=== WP-21a + WP-21b Phase C: BIFs ===\n");
+    printf("=== WP-21a + WP-21b Phase C+D: BIFs ===\n");
     test_phase_b();
     test_phase_c();
     test_phase_d();
@@ -786,6 +1101,12 @@ int main(void)
     test_phase_c_numeric();
     test_phase_c_nonnumeric();
     test_phase_c_edges();
+    test_phase_d_byte_conv();
+    test_phase_d_c2d_x2d();
+    test_phase_d_d2c_d2x();
+    test_phase_d_roundtrips();
+    test_phase_d_bcd_path();
+    test_phase_d_errors();
     test_error_paths();
     test_find_phrase_cap();
 


### PR DESCRIPTION
## Summary

Eight SC28-1883-0 §4 conversion BIFs, split into byte-based (C2X, X2C, B2X, X2B) and number-bearing (C2D, X2D, D2C, D2X) sub-groups.

Byte-based handlers are pure character-level conversions with no IRXARITH dependency. Number-bearing handlers route small values through direct `long` arithmetic and larger ones through `irx_arith_from_digits` / `irx_arith_to_digits` (Phase B, #30).

Two's-complement arithmetic is handled in the BIF layer at the correct bit width (nibble-accurate for X2D / D2X when length is odd), so `compute_c2d` / the byte-backing path never needs to know about sign tricks — it receives an already-absolute magnitude and emits a decimal with the given sign.

## Test suite delta

| Suite | Before | After | Δ |
|---|---:|---:|---:|
| test_bifs | 162 | 312 | +150 |
| test_tokenizer | 70 | 70 | 0 |
| test_vpool | 47 | 47 | 0 |
| test_parser | 39 | 39 | 0 |
| test_say | 27 | 27 | 0 |
| test_irxlstr | 50 | 50 | 0 |
| test_control | 62 | 62 | 0 |
| test_hello | 16 | 16 | 0 |
| test_parse | 74 | 74 | 0 |
| test_procedure | 53 | 53 | 0 |
| test_phase1 | 38 | 38 | 0 |
| test_arith | 128 | 128 | 0 |
| test_arith_extended | 113 | 113 | 0 |
| test_bif | 29 | 29 | 0 |
| **Total** | **908** | **1058** | **+150** |

Zero regressions. Round-2 added 6 tests (three X2D odd-nibble truncation cases, `D2C('1E-5')`, two non-hex-between-blanks guards).

## Acceptance criteria coverage

| AC | Covered by |
|---|---|
| AC-D1 (`C2D` decimal encoding) | `C2D(X2C('01'))`, `C2D(X2C('FFFFFF'))`, `C2D(X2C('01000000'))` |
| AC-D2 (`C2X` uppercase) | `C2X(X2C('ff'))` → `FF` |
| AC-D3 (`D2C` byte-exact) | `C2X(D2C(65))` → `41`, `C2X(D2C(193))` → `C1` |
| AC-D4 (`D2X` / `X2D` basics) | `D2X(0)`, `D2X(255)`, `X2D('FF')` + round-trip block |
| AC-D5 (`B2X` / `X2B`) | `B2X('11111111')` → `FF`, `X2B('FF')` → `11111111` |
| AC-D6 (BCD-path routing) | `C2D(X2C('0100000000'))` → 2^32 via `irx_arith_from_digits` |
| AC-D7 (`X2D('GG')` SYNTAX) | raises 40.25 via `ERR40_BAD_HEX` |
| AC-D8 (charset-neutral tests) | every byte-level expectation wrapped with `C2X(...)`; `EXPECT_OK_BIG` prepends `numeric digits 20` for BCD cases |
| AC-D9 (BCD byte-exact) | `test_phase_d_bcd_path` round-trips 5-byte magnitudes both directions |
| AC-D10 (two's complement) | `C2D('7F'x,1)=127`, `C2D('80'x,1)=-128`, `X2D('FFF',3)=-1`, `X2D('800',3)=-2048`, full round-trip block across {-int32, -int16, -128, -1, 1, 127, int16 max, int32 max, -2^32} × widths |
| AC-D11 (no regressions) | all 14 suites green |

## Implementation notes

### Subcodes

Two new SYNTAX 40.x entries in `irxcond.h` matching SC28-1883-0 Appendix E:
- `ERR40_BAD_BINARY = 24` (argument 1 must be a binary string — B2X)
- `ERR40_BAD_HEX    = 25` (argument 1 must be a hexadecimal string — X2C, X2D, X2B)

Reuse for Phase D:
- `D2C(-1)` / `D2X(-1)` without length → `ERR40_NONNEG_WHOLE`
- Fractional `n` for D2C / D2X → `ERR40_WHOLE_NUMBER`
- Non-numeric `n` → `ERR41_NONNUMERIC` (via the Phase C `raise_nonnumeric` helper)
- Negative `n` argument to C2D / X2D → `ERR40_NONNEG_WHOLE` via `irx_bif_whole_nonneg`

**Finding (not blocking this PR):** rexx370's existing `ERR40_*` numbering (`NONNEG_WHOLE=11`, `WHOLE_NUMBER=5`, `SINGLE_CHAR=14`, `OPTION_INVALID=23`, etc.) diverges from SC28-1883-0 Appendix E (which uses 11 for \"must be a number\", 13 for \"zero or positive\", 12 for \"whole number\", 23 for \"single character\", 28 for option). The two new codes added here (`BAD_BINARY=24`, `BAD_HEX=25`) match Appendix E because those slots are free in the rexx370 space. A follow-up to realign the pre-existing codes is out of scope for this PR.

### Threshold

Small/BCD path cutoff: `byte_len ≤ 3` uses direct `long` arithmetic. Larger widths go through the BCD helpers. This sits one below what the issue body suggested (`> 4`) because the Linux cross-compile host has a 64-bit `long` while MVS has 32-bit — keeping the small path at three bytes sidesteps the two's-complement wraparound trick that would produce different results on the two platforms. The performance cost of one extra BCD conversion at exactly 4 bytes is negligible.

### Hex-literal tests use `X2C(...)`

The parser currently stores `'41'x` hex-literal tokens as the raw 2-character string \"41\" (WP-13 deferred the actual hex decoding, see `src/irx#pars.c:3743`). All byte-constructor tests therefore use `X2C('41')` rather than `'41'x` to produce the byte 0x41 until a future work package enables hex-literal decoding.

### Two's complement at nibble granularity (X2D / D2X)

X2D with odd `n` treats the input as an `n*4`-bit signed field. The sign bit is bit 3 of the leftmost real hex nibble; two's-complement negation is a byte-level flip + add 1 with the high nibble of `byte[0]` masked before and after. Verified by `X2D('FFF',3) = -1`, `X2D('800',3) = -2048`, `X2D('7FF',3) = 2047`.

D2X with odd `length` uses the same masked-flip logic on the output buffer. Verified by `D2X(-1,3) = 'FFF'` and `D2X(-256,3) = 'F00'`.

## Test plan

- [x] `gcc -Wall -Wextra -std=gnu99` cross-compile, all 14 suites
- [x] AC-D1..AC-D11 covered (see table above)
- [x] BCD path exercised in both directions with byte-exact assertions
- [x] Error paths: non-hex / non-binary / negative-no-length / fractional / non-numeric / negative-n
- [x] TSO/E REXX cross-check of the round-2 expected values (X2D('ABCD',3)=-1075, X2D('A7CD',3)=1997, X2D('A00D',3)=13, D2C('1E-5') → SYNTAX 40). See round-2 fix-map comment.
- [ ] Full EBCDIC suite run on MVS — pending the ECTENVBK anchor fix (TSK-3463). Every charset-sensitive assertion already uses `C2X(...)` wrapping so the suite should port byte-for-byte.
- [ ] `-O0` vs `-O1` parity check on MVS (Notion: `3463d993-8787-81ee-8ff9-c4f09ebe3ffb`) — also gated on TSK-3463.

Fixes #32
