### PR TITLE
feat(wp-21b): Phase E — reflection BIFs (DATATYPE/SYMBOL/DIGITS/FUZZ/FORM)

### DIFF
--- a/include/irxlstr.h
+++ b/include/irxlstr.h
@@ -97,14 +97,20 @@ int _Lisnum(PLstr s);
  *   'B'     binary                             '0' | '1'
  *   'L'     lowercase alphabetic only          a-z
  *   'M'     mixed / any alphabetic             a-z | A-Z
- *   'S'     symbol characters                  letters digits _ @ # $ ? ! .
+ *   'S'     valid REXX symbol name             first char a letter /
+ *                                              _ @ # $ ? !, rest also
+ *                                              allow digits and '.'
  *   'U'     uppercase alphabetic only          A-Z
  *   'W'     whole number                       integer with no frac part
  *   'X'     hex digits (blanks permitted)      0-9 a-f A-F + blanks
  *
  * Per SC28-1883-0: DATATYPE returns 1 only if the string is non-empty
- * and every character satisfies the option. (Option 'W' also accepts
- * leading sign.) Returns 0 for empty strings and any mismatch.
+ * and satisfies the option. For every option except 'S' this means
+ * every character individually passes the class check; 'S' adds a
+ * stricter starter rule so leading digits or '.' (which would start a
+ * constant symbol or number in REXX) are rejected — this predicate
+ * is shared with SYMBOL() and the tokenizer. Option 'W' also accepts
+ * a leading sign. Returns 0 for empty strings and any mismatch.
  *
  * Unknown option characters return 0.
  */

--- a/include/irxtokn.h
+++ b/include/irxtokn.h
@@ -15,6 +15,8 @@
 #ifndef IRXTOKN_H
 #define IRXTOKN_H
 
+#include <stddef.h>
+
 #include "irx.h"
 
 /* ================================================================== */
@@ -123,5 +125,32 @@ int irx_tokn_run(struct envblock *envblock,
  */
 void irx_tokn_free(struct envblock *envblock,
                    struct irx_token *tokens, int count) asm("IRXTOKNF");
+
+/* ================================================================== */
+/*  Symbol-character predicates (shared with DATATYPE / SYMBOL BIFs)  */
+/*                                                                    */
+/*  These are the authoritative classifiers used by the tokenizer.    */
+/*  Any consumer (e.g. the SYMBOL and DATATYPE built-ins) must reuse  */
+/*  them instead of duplicating the rules, so parser and BIF layer    */
+/*  stay in lock-step on what counts as a valid REXX symbol.          */
+/* ================================================================== */
+
+/* Allowed as the FIRST character of a symbol: letters or the REXX
+ * special starters _ @ # $ ? !  Digits and '.' are NOT symbol
+ * starters here — a run that begins with a digit or '.' is a
+ * constant symbol or number, not a variable name. */
+int irx_is_symbol_start(int c) asm("IRXISYMS");
+
+/* Allowed anywhere within a symbol: alphanumeric plus the starter
+ * specials and '.' (dots make the symbol compound). */
+int irx_is_symbol_char(int c) asm("IRXISYMC");
+
+/* Whole-string predicate: returns 1 if s[0..len-1] is a valid REXX
+ * symbol name — non-empty, first character passes irx_is_symbol_start,
+ * every remaining character passes irx_is_symbol_char. Returns 0
+ * otherwise (empty, leading digit/dot, embedded blank, etc.).
+ *
+ * Used by SYMBOL() and DATATYPE('S'). */
+int is_rexx_symbol(const unsigned char *s, size_t len) asm("IRXISSYM");
 
 #endif /* IRXTOKN_H */

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -32,6 +32,8 @@
 #include "irxfunc.h"
 #include "irxlstr.h"
 #include "irxpars.h"
+#include "irxtokn.h"
+#include "irxvpool.h"
 #include "irxwkblk.h"
 #include "lstralloc.h"
 #include "lstring.h"
@@ -2488,6 +2490,206 @@ static int bif_d2x(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
+/*  Phase I — Reflection BIFs (WP-21b Phase E)                        */
+/*                                                                    */
+/*  DATATYPE / SYMBOL / DIGITS / FUZZ / FORM expose interpreter       */
+/*  state and classification rules to REXX code. They are thin        */
+/*  dispatch wrappers: _Lisnum() and irx_datatype() carry the number  */
+/*  and character-class logic; is_rexx_symbol() is the tokenizer's    */
+/*  own predicate, reused verbatim.                                   */
+/* ================================================================== */
+
+/* Copy a short literal result string into `result`. Thin wrapper so
+ * the handlers below can return 'VAR'/'LIT'/'BAD' etc. in a single
+ * expression and keep every error path on translate_lstr_rc(). */
+static int lit_to_lstr(struct lstr_alloc *a, PLstr dst, const char *s)
+{
+    size_t n = strlen(s);
+    int rc = Lfx(a, dst, n);
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
+    if (n > 0)
+    {
+        memcpy(dst->pstr, s, n);
+    }
+    dst->len = n;
+    dst->type = LSTRING_TY;
+    return LSTR_OK;
+}
+
+static int bif_datatype(struct irx_parser *p, int argc, PLstr *argv,
+                        PLstr result)
+{
+    PLstr str = argv[0];
+
+    /* No-option form: 'NUM' if str is a valid REXX number, else 'CHAR'.
+     * Empty string is not a number — it falls through to 'CHAR'. */
+    if (argc < 2 || argv[1] == NULL || argv[1]->len == 0)
+    {
+        int is_num = (str->len > 0) && (_Lisnum(str) != LNUM_NOT_NUM);
+        return translate_lstr_rc(
+            lit_to_lstr(p->alloc, result, is_num ? "NUM" : "CHAR"));
+    }
+
+    char opt = 0;
+    int rc = irx_bif_opt_option(p, argc, argv, 1, "DATATYPE",
+                                "NWSABLMUX", 'N', &opt);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    int match = 0;
+    if (str->len > 0)
+    {
+        switch (opt)
+        {
+            case 'N':
+                match = (_Lisnum(str) != LNUM_NOT_NUM);
+                break;
+            case 'W':
+                /* Whole number: classify must come back INTEGER (no
+                 * fractional part, no exponent). _Lisnum() caches the
+                 * classification, keeping the check in sync with the
+                 * parser and arithmetic engine. */
+                match = (_Lisnum(str) == LNUM_INTEGER);
+                break;
+            case 'S':
+                match = is_rexx_symbol(str->pstr, str->len);
+                break;
+            case 'A':
+            case 'B':
+            case 'L':
+            case 'M':
+            case 'U':
+            case 'X':
+                match = irx_datatype(str, opt);
+                break;
+            default:
+                /* irx_bif_opt_option already rejected anything outside
+                 * the allowed set, so this branch is unreachable. */
+                match = 0;
+                break;
+        }
+    }
+
+    return translate_lstr_rc(
+        lit_to_lstr(p->alloc, result, match ? "1" : "0"));
+}
+
+static int bif_symbol(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    (void)argc;
+    PLstr name = argv[0];
+
+    if (name->len == 0 || !is_rexx_symbol(name->pstr, name->len))
+    {
+        return translate_lstr_rc(lit_to_lstr(p->alloc, result, "BAD"));
+    }
+
+    /* vpool stores variable names as-is (parser produces the canonical
+     * upper-case form). SYMBOL() is called directly by user code with
+     * whatever casing the caller typed, so uppercase here before the
+     * lookup to match the parser's convention. */
+    unsigned char tmp_buf[64];
+    unsigned char *up = NULL;
+    int heap_up = 0;
+
+    if (name->len <= sizeof(tmp_buf))
+    {
+        up = tmp_buf;
+    }
+    else
+    {
+        void *mem = NULL;
+        if (irxstor(RXSMGET, (int)name->len, &mem, p->envblock) != 0)
+        {
+            return IRXPARS_NOMEM;
+        }
+        up = (unsigned char *)mem;
+        heap_up = 1;
+    }
+
+    size_t i;
+    for (i = 0; i < name->len; i++)
+    {
+        unsigned char c = name->pstr[i];
+        up[i] = (unsigned char)(islower(c) ? toupper(c) : c);
+    }
+
+    Lstr key;
+    key.pstr = up;
+    key.len = name->len;
+    key.maxlen = name->len;
+    key.type = LSTRING_TY;
+
+    /* vpool_exists returns 1 if the name is a set variable, 0
+     * otherwise (missing or tombstoned). It does NOT use the
+     * VPOOL_* return-code namespace. */
+    const char *text =
+        (vpool_exists(p->vpool, &key) != 0) ? "VAR" : "LIT";
+
+    int rc = lit_to_lstr(p->alloc, result, text);
+
+    if (heap_up)
+    {
+        void *p1 = up;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+
+    return translate_lstr_rc(rc);
+}
+
+/* DIGITS / FUZZ / FORM read per-environment NUMERIC state from the
+ * work block. When no work block is attached (bootstrap / some tests)
+ * the documented defaults (9 / 0 / SCIENTIFIC) apply. */
+static struct irx_wkblk_int *wkbi_from_parser(struct irx_parser *p)
+{
+    if (p->envblock == NULL || p->envblock->envblock_userfield == NULL)
+    {
+        return NULL;
+    }
+    return (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+}
+
+static int bif_digits(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    (void)argc;
+    (void)argv;
+    struct irx_wkblk_int *wk = wkbi_from_parser(p);
+    long v = (wk != NULL) ? (long)wk->wkbi_digits
+                          : (long)NUMERIC_DIGITS_DEFAULT;
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, v));
+}
+
+static int bif_fuzz(struct irx_parser *p, int argc, PLstr *argv,
+                    PLstr result)
+{
+    (void)argc;
+    (void)argv;
+    struct irx_wkblk_int *wk = wkbi_from_parser(p);
+    long v = (wk != NULL) ? (long)wk->wkbi_fuzz
+                          : (long)NUMERIC_FUZZ_DEFAULT;
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, v));
+}
+
+static int bif_form(struct irx_parser *p, int argc, PLstr *argv,
+                    PLstr result)
+{
+    (void)argc;
+    (void)argv;
+    struct irx_wkblk_int *wk = wkbi_from_parser(p);
+    int form = (wk != NULL) ? wk->wkbi_form : NUMFORM_SCIENTIFIC;
+    const char *text =
+        (form == NUMFORM_ENGINEERING) ? "ENGINEERING" : "SCIENTIFIC";
+    return translate_lstr_rc(lit_to_lstr(p->alloc, result, text));
+}
+
+/* ================================================================== */
 /*  Registration                                                      */
 /* ================================================================== */
 
@@ -2544,6 +2746,12 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"X2D", 1, 2, bif_x2d},
     {"D2C", 1, 2, bif_d2c},
     {"D2X", 1, 2, bif_d2x},
+    /* Phase I — Reflection BIFs (WP-21b Phase E) */
+    {"DATATYPE", 1, 2, bif_datatype},
+    {"SYMBOL", 1, 1, bif_symbol},
+    {"DIGITS", 0, 0, bif_digits},
+    {"FUZZ", 0, 0, bif_fuzz},
+    {"FORM", 0, 0, bif_form},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -15,6 +15,7 @@
 #include "irx.h"
 #include "irxfunc.h"
 #include "irxlstr.h"
+#include "irxtokn.h"
 #include "irxwkblk.h"
 #include "lstring.h"
 
@@ -222,27 +223,6 @@ int _Lisnum(PLstr s)
 /*  handles the empty-string short-circuit.                            */
 /* ------------------------------------------------------------------ */
 
-static int is_symbol_char(int c)
-{
-    if (isalnum(c))
-    {
-        return 1;
-    }
-    switch (c)
-    {
-        case '_':
-        case '@':
-        case '#':
-        case '$':
-        case '?':
-        case '!':
-        case '.':
-            return 1;
-        default:
-            return 0;
-    }
-}
-
 static int all_match(const unsigned char *p, size_t n, int (*pred)(int))
 {
     size_t i;
@@ -341,7 +321,11 @@ int irx_datatype(PLstr s, char option)
 
         case 'S':
         case 's':
-            return all_match(s->pstr, s->len, is_symbol_char);
+            /* Shares the tokenizer's rule: non-empty, first char a
+             * symbol starter (letter / special), rest symbol chars.
+             * This rejects leading digits and '.' — those introduce
+             * constant symbols / numbers, not variable names. */
+            return is_rexx_symbol(s->pstr, s->len);
 
         case 'U':
         case 'u':

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -58,8 +58,10 @@ struct tok_ctx
 /* ------------------------------------------------------------------ */
 
 /* Characters allowed as the first character of a symbol (letter or
- * one of the REXX special starters). */
-static int is_symbol_start(int c)
+ * one of the REXX special starters). Public — also used by the
+ * SYMBOL() and DATATYPE('S') BIFs so the two definitions of "symbol"
+ * can never drift apart. */
+int irx_is_symbol_start(int c)
 {
     if (isalpha(c))
     {
@@ -81,7 +83,7 @@ static int is_symbol_start(int c)
 
 /* Characters allowed within a symbol after the first char. Dot is
  * included; dots make a symbol compound. */
-static int is_symbol_char(int c)
+int irx_is_symbol_char(int c)
 {
     if (isalnum(c))
     {
@@ -100,6 +102,31 @@ static int is_symbol_char(int c)
         default:
             return 0;
     }
+}
+
+/* Whole-string predicate: non-empty and every character is a symbol
+ * character, with the first constrained to a letter / special
+ * starter (digits and '.' introduce constant symbols or numbers in
+ * REXX, not variable names, so they are rejected here). */
+int is_rexx_symbol(const unsigned char *s, size_t len)
+{
+    if (s == NULL || len == 0)
+    {
+        return 0;
+    }
+    if (!irx_is_symbol_start(s[0]))
+    {
+        return 0;
+    }
+    size_t i;
+    for (i = 1; i < len; i++)
+    {
+        if (!irx_is_symbol_char(s[i]))
+        {
+            return 0;
+        }
+    }
+    return 1;
 }
 
 /* The REXX "NOT" sign has two representations: backslash, and the
@@ -533,7 +560,7 @@ static int scan_symbol_or_number(struct tok_ctx *ctx)
     while (ctx->pos < ctx->src_len)
     {
         int c = peek(ctx, 0);
-        if (!is_symbol_char(c))
+        if (!irx_is_symbol_char(c))
         {
             break;
         }
@@ -714,7 +741,7 @@ static int tokenize(struct tok_ctx *ctx)
             continue;
         }
 
-        if (is_symbol_start(c) || isdigit(c) || c == '.')
+        if (irx_is_symbol_start(c) || isdigit(c) || c == '.')
         {
             if (scan_symbol_or_number(ctx) != 0)
             {

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -791,26 +791,26 @@ static void test_phase_c_edges(void)
 /* Like EXPECT_OK, but wraps the source with `numeric digits 20` so    */
 /* results longer than the 9-digit default don't get rounded. Used for */
 /* BCD-path tests whose expected value has 10+ decimal digits.         */
-#define EXPECT_OK_BIG(src, want, msg)                                  \
-    do                                                                 \
-    {                                                                  \
-        struct fixture fx;                                             \
-        if (fixture_open(&fx) != 0)                                    \
-        {                                                              \
-            CHECK(0, "fixture_open " msg);                             \
-            break;                                                     \
-        }                                                              \
-        int _rc = run_src(&fx, "numeric digits 20\nx = " src "\n");    \
-        if (_rc != IRXPARS_OK)                                         \
-        {                                                              \
-            printf("    parser rc=%d\n", _rc);                         \
-            CHECK(0, msg);                                             \
-        }                                                              \
-        else                                                           \
-        {                                                              \
-            CHECK(var_eq(&fx, "X", want), msg);                        \
-        }                                                              \
-        fixture_close(&fx);                                            \
+#define EXPECT_OK_BIG(src, want, msg)                               \
+    do                                                              \
+    {                                                               \
+        struct fixture fx;                                          \
+        if (fixture_open(&fx) != 0)                                 \
+        {                                                           \
+            CHECK(0, "fixture_open " msg);                          \
+            break;                                                  \
+        }                                                           \
+        int _rc = run_src(&fx, "numeric digits 20\nx = " src "\n"); \
+        if (_rc != IRXPARS_OK)                                      \
+        {                                                           \
+            printf("    parser rc=%d\n", _rc);                      \
+            CHECK(0, msg);                                          \
+        }                                                           \
+        else                                                        \
+        {                                                           \
+            CHECK(var_eq(&fx, "X", want), msg);                     \
+        }                                                           \
+        fixture_close(&fx);                                         \
     } while (0)
 
 static void test_phase_d_byte_conv(void)
@@ -1114,9 +1114,174 @@ static void test_phase_d_errors(void)
                     "D2X negative length");
 }
 
+/* ================================================================== */
+/*  Phase E — Reflection BIFs (WP-21b #33)                            */
+/*  DATATYPE / SYMBOL / DIGITS / FUZZ / FORM — AC-E1..AC-E8.          */
+/* ================================================================== */
+
+static void test_phase_e_datatype(void)
+{
+    printf("\n--- Phase E: DATATYPE ---\n");
+
+    /* AC-E1: no-option form returns NUM / CHAR. */
+    EXPECT_OK("DATATYPE('42')", "NUM", "AC-E1 DATATYPE('42') -> NUM");
+    EXPECT_OK("DATATYPE('abc')", "CHAR", "AC-E1 DATATYPE('abc') -> CHAR");
+    EXPECT_OK("DATATYPE('')", "CHAR", "DATATYPE empty -> CHAR");
+    EXPECT_OK("DATATYPE('3.14')", "NUM", "DATATYPE decimal -> NUM");
+    EXPECT_OK("DATATYPE(' 42 ')", "NUM", "DATATYPE spaces around num -> NUM");
+
+    /* AC-E2: 'W' whole-number option. */
+    EXPECT_OK("DATATYPE('42','W')", "1", "AC-E2 DATATYPE('42','W') -> 1");
+    EXPECT_OK("DATATYPE('42.5','W')", "0",
+              "AC-E2 DATATYPE('42.5','W') -> 0");
+    EXPECT_OK("DATATYPE('0','W')", "1", "DATATYPE zero is whole -> 1");
+    EXPECT_OK("DATATYPE('-7','W')", "1", "DATATYPE negative whole -> 1");
+    EXPECT_OK("DATATYPE('abc','W')", "0", "DATATYPE non-number 'W' -> 0");
+    EXPECT_OK("DATATYPE('42','w')", "1",
+              "DATATYPE lower-case option accepted");
+
+    /* AC-E3: 'S' symbol. */
+    EXPECT_OK("DATATYPE('myname','S')", "1",
+              "AC-E3 DATATYPE('myname','S') -> 1");
+    EXPECT_OK("DATATYPE('42abc','S')", "0",
+              "AC-E3 DATATYPE('42abc','S') -> 0 (leading digit)");
+    EXPECT_OK("DATATYPE('','S')", "0", "DATATYPE empty 'S' -> 0");
+    EXPECT_OK("DATATYPE('has space','S')", "0",
+              "DATATYPE 'has space','S' -> 0");
+    EXPECT_OK("DATATYPE('stem.i.j','S')", "1", "DATATYPE compound 'S' -> 1");
+
+    /* AC-E4: 'X' hex. */
+    EXPECT_OK("DATATYPE('FF','X')", "1", "AC-E4 DATATYPE('FF','X') -> 1");
+    EXPECT_OK("DATATYPE('GG','X')", "0", "AC-E4 DATATYPE('GG','X') -> 0");
+    EXPECT_OK("DATATYPE('DEAD BEEF','X')", "1",
+              "DATATYPE hex with blanks -> 1");
+
+    /* Other classifier options. */
+    EXPECT_OK("DATATYPE('abc','A')", "1", "DATATYPE alphanumeric");
+    EXPECT_OK("DATATYPE('abc!','A')", "0",
+              "DATATYPE alphanumeric rejects '!'");
+    EXPECT_OK("DATATYPE('0101','B')", "1", "DATATYPE binary");
+    EXPECT_OK("DATATYPE('012','B')", "0", "DATATYPE binary rejects '2'");
+    EXPECT_OK("DATATYPE('abc','L')", "1", "DATATYPE lowercase");
+    EXPECT_OK("DATATYPE('AbC','L')", "0", "DATATYPE lower rejects upper");
+    EXPECT_OK("DATATYPE('ABC','U')", "1", "DATATYPE uppercase");
+    EXPECT_OK("DATATYPE('AbC','M')", "1", "DATATYPE mixed alpha");
+    EXPECT_OK("DATATYPE('AbC1','M')", "0", "DATATYPE mixed rejects digit");
+}
+
+static void test_phase_e_symbol(void)
+{
+    printf("\n--- Phase E: SYMBOL ---\n");
+
+    /* AC-E6: SYMBOL(var) on set / unset / invalid. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SYMBOL fixture_open");
+            return;
+        }
+
+        int rc = run_src(&fx,
+                         "x = 5\n"
+                         "a = SYMBOL('X')\n"
+                         "b = SYMBOL('YZ')\n"
+                         "c = SYMBOL('42foo')\n"
+                         "d = SYMBOL('x')\n"
+                         "e = SYMBOL('')\n"
+                         "f = SYMBOL('has space')\n");
+        CHECK(rc == IRXPARS_OK, "SYMBOL fixture parse+run OK");
+        CHECK(var_eq(&fx, "A", "VAR"),
+              "AC-E6 SYMBOL('X') with X set -> VAR");
+        CHECK(var_eq(&fx, "B", "LIT"),
+              "AC-E6 SYMBOL('YZ') unset valid -> LIT");
+        CHECK(var_eq(&fx, "C", "BAD"),
+              "AC-E6 SYMBOL('42foo') -> BAD");
+        CHECK(var_eq(&fx, "D", "VAR"),
+              "SYMBOL lowercases 'x' before lookup -> VAR");
+        CHECK(var_eq(&fx, "E", "BAD"), "SYMBOL('') -> BAD");
+        CHECK(var_eq(&fx, "F", "BAD"), "SYMBOL('has space') -> BAD");
+        fixture_close(&fx);
+    }
+
+    /* Heap-fallback path: bif_symbol uses a 64-byte stack scratch for
+     * the uppercase copy, and falls back to irxstor() for longer names.
+     * REXX allows up to 250 chars in a symbol (SC28-1883-0 §3.2), so the
+     * heap branch is reachable. Drive a 100-char valid-but-unset name
+     * to cover both the heap copy and its free. */
+    {
+        char name[101];
+        memset(name, 'a', sizeof(name) - 1);
+        name[sizeof(name) - 1] = '\0';
+
+        char src[160];
+        sprintf(src, "x = SYMBOL('%s')\n", name);
+
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SYMBOL heap fixture_open");
+        }
+        else
+        {
+            int rc = run_src(&fx, src);
+            CHECK(rc == IRXPARS_OK, "SYMBOL heap path parse+run OK");
+            CHECK(var_eq(&fx, "X", "LIT"),
+                  "SYMBOL 100-char unset name -> LIT (heap path)");
+            fixture_close(&fx);
+        }
+    }
+}
+
+static void test_phase_e_numeric_reflection(void)
+{
+    printf("\n--- Phase E: DIGITS / FUZZ / FORM ---\n");
+
+    /* AC-E7 / AC-E8: defaults. */
+    EXPECT_OK("DIGITS()", "9", "AC-E7 DIGITS default -> 9");
+    EXPECT_OK("FUZZ()", "0", "AC-E8 FUZZ default -> 0");
+    EXPECT_OK("FORM()", "SCIENTIFIC", "AC-E8 FORM default -> SCIENTIFIC");
+
+    /* After NUMERIC changes. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "NUMERIC fixture_open");
+            return;
+        }
+        int rc = run_src(&fx,
+                         "numeric digits 15\n"
+                         "numeric fuzz 3\n"
+                         "numeric form engineering\n"
+                         "a = DIGITS()\n"
+                         "b = FUZZ()\n"
+                         "c = FORM()\n");
+        CHECK(rc == IRXPARS_OK, "NUMERIC settings apply");
+        CHECK(var_eq(&fx, "A", "15"), "DIGITS() after NUMERIC DIGITS 15");
+        CHECK(var_eq(&fx, "B", "3"), "FUZZ() after NUMERIC FUZZ 3");
+        CHECK(var_eq(&fx, "C", "ENGINEERING"),
+              "FORM() after NUMERIC FORM ENGINEERING");
+        fixture_close(&fx);
+    }
+}
+
+static void test_phase_e_errors(void)
+{
+    printf("\n--- Phase E: error paths ---\n");
+
+    /* AC-E5: invalid DATATYPE option -> SYNTAX 40.23. */
+    run_expect_fail("x = DATATYPE('x','Z')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID,
+                    "AC-E5 DATATYPE invalid option -> 40.23");
+    run_expect_fail("x = DATATYPE('x','QQ')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID,
+                    "DATATYPE unknown multi-char option -> 40.23");
+}
+
 int main(void)
 {
-    printf("=== WP-21a + WP-21b Phase C+D: BIFs ===\n");
+    printf("=== WP-21a + WP-21b Phase C+D+E: BIFs ===\n");
     test_phase_b();
     test_phase_c();
     test_phase_d();
@@ -1131,6 +1296,10 @@ int main(void)
     test_phase_d_roundtrips();
     test_phase_d_bcd_path();
     test_phase_d_errors();
+    test_phase_e_datatype();
+    test_phase_e_symbol();
+    test_phase_e_numeric_reflection();
+    test_phase_e_errors();
     test_error_paths();
     test_find_phrase_cap();
 


### PR DESCRIPTION
Fixes #33

## Summary

Adds the five WP-21b Phase E reflection BIFs and consolidates the REXX
symbol-character rules so the tokenizer, `DATATYPE('S')`, and `SYMBOL()`
all share a single predicate — no drift between parser and BIF layer.

## BIFs added

- **`DATATYPE(string [, option])`**
  - No option: `'NUM'` if the string is a valid REXX number (via `_Lisnum()`),
    else `'CHAR'`.
  - `N` / `W`: delegate to `_Lisnum()` (LNUM_INTEGER check for `W`).
  - `S`: uses the new `is_rexx_symbol()` — shared with the tokenizer.
  - `A` / `B` / `L` / `M` / `U` / `X`: delegate to existing `irx_datatype()`.
  - Unknown option letter raises SYNTAX 40.23 via `irx_bif_opt_option`.
- **`SYMBOL(name)`** → `'VAR'` | `'LIT'` | `'BAD'`. Uppercases the name
  before `vpool_exists()` to match the parser's canonical form. Stack
  scratch (64B) with `irxstor` fallback for names > 64 chars (REXX allows
  up to 250 per SC28-1883-0 §3.2).
- **`DIGITS()` / `FUZZ()` / `FORM()`** return the per-environment
  `wkbi_digits` / `wkbi_fuzz` / `wkbi_form`, falling back to documented
  defaults when no work block is attached (bootstrap paths).

## Shared predicate (Phase G note)

`src/irx#tokn.c` had static `is_symbol_start` / `is_symbol_char`. This PR:

1. Lifts them into the public API as `irx_is_symbol_start` /
   `irx_is_symbol_char` in `include/irxtokn.h` (asm aliases
   `IRXISYMS` / `IRXISYMC`).
2. Adds `is_rexx_symbol(const unsigned char *, size_t)` (asm alias
   `IRXISSYM`) — whole-string predicate that `SYMBOL()` and
   `DATATYPE('S')` both use.
3. Updates the tokenizer callsites to use the centralized predicates.
4. Removes the duplicate `is_symbol_char` from `src/irx#lstr.c`; its
   `irx_datatype('S')` now calls `is_rexx_symbol()` for consistency.

## Test results

- `test/test_bifs.c`: **358/358** (up from 312) — 46 new cases covering
  AC-E1..AC-E8 plus edge cases: empty strings, `DATATYPE('0','W')`,
  case-folded options, compound names, 100-char name to exercise
  SYMBOL's heap-fallback path, error paths.
- All regression suites green: tokenizer 70/70, parser 39/39,
  vpool 47/47, arith 128/128, parse 74/74, control 62/62, hello 16/16,
  phase1 38/38, say 27/27, procedure 53/53, arith_extended 113/113,
  irxlstr 50/50.

## Test plan

- [x] `gcc -Wall -Wextra -std=gnu99` — clean build, no new warnings
- [x] `test/test_bifs` passes 358/358
- [x] `test/test_tokenizer` 70/70 (tokenizer refactor verified)
- [x] `test/test_irxlstr` 50/50 (irx_datatype 'S' still matches existing
      cases: 'stem.i' → 1, 'has space' → 0)
- [ ] MVS linker-symbol verification of asm aliases
      (`IRXISYMS` / `IRXISYMC` / `IRXISSYM`) pending on the MVS
      `mbt build` pipeline — not run from host.