### PR TITLE
docs: update workpackages.md status for WP-21a and WP-21b

### DIFF
--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -26,8 +26,8 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-17 | PROCEDURE EXPOSE | 2 | DONE (53/53) — PR #16 |
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | DONE (128/128) — PR #24 |
-| WP-21a | String BIFs (IRXBIFS) | 3 | DONE (29/29 + 87/87) |
-| WP-21b | Misc BIFs | 3 | OPEN |
+| WP-21a | String BIFs (IRXBIFS) | 3 | DONE (29/29 + 87/87) — PR #26 |
+| WP-21b | Misc BIFs | 3 | IN PROGRESS — Phases A–E done (PRs #28, #30, #36, #38, #39); F (#34) + H (#35) open |
 | WP-22 | Built-in misc functions | 3 | OPEN |
 | WP-23 | INTERPRET instruction | 3 | OPEN |
 | WP-30 | EXECIO command | 4 | OPEN |


### PR DESCRIPTION
Fixes #40

## Summary

- WP-21a: add missing PR reference (#26).
- WP-21b: flip from `OPEN` to `IN PROGRESS`, list the merged phase PRs
  (A: #28, B: #30, C: #36, D: #38, E: #39), and name the pending phases
  (F: #34, H: #35).

## Test plan

- [x] Table still renders as valid GitHub-flavoured Markdown
- [x] No code touched