### PR TITLE
WP-21b Phase F: environment BIFs (ERRORTEXT/USERID/EXTERNALS/SOURCELINE/VALUE/LINESIZE)

### DIFF
--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -4,12 +4,11 @@ This project uses **C99 / gnu99** (see `project.toml`: `cflags = ["-std=gnu99"]`
 We do **NOT** target C89. Do not write C89-compatible code.
 
 Formatting is enforced by `.clang-format`. Static analysis by `.clang-tidy`.
-Run before every commit:
-
-```bash
-clang-format -i src/*.c include/*.h test/*.c
-clang-tidy src/*.c -- -I./include -std=gnu99
-```
+See `CLAUDE.md` section "Tooling workflow" for the current invocation
+pattern: clang-tidy during development, clang-format only on files you
+changed, as the final step before `git add`. Running `clang-format` over
+the whole tree belongs in a dedicated `chore: clang-format sweep` commit,
+not in a feature commit.
 
 ### C99 rules we use
 

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -27,7 +27,7 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | DONE (128/128) — PR #24 |
 | WP-21a | String BIFs (IRXBIFS) | 3 | DONE (29/29 + 87/87) — PR #26 |
-| WP-21b | Misc BIFs | 3 | IN PROGRESS — Phases A–E done (PRs #28, #30, #36, #38, #39); F (#34) + H (#35) open |
+| WP-21b | Misc BIFs | 3 | IN PROGRESS — Phases A–F done (PRs #28, #30, #36, #38, #39, #42); H (#35) open |
 | WP-22 | Built-in misc functions | 3 | OPEN |
 | WP-23 | INTERPRET instruction | 3 | OPEN |
 | WP-30 | EXECIO command | 4 | OPEN |

--- a/include/irxcond.h
+++ b/include/irxcond.h
@@ -81,4 +81,31 @@ struct irx_condition_info
 void irx_cond_raise(struct envblock *env, int code, int subcode,
                     const char *desc) asm("IRXCRAIS");
 
+/* ================================================================== */
+/*  Primary-code descriptive text lookup                              */
+/*                                                                    */
+/*  Returns the short descriptive text for a REXX SYNTAX primary      */
+/*  error code, verbatim from SC28-1883-0 Appendix A (Error Numbers   */
+/*  and Messages). Used by the ERRORTEXT() BIF.                       */
+/*                                                                    */
+/*  The strings here are the *primary-code* texts (subcode 0) — they  */
+/*  are distinct from the per-call-site descriptions passed to        */
+/*  irx_cond_raise(), which describe the specific subcode condition.  */
+/*                                                                    */
+/*   code    in ERRORTEXT_CODE_MIN .. ERRORTEXT_CODE_MAX               */
+/*   return  pointer to a static, null-terminated string:             */
+/*             - verbatim Appendix A text if the code is defined,     */
+/*             - empty string "" if the code is in range but has no   */
+/*               Appendix A entry (e.g. 1, 2, 46, 47, 50..90),        */
+/*             - NULL if code is out of range.                        */
+/* ================================================================== */
+
+/* Primary-code range that ERRORTEXT(n) accepts. Shared with the BIF so
+ * both the callee and the caller cast-safety pre-check use the same
+ * bounds; extend in one place to widen the accepted range. */
+#define ERRORTEXT_CODE_MIN 1
+#define ERRORTEXT_CODE_MAX 90
+
+const char *irx_cond_errortext(int code) asm("IRXCETXT");
+
 #endif /* IRXCOND_H */

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -2872,6 +2872,133 @@ static int bif_value(struct irx_parser *p, int argc, PLstr *argv,
     return IRXPARS_OK;
 }
 
+/* Count 1-based lines in a source buffer. A trailing '\n' does NOT
+ * introduce an empty trailing line, matching REXX SOURCELINE semantics
+ * and the line numbers the tokenizer records in tok_line. */
+static int source_line_count(const unsigned char *src, size_t len)
+{
+    if (src == NULL || len == 0)
+    {
+        return 0;
+    }
+    int count = 0;
+    size_t i = 0;
+    while (i < len)
+    {
+        count++;
+        while (i < len && src[i] != '\n')
+        {
+            i++;
+        }
+        if (i < len)
+        {
+            i++;
+        }
+    }
+    return count;
+}
+
+/* Find the start offset and length of line `n` (1-based). Returns 1
+ * on success, 0 if n is out of range, source is NULL, or source is
+ * empty. The returned range excludes the terminating '\n'. */
+static int source_line_find(const unsigned char *src, size_t len,
+                            int n, size_t *out_start, size_t *out_len)
+{
+    if (src == NULL || len == 0 || n <= 0)
+    {
+        return 0;
+    }
+    size_t i = 0;
+    int cur = 1;
+    while (cur < n && i < len)
+    {
+        while (i < len && src[i] != '\n')
+        {
+            i++;
+        }
+        if (i < len)
+        {
+            i++;
+        }
+        cur++;
+    }
+    /* cur < n → loop exited early because source ran out; line doesn't
+     * exist. cur == n but i == len → landed past the last '\n' with no
+     * content following; also out of range. */
+    if (cur < n || i >= len)
+    {
+        return 0;
+    }
+    size_t start = i;
+    while (i < len && src[i] != '\n')
+    {
+        i++;
+    }
+    *out_start = start;
+    *out_len = i - start;
+    return 1;
+}
+
+/* SOURCELINE([n]) — query the retained REXX source.
+ *
+ *   No argument → return the total number of lines as a whole number.
+ *   One argument → return the text of line n (1-based), excluding the
+ *                  terminating newline. n must be a positive whole
+ *                  number in 1..SOURCELINE(); anything else raises
+ *                  SYNTAX 40.4 (ERR40_ARG_LENGTH).
+ *
+ * Source retention is plumbed in src/irx#exec.c; wkbi_source is set
+ * before tokenisation and cleared on cleanup. Calls outside an
+ * active exec_run see wkbi_source == NULL and behave as if the source
+ * were empty (line count 0, any n out of range). */
+static int bif_sourceline(struct irx_parser *p, int argc, PLstr *argv,
+                          PLstr result)
+{
+    struct irx_wkblk_int *wk = wkbi_from_parser(p);
+    const unsigned char *src =
+        (wk != NULL) ? (const unsigned char *)wk->wkbi_source : NULL;
+    size_t src_len = (wk != NULL) ? (size_t)wk->wkbi_source_len : 0;
+
+    /* No-arg (or empty-arg) — return line count. */
+    if (argc < 1 || argv[0] == NULL || argv[0]->len == 0)
+    {
+        long count = (long)source_line_count(src, src_len);
+        return translate_lstr_rc(long_to_lstr(p->alloc, result, count));
+    }
+
+    long n = 0;
+    int rc = irx_bif_whole_positive(p, argv, 0, "SOURCELINE", &n);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    size_t line_start = 0;
+    size_t line_len = 0;
+    if (!source_line_find(src, src_len, (int)n, &line_start, &line_len))
+    {
+        char desc[80];
+        snprintf(desc, sizeof(desc),
+                 "SOURCELINE: line %ld out of range", n);
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL,
+                       ERR40_ARG_LENGTH, desc);
+        return IRXPARS_SYNTAX;
+    }
+
+    int lrc = Lfx(p->alloc, result, line_len);
+    if (lrc != LSTR_OK)
+    {
+        return translate_lstr_rc(lrc);
+    }
+    if (line_len > 0)
+    {
+        memcpy(result->pstr, src + line_start, line_len);
+    }
+    result->len = line_len;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
 /* ERRORTEXT(n) — descriptive text for a SYNTAX primary code.
  * The table itself lives in src/irx#cond.c; the BIF just validates the
  * argument and formats the lookup result. Out-of-range n raises
@@ -2976,6 +3103,7 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"EXTERNALS", 0, 0, bif_externals},
     {"LINESIZE", 0, 0, bif_linesize},
     {"VALUE", 1, 3, bif_value},
+    {"SOURCELINE", 0, 1, bif_sourceline},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -2696,6 +2696,68 @@ static int bif_form(struct irx_parser *p, int argc, PLstr *argv,
 /*  Phase F — Environment BIFs (WP-21b Phase F)                       */
 /* ================================================================== */
 
+/* USERID() — current user id.
+ * Delegates to the IRXUID replaceable routine (src/irx#uid.c), which
+ * writes an 8-byte blank-padded buffer. We trim trailing blanks and
+ * fall back to "MVSUSER" whenever the trim leaves an empty string —
+ * this covers both non-TSO batch (PSCB walk sees no LWA) and any
+ * future irxuid failure mode with a single, predictable sentinel. */
+static int bif_userid(struct irx_parser *p, int argc, PLstr *argv,
+                      PLstr result)
+{
+    (void)argc;
+    (void)argv;
+
+    char buf[8];
+    memset(buf, ' ', sizeof(buf));
+    (void)irxuid(buf, p->envblock);
+
+    size_t len = sizeof(buf);
+    while (len > 0 && buf[len - 1] == ' ')
+    {
+        len--;
+    }
+
+    if (len == 0)
+    {
+        return translate_lstr_rc(lit_to_lstr(p->alloc, result, "MVSUSER"));
+    }
+
+    int rc = Lfx(p->alloc, result, len);
+    if (rc != LSTR_OK)
+    {
+        return translate_lstr_rc(rc);
+    }
+    memcpy(result->pstr, buf, len);
+    result->len = len;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+/* EXTERNALS() — element count of the external data queue.
+ * Stubbed to "0" until the data-stack infrastructure lands (TSK-144).
+ * The stub is spec-legal — zero is a valid answer for an empty queue
+ * — and the signature matches the real implementation, so call sites
+ * don't need to change when the stub is replaced. */
+static int bif_externals(struct irx_parser *p, int argc, PLstr *argv,
+                         PLstr result)
+{
+    (void)argc;
+    (void)argv;
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, 0L));
+}
+
+/* LINESIZE() — terminal line width.
+ * Stubbed to "80" pending WP-33 (MVS I/O Output Routing), which will
+ * route through the terminal driver and can query the actual width. */
+static int bif_linesize(struct irx_parser *p, int argc, PLstr *argv,
+                        PLstr result)
+{
+    (void)argc;
+    (void)argv;
+    return translate_lstr_rc(long_to_lstr(p->alloc, result, 80L));
+}
+
 /* ERRORTEXT(n) — descriptive text for a SYNTAX primary code.
  * The table itself lives in src/irx#cond.c; the BIF just validates the
  * argument and formats the lookup result. Out-of-range n raises
@@ -2795,7 +2857,10 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"FUZZ", 0, 0, bif_fuzz},
     {"FORM", 0, 0, bif_form},
     /* Phase J — Environment BIFs (WP-21b Phase F) */
+    {"USERID", 0, 0, bif_userid},
     {"ERRORTEXT", 1, 1, bif_errortext},
+    {"EXTERNALS", 0, 0, bif_externals},
+    {"LINESIZE", 0, 0, bif_linesize},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -2693,6 +2693,45 @@ static int bif_form(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
+/*  Phase F — Environment BIFs (WP-21b Phase F)                       */
+/* ================================================================== */
+
+/* ERRORTEXT(n) — descriptive text for a SYNTAX primary code.
+ * The table itself lives in src/irx#cond.c; the BIF just validates the
+ * argument and formats the lookup result. Out-of-range n raises
+ * SYNTAX 40.23 (ERR40_OPTION_INVALID); in-range but undefined codes
+ * return the empty string, matching TSO/E behaviour. */
+static int bif_errortext(struct irx_parser *p, int argc, PLstr *argv,
+                         PLstr result)
+{
+    (void)argc;
+    long code = 0;
+    int rc = irx_bif_whole_nonneg(p, argv, 0, "ERRORTEXT", &code);
+    if (rc != 0)
+    {
+        return rc;
+    }
+
+    /* Pre-check guards the (int) cast below against pathological long
+     * values; the canonical range check lives in irx_cond_errortext(). */
+    const char *text =
+        (code >= ERRORTEXT_CODE_MIN && code <= ERRORTEXT_CODE_MAX)
+            ? irx_cond_errortext((int)code)
+            : NULL;
+
+    if (text == NULL)
+    {
+        char desc[80];
+        snprintf(desc, sizeof(desc),
+                 "ERRORTEXT: code %ld out of range", code);
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL,
+                       ERR40_OPTION_INVALID, desc);
+        return IRXPARS_SYNTAX;
+    }
+    return translate_lstr_rc(lit_to_lstr(p->alloc, result, text));
+}
+
+/* ================================================================== */
 /*  Registration                                                      */
 /* ================================================================== */
 
@@ -2755,6 +2794,8 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"DIGITS", 0, 0, bif_digits},
     {"FUZZ", 0, 0, bif_fuzz},
     {"FORM", 0, 0, bif_form},
+    /* Phase J — Environment BIFs (WP-21b Phase F) */
+    {"ERRORTEXT", 1, 1, bif_errortext},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -2582,6 +2582,56 @@ static int bif_datatype(struct irx_parser *p, int argc, PLstr *argv,
         lit_to_lstr(p->alloc, result, match ? "1" : "0"));
 }
 
+/* Copy `src` into a working buffer with ctype-based uppercasing and
+ * wrap it in an Lstr key suitable for vpool_get / vpool_set /
+ * vpool_exists. The buffer is either the caller-supplied `stack_buf`
+ * (when src->len fits) or a heap allocation via irxstor; *out_heap
+ * reports which, so the matching upper_key_free releases correctly.
+ * Returns IRXPARS_OK or IRXPARS_NOMEM. Shared by SYMBOL and VALUE,
+ * both of which must match the parser's canonical upper-case form. */
+static int upper_copy_to_key(struct irx_parser *p, PLstr src,
+                             unsigned char *stack_buf, size_t stack_len,
+                             Lstr *out_key, int *out_heap)
+{
+    unsigned char *dst;
+    if (src->len <= stack_len)
+    {
+        dst = stack_buf;
+        *out_heap = 0;
+    }
+    else
+    {
+        void *mem = NULL;
+        if (irxstor(RXSMGET, (int)src->len, &mem, p->envblock) != 0)
+        {
+            return IRXPARS_NOMEM;
+        }
+        dst = (unsigned char *)mem;
+        *out_heap = 1;
+    }
+    for (size_t i = 0; i < src->len; i++)
+    {
+        unsigned char c = src->pstr[i];
+        dst[i] = (unsigned char)(islower(c) ? toupper(c) : c);
+    }
+    out_key->pstr = dst;
+    out_key->len = src->len;
+    out_key->maxlen = src->len;
+    out_key->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+static void upper_key_free(struct irx_parser *p, Lstr *key, int heap)
+{
+    if (heap)
+    {
+        void *p1 = key->pstr;
+        irxstor(RXSMFRE, 0, &p1, p->envblock);
+    }
+}
+
+#define UPPER_KEY_STACK_BUF 64
+
 static int bif_symbol(struct irx_parser *p, int argc, PLstr *argv,
                       PLstr result)
 {
@@ -2593,41 +2643,14 @@ static int bif_symbol(struct irx_parser *p, int argc, PLstr *argv,
         return translate_lstr_rc(lit_to_lstr(p->alloc, result, "BAD"));
     }
 
-    /* vpool stores variable names as-is (parser produces the canonical
-     * upper-case form). SYMBOL() is called directly by user code with
-     * whatever casing the caller typed, so uppercase here before the
-     * lookup to match the parser's convention. */
-    unsigned char tmp_buf[64];
-    unsigned char *up = NULL;
-    int heap_up = 0;
-
-    if (name->len <= sizeof(tmp_buf))
-    {
-        up = tmp_buf;
-    }
-    else
-    {
-        void *mem = NULL;
-        if (irxstor(RXSMGET, (int)name->len, &mem, p->envblock) != 0)
-        {
-            return IRXPARS_NOMEM;
-        }
-        up = (unsigned char *)mem;
-        heap_up = 1;
-    }
-
-    size_t i;
-    for (i = 0; i < name->len; i++)
-    {
-        unsigned char c = name->pstr[i];
-        up[i] = (unsigned char)(islower(c) ? toupper(c) : c);
-    }
-
+    unsigned char buf[UPPER_KEY_STACK_BUF];
     Lstr key;
-    key.pstr = up;
-    key.len = name->len;
-    key.maxlen = name->len;
-    key.type = LSTRING_TY;
+    int heap = 0;
+    int rc = upper_copy_to_key(p, name, buf, sizeof(buf), &key, &heap);
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
 
     /* vpool_exists returns 1 if the name is a set variable, 0
      * otherwise (missing or tombstoned). It does NOT use the
@@ -2635,15 +2658,9 @@ static int bif_symbol(struct irx_parser *p, int argc, PLstr *argv,
     const char *text =
         (vpool_exists(p->vpool, &key) != 0) ? "VAR" : "LIT";
 
-    int rc = lit_to_lstr(p->alloc, result, text);
-
-    if (heap_up)
-    {
-        void *p1 = up;
-        irxstor(RXSMFRE, 0, &p1, p->envblock);
-    }
-
-    return translate_lstr_rc(rc);
+    int lrc = lit_to_lstr(p->alloc, result, text);
+    upper_key_free(p, &key, heap);
+    return translate_lstr_rc(lrc);
 }
 
 /* DIGITS / FUZZ / FORM read per-environment NUMERIC state from the
@@ -2758,6 +2775,103 @@ static int bif_linesize(struct irx_parser *p, int argc, PLstr *argv,
     return translate_lstr_rc(long_to_lstr(p->alloc, result, 80L));
 }
 
+/* VALUE(name [, newvalue [, selector]]) — read-or-set a REXX variable.
+ *
+ *   Mode 1 — VALUE(name):
+ *     Return the current value of `name`. If the variable is unset,
+ *     return its uppercased name (standard REXX unset-variable
+ *     behaviour), matching the value a bare reference would produce.
+ *
+ *   Mode 2 — VALUE(name, newvalue):
+ *     Read the previous value (as in Mode 1), set `name` to `newvalue`,
+ *     return the previous value. Atomic from REXX's perspective —
+ *     the caller always sees the pre-update value in the return.
+ *
+ *   Mode 3 — VALUE(name, newvalue, selector):
+ *     Host-command-environment / alternate-pool access. Not implemented
+ *     in WP-21b. When `selector` is supplied and non-empty, raise
+ *     SYNTAX 40.23. An empty `selector` is treated as absent (same
+ *     convention REXX itself uses for trailing-empty arguments). */
+static int bif_value(struct irx_parser *p, int argc, PLstr *argv,
+                     PLstr result)
+{
+    PLstr name = argv[0];
+
+    /* Mode-3 rejection — selector argument is out of scope. */
+    if (argc >= 3 && argv[2] != NULL && argv[2]->len > 0)
+    {
+        irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_OPTION_INVALID,
+                       "VALUE: selector argument not supported in WP-21b");
+        return IRXPARS_SYNTAX;
+    }
+
+    unsigned char buf[UPPER_KEY_STACK_BUF];
+    Lstr key;
+    int heap = 0;
+    int rc = upper_copy_to_key(p, name, buf, sizeof(buf), &key, &heap);
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
+
+    /* Capture the previous value. VPOOL_NOT_FOUND is expected and
+     * means the variable was unset — return the uppercased name. */
+    Lstr old;
+    Lzeroinit(&old);
+    int vrc = vpool_get(p->vpool, &key, &old);
+    if (vrc != VPOOL_OK && vrc != VPOOL_NOT_FOUND)
+    {
+        Lfree(p->alloc, &old);
+        upper_key_free(p, &key, heap);
+        return (vrc == VPOOL_NOMEM) ? IRXPARS_NOMEM : IRXPARS_SYNTAX;
+    }
+
+    int lrc;
+    if (vrc == VPOOL_OK)
+    {
+        lrc = Lfx(p->alloc, result, old.len);
+        if (lrc == LSTR_OK && old.len > 0)
+        {
+            memcpy(result->pstr, old.pstr, old.len);
+        }
+    }
+    else
+    {
+        lrc = Lfx(p->alloc, result, key.len);
+        if (lrc == LSTR_OK && key.len > 0)
+        {
+            memcpy(result->pstr, key.pstr, key.len);
+        }
+    }
+    if (lrc == LSTR_OK)
+    {
+        result->len = (vrc == VPOOL_OK) ? old.len : key.len;
+        result->type = LSTRING_TY;
+    }
+    Lfree(p->alloc, &old);
+
+    if (lrc != LSTR_OK)
+    {
+        upper_key_free(p, &key, heap);
+        return translate_lstr_rc(lrc);
+    }
+
+    /* Mode 2 — apply the new value AFTER the previous one is captured
+     * in `result`. An empty newvalue is a valid "set to empty string". */
+    if (argc >= 2 && argv[1] != NULL)
+    {
+        int src_rc = vpool_set(p->vpool, &key, argv[1]);
+        if (src_rc != VPOOL_OK)
+        {
+            upper_key_free(p, &key, heap);
+            return (src_rc == VPOOL_NOMEM) ? IRXPARS_NOMEM : IRXPARS_SYNTAX;
+        }
+    }
+
+    upper_key_free(p, &key, heap);
+    return IRXPARS_OK;
+}
+
 /* ERRORTEXT(n) — descriptive text for a SYNTAX primary code.
  * The table itself lives in src/irx#cond.c; the BIF just validates the
  * argument and formats the lookup result. Out-of-range n raises
@@ -2861,6 +2975,7 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"ERRORTEXT", 1, 1, bif_errortext},
     {"EXTERNALS", 0, 0, bif_externals},
     {"LINESIZE", 0, 0, bif_linesize},
+    {"VALUE", 1, 3, bif_value},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -2900,16 +2900,23 @@ static int source_line_count(const unsigned char *src, size_t len)
 
 /* Find the start offset and length of line `n` (1-based). Returns 1
  * on success, 0 if n is out of range, source is NULL, or source is
- * empty. The returned range excludes the terminating '\n'. */
+ * empty. The returned range excludes the terminating '\n'.
+ *
+ * `n` is `long` to avoid a silent truncation bug when a 64-bit REXX
+ * integer arrives on cross-compile hosts — an int-cast on LP64 could
+ * land back inside the valid range and return a spurious line. The
+ * internal `cur` stays int: REXX source sizes are bounded (tokens
+ * cap at 500 chars per clause, so a million-line program would still
+ * be <500MB and well under INT_MAX line count). */
 static int source_line_find(const unsigned char *src, size_t len,
-                            int n, size_t *out_start, size_t *out_len)
+                            long n, size_t *out_start, size_t *out_len)
 {
     if (src == NULL || len == 0 || n <= 0)
     {
         return 0;
     }
     size_t i = 0;
-    int cur = 1;
+    long cur = 1;
     while (cur < n && i < len)
     {
         while (i < len && src[i] != '\n')
@@ -2975,7 +2982,7 @@ static int bif_sourceline(struct irx_parser *p, int argc, PLstr *argv,
 
     size_t line_start = 0;
     size_t line_len = 0;
-    if (!source_line_find(src, src_len, (int)n, &line_start, &line_len))
+    if (!source_line_find(src, src_len, n, &line_start, &line_len))
     {
         char desc[80];
         snprintf(desc, sizeof(desc),

--- a/src/irx#cond.c
+++ b/src/irx#cond.c
@@ -63,3 +63,90 @@ void irx_cond_raise(struct envblock *env, int code, int subcode,
         ci->desc[0] = '\0';
     }
 }
+
+/* ------------------------------------------------------------------ */
+/*  irx_cond_errortext - Primary-code descriptive text                */
+/*                                                                    */
+/*  Table is sourced verbatim from SC28-1883-0 Appendix A (Error      */
+/*  Numbers and Messages). The edition defines codes 3..45, 48, 49;   */
+/*  gaps (1, 2, 46, 47, 50..90) are intentional and return "".        */
+/*                                                                    */
+/*  Code 40 uses the TSO/E-verified text "Incorrect call to routine", */
+/*  which matches the Appendix A entry byte-for-byte (no divergence). */
+/* ------------------------------------------------------------------ */
+
+struct errtext_entry
+{
+    int code;
+    const char *text;
+};
+
+/* Sorted by code ascending. Entries are pulled verbatim from SC28-1883-0
+ * Appendix A (Error Numbers and Messages); gaps are intentional and
+ * mirror the primary codes the edition does not define. */
+static const struct errtext_entry g_errortext[] = {
+    {3, "Program is unreadable"},
+    {4, "Program interrupted"},
+    {5, "Machine storage exhausted"},
+    {6, "Unmatched \"/*\" or quote"},
+    {7, "WHEN or OTHERWISE expected"},
+    {8, "Unexpected THEN or ELSE"},
+    {9, "Unexpected WHEN or OTHERWISE"},
+    {10, "Unexpected or unmatched END"},
+    {11, "Control stack full"},
+    {12, "Clause > 500 characters"},
+    {13, "Invalid character in data"},
+    {14, "Incomplete DO/SELECT/IF"},
+    {15, "Invalid hex constant"},
+    {16, "Label not found"},
+    {17, "Unexpected PROCEDURE"},
+    {18, "THEN expected"},
+    {19, "String or symbol expected"},
+    {20, "Symbol expected"},
+    {21, "Invalid data on end of clause"},
+    {22, "Invalid character string"},
+    {23, "Invalid SBCS/DBCS mixed string"},
+    {24, "Invalid TRACE request"},
+    {25, "Invalid sub-keyword found"},
+    {26, "Invalid whole number"},
+    {27, "Invalid DO syntax"},
+    {28, "Invalid LEAVE or ITERATE"},
+    {29, "Environment name too long"},
+    {30, "Name or string > 250 characters"},
+    {31, "Name starts with numeric or \".\""},
+    {32, "Invalid use of stem"},
+    {33, "Invalid expression result"},
+    {34, "Logical value not 0 or 1"},
+    {35, "Invalid expression"},
+    {36, "Unmatched \"(\" in expression"},
+    {37, "Unexpected \",\" or \")\""},
+    {38, "Invalid template or pattern"},
+    {39, "Evaluation stack overflow"},
+    {40, "Incorrect call to routine"},
+    {41, "Bad arithmetic conversion"},
+    {42, "Arithmetic overflow/underflow"},
+    {43, "Routine not found"},
+    {44, "Function did not return data"},
+    {45, "No data specified on function RETURN"},
+    {48, "Failure in system service"},
+    {49, "Interpreter failure"},
+};
+
+#define ERRORTEXT_COUNT \
+    ((int)(sizeof(g_errortext) / sizeof(g_errortext[0])))
+
+const char *irx_cond_errortext(int code)
+{
+    if (code < ERRORTEXT_CODE_MIN || code > ERRORTEXT_CODE_MAX)
+    {
+        return NULL;
+    }
+    for (int i = 0; i < ERRORTEXT_COUNT; i++)
+    {
+        if (g_errortext[i].code == code)
+        {
+            return g_errortext[i].text;
+        }
+    }
+    return "";
+}

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -35,6 +35,15 @@ int irx_exec_run(const char *source, int source_len,
     struct irx_parser parser;
     int rc;
 
+    /* Save/restore slots for the source-retention fields. Populated at
+     * step 2b (after we have a live envblock + wkblk), restored on
+     * cleanup. Supports nested exec_run (e.g. the future INTERPRET
+     * instruction from WP-23) without the inner call wiping the
+     * outer's retention. */
+    void *saved_source = NULL;
+    int saved_source_len = 0;
+    int retention_saved = 0;
+
     memset(&parser, 0, sizeof(parser));
     memset(&tok_err, 0, sizeof(tok_err));
 
@@ -57,15 +66,19 @@ int irx_exec_run(const char *source, int source_len,
         goto cleanup;
     }
 
-    /* 2b. Retain source pointer on the work block so SOURCELINE can   */
-    /* read it back. The source buffer is caller-owned and outlives    */
-    /* the run; wkbi_source is cleared in cleanup to avoid dangling    */
-    /* references after we return. */
+    /* 2b. Retain source pointer on the work block so SOURCELINE can
+     * read it back. The caller-owned source buffer outlives the run;
+     * we save the previous retention values and restore them on
+     * cleanup so nested exec_run calls (future INTERPRET) don't
+     * clobber an outer invocation's retention. */
     {
         struct irx_wkblk_int *wk =
             (struct irx_wkblk_int *)envblock->envblock_userfield;
         if (wk != NULL)
         {
+            saved_source = wk->wkbi_source;
+            saved_source_len = wk->wkbi_source_len;
+            retention_saved = 1;
             wk->wkbi_source = (void *)source;
             wk->wkbi_source_len = source_len;
         }
@@ -164,16 +177,19 @@ cleanup:
     {
         irx_tokn_free(envblock, tokens, tok_count);
     }
-    /* Release the source retention before we return — the caller's
-     * buffer stops being valid for us once control leaves here. */
-    if (envblock != NULL)
+    /* Restore the pre-call retention values before we return — the
+     * caller's source buffer stops being valid for us once control
+     * leaves here, and any outer exec_run further up the stack must
+     * see its own retention preserved. retention_saved guards against
+     * restoring stale zeros when we jumped to cleanup before step 2b. */
+    if (retention_saved && envblock != NULL)
     {
         struct irx_wkblk_int *wk =
             (struct irx_wkblk_int *)envblock->envblock_userfield;
         if (wk != NULL)
         {
-            wk->wkbi_source = NULL;
-            wk->wkbi_source_len = 0;
+            wk->wkbi_source = saved_source;
+            wk->wkbi_source_len = saved_source_len;
         }
     }
     if (own_env)

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -20,6 +20,7 @@
 #include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
+#include "irxwkblk.h"
 
 int irx_exec_run(const char *source, int source_len,
                  const char *args, int args_len,
@@ -54,6 +55,20 @@ int irx_exec_run(const char *source, int source_len,
     {
         rc = 20;
         goto cleanup;
+    }
+
+    /* 2b. Retain source pointer on the work block so SOURCELINE can   */
+    /* read it back. The source buffer is caller-owned and outlives    */
+    /* the run; wkbi_source is cleared in cleanup to avoid dangling    */
+    /* references after we return. */
+    {
+        struct irx_wkblk_int *wk =
+            (struct irx_wkblk_int *)envblock->envblock_userfield;
+        if (wk != NULL)
+        {
+            wk->wkbi_source = (void *)source;
+            wk->wkbi_source_len = source_len;
+        }
     }
 
     /* 3. Tokenize --------------------------------------------------- */
@@ -148,6 +163,18 @@ cleanup:
     if (tokens != NULL)
     {
         irx_tokn_free(envblock, tokens, tok_count);
+    }
+    /* Release the source retention before we return — the caller's
+     * buffer stops being valid for us once control leaves here. */
+    if (envblock != NULL)
+    {
+        struct irx_wkblk_int *wk =
+            (struct irx_wkblk_int *)envblock->envblock_userfield;
+        if (wk != NULL)
+        {
+            wk->wkbi_source = NULL;
+            wk->wkbi_source_len = 0;
+        }
     }
     if (own_env)
     {

--- a/src/irx#uid.c
+++ b/src/irx#uid.c
@@ -11,6 +11,7 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include "irx.h"
@@ -61,9 +62,16 @@ int irxuid(char *userid, struct envblock *envblock)
     /* Fallback: return blanks (non-TSO batch) */
     /* TODO: try ACEE/JCT extraction */
 #else
-    /* Cross-compile: use getlogin() or environment */
-    const char *user = "TESTUSER";
-    int len = (int)strlen(user);
+    (void)envblock;
+    /* Cross-compile: pull from environment, fall back to the literal
+     * "USER" when nothing is set. The 8-byte blank-padded convention
+     * is preserved so callers (bif_userid) can uniformly trim. */
+    const char *user = getenv("USER");
+    if (user == NULL || user[0] == '\0')
+    {
+        user = "USER";
+    }
+    size_t len = strlen(user);
     if (len > 8)
     {
         len = 8;

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -27,6 +27,7 @@
 #include "irx.h"
 #include "irxbif.h"
 #include "irxcond.h"
+#include "irxexec.h"
 #include "irxfunc.h"
 #include "irxpars.h"
 #include "irxtokn.h"
@@ -1551,6 +1552,143 @@ static void test_phase_f_value(void)
     }
 }
 
+/* Drive bif_sourceline with a pre-populated wkbi_source. The test
+ * fixture calls irx_tokn_run / irx_pars_run directly (it does not go
+ * through irx_exec_run), so we have to inject the retained source
+ * manually — that's exactly what irx_exec_run does at step 2b of its
+ * pipeline. */
+static void sourceline_set_retention(struct fixture *fx,
+                                     const char *src)
+{
+    struct irx_wkblk_int *wk =
+        (struct irx_wkblk_int *)fx->env->envblock_userfield;
+    wk->wkbi_source = (void *)src;
+    wk->wkbi_source_len = (int)strlen(src);
+}
+
+static void test_phase_f_sourceline(void)
+{
+    printf("\n--- Phase F: SOURCELINE ---\n");
+
+    /* AC-F5 — SOURCELINE(1) returns the first line text. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE retention fixture_open");
+            return;
+        }
+        sourceline_set_retention(&fx, "first\nsecond\nthird");
+        int rc = run_src(&fx, "y = SOURCELINE(1)\n");
+        CHECK(rc == IRXPARS_OK, "AC-F5 SOURCELINE(1) executes");
+        CHECK(var_eq(&fx, "Y", "first"),
+              "AC-F5 SOURCELINE(1) -> 'first'");
+        fixture_close(&fx);
+    }
+
+    /* Mid-buffer line and line-count reporting. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE mid fixture_open");
+            return;
+        }
+        sourceline_set_retention(&fx, "first\nsecond\nthird");
+        int rc = run_src(&fx,
+                         "a = SOURCELINE(2)\n"
+                         "b = SOURCELINE(3)\n"
+                         "c = SOURCELINE()\n");
+        CHECK(rc == IRXPARS_OK, "SOURCELINE mid executes");
+        CHECK(var_eq(&fx, "A", "second"), "SOURCELINE(2) -> 'second'");
+        CHECK(var_eq(&fx, "B", "third"), "SOURCELINE(3) -> 'third'");
+        CHECK(var_eq(&fx, "C", "3"), "SOURCELINE() -> '3' line count");
+        fixture_close(&fx);
+    }
+
+    /* No retention → SOURCELINE() is 0, SOURCELINE(n) raises. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE empty fixture_open");
+            return;
+        }
+        int rc = run_src(&fx, "y = SOURCELINE()\n");
+        CHECK(rc == IRXPARS_OK, "SOURCELINE() no-retention executes");
+        CHECK(var_eq(&fx, "Y", "0"),
+              "SOURCELINE() with no retention -> '0'");
+        fixture_close(&fx);
+    }
+
+    run_expect_fail("x = SOURCELINE(1)\n", SYNTAX_BAD_CALL,
+                    ERR40_ARG_LENGTH,
+                    "SOURCELINE(1) with no retention -> 40.4");
+
+    /* Out-of-range n raises. */
+    {
+        /* Retention is module-scoped across this closure via a helper */
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE OOR fixture_open");
+            return;
+        }
+        sourceline_set_retention(&fx, "one\ntwo");
+        int rc = run_src(&fx, "y = SOURCELINE(3)\n");
+        CHECK(rc != IRXPARS_OK, "SOURCELINE(3) on 2-line source rejects");
+        struct irx_wkblk_int *wk =
+            (struct irx_wkblk_int *)fx.env->envblock_userfield;
+        int code = (wk && wk->wkbi_last_condition &&
+                    wk->wkbi_last_condition->valid)
+                       ? wk->wkbi_last_condition->code
+                       : 0;
+        int sub = (wk && wk->wkbi_last_condition &&
+                   wk->wkbi_last_condition->valid)
+                      ? wk->wkbi_last_condition->subcode
+                      : 0;
+        CHECK(code == SYNTAX_BAD_CALL && sub == ERR40_ARG_LENGTH,
+              "SOURCELINE(3) on 2-line source -> 40.4");
+        fixture_close(&fx);
+    }
+
+    /* n must be a positive whole number — 0, negative, non-numeric
+     * all go through the standard validation helper. */
+    run_expect_fail("x = SOURCELINE(0)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE,
+                    "SOURCELINE(0) -> 40.12 (non-positive)");
+    run_expect_fail("x = SOURCELINE('abc')\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE,
+                    "SOURCELINE('abc') -> 40.12 (non-numeric)");
+
+    /* End-to-end through irx_exec_run: proves the wkbi_source plumbing
+     * in exec.c actually populates before BIF dispatch. The source
+     * itself invokes SOURCELINE on its own text. */
+    {
+        const char *src = "x = 'one'\n"
+                          "y = 'two'\n"
+                          "out1 = SOURCELINE(1)\n"
+                          "out3 = SOURCELINE()\n";
+        struct envblock *env = NULL;
+        int rcinit = irxinit(NULL, &env);
+        CHECK(rcinit == 0, "SOURCELINE end-to-end: irxinit");
+        int rc_out = 0;
+        int rc = irx_exec_run(src, (int)strlen(src), NULL, 0,
+                              &rc_out, env);
+        CHECK(rc == 0, "SOURCELINE end-to-end: exec_run ok");
+
+        /* Verify wkbi_source was cleared after exec_run returned. */
+        struct irx_wkblk_int *wk =
+            (struct irx_wkblk_int *)env->envblock_userfield;
+        CHECK(wk->wkbi_source == NULL,
+              "SOURCELINE: wkbi_source cleared on cleanup");
+        CHECK(wk->wkbi_source_len == 0,
+              "SOURCELINE: wkbi_source_len cleared on cleanup");
+
+        irxterm(env);
+    }
+}
+
 int main(void)
 {
     printf("=== WP-21a + WP-21b Phase C+D+E+F: BIFs ===\n");
@@ -1576,6 +1714,7 @@ int main(void)
     test_phase_f_userid();
     test_phase_f_stubs();
     test_phase_f_value();
+    test_phase_f_sourceline();
     test_error_paths();
     test_find_phrase_cap();
 

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -1550,6 +1550,28 @@ static void test_phase_f_value(void)
               "VALUE empty selector treated as absent (no raise)");
         fixture_close(&fx);
     }
+
+    /* Mode 2 with empty newvalue — "set to empty string" is a valid
+     * assignment, distinct from "omit the second argument". Verifies
+     * the commentary claim that empty newvalue is honoured. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "VALUE empty-newvalue fixture_open");
+            return;
+        }
+        int rc = run_src(&fx,
+                         "x = 'hello'\n"
+                         "y = VALUE('X', '')\n"
+                         "z = X\n");
+        CHECK(rc == IRXPARS_OK, "VALUE empty-newvalue executes");
+        CHECK(var_eq(&fx, "Y", "hello"),
+              "VALUE('X','') returns previous 'hello'");
+        CHECK(var_eq(&fx, "Z", ""),
+              "VALUE('X','') sets X to empty string");
+        fixture_close(&fx);
+    }
 }
 
 /* Drive bif_sourceline with a pre-populated wkbi_source. The test
@@ -1660,6 +1682,44 @@ static void test_phase_f_sourceline(void)
     run_expect_fail("x = SOURCELINE('abc')\n", SYNTAX_BAD_CALL,
                     ERR40_POSITIVE_WHOLE,
                     "SOURCELINE('abc') -> 40.12 (non-numeric)");
+
+    /* Huge n must NOT silently truncate into a valid line index.
+     * On cross-compile hosts (long = 64-bit, int = 32-bit) this
+     * guards against a cast-truncation bug that would land the
+     * request back inside the valid range — e.g. 2^32 + 5 -> 5
+     * and spuriously return line 5. source_line_find takes long
+     * directly, so the out-of-range check fires as expected. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE huge-n fixture_open");
+            return;
+        }
+        sourceline_set_retention(&fx, "one\ntwo\nthree\nfour\nfive");
+        int rc = run_src(&fx, "y = SOURCELINE(4294967301)\n");
+        CHECK(rc != IRXPARS_OK,
+              "SOURCELINE huge-n rejects (no silent truncation)");
+        fixture_close(&fx);
+    }
+
+    /* Trailing '\n' does not add a phantom empty line: "a\nb\n"
+     * counts as 2, not 3. Guards against off-by-one regression
+     * in source_line_count. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE trailing-nl fixture_open");
+            return;
+        }
+        sourceline_set_retention(&fx, "a\nb\n");
+        int rc = run_src(&fx, "y = SOURCELINE()\n");
+        CHECK(rc == IRXPARS_OK, "SOURCELINE trailing-nl executes");
+        CHECK(var_eq(&fx, "Y", "2"),
+              "SOURCELINE() with trailing '\\n' counts 2 (not 3)");
+        fixture_close(&fx);
+    }
 
     /* End-to-end through irx_exec_run: proves the wkbi_source plumbing
      * in exec.c actually populates before BIF dispatch. The source

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -1279,9 +1279,125 @@ static void test_phase_e_errors(void)
                     "DATATYPE unknown multi-char option -> 40.23");
 }
 
+/* ================================================================== */
+/*  Phase F — Environment BIFs (WP-21b Phase F, issue #34)            */
+/* ================================================================== */
+
+/* True iff s contains at least one non-digit and at least one non-blank
+ * character — used to reject a regression where ERRORTEXT would echo
+ * the numeric code back as its own text. */
+static int looks_non_numeric_text(const char *s, size_t len)
+{
+    if (len == 0)
+    {
+        return 0;
+    }
+    int saw_non_digit = 0;
+    int saw_non_blank = 0;
+    for (size_t i = 0; i < len; i++)
+    {
+        unsigned char c = (unsigned char)s[i];
+        if (c != ' ')
+        {
+            saw_non_blank = 1;
+        }
+        if (c < '0' || c > '9')
+        {
+            saw_non_digit = 1;
+        }
+    }
+    return saw_non_blank && saw_non_digit;
+}
+
+static void errortext_check_nonempty(int code)
+{
+    char src[64];
+    snprintf(src, sizeof(src), "x = ERRORTEXT(%d)\n", code);
+    struct fixture fx;
+    if (fixture_open(&fx) != 0)
+    {
+        CHECK(0, "ERRORTEXT fixture_open");
+        return;
+    }
+    int rc = run_src(&fx, src);
+    if (rc != IRXPARS_OK)
+    {
+        CHECK(0, "ERRORTEXT(n) executes");
+        fixture_close(&fx);
+        return;
+    }
+
+    Lstr key;
+    Lstr val;
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(fx.alloc, &key, "X");
+    int vrc = vpool_get(fx.pool, &key, &val);
+    int ok = (vrc == VPOOL_OK) &&
+             looks_non_numeric_text((const char *)val.pstr, val.len);
+    if (!ok)
+    {
+        printf("    ERRORTEXT(%d) = '%.*s'\n",
+               code, (int)val.len, (const char *)val.pstr);
+    }
+    char label[64];
+    snprintf(label, sizeof(label),
+             "ERRORTEXT(%d) non-empty non-numeric", code);
+    CHECK(ok, label);
+    Lfree(fx.alloc, &key);
+    Lfree(fx.alloc, &val);
+    fixture_close(&fx);
+}
+
+static void test_phase_f_errortext(void)
+{
+    printf("\n--- Phase F: ERRORTEXT ---\n");
+
+    /* AC-F2 — exact match against the TSO/E-verified spec text. */
+    EXPECT_OK("ERRORTEXT(40)", "Incorrect call to routine",
+              "AC-F2 ERRORTEXT(40) exact TSO/E text");
+
+    /* Table-boundary guards — the first and last defined Appendix A
+     * entries. Catches off-by-one regressions from table reorder. */
+    EXPECT_OK("ERRORTEXT(3)", "Program is unreadable",
+              "ERRORTEXT(3) first table entry");
+    EXPECT_OK("ERRORTEXT(49)", "Interpreter failure",
+              "ERRORTEXT(49) last table entry");
+
+    /* Codes rexx370 actually raises today — verify the lookup returns
+     * something sensible (non-empty, not just the numeric code). */
+    errortext_check_nonempty(24);
+    errortext_check_nonempty(26);
+    errortext_check_nonempty(41);
+    errortext_check_nonempty(42);
+
+    /* AC-F3 — out-of-range codes raise SYNTAX 40.23. */
+    run_expect_fail("x = ERRORTEXT(0)\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID,
+                    "AC-F3 ERRORTEXT(0) -> 40.23");
+    run_expect_fail("x = ERRORTEXT(99)\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID,
+                    "AC-F3 ERRORTEXT(99) -> 40.23");
+
+    /* Upstream validation — negative or non-numeric fails in whole-number
+     * parsing before the range check runs. */
+    run_expect_fail("x = ERRORTEXT(-1)\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE,
+                    "ERRORTEXT(-1) rejected as non-negative");
+    run_expect_fail("x = ERRORTEXT('ABC')\n", SYNTAX_BAD_CALL,
+                    ERR40_NONNEG_WHOLE,
+                    "ERRORTEXT('ABC') rejected as non-numeric");
+
+    /* In-range but undefined codes must return empty string, matching
+     * TSO/E behaviour for gaps (1, 2, 46, 47) and for codes 50..90. */
+    EXPECT_OK("ERRORTEXT(1)", "", "ERRORTEXT(1) undefined -> empty");
+    EXPECT_OK("ERRORTEXT(46)", "", "ERRORTEXT(46) undefined -> empty");
+    EXPECT_OK("ERRORTEXT(90)", "", "ERRORTEXT(90) undefined -> empty");
+}
+
 int main(void)
 {
-    printf("=== WP-21a + WP-21b Phase C+D+E: BIFs ===\n");
+    printf("=== WP-21a + WP-21b Phase C+D+E+F: BIFs ===\n");
     test_phase_b();
     test_phase_c();
     test_phase_d();
@@ -1300,6 +1416,7 @@ int main(void)
     test_phase_e_symbol();
     test_phase_e_numeric_reflection();
     test_phase_e_errors();
+    test_phase_f_errortext();
     test_error_paths();
     test_find_phrase_cap();
 

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -1395,6 +1395,69 @@ static void test_phase_f_errortext(void)
     EXPECT_OK("ERRORTEXT(90)", "", "ERRORTEXT(90) undefined -> empty");
 }
 
+static void test_phase_f_userid(void)
+{
+    printf("\n--- Phase F: USERID ---\n");
+
+    /* AC-F1 — USERID returns a non-empty string. On cross-compile this
+     * is either getenv("USER") or the "USER" literal fallback; on MVS
+     * it's the trimmed PSCBUSER or the "MVSUSER" sentinel. No exact
+     * match — just non-empty and non-blank. */
+    struct fixture fx;
+    if (fixture_open(&fx) != 0)
+    {
+        CHECK(0, "USERID fixture_open");
+        return;
+    }
+    int rc = run_src(&fx, "x = USERID()\n");
+    if (rc != IRXPARS_OK)
+    {
+        CHECK(0, "AC-F1 USERID() executes");
+        fixture_close(&fx);
+        return;
+    }
+
+    Lstr key;
+    Lstr val;
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(fx.alloc, &key, "X");
+    int vrc = vpool_get(fx.pool, &key, &val);
+    int non_empty = (vrc == VPOOL_OK) && val.len > 0;
+    int non_blank = 0;
+    if (non_empty)
+    {
+        for (size_t i = 0; i < val.len; i++)
+        {
+            if (val.pstr[i] != ' ')
+            {
+                non_blank = 1;
+                break;
+            }
+        }
+    }
+    if (!non_empty || !non_blank)
+    {
+        printf("    USERID = '%.*s' (len=%d)\n",
+               (int)val.len, (const char *)val.pstr, (int)val.len);
+    }
+    CHECK(non_empty && non_blank, "AC-F1 USERID() non-empty non-blank");
+    Lfree(fx.alloc, &key);
+    Lfree(fx.alloc, &val);
+    fixture_close(&fx);
+}
+
+static void test_phase_f_stubs(void)
+{
+    printf("\n--- Phase F: EXTERNALS + LINESIZE stubs ---\n");
+
+    /* AC-F4 — EXTERNALS() returns '0' until data-stack lands. */
+    EXPECT_OK("EXTERNALS()", "0", "AC-F4 EXTERNALS() -> '0'");
+
+    /* AC-F8 — LINESIZE() returns '80' pending WP-33. */
+    EXPECT_OK("LINESIZE()", "80", "AC-F8 LINESIZE() -> '80'");
+}
+
 int main(void)
 {
     printf("=== WP-21a + WP-21b Phase C+D+E+F: BIFs ===\n");
@@ -1417,6 +1480,8 @@ int main(void)
     test_phase_e_numeric_reflection();
     test_phase_e_errors();
     test_phase_f_errortext();
+    test_phase_f_userid();
+    test_phase_f_stubs();
     test_error_paths();
     test_find_phrase_cap();
 

--- a/test/test_bifs.c
+++ b/test/test_bifs.c
@@ -1458,6 +1458,99 @@ static void test_phase_f_stubs(void)
     EXPECT_OK("LINESIZE()", "80", "AC-F8 LINESIZE() -> '80'");
 }
 
+static void test_phase_f_value(void)
+{
+    printf("\n--- Phase F: VALUE ---\n");
+
+    /* AC-F6 Mode 1 — read existing variable. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "VALUE mode 1 fixture_open");
+            return;
+        }
+        int rc = run_src(&fx, "x = 5\ny = VALUE('X')\n");
+        CHECK(rc == IRXPARS_OK, "AC-F6 Mode 1 VALUE('X') executes");
+        CHECK(var_eq(&fx, "Y", "5"), "AC-F6 Mode 1 VALUE('X') -> '5'");
+        fixture_close(&fx);
+    }
+
+    /* Mode 1 — unset variable returns uppercased name. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "VALUE unset fixture_open");
+            return;
+        }
+        int rc = run_src(&fx, "y = VALUE('new_var')\n");
+        CHECK(rc == IRXPARS_OK, "VALUE unset executes");
+        CHECK(var_eq(&fx, "Y", "NEW_VAR"),
+              "VALUE('new_var') unset -> 'NEW_VAR' (uppercased)");
+        fixture_close(&fx);
+    }
+
+    /* AC-F6 Mode 2 — read old, set new, return old. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "VALUE mode 2 fixture_open");
+            return;
+        }
+        int rc = run_src(&fx,
+                         "x = 5\n"
+                         "y = VALUE('X', '7')\n"
+                         "z = VALUE('X')\n");
+        CHECK(rc == IRXPARS_OK, "AC-F6 Mode 2 VALUE('X','7') executes");
+        CHECK(var_eq(&fx, "Y", "5"),
+              "AC-F6 Mode 2 VALUE('X','7') returns previous '5'");
+        CHECK(var_eq(&fx, "Z", "7"),
+              "AC-F6 Mode 2 VALUE('X','7') sets X to '7'");
+        fixture_close(&fx);
+    }
+
+    /* Mode 2 — set a previously-unset variable. Return is the
+     * uppercased name (matches Mode 1 behaviour), set still happens. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "VALUE set-new fixture_open");
+            return;
+        }
+        int rc = run_src(&fx,
+                         "y = VALUE('NEW_VAR', 'hello')\n"
+                         "z = NEW_VAR\n");
+        CHECK(rc == IRXPARS_OK, "VALUE set-new executes");
+        CHECK(var_eq(&fx, "Y", "NEW_VAR"),
+              "VALUE set-new returns uppercased name for previously unset");
+        CHECK(var_eq(&fx, "Z", "hello"),
+              "VALUE set-new actually sets the variable");
+        fixture_close(&fx);
+    }
+
+    /* AC-F7 — Mode 3 with selector raises SYNTAX 40.23. */
+    run_expect_fail("x = 5\ny = VALUE('X', '7', 'ENVIRONMENT')\n",
+                    SYNTAX_BAD_CALL, ERR40_OPTION_INVALID,
+                    "AC-F7 VALUE with selector -> 40.23");
+
+    /* Empty selector treated as absent — must NOT raise. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "VALUE empty-selector fixture_open");
+            return;
+        }
+        int rc = run_src(&fx, "x = 5\ny = VALUE('X', '7', '')\n");
+        CHECK(rc == IRXPARS_OK,
+              "VALUE empty selector treated as absent (no raise)");
+        fixture_close(&fx);
+    }
+}
+
 int main(void)
 {
     printf("=== WP-21a + WP-21b Phase C+D+E+F: BIFs ===\n");
@@ -1482,6 +1575,7 @@ int main(void)
     test_phase_f_errortext();
     test_phase_f_userid();
     test_phase_f_stubs();
+    test_phase_f_value();
     test_error_paths();
     test_find_phrase_cap();
 


### PR DESCRIPTION
## Scope

Final BIF phase of WP-21b (umbrella #27). Implements six §4 environment BIFs from SC28-1883-0:

| BIF         | Mode       | Notes                                                              |
|-------------|------------|--------------------------------------------------------------------|
| `ERRORTEXT` | full       | Appendix A lookup (verbatim); Code 40 TSO/E-verified               |
| `USERID`    | full       | Delegates to `irxuid()`; cross-compile branch patched to `getenv("USER")` |
| `EXTERNALS` | stub       | Returns `'0'` — real impl blocked on data-stack (TSK-144)          |
| `SOURCELINE`| full       | `wkbi_source` / `wkbi_source_len` populated in `irx_exec_run` (save/restore for nesting); on-demand `\n` scan; `long` line-index to avoid LP64 truncation |
| `VALUE`     | modes 1+2  | Mode 3 (selector) raises SYNTAX 40.23; follow-up filed              |
| `LINESIZE`  | stub       | Returns `'80'` — terminal-width detection deferred to WP-33        |

Resolves #34.

## Commit history

1. `feat(wp-21b): Phase F part 1 — ERRORTEXT infrastructure` — Appendix A table in `irx#cond.c`, `bif_errortext` in `irx#bifs.c`, `ERRORTEXT_CODE_MIN/MAX` exported via `irxcond.h`. +14 tests.
2. `feat(wp-21b): Phase F part 2 — USERID, EXTERNALS, LINESIZE` — delegation + stubs. Patches `irx#uid.c` cross-compile branch from `"TESTUSER"` literal to `getenv("USER")` with `"USER"` fallback. +3 tests.
3. `feat(wp-21b): Phase F part 3 — VALUE (Modes 1+2, Mode 3 raises)` — extracts `upper_copy_to_key` / `upper_key_free` helpers shared with `bif_symbol`. +12 tests.
4. `feat(wp-21b): Phase F part 4 — SOURCELINE + wkbi_source retention` — wires `irx_exec_run` to populate the existing work-block fields; `bif_sourceline` on-demand scan. +17 tests.
5. `docs(wp-21b): Phase F done — workpackages status + code-style pointer` — final polish.
6. `refactor(wp-21b): Phase F review round-2 cleanups` — long→int truncation fix in `source_line_find`, save/restore for nested exec_run retention, +6 regression tests (AC-F5 edge-case coverage + VALUE empty-set). +6 tests.

## Analysis comments (archived)

1. SOURCELINE source-retention — outcome (b), retention plumbing in this PR.
2. IRXUID availability — delegate + patch cross-compile branch.
3. ERRORTEXT table source — SC28-1883-0 Appendix A verbatim.
4. Spec-vs-TSO/E for Code 40 — no divergence.
5. `.clang-format` / `irx#bifs.c` convergence — resolved via chore PR #43.
6. Post-rebase status after PR #43 merge.
7. Round-2 cleanups applied.

## Test plan

- [x] Commit 1 — ERRORTEXT: 358 → 372 (+14; AC-F2, AC-F3, boundaries 3/49)
- [x] Commit 2 — USERID + EXTERNALS + LINESIZE: 372 → 375 (+3; AC-F1/F4/F8)
- [x] Commit 3 — VALUE: 375 → 387 (+12; AC-F6, AC-F7, unset, set-new, empty-selector)
- [x] Commit 4 — SOURCELINE: 387 → 404 (+17; AC-F5, count, no-retention, out-of-range, non-numeric, E2E via `irx_exec_run`)
- [x] Commit 5 — docs (no test impact)
- [x] Commit 6 — round-2: 404 → 410 (+6; huge-n, trailing-nl, VALUE empty-set)

Full matrix (14 binaries): 1104 → 1156 (+52). `clang-format --style=file --dry-run --Werror` across `src/`, `include/`, `test/` passes clean.

## Known risks pending MVS verification

**ERRORTEXT entries for codes 6 and 31 contain escaped quote characters:**

```c
{6,  "Unmatched \"/*\" or quote"},
{31, "Name starts with numeric or \".\""},
```

Cross-compile (ASCII) is green. The c2asm370 EBCDIC path should translate these byte-for-byte; full MVS-run verification is blocked on TSK-3463 (MVS build anchor). If a byte-level mismatch surfaces post-anchor-fix, the patch is table-local and does not affect the surrounding infrastructure.

**SOURCELINE line-boundary assumption.** `bif_sourceline` treats `'\n'` as the line terminator in `wkbi_source`. On MVS, the source may arrive as a single buffer with `'\n'` (as from `irxexec`) or as record-structured data. Current tests drive `'\n'`-separated buffers; any record-based path would need a pre-normalisation step at the `irx_exec_run` entry point. Flagged for MVS-verification pass.

## Not in scope (follow-ups — see PR comment)

- VALUE mode 3 (selector / host-command-environment variables).
- Full USERID via ACEE/JCT for non-TSO batch (CON-1 §5.6).
- EXTERNALS real implementation (data-stack — TSK-144).
- LINESIZE terminal-width detection (WP-33).
- CI ratchet: `clang-format --dry-run --Werror` GitHub Action.