### PR TITLE
WP-21b Phase H: close-out — docs, test counts, section label cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Tests: `test/test_name.c`
 | `src/irx#exec.c` | IRX#EXEC | End-to-end execution pipeline irx_exec_run() (WP-18) |
 | `src/irx#cond.c` | IRX#COND | Condition raise helper (irx_cond_raise, WP-21a) |
 | `src/irx#bif.c`  | IRX#BIF  | BIF registry + argument-validation helpers (WP-21a) |
-| `src/irx#bifs.c` | IRX#BIFS | String BIFs (LENGTH, SUBSTR, WORD, ... WP-21a) |
+| `src/irx#bifs.c` | IRX#BIFS | All §4 BIFs — string (WP-21a) + numeric, conversion, reflection, environment (WP-21b) |
 
 New source files follow the same pattern: `src/irx#xxxx.c` where
 `xxxx` is a 4-character identifier. Member names must be ≤ 8 chars.
@@ -349,7 +349,7 @@ gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     $LSTRING_SRC
 ./test/test_vpool
 
-# Parser (WP-13) — 38/38
+# Parser (WP-13) — 39/39
 gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     -o test/test_parser test/test_parser.c \
     $PHASE1_SRC 'src/irx#lstr.c' 'src/irx#tokn.c' \
@@ -398,12 +398,21 @@ gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' 'src/irx#arith.c' $LSTRING_SRC
 ./test/test_bif
 
-# String BIFs end-to-end (WP-21a) — 87/87
+# All §4 BIFs end-to-end (WP-21a + WP-21b) — 410/410
 gcc -I include $LSTRING_INC -Wall -Wextra -std=gnu99 \
     -o test/test_bifs test/test_bifs.c \
     $PHASE1_SRC $PHASE2_SRC 'src/irx#exec.c' 'src/irx#arith.c' $LSTRING_SRC
 ./test/test_bifs
 ```
+
+Additional test binaries (same dependency sets as above; check each
+file's header comment for the exact invocation):
+
+- `test/test_arith_extended` — direct IRXARITH API tests (WP-20 + WP-21b Phase B) — 113/113
+- `test/test_procedure` — PROCEDURE EXPOSE (WP-17) — 53/53
+- `test/test_phase1` — Phase 1 control-block smoke tests — 38/38
+
+Full matrix: 14 binaries, **1156 tests green** as of WP-21b Phase H close-out.
 
 ## Work packages
 
@@ -415,8 +424,9 @@ Current status:
 - Phase 1 (WP-01 through WP-05): complete
 - Phase 2 (WP-10 through WP-18): complete
 - Phase 3 in progress:
-  - WP-20 (Arithmetic engine — 128/128)
-  - WP-21a (String BIFs — 29/29 + 87/87)
+  - WP-20 (Arithmetic engine — 128/128 + 113/113 extended)
+  - WP-21a (String BIFs, 29 BIFs) — done
+  - WP-21b (Numeric/Conversion/Reflection/Environment BIFs, 23 BIFs) — done
 
 ## Knowledge sources
 

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -27,7 +27,7 @@ Reference: [Architecture Design v0.1.0](https://www.notion.so/3283d9938787811ba3
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | DONE (128/128) — PR #24 |
 | WP-21a | String BIFs (IRXBIFS) | 3 | DONE (29/29 + 87/87) — PR #26 |
-| WP-21b | Misc BIFs | 3 | IN PROGRESS — Phases A–F done (PRs #28, #30, #36, #38, #39, #42); H (#35) open |
+| WP-21b | Misc BIFs | 3 | DONE — 23 BIFs across Phases A (#28, registry), B (#30, IRXARITH API), C (#36, numeric), D (#38, conversion), E (#39, reflection), F (#42, environment); Phase H closes the work package. Suite: 1156 total across 14 cross-compile binaries |
 | WP-22 | Built-in misc functions | 3 | OPEN |
 | WP-23 | INTERPRET instruction | 3 | OPEN |
 | WP-30 | EXECIO command | 4 | OPEN |

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -93,7 +93,7 @@ static int set_one(struct lstr_alloc *a, PLstr s, unsigned char c)
 }
 
 /* ================================================================== */
-/*  Phase B — Substring & position                                    */
+/*  String — Substring & position (WP-21a)                            */
 /* ================================================================== */
 
 static int bif_length(struct irx_parser *p, int argc, PLstr *argv,
@@ -216,7 +216,7 @@ static int bif_lastpos(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase C — Word operations                                         */
+/*  String — Word operations (WP-21a)                                 */
 /* ================================================================== */
 
 static int bif_words(struct irx_parser *p, int argc, PLstr *argv,
@@ -308,7 +308,7 @@ static int bif_wordpos(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase D — Padding, stripping, formatting                          */
+/*  String — Padding, stripping, formatting (WP-21a)                  */
 /* ================================================================== */
 
 static int bif_center(struct irx_parser *p, int argc, PLstr *argv,
@@ -522,7 +522,7 @@ static int bif_justify(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase E — Insert, delete, overlay                                 */
+/*  String — Insert, delete, overlay (WP-21a)                         */
 /* ================================================================== */
 
 static int bif_insert(struct irx_parser *p, int argc, PLstr *argv,
@@ -729,7 +729,7 @@ static int bif_delword(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase F — Translation & verification                              */
+/*  String — Translation & verification (WP-21a)                      */
 /* ================================================================== */
 
 static int bif_translate(struct irx_parser *p, int argc, PLstr *argv,
@@ -1000,7 +1000,7 @@ static int bif_find(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase G — Numeric BIFs (WP-21b Phase C)                           */
+/*  Numeric (WP-21b)                                                  */
 /*                                                                    */
 /*  All seven BIFs delegate to IRXARITH primitives (irx_arith_op,     */
 /*  irx_arith_compare, irx_arith_trunc, irx_arith_format,             */
@@ -1390,7 +1390,7 @@ static int bif_random(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase H — Conversion BIFs (WP-21b Phase D)                        */
+/*  Conversion (WP-21b)                                               */
 /*                                                                    */
 /*  C2X / X2C / B2X / X2B are pure byte-level conversions; they       */
 /*  neither inspect nor produce REXX numbers. C2D / X2D / D2C / D2X   */
@@ -2493,7 +2493,7 @@ static int bif_d2x(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase I — Reflection BIFs (WP-21b Phase E)                        */
+/*  Reflection (WP-21b)                                               */
 /*                                                                    */
 /*  DATATYPE / SYMBOL / DIGITS / FUZZ / FORM expose interpreter       */
 /*  state and classification rules to REXX code. They are thin        */
@@ -2710,7 +2710,7 @@ static int bif_form(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
-/*  Phase F — Environment BIFs (WP-21b Phase F)                       */
+/*  Environment (WP-21b)                                              */
 /* ================================================================== */
 
 /* USERID() — current user id.
@@ -3045,8 +3045,12 @@ static int bif_errortext(struct irx_parser *p, int argc, PLstr *argv,
 /*  Registration                                                      */
 /* ================================================================== */
 
+/* Registration order groups by functional category; within a group
+ * the sequence reflects implementation order rather than alphabetical
+ * sort — semantically related BIFs cluster (word ops together, byte-
+ * conversion together) for faster review scanning. */
 static const struct irx_bif_entry g_bifstr_table[] = {
-    /* Phase B */
+    /* String — substring & position (WP-21a) */
     {"LENGTH", 1, 1, bif_length},
     {"LEFT", 2, 3, bif_left},
     {"RIGHT", 2, 3, bif_right},
@@ -3054,14 +3058,14 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"POS", 2, 3, bif_pos},
     {"INDEX", 2, 3, bif_index},
     {"LASTPOS", 2, 3, bif_lastpos},
-    /* Phase C */
+    /* String — word operations (WP-21a) */
     {"WORDS", 1, 1, bif_words},
     {"WORD", 2, 2, bif_word},
     {"WORDINDEX", 2, 2, bif_wordindex},
     {"WORDLENGTH", 2, 2, bif_wordlength},
     {"SUBWORD", 2, 3, bif_subword},
     {"WORDPOS", 2, 3, bif_wordpos},
-    /* Phase D */
+    /* String — padding, stripping, formatting (WP-21a) */
     {"CENTER", 2, 3, bif_center},
     {"CENTRE", 2, 3, bif_center},
     {"STRIP", 1, 3, bif_strip},
@@ -3069,19 +3073,19 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"JUSTIFY", 2, 3, bif_justify},
     {"COPIES", 2, 2, bif_copies},
     {"REVERSE", 1, 1, bif_reverse},
-    /* Phase E */
+    /* String — insert, delete, overlay (WP-21a) */
     {"INSERT", 2, 5, bif_insert},
     {"OVERLAY", 2, 5, bif_overlay},
     {"DELSTR", 2, 3, bif_delstr},
     {"DELWORD", 2, 3, bif_delword},
-    /* Phase F */
+    /* String — translation & verification (WP-21a) */
     {"TRANSLATE", 1, 4, bif_translate},
     {"VERIFY", 2, 4, bif_verify},
     {"COMPARE", 2, 3, bif_compare},
     {"ABBREV", 2, 3, bif_abbrev},
     {"XRANGE", 0, 2, bif_xrange},
     {"FIND", 2, 2, bif_find},
-    /* Phase G — Numeric BIFs (WP-21b Phase C) */
+    /* Numeric (WP-21b) */
     {"MAX", 1, IRX_MAX_ARGS, bif_max},
     {"MIN", 1, IRX_MAX_ARGS, bif_min},
     {"ABS", 1, 1, bif_abs},
@@ -3089,7 +3093,7 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"TRUNC", 1, 2, bif_trunc},
     {"FORMAT", 1, 5, bif_format},
     {"RANDOM", 0, 3, bif_random},
-    /* Phase H — Conversion BIFs (WP-21b Phase D) */
+    /* Conversion (WP-21b) */
     {"C2X", 1, 1, bif_c2x},
     {"X2C", 1, 1, bif_x2c},
     {"B2X", 1, 1, bif_b2x},
@@ -3098,13 +3102,13 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"X2D", 1, 2, bif_x2d},
     {"D2C", 1, 2, bif_d2c},
     {"D2X", 1, 2, bif_d2x},
-    /* Phase I — Reflection BIFs (WP-21b Phase E) */
+    /* Reflection (WP-21b) */
     {"DATATYPE", 1, 2, bif_datatype},
     {"SYMBOL", 1, 1, bif_symbol},
     {"DIGITS", 0, 0, bif_digits},
     {"FUZZ", 0, 0, bif_fuzz},
     {"FORM", 0, 0, bif_form},
-    /* Phase J — Environment BIFs (WP-21b Phase F) */
+    /* Environment (WP-21b) */
     {"USERID", 0, 0, bif_userid},
     {"ERRORTEXT", 1, 1, bif_errortext},
     {"EXTERNALS", 0, 0, bif_externals},


### PR DESCRIPTION
## Scope

Phase H of WP-21b (umbrella #27) — no code changes, just the close-out that the per-phase PRs left behind.

## Changes

- **`src/irx#bifs.c`** — unified the section labels. WP-21a used internal "Phase B–F" letters for its string-BIF implementation order; WP-21b continued with "Phase G/H/I/J" carrying "(WP-21b Phase C)" parentheticals. The collision on "Phase F" (string translation vs. environment BIFs) made review navigation unnecessarily confusing. Collapsed to functional labels — `String — Substring & position (WP-21a)`, `Numeric (WP-21b)`, `Conversion (WP-21b)`, `Reflection (WP-21b)`, `Environment (WP-21b)`, etc. Registration order preserved; functional clusters retained over alphabetical sort.
- **`docs/workpackages.md`** — WP-21b row flipped to `DONE` with all six merged phase PRs referenced.
- **`CLAUDE.md`** — test counts synced to reality:
  - `test_parser`: 38 → 39
  - `test_bifs`: 87 → 410
  - Added entries for `test_arith_extended` (113), `test_procedure` (53), `test_phase1` (38) that were missing from the reference block.
  - `src/irx#bifs.c` file description updated: "String BIFs" → all §4 BIFs after WP-21b.
  - Current-status section updated: WP-21b marked done.

## Test plan

- [x] Full cross-compile matrix on this branch: 14 binaries, **1156 / 1156 tests green**.
- [x] `clang-format --style=file --dry-run --Werror` on `src/irx#bifs.c`: clean (section-header-only comment edits, no code touched).
- [x] No new warnings under `-Wall -Wextra -std=gnu99`.

### Per-binary counts (close-out baseline)

| Binary | Count |
|---|---|
| test_tokenizer | 70 |
| test_vpool | 47 |
| test_parser | 39 |
| test_say | 27 |
| test_irxlstr | 50 |
| test_control | 62 |
| test_hello | 16 |
| test_parse | 74 |
| test_arith | 128 |
| test_arith_extended | 113 |
| test_bif | 29 |
| test_bifs | 410 |
| test_procedure | 53 |
| test_phase1 | 38 |
| **Total** | **1156** |

## Not in scope

- New BIFs or refactoring (belongs to individual phase PRs, all merged).
- MVS-run verification (blocked on TSK-3463; tracked as Notion follow-up for ERRORTEXT codes 6/31 and SOURCELINE record-input).
- The six WP-21b follow-up tickets (VALUE mode 3, USERID ACEE/JCT, EXTERNALS real impl, LINESIZE real impl, plus the two MVS-verify items) — already filed in the MVSLOVERS Notion backlog; this PR does not touch them.

## References

- Parent work package: #27
- Phase A: #28, Phase B: #30, Phase C: #36, Phase D: #38, Phase E: #39, Phase F: #42 — all merged.
- Closes #35.