### PR TITLE
refactor(anchor): switch ECTENVBK to read-mostly (CON-1 §6.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,10 +19,13 @@ https://www.notion.so/3283d9938787811ba3f4d3308b254cad
 
 Key points:
 - **ENVBLOCK** is the anchor for each Language Processor Environment
-- **ECTENVBK** (offset +30 in the TSO ECT) anchors the current ENVBLOCK;
-  `rexx370_prev` at ENVBLOCK+304 chains prior environments for push/pop.
-  In batch (no ECT) the slot is NULL and IRXINIT still succeeds
-  locally — see `include/irxanchor.h`
+- **ECTENVBK** (offset +30 in the TSO ECT) anchors the current ENVBLOCK
+  under read-mostly discipline: IRXINIT writes the slot only when it is
+  NULL, IRXTERM clears it only when it still points to the terminating
+  env. Any other value (e.g. a coexisting BREXX/370 environment on the
+  same ECT) is left untouched. In batch (no ECT reachable) the slot is
+  never written and IRXINIT still succeeds locally. See CON-1 §6.1 and
+  `include/irxanchor.h`
 - **IRXEXTE** (Vector of External Entry Points) holds all replaceable
   routine pointers — SAY, PULL, I/O, Host Command, etc.
 - **irx_wkblk_int** (our internal Work Block) holds all per-environment

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ designed to be interface-compatible with the TSO/E Version 2 REXX specification
 rexx370/
   inc/            C headers
     irx.h           IBM-compatible control block definitions
-    irxanchor.h     ECTENVBK anchor API (environment push/pop)
+    irxanchor.h     ECTENVBK anchor API (read-mostly: claim when NULL,
+                    clear only when still holding)
     irxwkblk.h      Internal Work Block (per-environment interpreter state)
     irxfunc.h       Service function prototypes
   src/            C source (CRENT370)

--- a/include/irx.h
+++ b/include/irx.h
@@ -81,16 +81,7 @@ struct envblock
         } _envblock_struct2;
     } _envblock_union2;
 
-    /* rexx370 anchor chain pointer.
-     *
-     * Lives at offset +304 (0x130) inside the IBM-reserved tail of the
-     * ENVBLOCK (SC28-1883-0/-4 leave +304..+319 reserved). On IRXINIT we
-     * save the previous ECTENVBK value here and install ourselves; on
-     * IRXTERM we restore it. See CON-1 §3.1 for the full layout and
-     * §6.1 for the push/pop discipline. */
-    struct envblock *rexx370_prev;
-
-    int _filler3[3]; /* +308..+319 reserved                            */
+    int _filler3[4]; /* +304..+319 reserved for rexx370 future use     */
 };
 
 #define ENVBLOCK_ID           "ENVBLOCK"

--- a/include/irxanchor.h
+++ b/include/irxanchor.h
@@ -1,11 +1,27 @@
 /* ------------------------------------------------------------------ */
-/*  irxanchor.h - ECTENVBK anchor discipline for REXX/370             */
+/*  irxanchor.h - ECTENVBK read-mostly anchor for REXX/370            */
 /*                                                                    */
 /*  A REXX Language Processor Environment is anchored in the TSO ECT  */
-/*  at offset +30 (ECTENVBK). On IRXINIT we push the new ENVBLOCK,    */
-/*  saving the previous ECTENVBK value in ENVBLOCK+304 (rexx370_prev).*/
-/*  On IRXTERM we pop, restoring the previous value — but only if     */
-/*  we're still the current anchor (lenient pop).                     */
+/*  at offset +30 (ECTENVBK). rexx370 treats that slot as read-mostly */
+/*  per CON-1 §6.1: at any point it is in one of three states —       */
+/*                                                                    */
+/*    (a) NULL            no REXX environment active; rexx370 may     */
+/*                        claim the slot on IRXINIT                   */
+/*                                                                    */
+/*    (b) non-rexx370     another REXX holds the anchor (on MVS 3.8j  */
+/*                        typically BREXX/370, but the slot is also   */
+/*                        compatible with any other env). rexx370     */
+/*                        leaves the slot untouched and the caller    */
+/*                        tracks its own ENVBLOCK via the IRXINIT     */
+/*                        return value                                */
+/*                                                                    */
+/*    (c) our own env     we claimed the slot earlier; IRXTERM may    */
+/*                        clear it back to NULL                       */
+/*                                                                    */
+/*  Consequence: anch_push writes ECTENVBK *only* when it observes    */
+/*  state (a), and anch_pop clears it *only* when the slot still      */
+/*  equals the environment being terminated. We never save a prior    */
+/*  value and we never restore one — there is no chain.               */
 /*                                                                    */
 /*  Cold-path walk on MVS 3.8j (validated on Hercules since 2019,     */
 /*  offsets from IBM macros):                                         */
@@ -17,10 +33,12 @@
 /*     ECT  + ECTENVBK  (0x030) -> ENVBLOCK                           */
 /*                                                                    */
 /*  In batch any link in this chain can be NULL (LWA is typical);     */
-/*  anch_walk() returns NULL and anch_push/pop become      */
-/*  local-state-only operations on the ENVBLOCK itself.               */
+/*  the walk returns NULL and anch_push / anch_pop reduce to local    */
+/*  field updates on the ENVBLOCK.                                    */
 /*                                                                    */
-/*  Ref: CON-1 §3.1 (ENVBLOCK layout), §6.1 (push/pop discipline).    */
+/*  Ref: CON-1 §3.1 (ENVBLOCK layout), §6.1 (read-mostly anchor),     */
+/*       §6.3 step 8 (IRXINIT), §6.4 step 2 (IRXTERM),                */
+/*       §14.2 (20-April decision with coexistence rationale).        */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
 /* ------------------------------------------------------------------ */
@@ -31,42 +49,44 @@
 #include "irx.h"
 
 /* c2asm370 truncates snake_case C names to 8 chars with underscores
- * mapped to `@`. Without explicit asm() names, anch_push and
+ * mapped to `@`. Without distinct C-level names, anch_push and
  * anch_pop both collapse to ANCHOR@P and IFOX00 rejects the
- * duplicate ENTRY. Give every exported symbol a distinct, MVS-friendly
- * 8-char external name. */
+ * duplicate ENTRY. asm() attributes are not honored by c2asm370
+ * for definitions, so the names below are already distinct at the
+ * C level; the asm() overrides just give them tidier MVS symbols. */
 
 /* Cold-path walk PSA -> ASCB -> ASXB -> LWA -> ECT.
  * Returns ECT address, or NULL if any link in the chain is NULL
  * (typical in batch, where LWA is not established). */
 void *anch_walk(void) asm("ANCHWALK");
 
-/* TSO detection via crent370's CLIBCRT.crtflag (CRTFLAG_TSO bit).
- * On non-MVS builds, returns 0 (cross-compile = batch-like). */
+/* TSO detection via crent370's CLIBPPA.ppaflag
+ * (PPAFLAG_TSOFG for TSO foreground, PPAFLAG_TSOBG for TSO background
+ * invoked via IKJEFT01). Returns 1 when either bit is set, 0 in pure
+ * batch and on non-MVS builds. */
 int anch_tso(void) asm("ANCHISTS");
 
-/* Read ECTENVBK — the currently installed ENVBLOCK, or NULL if none
- * (batch, or between push/pop sequences). */
+/* Read ECTENVBK — the currently installed ENVBLOCK, or NULL when
+ * the slot is empty or unreachable. */
 struct envblock *anch_curr(void) asm("ANCHCURR");
 
-/* Push new_env onto the anchor. Saves the previous ECTENVBK in
- * new_env->rexx370_prev, populates new_env->envblock_ectptr with the
- * ECT address (for later reflection routines), then writes
- * ECTENVBK = new_env.
+/* Populate new_env->envblock_ectptr with the ECT address (so later
+ * reflection routines have a cheap back-pointer), then claim
+ * ECTENVBK = new_env *only if* the slot is currently NULL.
  *
- * In batch (no ECT): sets new_env->rexx370_prev = NULL and
- * new_env->envblock_ectptr = NULL; ECTENVBK is not touched. IRXINIT
- * still succeeds — anch_curr() will continue to return NULL.
+ * If the slot is non-NULL, leave it alone — another REXX already
+ * holds the anchor. IRXINIT still succeeds in that case; the caller
+ * owns the new ENVBLOCK via the return value.
  *
- * This function is infallible; any structural problem has already
- * been screened by IRXINIT's storage allocation. */
+ * In batch (no ECT reachable) this reduces to setting
+ * new_env->envblock_ectptr = NULL. */
 void anch_push(struct envblock *new_env) asm("ANCHPUSH");
 
-/* Pop env from the anchor. Lenient: only restores rexx370_prev into
- * ECTENVBK when env is still the current anchor. Mismatches are a
- * no-op (a Phase-6 diagnostic hook may be wired in later).
+/* Clear ECTENVBK *only if* the slot currently equals env. Any other
+ * value (NULL, some other REXX's ENVBLOCK, a later rexx370 env) is
+ * a no-op.
  *
- * In batch, this is always a no-op. */
+ * In batch this is always a no-op. */
 void anch_pop(struct envblock *env) asm("ANCHPOP");
 
 #endif /* IRXANCHOR_H */

--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -119,20 +119,29 @@ void anch_push(struct envblock *new_env)
     struct envblock **slot = ectenvbk_slot();
     if (slot == NULL)
     {
-        /* Batch (no ECT reachable) — we still record the absence in
-         * the ENVBLOCK so the cleanup path can be symmetric. */
-        new_env->rexx370_prev = NULL;
+        /* Batch — no anchor reachable. Only populate the local
+         * ENVBLOCK field so the symmetric cleanup path still works. */
         new_env->envblock_ectptr = NULL;
         return;
     }
 
-    new_env->rexx370_prev = *slot;
 #ifdef __MVS__
     new_env->envblock_ectptr = (char *)slot - ECTENVBK;
 #else
     new_env->envblock_ectptr = NULL;
 #endif
-    *slot = new_env;
+
+    /* Read-mostly anchor per CON-1 §6.1: only claim the ECTENVBK
+     * slot when it is NULL. Any non-NULL value means another REXX
+     * (on MVS 3.8j that is typically a parallel BREXX environment,
+     * or an earlier rexx370 environment that is still live) already
+     * owns the anchor — leave it alone. The caller manages the new
+     * ENVBLOCK pointer explicitly via the IRXINIT return value, per
+     * SC28-1883-0 §15 for reentrant environments. */
+    if (*slot == NULL)
+    {
+        *slot = new_env;
+    }
 }
 
 void anch_pop(struct envblock *env)
@@ -145,16 +154,15 @@ void anch_pop(struct envblock *env)
     struct envblock **slot = ectenvbk_slot();
     if (slot == NULL)
     {
-        /* Batch — nothing was installed; nothing to restore. */
         return;
     }
 
-    /* Lenient pop: only unwind when we're still on top. A caller
-     * that terminates environments out of LIFO order loses their
-     * rexx370_prev link by design; the spec doesn't define nested
-     * non-LIFO termination and IBM's IRXTERM is likewise lenient. */
+    /* Only clear when we are still the anchor holder. Any other
+     * value means either we never wrote the slot (another REXX was
+     * already there at push time) or something else has taken over
+     * since — leave the slot unchanged in both cases. */
     if (*slot == env)
     {
-        *slot = env->rexx370_prev;
+        *slot = NULL;
     }
 }

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -24,18 +24,17 @@
 #include "irxpars.h"
 #include "irxwkblk.h"
 
-/* Lock the CON-1 §3.1 layout on MVS. The IBM reserved tail ends at
- * +320 and rexx370_prev sits at +304, inside that tail. Any drift
- * trips the compile (array of size -1) — preferable to debugging an
- * S0C4 on Hercules.
+/* Lock the CON-1 §3.1 total ENVBLOCK size on MVS — the IBM-reserved
+ * tail at +304..+319 must stay intact so the physical layout remains
+ * byte-exact against SC28-1883-0/-4 and z/OS 2.5. Any drift trips the
+ * compile (array of size -1) — preferable to debugging an S0C4 on
+ * Hercules.
  *
  * Only meaningful on the real target: host builds use 8-byte pointers
  * and therefore have a different physical layout, which is irrelevant
  * since host tests never exchange binaries with MVS. _Static_assert
  * is C11, c2asm370 is gnu99 — use the typedef-array idiom instead. */
 #ifdef __MVS__
-typedef char envblock_prev_at_304
-    [(offsetof(struct envblock, rexx370_prev) == 304) ? 1 : -1];
 typedef char envblock_size_is_320
     [(sizeof(struct envblock) == 320) ? 1 : -1];
 #endif

--- a/src/tst#anch.c
+++ b/src/tst#anch.c
@@ -7,16 +7,20 @@
 /*  content through printf (crent370 maps to PUTLINE/WTO depending on */
 /*  how the module is invoked).                                       */
 /*                                                                    */
-/*  The purpose is not to exercise the interpreter but to verify the  */
-/*  ECTENVBK anchor discipline end-to-end: push on IRXINIT, anchor    */
-/*  is observable at ECTENVBK+30, rexx370_prev captures the previous  */
-/*  value, anch_pop restores it on IRXTERM. When ECT is unreachable */
-/*  (batch), everything stays zero and both calls still succeed.      */
+/*  Verifies the read-mostly ECTENVBK anchor described in CON-1 §6.1  */
+/*  end-to-end, starting from an empty slot (state (a)):              */
+/*   - IRXINIT sees ECTENVBK == NULL and claims it.                   */
+/*   - envblock_ectptr is populated with the ECT address so later     */
+/*     reflection routines have a cheap back-pointer.                 */
+/*   - IRXTERM clears ECTENVBK because we are still the holder.       */
+/*  In batch (ECT not reachable) the slot is never written; IRXINIT   */
+/*  and IRXTERM still succeed with local-field-only semantics.        */
 /*                                                                    */
 /*  Exit codes:                                                       */
-/*     0 — push/pop observed symmetric behavior                       */
-/*     8 — anchor semantics violation (current != env after push,     */
-/*         anchor not cleared after pop, or rexx370_prev corrupted)   */
+/*     0 — anchor behavior observed correct                           */
+/*     8 — anchor semantics violation (slot written despite           */
+/*         non-NULL, slot not cleared after pop, or batch path did    */
+/*         not reach the expected zero-field state)                   */
 /*    16 — IRXINIT or IRXTERM failed                                  */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
@@ -81,7 +85,6 @@ static void dump_state(const char *label, struct envblock *env)
     {
         printf("    envblock addr  = %p\n", (void *)env);
         printf("    envblock_ectptr= %p\n", env->envblock_ectptr);
-        printf("    rexx370_prev   = %p\n", (void *)env->rexx370_prev);
     }
 }
 
@@ -112,26 +115,25 @@ int main(void)
 
     if (anch_walk() != NULL)
     {
-        /* TSO-ish path: ECT reachable, anchor must be current. */
-        if (anch_curr() != env)
+        /* TSO-ish path: slot was empty at entry, so read-mostly
+         * claimed it. Our env must now be the anchor. */
+        if (initial_anchor == NULL && anch_curr() != env)
         {
-            printf("FAIL: ECTENVBK was not updated to our envblock\n");
+            printf("FAIL: ECTENVBK was not claimed for our envblock\n");
             exit_rc = RC_ANCHOR_BROKEN;
         }
-        if (env->rexx370_prev != initial_anchor)
+        if (initial_anchor != NULL && anch_curr() != initial_anchor)
         {
-            printf("FAIL: rexx370_prev did not capture previous anchor\n");
+            printf("FAIL: ECTENVBK was overwritten despite non-NULL slot\n");
             exit_rc = RC_ANCHOR_BROKEN;
         }
     }
     else
     {
-        /* Batch path: no ECT, no anchor state, but envblock still
-         * allocated locally. rexx370_prev and envblock_ectptr must
-         * both be NULL per anch_push semantics. */
-        if (env->rexx370_prev != NULL || env->envblock_ectptr != NULL)
+        /* Batch path: no ECT; local-only push, slot stays untouched. */
+        if (env->envblock_ectptr != NULL)
         {
-            printf("FAIL: batch envblock has non-NULL anchor fields\n");
+            printf("FAIL: batch envblock_ectptr is non-NULL\n");
             exit_rc = RC_ANCHOR_BROKEN;
         }
         if (anch_curr() != NULL)
@@ -151,15 +153,19 @@ int main(void)
 
     dump_state("after irxterm", NULL);
 
+    /* After pop: slot must equal the initial_anchor. Either we
+     * claimed and then cleared (initial was NULL), or we never
+     * wrote it to begin with (initial was non-NULL) — in both
+     * cases the slot is back to its entry value. */
     if (anch_curr() != initial_anchor)
     {
-        printf("FAIL: ECTENVBK was not restored to initial value\n");
+        printf("FAIL: ECTENVBK not back at its initial value\n");
         exit_rc = RC_ANCHOR_BROKEN;
     }
 
     if (exit_rc == 0)
     {
-        printf("PASS: anchor push/pop symmetric; exiting rc=0\n");
+        printf("PASS: anchor behavior correct; exiting rc=0\n");
     }
     return exit_rc;
 }

--- a/test/test_anchor_readmostly.c
+++ b/test/test_anchor_readmostly.c
@@ -1,0 +1,110 @@
+/* ------------------------------------------------------------------ */
+/*  test_anchor_readmostly.c - Case (b) verification for CON-1 §6.1   */
+/*                                                                    */
+/*  The read-mostly ECTENVBK anchor has three distinguishable         */
+/*  states. TSTANCH exercises state (a) (slot is NULL at entry) and   */
+/*  state (c) (slot ends up holding our env) — but in the common     */
+/*  "fresh login" case those two paths are byte-identical to what     */
+/*  an old-style push/pop implementation would do. The test below    */
+/*  pins down state (b) explicitly: another REXX already owns the    */
+/*  anchor when IRXINIT runs.                                         */
+/*                                                                    */
+/*  Under read-mostly we must observe:                                */
+/*    - IRXINIT succeeds and returns a valid ENVBLOCK                 */
+/*    - ECTENVBK stays at the pre-existing value — not overwritten   */
+/*    - IRXTERM is lenient: because ECTENVBK never equalled our env, */
+/*      the terminate path does not clear the slot                    */
+/*                                                                    */
+/*  A push/pop implementation would fail both of the slot checks.    */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 \                                  */
+/*        -o test/test_anchor_readmostly \                            */
+/*        test/test_anchor_readmostly.c \                             */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \       */
+/*        'src/irx#anch.c' 'src/irx#uid.c'  'src/irx#msid.c' \       */
+/*        'src/irx#cond.c' 'src/irx#bif.c'  'src/irx#bifs.c' \       */
+/*        'src/irx#io.c'   'src/irx#lstr.c' 'src/irx#tokn.c' \       */
+/*        'src/irx#vpol.c' 'src/irx#pars.c' 'src/irx#ctrl.c' \       */
+/*        'src/irx#arith.c' \                                         */
+/*        ../lstring370/src/lstr#*.c                                  */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+
+#include "irx.h"
+#include "irxanchor.h"
+#include "irxfunc.h"
+
+void *_simulated_ectenvbk = NULL;
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* Pin ECTENVBK to a sentinel that cannot collide with any real
+ * ENVBLOCK address returned by the host malloc. */
+static void *const SENTINEL = (void *)(unsigned long)0xDEAD0001UL;
+
+int main(void)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    printf("=== Read-mostly ECTENVBK — Case (b): slot already owned ===\n");
+
+    /* Seed the fake anchor. On the host this is the storage the
+     * anchor API reads/writes directly; on MVS the same test would
+     * need a different injection point, which is out of scope for
+     * this cross-compile unit. */
+    _simulated_ectenvbk = SENTINEL;
+    CHECK(anch_curr() == SENTINEL, "pre-seed: anch_curr() == SENTINEL");
+
+    rc = irxinit(NULL, &env);
+    CHECK(rc == 0, "irxinit returns 0");
+    CHECK(env != NULL, "irxinit produced an ENVBLOCK");
+
+    CHECK(anch_curr() == SENTINEL,
+          "ECTENVBK NOT overwritten (read-mostly guard holds)");
+    CHECK(env != (struct envblock *)SENTINEL,
+          "returned env is distinct from the pre-existing anchor");
+
+    rc = irxterm(env);
+    CHECK(rc == 0, "irxterm returns 0");
+
+    CHECK(anch_curr() == SENTINEL,
+          "ECTENVBK still untouched after irxterm (lenient pop)");
+
+    /* Restore the slot so any follow-up harness starts clean. */
+    _simulated_ectenvbk = NULL;
+    CHECK(anch_curr() == NULL, "post-cleanup: anch_curr() == NULL");
+
+    printf("\n=== Results: %d/%d passed",
+           tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/test_phase1.c
+++ b/test/test_phase1.c
@@ -133,6 +133,13 @@ static void test_single_env(void)
 
 /* ------------------------------------------------------------------ */
 /*  Test 2: Multiple concurrent environments                          */
+/*                                                                    */
+/*  Under the read-mostly anchor (CON-1 §6.1) only the first IRXINIT  */
+/*  claims ECTENVBK; later IRXINITs observe a non-NULL slot and       */
+/*  leave it alone. IRXTERM is lenient and only clears when the slot */
+/*  still equals the terminating env. So regardless of the order of   */
+/*  the IRXTERMs, the slot stays pinned to env1 until env1 itself is  */
+/*  terminated.                                                       */
 /* ------------------------------------------------------------------ */
 
 static void test_multiple_envs(void)
@@ -153,23 +160,24 @@ static void test_multiple_envs(void)
     rc = irxinit(NULL, &env3);
     CHECK(rc == 0 && env3 != NULL, "env3 created");
 
-    /* Most recent should be env3 */
-    CHECK(anch_curr() == env3,
-          "anch_curr returns most recent (env3)");
+    /* Read-mostly: env1 got the slot, env2/env3 never touched it. */
+    CHECK(anch_curr() == env1,
+          "anch_curr holds the first claimant (env1)");
 
     CHECK(env1 != env2 && env2 != env3,
           "all envblocks are distinct");
 
-    /* Terminate in reverse order */
+    /* Terminate in reverse order. env3 and env2 were never in the
+     * slot, so their terminates are no-ops at the anchor. */
     rc = irxterm(env3);
     CHECK(rc == 0, "env3 terminated");
-    CHECK(anch_curr() == env2,
-          "after env3 term, current is env2");
+    CHECK(anch_curr() == env1,
+          "after env3 term, anchor still env1");
 
     rc = irxterm(env2);
     CHECK(rc == 0, "env2 terminated");
     CHECK(anch_curr() == env1,
-          "after env2 term, current is env1");
+          "after env2 term, anchor still env1");
 
     rc = irxterm(env1);
     CHECK(rc == 0, "env1 terminated");


### PR DESCRIPTION
## Summary

Scope: **TSK-3463 Phase D — switch ECTENVBK from push/pop to read-mostly per CON-1 v0.2.0 §6.1.**

rexx370 now treats the ECTENVBK slot as read-mostly. The three distinguishable states the slot can be in on MVS 3.8j:

| State | Value                            | IRXINIT writes? | IRXTERM clears? |
|-------|----------------------------------|-----------------|-----------------|
| (a)   | `NULL`                           | yes (claim it)  | n/a             |
| (b)   | another REXX's ENVBLOCK          | **no** — leave alone | **no** — lenient  |
| (c)   | our own ENVBLOCK                 | n/a             | yes             |

On MVS 3.8j the typical coexistence case is a parallel BREXX/370 environment (the "(b)" state). Under the old push/pop discipline we saved the prior value in `ENVBLOCK+304 (rexx370_prev)` and restored it on pop — but on close reading that prior value is either `NULL` (safe to claim), a BREXX anchor (must not overwrite), or one of our own earlier envs (already tracked by the IRXINIT return value, per SC28-1883-0 §15 for reentrant environments). The chain field was dead weight and "write only when NULL" is the right rule in all three cases.

## Code changes

- `include/irx.h`: drop `struct envblock.rexx370_prev`; restore the full 16-byte IBM-reserved tail at +304..+319 as `int _filler3[4]` — the layout is back to byte-exact SC28-1883-0/-4.
- `src/irx#init.c`: drop the `envblock_prev_at_304` typedef-array guard (the field is gone); keep `envblock_size_is_320` — the 320-byte layout invariant still holds and catches future drift.
- `src/irx#anch.c`:
  - `anch_push`: populate `envblock_ectptr` first, then write the slot only when `*slot == NULL`.
  - `anch_pop`: clear the slot only when `*slot == env`.
  - No rexx370_prev save/restore anywhere.
- `include/irxanchor.h`: docstring rewritten with the three ECTENVBK states spelled out; per-function contracts updated.
- `src/tst#anch.c`: dropped the rexx370_prev dump & checks; TSO-path assertion now gates on the `initial_anchor == NULL` vs non-NULL cases; PASS label generalised to "anchor behavior correct".
- `test/test_phase1.c`: multi-env test rewritten. Under read-mostly the first IRXINIT becomes the anchor holder and later IRXINITs do not mutate the slot; IRXTERMs of non-holders are no-ops, so the slot stays pinned to env1 until env1 itself terminates.
- `CLAUDE.md`, `README.md`: anchor key-point + API line updated.

## New test: explicit Case-(b) verification

`test/test_anchor_readmostly.c` pins down what the MVS run cannot demonstrate:

1. Pre-seed ECTENVBK with a sentinel (`0xDEAD0001`) — simulates a coexisting REXX.
2. `IRXINIT` → succeeds, returns a valid ENVBLOCK.
3. Assert slot still equals sentinel (read-mostly guard held).
4. Assert returned env is distinct from sentinel.
5. `IRXTERM` → succeeds.
6. Assert slot still equals sentinel (lenient pop, never matched).
7. Cleanup slot.

Push/pop would fail steps 3 and 6; read-mostly passes both. **8/8 green** on host.

This is the only empirical verification that the read-mostly guard actually fires. On MVS the slot starts at NULL in every available scenario (TSO-FG / TSO-BG / pure batch all begin in state (a)), so read-mostly and push/pop would produce identical observations there.

## Verification matrix

### Cross-compile (Linux/gcc)

- [x] test_tokenizer — 70/70
- [x] test_vpool — 47/47
- [x] test_parser — 39/39
- [x] test_say — 27/27
- [x] test_irxlstr — 50/50
- [x] test_control — 62/62
- [x] test_hello — 16/16
- [x] test_parse — 74/74
- [x] test_arith — 128/128
- [x] test_arith_extended — 113/113
- [x] test_bif — 29/29
- [x] test_bifs — 410/410
- [x] test_procedure — 53/53
- [x] test_phase1 — 38/38 (multi-env test rewritten)
- [x] **test_anchor_readmostly — 8/8 (new)**

Total: 15 binaries, **1164 tests green**.

### MVS (Hercules 3.8j)

```
TSO-FG (CALL from READY)
  ppaflag=0xC0  walk=0x97CF4  push: 0 -> env  pop: env -> 0   PASS rc=0
TSO-BG (IKJEFT01 -> CALL)
  ppaflag=0x40  walk=0x96CF4  push: 0 -> env  pop: env -> 0   PASS rc=0
Batch (EXEC PGM=TSTANCH)
  ppaflag=0x00  walk=NULL     local-only fields zero          PASS rc=0
```

Output differs from PR #45 only on two lines, as predicted: the `rexx370_prev = …` line is gone from `dump_state` (field removed) and the PASS label is generalised. `envblock_size_is_320` MVS-only guard still compiles — the 320-byte layout invariant holds.

## Cleanup status

`grep -r rexx370_prev include/ src/*.c test/ CLAUDE.md README.md project.toml` returns **empty**. Stale mentions in generated `src/*.s` regenerate on each MVS build. `docs/architecture.md` and `docs/workpackages.md` are intentionally untouched — they are out of scope per the Phase-D brief (handled separately).

## Refs

- CON-1 §3.1 — ENVBLOCK layout without rexx370_prev
- CON-1 §6.1 — read-mostly semantics with the three ECTENVBK states
- CON-1 §6.3 step 8 — IRXINIT writes only when NULL
- CON-1 §6.4 step 2 — IRXTERM clears only when still holding
- CON-1 §14.2 — 20-April decision + coexistence rationale
- SC28-1883-0 §15 — reentrant environments pass the ENVBLOCK through return values, not through a chain