### PR TITLE
test(anchor): batch gating + MVS harness fix for read-mostly tests

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -39,7 +39,7 @@ dsorg = "PO"
 recfm = "U"
 lrecl = 0
 blksize = 15040
-space = ["TRK", 150, 50, 30]
+space = ["TRK", 600, 100, 60]
 
 [dependencies]
 "mvslovers/crent370" = ">=1.0.9"

--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -62,7 +62,12 @@ int anch_tso(void)
     return (ppa->ppaflag & (PPAFLAG_TSOFG | PPAFLAG_TSOBG)) != 0;
 }
 
-static struct envblock **ectenvbk_slot(void)
+/* Intentionally non-static: the test harness forward-declares this
+ * helper (see test/mvs/tstanrm.c) so Case-b and Case-c on MVS can
+ * seed the real ECTENVBK slot instead of the unused host-only
+ * simulation variable. Production callers stay on anch_push /
+ * anch_pop / anch_curr. */
+struct envblock **ectenvbk_slot(void)
 {
     void *ect = anch_walk();
     if (ect == NULL)
@@ -79,7 +84,9 @@ static struct envblock **ectenvbk_slot(void)
  * burden off the test harness — we cast here). */
 extern void *_simulated_ectenvbk;
 
-static struct envblock **ectenvbk_slot(void)
+/* Non-static for symmetry with the MVS branch; the test harness never
+ * calls this on host (it goes through _simulated_ectenvbk directly). */
+struct envblock **ectenvbk_slot(void)
 {
     return (struct envblock **)&_simulated_ectenvbk;
 }

--- a/test/mvs/tstanrm.c
+++ b/test/mvs/tstanrm.c
@@ -21,11 +21,30 @@
 /*  An old push/pop implementation would fail cases (b) and (c);      */
 /*  read-mostly passes all three.                                     */
 /*                                                                    */
+/*  Platform-aware seed helper                                        */
+/*  --------------------------                                        */
+/*  On MVS, production anch_push / anch_pop / anch_curr read and      */
+/*  write the real ECTENVBK slot via ectenvbk_slot() (which walks     */
+/*  PSA→ASCB→ASXB→LWA→ECT). The host-only `_simulated_ectenvbk`       */
+/*  global is unused on MVS. Cases (b) and (c) need to simulate a     */
+/*  non-NULL initial slot state; _test_set_anchor() below targets     */
+/*  whichever storage the production code actually reads, per         */
+/*  platform. Do not re-introduce direct `_simulated_ectenvbk = ...`  */
+/*  writes in Case (b) / Case (c) — they silently no-op on MVS and    */
+/*  make the test look like it passes on host while failing on MVS.   */
+/*  See CON-1 §6.1.                                                   */
+/*                                                                    */
+/*  Cases that require a specific anchor state (seeding a sentinel,   */
+/*  asserting that irxinit claimed the slot, asserting lenient pop)   */
+/*  only run when anch_tso() is true — i.e. the TSO ECT chain is      */
+/*  reachable. In pure batch (EXEC PGM=... direct) the walk returns   */
+/*  NULL and anch_push / anch_pop reduce to local field updates, so   */
+/*  those assertions are skipped (tests_skipped) rather than failed.  */
+/*                                                                    */
 /*  Cross-compile build (Linux/gcc):                                  */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
 /*        -Wall -Wextra -std=gnu99 \                                  */
-/*        -o test/test_anchor_readmostly \                            */
-/*        test/test_anchor_readmostly.c \                             */
+/*        -o /tmp/tstanrm test/mvs/tstanrm.c \                        */
 /*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \       */
 /*        'src/irx#anch.c' 'src/irx#uid.c'  'src/irx#msid.c' \       */
 /*        'src/irx#cond.c' 'src/irx#bif.c'  'src/irx#bifs.c' \       */
@@ -43,11 +62,21 @@
 #include "irxanchor.h"
 #include "irxfunc.h"
 
+#ifndef __MVS__
 void *_simulated_ectenvbk = NULL;
+#endif
+
+/* Forward-declare the ECTENVBK slot accessor implemented in
+ * src/irx#anch.c. Production code reaches it through anch_push /
+ * anch_pop / anch_curr; the test harness needs direct access so it
+ * can seed the real slot on MVS to simulate a foreign REXX owning
+ * the anchor (Case b) or a prior own-env claim (Case c). */
+struct envblock **ectenvbk_slot(void);
 
 static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
+static int tests_skipped = 0;
 
 #define CHECK(cond, msg)                 \
     do                                   \
@@ -65,9 +94,62 @@ static int tests_failed = 0;
         }                                \
     } while (0)
 
+/* Run `stmt` only when the ECTENVBK slot is reachable; otherwise
+ * count it as skipped with a diagnostic line. `stmt` is expected
+ * to contain exactly one CHECK.
+ *
+ * "Reachable" means ectenvbk_slot() returns non-NULL: true on host
+ * (the slot is the simulation global, always present) and on MVS
+ * under TSO (the PSA→ASCB→ASXB→LWA→ECT walk completes); false only
+ * on pure MVS batch where LWA is NULL. Gating on slot reachability
+ * — not on anch_tso() — keeps the host cross-compile counts
+ * unchanged while still skipping the four/seven assertions that
+ * cannot hold under batch. */
+#define CHECK_IF_REACHABLE(stmt, msg)                      \
+    do                                                     \
+    {                                                      \
+        if (ectenvbk_slot() != NULL)                       \
+        {                                                  \
+            stmt;                                          \
+        }                                                  \
+        else                                               \
+        {                                                  \
+            tests_skipped++;                               \
+            printf("  SKIP: %s (no ECT slot reachable)\n", \
+                   msg);                                   \
+        }                                                  \
+    } while (0)
+
 /* Sentinel for Case (b) — any value that cannot collide with a real
  * ENVBLOCK address returned by the host allocator. */
 static void *const SENTINEL = (void *)(unsigned long)0xDEAD0001UL;
+
+/* Platform-aware slot seed / read. Tests never touch
+ * _simulated_ectenvbk directly — use these so MVS and host builds
+ * exercise the same code path that production anch_* functions
+ * observe. */
+static void _test_set_anchor(struct envblock *value)
+{
+#ifdef __MVS__
+    struct envblock **slot = ectenvbk_slot();
+    if (slot != NULL)
+    {
+        *slot = value;
+    }
+#else
+    _simulated_ectenvbk = value;
+#endif
+}
+
+static struct envblock *_test_get_anchor(void)
+{
+#ifdef __MVS__
+    struct envblock **slot = ectenvbk_slot();
+    return (slot != NULL) ? *slot : NULL;
+#else
+    return (struct envblock *)_simulated_ectenvbk;
+#endif
+}
 
 /* ------------------------------------------------------------------ */
 /*  Case (a) — empty-slot baseline                                    */
@@ -80,14 +162,16 @@ static void case_a_empty_slot_baseline(void)
 
     printf("\n--- Case (a): empty-slot baseline ---\n");
 
-    _simulated_ectenvbk = NULL;
+    _test_set_anchor(NULL);
     CHECK(anch_curr() == NULL, "precondition: anch_curr() == NULL");
 
     rc = irxinit(NULL, &env);
     CHECK(rc == 0, "irxinit returns 0");
     CHECK(env != NULL, "irxinit produced an ENVBLOCK");
-    CHECK(anch_curr() == env,
-          "slot claimed: anch_curr() == env (was NULL at push)");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == env,
+              "slot claimed: anch_curr() == env (was NULL at push)"),
+        "slot claimed: anch_curr() == env");
 
     rc = irxterm(env);
     CHECK(rc == 0, "irxterm returns 0");
@@ -106,23 +190,36 @@ static void case_b_simulated_brexx_owns_slot(void)
 
     printf("\n--- Case (b): BREXX-simulated non-NULL slot ---\n");
 
-    _simulated_ectenvbk = SENTINEL;
-    CHECK(anch_curr() == SENTINEL, "pre-seed: anch_curr() == SENTINEL");
+    /* Seed the real slot (TSO) or the host simulation variable. On
+     * batch MVS the slot is unreachable and the seed is a no-op —
+     * the dependent assertions below are gated behind anch_tso(). */
+    _test_set_anchor((struct envblock *)SENTINEL);
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == SENTINEL,
+              "pre-seed: anch_curr() == SENTINEL"),
+        "pre-seed: anch_curr() == SENTINEL");
 
     rc = irxinit(NULL, &env);
     CHECK(rc == 0, "irxinit returns 0");
     CHECK(env != NULL, "irxinit produced an ENVBLOCK");
-    CHECK(anch_curr() == SENTINEL,
-          "slot NOT overwritten (read-mostly guard holds)");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == SENTINEL,
+              "slot NOT overwritten (read-mostly guard holds)"),
+        "slot NOT overwritten after irxinit");
     CHECK(env != (struct envblock *)SENTINEL,
           "returned env is distinct from the pre-existing anchor");
 
     rc = irxterm(env);
     CHECK(rc == 0, "irxterm returns 0");
-    CHECK(anch_curr() == SENTINEL,
-          "slot still SENTINEL after irxterm (lenient pop)");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == SENTINEL,
+              "slot still SENTINEL after irxterm (lenient pop)"),
+        "slot still SENTINEL after irxterm");
 
-    _simulated_ectenvbk = NULL;
+    /* Always run the post-cleanup restore: on MVS batch the slot was
+     * never touched, on host the simulation variable was, and the
+     * helper handles both. Keeps Case (c)'s precondition clean. */
+    _test_set_anchor(NULL);
     CHECK(anch_curr() == NULL, "post-cleanup: anch_curr() == NULL");
 }
 
@@ -138,24 +235,30 @@ static void case_c_own_env_stacking(void)
 
     printf("\n--- Case (c): own-env stacking ---\n");
 
-    _simulated_ectenvbk = NULL;
+    _test_set_anchor(NULL);
     CHECK(anch_curr() == NULL, "precondition: anch_curr() == NULL");
 
     rc = irxinit(NULL, &outer);
     CHECK(rc == 0 && outer != NULL, "outer irxinit returned a valid env");
-    CHECK(anch_curr() == outer,
-          "outer claimed the slot (was NULL at push)");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == outer,
+              "outer claimed the slot (was NULL at push)"),
+        "outer claimed the slot");
 
     rc = irxinit(NULL, &inner);
     CHECK(rc == 0 && inner != NULL, "inner irxinit returned a valid env");
     CHECK(inner != outer, "inner env is distinct from outer");
-    CHECK(anch_curr() == outer,
-          "slot still outer (inner read-mostly-skipped the write)");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == outer,
+              "slot still outer (inner read-mostly-skipped the write)"),
+        "slot still outer after inner irxinit");
 
     rc = irxterm(inner);
     CHECK(rc == 0, "inner irxterm returns 0");
-    CHECK(anch_curr() == outer,
-          "slot still outer (inner was not the holder; lenient pop)");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == outer,
+              "slot still outer (inner was not the holder; lenient pop)"),
+        "slot still outer after inner irxterm");
 
     rc = irxterm(outer);
     CHECK(rc == 0, "outer irxterm returns 0");
@@ -170,16 +273,24 @@ static void case_c_own_env_stacking(void)
 int main(void)
 {
     printf("=== Read-mostly ECTENVBK protection tests (CON-1 §6.1) ===\n");
+    printf("    mode: %s\n", anch_tso() ? "TSO (ECT reachable)"
+                                        : "batch (no ECT — TSO-only "
+                                          "assertions will skip)");
+
+    /* Silence unused-function warning on host where _test_get_anchor
+     * is not exercised by any case today. The helper is kept for
+     * symmetry with _test_set_anchor and future tests. */
+    (void)_test_get_anchor;
 
     case_a_empty_slot_baseline();
     case_b_simulated_brexx_owns_slot();
     case_c_own_env_stacking();
 
-    printf("\n=== Results: %d/%d passed",
-           tests_passed, tests_run);
+    printf("\n=== Results: passed=%d run=%d skipped=%d",
+           tests_passed, tests_run, tests_skipped);
     if (tests_failed > 0)
     {
-        printf(", %d FAILED", tests_failed);
+        printf(" FAILED=%d", tests_failed);
     }
     printf(" ===\n");
 

--- a/test/mvs/tstphas1.c
+++ b/test/mvs/tstphas1.c
@@ -27,9 +27,15 @@
 void *_simulated_ectenvbk = NULL;
 #endif
 
+/* Forward-declare the ECTENVBK slot accessor implemented in
+ * src/irx#anch.c. Used by CHECK_IF_REACHABLE below to decide whether
+ * the read-mostly anchor assertions can hold on this run. */
+struct envblock **ectenvbk_slot(void);
+
 static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
+static int tests_skipped = 0;
 
 #define CHECK(cond, msg)                 \
     do                                   \
@@ -45,6 +51,28 @@ static int tests_failed = 0;
             tests_failed++;              \
             printf("  FAIL: %s\n", msg); \
         }                                \
+    } while (0)
+
+/* Assertions that check anch_curr() against a non-NULL ENVBLOCK only
+ * hold when the ECTENVBK slot is reachable so anch_push can actually
+ * write it. ectenvbk_slot() returns non-NULL on host (the slot is the
+ * `_simulated_ectenvbk` global) and on MVS under TSO (the
+ * PSA→ASCB→ASXB→LWA→ECT walk completes); it returns NULL on pure
+ * batch. Skip rather than fail when unreachable. Assertions that
+ * check anch_curr() == NULL hold in both modes and run
+ * unconditionally. */
+#define CHECK_IF_REACHABLE(cond, msg)                            \
+    do                                                           \
+    {                                                            \
+        if (ectenvbk_slot() != NULL)                             \
+        {                                                        \
+            CHECK(cond, msg);                                    \
+        }                                                        \
+        else                                                     \
+        {                                                        \
+            tests_skipped++;                                     \
+            printf("  SKIP: %s (no ECT slot reachable)\n", msg); \
+        }                                                        \
     } while (0)
 
 /* ------------------------------------------------------------------ */
@@ -118,17 +146,19 @@ static void test_single_env(void)
               "wkblk back-pointer to envblock is correct");
     }
 
-    /* Validate ECTENVBK anchor */
-    struct envblock *found = anch_curr();
-    CHECK(found == envblk, "anch_curr returns our envblock");
+    /* Validate ECTENVBK anchor (TSO only — anch_push is a no-op when
+     * the slot is unreachable, so anch_curr stays NULL in batch). */
+    CHECK_IF_REACHABLE(anch_curr() == envblk,
+                       "anch_curr returns our envblock");
 
     /* IRXTERM */
     rc = irxterm(envblk);
     CHECK(rc == 0, "irxterm returns 0");
 
-    /* Verify cleanup */
-    found = anch_curr();
-    CHECK(found == NULL, "anch_curr returns NULL after term");
+    /* anch_curr is NULL in both modes after term: TSO because
+     * anch_pop cleared the slot, batch because the slot was never
+     * written. Run unconditionally. */
+    CHECK(anch_curr() == NULL, "anch_curr returns NULL after term");
 }
 
 /* ------------------------------------------------------------------ */
@@ -160,9 +190,11 @@ static void test_multiple_envs(void)
     rc = irxinit(NULL, &env3);
     CHECK(rc == 0 && env3 != NULL, "env3 created");
 
-    /* Read-mostly: env1 got the slot, env2/env3 never touched it. */
-    CHECK(anch_curr() == env1,
-          "anch_curr holds the first claimant (env1)");
+    /* Read-mostly: env1 got the slot, env2/env3 never touched it.
+     * The "still env1" checks below are TSO-only — see CHECK_IF_REACHABLE
+     * comment near the top of the file. */
+    CHECK_IF_REACHABLE(anch_curr() == env1,
+                       "anch_curr holds the first claimant (env1)");
 
     CHECK(env1 != env2 && env2 != env3,
           "all envblocks are distinct");
@@ -171,13 +203,13 @@ static void test_multiple_envs(void)
      * slot, so their terminates are no-ops at the anchor. */
     rc = irxterm(env3);
     CHECK(rc == 0, "env3 terminated");
-    CHECK(anch_curr() == env1,
-          "after env3 term, anchor still env1");
+    CHECK_IF_REACHABLE(anch_curr() == env1,
+                       "after env3 term, anchor still env1");
 
     rc = irxterm(env2);
     CHECK(rc == 0, "env2 terminated");
-    CHECK(anch_curr() == env1,
-          "after env2 term, anchor still env1");
+    CHECK_IF_REACHABLE(anch_curr() == env1,
+                       "after env2 term, anchor still env1");
 
     rc = irxterm(env1);
     CHECK(rc == 0, "env1 terminated");
@@ -235,16 +267,19 @@ static void test_uid_msgid(void)
 int main(void)
 {
     printf("=== REXX/370 Phase 1 Smoke Test ===\n");
+    printf("    mode: %s\n", anch_tso() ? "TSO (ECT reachable)"
+                                        : "batch (no ECT — anchor "
+                                          "checks will skip)");
 
     test_single_env();
     test_multiple_envs();
     test_uid_msgid();
 
-    printf("\n=== Results: %d/%d passed",
-           tests_passed, tests_run);
+    printf("\n=== Results: passed=%d run=%d skipped=%d",
+           tests_passed, tests_run, tests_skipped);
     if (tests_failed > 0)
     {
-        printf(", %d FAILED", tests_failed);
+        printf(" FAILED=%d", tests_failed);
     }
     printf(" ===\n");
 


### PR DESCRIPTION
## What

Closes the spurious failures that surfaced when the Phase 1 / read-mostly anchor tests started running on MVS via `tstall.jcl` (PR #49). Two distinct defects in the same two test files.

## How diagnosed

PR #49's MVS run reported five failures clustering into two patterns. **TSTPHAS1** failed four assertions in batch only — every one a check that `anch_curr() == <some env>` after IRXINIT. The cause: `anch_push()` is a no-op when the ECTENVBK slot is unreachable (LWA is NULL outside TSO), so the slot stays NULL regardless. **TSTANRM** Case (b) and Case (c) failed seven assertions in *both* TSO and batch on MVS. The harness wrote sentinel values to the host-only `_simulated_ectenvbk` global, but production `anch_push` / `anch_pop` / `anch_curr` on MVS reach the real ECT via `ectenvbk_slot()` — the simulation variable is unread, the fake writes were silently ignored, and the assertions saw an empty slot instead of the seeded sentinel.

## What changed

`test/mvs/tstanrm.c` gains `_test_set_anchor` / `_test_get_anchor` helpers that target whichever storage production code actually reads, per platform. `static` is dropped from `ectenvbk_slot()` in `src/irx#anch.c` so the test harness can forward-declare it locally without expanding the public header. Both test files gain a `CHECK_IF_REACHABLE` macro that gates anchor assertions on `ectenvbk_slot() != NULL`, increments a new `tests_skipped` counter, and reports `passed=X run=Y skipped=Z` in the final results line. The slot-reachable predicate (rather than `anch_tso()`) keeps the host cross-compile at 1180/1180 because the host's `_simulated_ectenvbk` is always reachable. A second commit bumps the LOAD dataset from `TRK 150,50 / DIRBLK 30` to `TRK 600,100 / DIRBLK 60`; the 17th test load module hit IEC032I E37-04 during link otherwise.

## How verified

Linux cross-compile: 1180/1180 (no change). MVS via `zowe jobs submit local-file test/mvs/tstall.jcl --wait-for-output`:

| step | mode | passed | run | skipped | failed |
|---|---|---|---|---|---|
| TPHAS1 | TSO | 38 | 38 | 0 | 0 |
| BPHAS1 | batch | 34 | 34 | 4 | 0 |
| TANRM | TSO | 24 | 24 | 0 | 0 |
| BANRM | batch | 17 | 17 | 7 | 0 |

The two remaining `tstall.jcl` failures (TBIFS / BBIFS, two each) are XRANGE and SOURCELINE — to be addressed in PR 2 and PR 3 of this prerequisite series.

Refs: CON-1 §6.1