### PR TITLE
test(bifs): XRANGE length assertions are codepage-aware

### DIFF
--- a/test/mvs/tstbifs.c
+++ b/test/mvs/tstbifs.c
@@ -315,6 +315,27 @@ static void test_phase_f(void)
      * (digits are always contiguous). Locks down that the codepage
      * fix above doesn't accidentally regress contiguous ranges. */
     EXPECT_OK("LENGTH(XRANGE('0','9'))", "10", "XRANGE digits 10");
+
+    /* Empirical proof that bif_xrange returns a true byte range,
+     * not an alphabet-based pseudo-range. Position 10 of
+     * XRANGE('A','Z') falls in the EBCDIC alphabet gap between
+     * 'I' = 0xC9 and 'J' = 0xD1, so the expected byte is 0xCA — a
+     * non-letter. An alphabet-iterating implementation would yield
+     * 'J' = 0xD1 there, not 0xCA. On ASCII the same position is
+     * 'J' = 0x4A (no gap). Endpoint asserts at 1 and len bracket
+     * the range. */
+    EXPECT_OK("SUBSTR(XRANGE('A','Z'),1,1)", "A",
+              "XRANGE byte 1 is 'A'");
+#ifdef __MVS__
+    EXPECT_OK("C2X(SUBSTR(XRANGE('A','Z'),10,1))", "CA",
+              "XRANGE byte 10 is EBCDIC gap 0xCA (not 'J')");
+#else
+    EXPECT_OK("C2X(SUBSTR(XRANGE('A','Z'),10,1))", "4A",
+              "XRANGE byte 10 is ASCII 'J' 0x4A");
+#endif
+    EXPECT_OK("SUBSTR(XRANGE('A','Z'),LENGTH(XRANGE('A','Z')),1)",
+              "Z", "XRANGE last byte is 'Z'");
+
     EXPECT_OK("LENGTH(XRANGE())", "256", "XRANGE default 256");
 }
 

--- a/test/mvs/tstbifs.c
+++ b/test/mvs/tstbifs.c
@@ -298,7 +298,23 @@ static void test_phase_f(void)
     EXPECT_OK("FIND('foo bar baz','bar')", "2", "FIND single word");
     EXPECT_OK("FIND('a b c d e','c d')", "3", "FIND multi-word");
     EXPECT_OK("FIND('a b c','x')", "0", "FIND not found");
-    EXPECT_OK("LENGTH(XRANGE('A','Z'))", "26", "XRANGE length 26");
+    /* XRANGE returns a byte range in the platform's native codepage,
+     * not an alphabet. ASCII 'A'..'Z' is 26 contiguous bytes; EBCDIC
+     * is 41 (the alphabet itself is non-contiguous, but XRANGE is
+     * defined as the inclusive byte range, see SC28-1883-0 App. A).
+     * Compute the expected length arithmetically so the assertion
+     * holds on both codepages. */
+    {
+        char want[8];
+        int n = (int)(unsigned char)'Z' - (int)(unsigned char)'A' + 1;
+        snprintf(want, sizeof(want), "%d", n);
+        EXPECT_OK("LENGTH(XRANGE('A','Z'))", want,
+                  "XRANGE length 'Z'-'A'+1");
+    }
+    /* '0'..'9' is 10 bytes on every codepage REXX/370 supports
+     * (digits are always contiguous). Locks down that the codepage
+     * fix above doesn't accidentally regress contiguous ranges. */
+    EXPECT_OK("LENGTH(XRANGE('0','9'))", "10", "XRANGE digits 10");
     EXPECT_OK("LENGTH(XRANGE())", "256", "XRANGE default 256");
 }
 


### PR DESCRIPTION
## What

Closes the second of three TSK-148 prerequisite findings: `XRANGE('A','Z')` length test failed on MVS because the expected value was hardcoded to 26 (ASCII).

## How diagnosed

PR #50 cleaned up the anchor failures; the remaining `tstall.jcl` failures localized to `TBIFS` / `BBIFS`, two each. Inspecting `test/mvs/tstbifs.c` (`test_phase_f`) showed:

```c
EXPECT_OK("LENGTH(XRANGE('A','Z'))", "26", "XRANGE length 26");
```

That assumes ASCII. On EBCDIC, `'A'..'Z'` spans `0xC1..0xE9` = 41 bytes (the alphabet itself is non-contiguous; XRANGE returns the full inclusive byte range per SC28-1883-0 Appendix A — defined as a byte range, not a letter range). The BIF implementation in `src/irx#bifs.c` (`bif_xrange`, lines 820-877) iterates `lo..hi` inclusive over byte values; by inspection correct on both codepages — only the test's expected value was wrong.

## What changed

Replaced the literal with arithmetic computed at runtime:

```c
int n = (int)(unsigned char)'Z' - (int)(unsigned char)'A' + 1;
snprintf(want, sizeof(want), "%d", n);
EXPECT_OK("LENGTH(XRANGE('A','Z'))", want, "XRANGE length 'Z'-'A'+1");
```

Yields 26 on ASCII, 41 on EBCDIC, both spec-correct. A second commit adds empirical byte-content assertions — length passing only proves the BIF returns N bytes, it does not prove those N bytes are the correct sequence. The lackmus test is position 10 of `XRANGE('A','Z')`, which on EBCDIC falls in the alphabet gap between `'I'=0xC9` and `'J'=0xD1`: expected byte is `0xCA`, a non-letter. An alphabet-iterating implementation would yield `'J'=0xD1` there, not `0xCA`. ASCII has no such gap — position 10 is `'J'=0x4A`. The assertion is platform-conditional because C2X output is codepage-specific.

Also added a contiguous-range regression `XRANGE('0','9')=10` since digits are contiguous on every codepage REXX/370 supports.

## How verified

Linux cross-compile: 1184/1184 (was 1180, +4 regression assertions).

MVS via `zowe jobs submit local-file test/mvs/tstall.jcl --wait-for-output`, inspecting TBIFS/BBIFS SYSPRINT:

```
  PASS: XRANGE length 'Z'-'A'+1
  PASS: XRANGE digits 10
  PASS: XRANGE byte 1 is 'A'
  PASS: XRANGE byte 10 is EBCDIC gap 0xCA (not 'J')
  PASS: XRANGE last byte is 'Z'
  PASS: XRANGE default 256
```

Verified via in-suite byte-content assertions at positions 1, 10, and last. The position-10 assertion specifically targets the EBCDIC alphabet gap (0xCA) to confirm true byte-range behaviour — an alphabet-iterating BIF would fail there.

| step | mode | passed/total | failures |
|---|---|---|---|
| TBIFS | TSO | 413/414 | 1 (SOURCELINE — PR 3) |
| BBIFS | batch | 413/414 | 1 (SOURCELINE — PR 3) |

Interactive `C2X(XRANGE('A','Z'))` on MVS was not run (no REXX shell in rexx370 yet — IRXJCL is Phase 5 / WP-41, not implemented). The in-suite assertions running on every MVS test pass are a stronger guarantee than a one-off interactive check anyway — they catch regressions.

Refs: SC28-1883-0 Appendix A