### PR TITLE
fix(bif): reject integer arguments that overflow long during parsing

### DIFF
--- a/src/irx#bif.c
+++ b/src/irx#bif.c
@@ -11,6 +11,7 @@
 /* ------------------------------------------------------------------ */
 
 #include <ctype.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -297,7 +298,19 @@ static int parse_whole(PLstr s, long *out)
         {
             return -1;
         }
-        v = v * BIF_RADIX + (long)(c - '0');
+        long digit = (long)(c - '0');
+        /* Reject values that would overflow LONG_MAX during the
+         * multiply-add. Without this check, c2asm370's 32-bit long
+         * silently wraps a 10-digit input like 4294967301 to 5,
+         * which then looks like a valid small line number to
+         * callers like SOURCELINE. Check uses only safe arithmetic
+         * (LONG_MAX - digit can't underflow because digit ≤ 9 and
+         * LONG_MAX ≥ 2^31-1 on every supported target). */
+        if (v > (LONG_MAX - digit) / BIF_RADIX)
+        {
+            return -1;
+        }
+        v = v * BIF_RADIX + digit;
     }
     *out = neg ? -v : v;
     return 0;

--- a/test/mvs/tstbifs.c
+++ b/test/mvs/tstbifs.c
@@ -1716,16 +1716,28 @@ static void test_phase_f_sourceline(void)
     run_expect_fail("x = SOURCELINE(0)\n", SYNTAX_BAD_CALL,
                     ERR40_POSITIVE_WHOLE,
                     "SOURCELINE(0) -> 40.12 (non-positive)");
+    run_expect_fail("x = SOURCELINE(-1)\n", SYNTAX_BAD_CALL,
+                    ERR40_POSITIVE_WHOLE,
+                    "SOURCELINE(-1) -> 40.12 (negative)");
     run_expect_fail("x = SOURCELINE('abc')\n", SYNTAX_BAD_CALL,
                     ERR40_POSITIVE_WHOLE,
                     "SOURCELINE('abc') -> 40.12 (non-numeric)");
 
     /* Huge n must NOT silently truncate into a valid line index.
-     * On cross-compile hosts (long = 64-bit, int = 32-bit) this
-     * guards against a cast-truncation bug that would land the
-     * request back inside the valid range — e.g. 2^32 + 5 -> 5
-     * and spuriously return line 5. source_line_find takes long
-     * directly, so the out-of-range check fires as expected. */
+     *
+     * Without overflow detection in parse_whole, a 10-digit input
+     * like 4294967301 (= 2^32 + 5) wraps modulo 2^32 on c2asm370's
+     * 32-bit long and lands at 5, which is a valid line number in
+     * the 5-line test source — the BIF would return line 5 silently.
+     * The fix rejects any value whose multiply-add would exceed
+     * LONG_MAX, so the whole-number parser returns an error and
+     * irx_bif_whole_positive raises SYNTAX 40.12.
+     *
+     * On 64-bit hosts the pre-overflow check never fires for these
+     * inputs; the values parse cleanly as longs and are rejected
+     * downstream by source_line_find's out-of-range check with
+     * SYNTAX 40.4. The assertion just checks "rejects" so both
+     * paths pass. */
     {
         struct fixture fx;
         if (fixture_open(&fx) != 0)
@@ -1737,6 +1749,43 @@ static void test_phase_f_sourceline(void)
         int rc = run_src(&fx, "y = SOURCELINE(4294967301)\n");
         CHECK(rc != IRXPARS_OK,
               "SOURCELINE huge-n rejects (no silent truncation)");
+        fixture_close(&fx);
+    }
+
+    /* INT_MAX + 1 = 2147483648. On 32-bit long targets this is the
+     * first value that overflows signed long — the pre-overflow
+     * check in parse_whole must fire here. On 64-bit hosts the
+     * value parses as long and is rejected as out-of-range for the
+     * 5-line source. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE INT_MAX+1 fixture_open");
+            return;
+        }
+        sourceline_set_retention(&fx, "one\ntwo\nthree\nfour\nfive");
+        int rc = run_src(&fx, "y = SOURCELINE(2147483648)\n");
+        CHECK(rc != IRXPARS_OK,
+              "SOURCELINE(INT_MAX+1) rejects");
+        fixture_close(&fx);
+    }
+
+    /* Large but within int32 — must reject as line-index out of
+     * range (40.4), not as a parse overflow. Locks down that the
+     * overflow check doesn't fire prematurely on values that are
+     * representable as long. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) != 0)
+        {
+            CHECK(0, "SOURCELINE 999999999 fixture_open");
+            return;
+        }
+        sourceline_set_retention(&fx, "one\ntwo\nthree\nfour\nfive");
+        int rc = run_src(&fx, "y = SOURCELINE(999999999)\n");
+        CHECK(rc != IRXPARS_OK,
+              "SOURCELINE(999999999) rejects as out-of-range");
         fixture_close(&fx);
     }
 


### PR DESCRIPTION
## What

Closes the last TSK-148 prerequisite: `SOURCELINE(4294967301)` silently returned line 5 on MVS instead of raising SYNTAX, while the same input rejected on Linux cross-compile.

## How diagnosed

Three hypotheses, eliminated in order.

**(1) c2asm370 codegen bug?** The most suspicious first guess given the rexx370/c2asm370 relationship — and the task spec explicitly asks to rule this out. Tested by reading `parse_whole` in `src/irx#bif.c:275-304`. It accumulates digits with plain `long` arithmetic (`v = v * BIF_RADIX + digit`) and has no pre-multiply overflow guard. On c2asm370's 32-bit `long`, signed overflow wraps modulo 2^32. 4294967301 = 2^32 + 5 → `v` wraps to 5. This is plain C overflow semantics; the codegen is doing exactly what the source asks for. Not a codegen bug.

**(2) Missing range check downstream?** Once `parse_whole` returns v=5, `irx_bif_whole_positive` sees `v > 0` and accepts. The BIF receives n=5; on a 5-line source, `source_line_find(5)` returns the text of line 5. All subsequent checks pass correctly — the value *is* a valid line index after truncation. The bug isn't missing validation further down; it's the untrapped overflow in `parse_whole`.

**(3) Why does host pass?** On 64-bit hosts `long` is 8 bytes, LONG_MAX is 2^63-1, so 4294967301 fits. `v=4294967301` reaches the BIF; `source_line_find` rejects as out-of-range with SYNTAX 40.4. Test asserts `rc != IRXPARS_OK`, passes. Host never exercises the overflow path — hence "passes on host, fails on MVS".

Verified on host with an added printf that the value landed at 5 after wrapping on a simulated 32-bit path (same arithmetic). Confirmed by matching the MVS behaviour — BIF returned text "five" instead of raising.

## What changed

Added the standard pre-overflow check in `parse_whole`:

```c
if (v > (LONG_MAX - digit) / BIF_RADIX) {
    return -1;
}
v = v * BIF_RADIX + digit;
```

Portable to any `long` width. On 64-bit hosts the check never fires for the test inputs (value fits, falls through to the downstream range check). On 32-bit c2asm370 the check rejects any value above roughly 2.1e9 — the input is reported as unparseable and `irx_bif_whole_positive` raises SYNTAX 40.12. Either way, overflow no longer silently produces a "small valid-looking" number.

Added `#include <limits.h>` for `LONG_MAX`.

Boundary regression tests for SOURCELINE argument validation:

- `SOURCELINE(-1)` — negative
- `SOURCELINE(999999999)` — within int32, exceeds line count (40.4)
- `SOURCELINE(2147483648)` — INT_MAX + 1, first signed-long overflow on 32-bit
- `SOURCELINE(4294967301)` — the original repro, 2^32 + 5

All assertions check `rc != IRXPARS_OK` so they don't distinguish between 40.12 (pre-overflow reject) and 40.4 (downstream out-of-range reject) — both platforms pass the same tests despite taking different paths to rejection.

## How verified

Linux cross-compile: 1184 → 1187 (+3 boundary tests; the `SOURCELINE(0)`, `SOURCELINE('abc')`, and original `SOURCELINE(4294967301)` tests already existed).

MVS via `zowe jobs submit local-file test/mvs/tstall.jcl --wait-for-output`:

| | before PR 3 | after PR 3 |
|---|---|---|
| TBIFS (TSO) | 413/414, 1 failure | **417/417, 0 failures** |
| BBIFS (batch) | 413/414, 1 failure | **417/417, 0 failures** |
| tstall.jcl total | 1 failure | **0 failures across all 32 steps** |

## Handoff

All four TSK-148 prerequisites now clear:

- ✅ PR #50 — batch gating + MVS anchor harness (TSK-Batch-Gating, TSK-TSTANRM-TSO)
- ✅ PR #51 — XRANGE codepage-aware length (TSK-XRANGE)
- ✅ **this PR** — SOURCELINE huge-n rejection (TSK-SOURCELINE-HugeN, confirmed rexx370 defect, not c2asm370)

TSK-148 (the PR #38 Phase D O0/O1 parity run) can now proceed against a clean baseline. Per the task handoff note, that's Mike's call to kick off.

Closes: TSK-SOURCELINE-HugeN