### PR TITLE
feat(asm): add IRXTMPW TMP wrapper and fix IRXANCHR slot layout

### DIFF
--- a/asm/irxanchr.asm
+++ b/asm/irxanchr.asm
@@ -8,14 +8,14 @@
 *
 *  Header layout (32 bytes, offset from module start):
 *    +0x00  8B  ENVTABLE_ID      C'IRXANCHR'  eye-catcher
-*    +0x08  4B  ENVTABLE_VERSION C'0100'
+*    +0x08  4B  ENVTABLE_VERSION C'0042'
 *    +0x0C  4B  ENVTABLE_TOTAL   64  slot count (REXX/370 adaptation)
 *    +0x10  4B  ENVTABLE_USED    0   high-watermark, initially zero
 *    +0x14  4B  ENVTABLE_LENGTH  40  bytes per entry
 *    +0x18  8B  (reserved)       zeros
 *
 *  Slot layout (40 bytes):
-*    +0x00  4B  ENVBLOCK_PTR     X'FFFFFFFF' = free slot
+*    +0x00  4B  ENVBLOCK_PTR     X'00000000' = free slot
 *    +0x04  4B  TOKEN
 *    +0x08 16B  (reserved)
 *    +0x18  4B  ANCHOR_HINT
@@ -32,7 +32,7 @@ IRXANCHR CSECT
 ***      Header (32 bytes)
 *
          DC    C'IRXANCHR'         +0x00  eye-catcher
-         DC    C'0100'             +0x08  version
+         DC    C'0042'             +0x08  version
          DC    F'64'               +0x0C  TOTAL: 64 slots
          DC    F'0'                +0x10  USED: 0 initial
          DC    F'40'               +0x14  LENGTH: 40 bytes per entry
@@ -46,131 +46,131 @@ IRXANCHR CSECT
 *
 *        Slot 0 - permanent sentinel, never allocated
          DC    XL4'FFFFFFFF',XL36'00'
-*        Slot 1
-         DC    XL4'FFFFFFFF',XL36'00'
-*        Slot 2
+*        Slot 1 - default environment
+         DC    XL4'00000000',XL36'00'
+*        Slot 2 - permanent sentinel, never allocated
          DC    XL4'FFFFFFFF',XL36'00'
 *        Slot 3
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 4
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 5
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 6
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 7
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 8
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 9
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 10
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 11
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 12
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 13
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 14
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 15
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 16
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 17
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 18
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 19
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 20
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 21
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 22
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 23
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 24
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 25
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 26
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 27
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 28
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 29
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 30
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 31
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 32
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 33
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 34
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 35
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 36
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 37
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 38
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 39
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 40
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 41
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 42
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 43
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 44
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 45
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 46
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 47
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 48
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 49
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 50
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 51
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 52
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 53
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 54
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 55
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 56
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 57
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 58
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 59
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 60
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 61
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 62
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *        Slot 63
-         DC    XL4'FFFFFFFF',XL36'00'
+         DC    XL4'00000000',XL36'00'
 *
          END   IRXANCHR

--- a/asm/irxtmpw.asm
+++ b/asm/irxtmpw.asm
@@ -1,0 +1,106 @@
+         TITLE 'IRXTMPW - REXX/370 TMP Wrapper'
+*
+*  IRXTMPW - If IRXANCHR is installed, LOAD it so its CDE lives in
+*            the Step-TCB JPQ (survives XCTL, found by command
+*            subtasks via JPA lookup). Otherwise, skip the LOAD
+*            silently. Either way, XCTL to IKJEFT01.
+*
+*  Must be link-edited AC(1),REUS into an APF-authorized library
+*  (e.g. SYS1.LINKLIB).
+*
+*  On entry: R1 = PARM pointer, R13 = caller SA, R14 = return.
+*  On exit:  no return - XCTLs to IKJEFT01 (which ends via SVC 3).
+*
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R8       EQU   8
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+*
+IRXTMPW  CSECT
+*
+         STM   R14,R12,12(R13)
+         BALR  R12,0
+         USING *,R12
+*
+         ST    R1,PARMSAVE
+*
+         LA    R2,SAVEAREA
+         ST    R13,4(,R2)
+         ST    R2,8(,R13)
+         LR    R13,R2
+*
+*  --- BLDL: check if IRXANCHR is in LNKLST/JOBLIB/STEPLIB ---
+*
+         MVC   BLDLCNT,=H'1'        one entry
+         MVC   BLDLLEN,=H'50'       length per entry
+         MVC   BLDLNAM,=CL8'IRXANCHR'
+         BLDL  0,BLDLLST            DCB=0 -> JOBLIB/LNKLST
+         LTR   R15,R15
+         BNZ   SKIPLOAD             not found - skip quietly
+*
+*  --- IRXANCHR found - LOAD it ---
+*
+         LOAD  EP=IRXANCHR,ERRET=SKIPLOAD
+         ST    R0,ANCHADR
+*
+*  Announce the anchor address to terminal
+*
+*         LA    R1,ANCHADR
+*         LA    R8,ANCHHEX
+*         BAL   R14,HEX4
+*         TPUT  LOADMSG,L'LOADMSG
+*
+*  --- XCTL to IKJEFT01 (always, even if no IRXANCHR) ---
+*
+SKIPLOAD DS    0H
+         L     R13,SAVEAREA+4
+         L     R1,PARMSAVE
+         L     R14,12(,R13)
+         XCTL  EP=IKJEFT01
+*
+*---------------------------------------------------------------
+HEX4     LA    R15,4
+HEXL     IC    R0,0(,R1)
+         LR    R2,R0
+         SRL   R2,4
+         N     R2,=F'15'
+         IC    R2,HEXTAB(R2)
+         STC   R2,0(,R8)
+         LR    R2,R0
+         N     R2,=F'15'
+         IC    R2,HEXTAB(R2)
+         STC   R2,1(,R8)
+         LA    R1,1(,R1)
+         LA    R8,2(,R8)
+         BCT   R15,HEXL
+         BR    R14
+*
+*---------------------------------------------------------------
+*  BLDL list - must be fullword aligned
+*---------------------------------------------------------------
+         DS    0F
+BLDLLST  DS    0CL54            full BLDL list area
+BLDLCNT  DS    H                FF = # entries
+BLDLLEN  DS    H                LL = length per entry
+BLDLNAM  DS    CL8              member name
+BLDLRET  DS    CL42             return data (TTR, K, Z, C, user)
+*
+*---------------------------------------------------------------
+LOADMSG  DS    0CL32
+         DC    C' IRXANCHR LOADED AT '
+ANCHHEX  DC    CL8'00000000'
+         DC    CL3' '
+*
+HEXTAB   DC    C'0123456789ABCDEF'
+*
+ANCHADR  DS    F
+PARMSAVE DS    F
+*
+SAVEAREA DS    18F
+*
+         LTORG
+         END   IRXTMPW

--- a/asm/irxtmpw.asm
+++ b/asm/irxtmpw.asm
@@ -1,106 +1,49 @@
          TITLE 'IRXTMPW - REXX/370 TMP Wrapper'
 *
-*  IRXTMPW - If IRXANCHR is installed, LOAD it so its CDE lives in
+*  IRXTMPW - Try loading IRXANCHR so its CDE lives in
 *            the Step-TCB JPQ (survives XCTL, found by command
-*            subtasks via JPA lookup). Otherwise, skip the LOAD
-*            silently. Either way, XCTL to IKJEFT01.
+*            subtasks via JPA lookup). XCTL to IKJEFT01.
 *
-*  Must be link-edited AC(1),REUS into an APF-authorized library
-*  (e.g. SYS1.LINKLIB).
+*  Must be link-edited AC(1),RENT and REUS into an APF-authorized 
+*  library (e.g. SYS2.LINKLIB).
 *
 *  On entry: R1 = PARM pointer, R13 = caller SA, R14 = return.
 *  On exit:  no return - XCTLs to IKJEFT01 (which ends via SVC 3).
 *
+         PRINT NOGEN
 R0       EQU   0
 R1       EQU   1
-R2       EQU   2
+R5       EQU   5
+R6       EQU   6
+R7       EQU   7
 R8       EQU   8
 R12      EQU   12
-R13      EQU   13
 R14      EQU   14
 R15      EQU   15
+         PRINT GEN
 *
 IRXTMPW  CSECT
-*
-         STM   R14,R12,12(R13)
          BALR  R12,0
          USING *,R12
 *
-         ST    R1,PARMSAVE
+* --- save registers that IKJEFT01 expects to be preserved ---
+         LR    R5,R0
+         LR    R6,R1
+         LR    R7,R14
+         LR    R8,R15
 *
-         LA    R2,SAVEAREA
-         ST    R13,4(,R2)
-         ST    R2,8(,R13)
-         LR    R13,R2
+* --- try loading IRXANCHR ---
+         LOAD  EP=IRXANCHR,ERRET=DUMMY
 *
-*  --- BLDL: check if IRXANCHR is in LNKLST/JOBLIB/STEPLIB ---
+* --- restore registers for IKJEFT01 ---
+DUMMY    DS    0H
+         LR    R0,R5
+         LR    R1,R6
+         LR    R14,R7
+         LR    R15,R8
 *
-         MVC   BLDLCNT,=H'1'        one entry
-         MVC   BLDLLEN,=H'50'       length per entry
-         MVC   BLDLNAM,=CL8'IRXANCHR'
-         BLDL  0,BLDLLST            DCB=0 -> JOBLIB/LNKLST
-         LTR   R15,R15
-         BNZ   SKIPLOAD             not found - skip quietly
-*
-*  --- IRXANCHR found - LOAD it ---
-*
-         LOAD  EP=IRXANCHR,ERRET=SKIPLOAD
-         ST    R0,ANCHADR
-*
-*  Announce the anchor address to terminal
-*
-*         LA    R1,ANCHADR
-*         LA    R8,ANCHHEX
-*         BAL   R14,HEX4
-*         TPUT  LOADMSG,L'LOADMSG
-*
-*  --- XCTL to IKJEFT01 (always, even if no IRXANCHR) ---
-*
-SKIPLOAD DS    0H
-         L     R13,SAVEAREA+4
-         L     R1,PARMSAVE
-         L     R14,12(,R13)
+* --- give control to IKJEFT01 ---
          XCTL  EP=IKJEFT01
-*
-*---------------------------------------------------------------
-HEX4     LA    R15,4
-HEXL     IC    R0,0(,R1)
-         LR    R2,R0
-         SRL   R2,4
-         N     R2,=F'15'
-         IC    R2,HEXTAB(R2)
-         STC   R2,0(,R8)
-         LR    R2,R0
-         N     R2,=F'15'
-         IC    R2,HEXTAB(R2)
-         STC   R2,1(,R8)
-         LA    R1,1(,R1)
-         LA    R8,2(,R8)
-         BCT   R15,HEXL
-         BR    R14
-*
-*---------------------------------------------------------------
-*  BLDL list - must be fullword aligned
-*---------------------------------------------------------------
-         DS    0F
-BLDLLST  DS    0CL54            full BLDL list area
-BLDLCNT  DS    H                FF = # entries
-BLDLLEN  DS    H                LL = length per entry
-BLDLNAM  DS    CL8              member name
-BLDLRET  DS    CL42             return data (TTR, K, Z, C, user)
-*
-*---------------------------------------------------------------
-LOADMSG  DS    0CL32
-         DC    C' IRXANCHR LOADED AT '
-ANCHHEX  DC    CL8'00000000'
-         DC    CL3' '
-*
-HEXTAB   DC    C'0123456789ABCDEF'
-*
-ANCHADR  DS    F
-PARMSAVE DS    F
-*
-SAVEAREA DS    18F
 *
          LTORG
          END   IRXTMPW

--- a/project.toml
+++ b/project.toml
@@ -56,10 +56,16 @@ naming = "fixed"
 # No C runtime — pure assembler data object.
 # ---------------------------------------------------------------
 [[link.module]]
-name    = "IRXANCHR"
-entry   = "IRXANCHR"
-options = ["LIST", "MAP", "XREF"]
+name = "IRXANCHR"
+entry = "IRXANCHR"
+options = ["LIST", "MAP", "XREF", "REUS"]
 include = ["IRXANCHR"]
+
+[[link.module]]
+name = "IRXTMPW"
+entry = "IRXTMPW"
+options = ["LIST", "MAP", "XREF", "AC=1", "REUS"]
+include = ["IRXTMPW"]
 
 # ---------------------------------------------------------------
 # TSTANCH - ENVBLOCK anchor smoketest pseudomodule
@@ -157,12 +163,7 @@ include = [
 name = "TSTTOKN"
 entry = "@@CRT0"
 options = ["LIST", "MAP", "XREF", "RENT"]
-include = [
-  "@@CRT1",
-  "TSTTOKN",
-  "IRX#TOKN",
-  "IRX#STOR",
-]
+include = ["@@CRT1", "TSTTOKN", "IRX#TOKN", "IRX#STOR"]
 
 [link.module.dep_includes]
 "mvslovers/lstring370" = "*"
@@ -189,10 +190,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTPHAS1",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -206,10 +219,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTANRM",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -223,10 +248,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTLSTR",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -240,10 +277,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTVPOL",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -257,10 +306,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTPRSR",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -274,10 +335,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTSAY",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -291,10 +364,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTCTRL",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -308,10 +393,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTHELO",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -325,10 +422,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTPARSE",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -342,10 +451,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTPROC",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -359,10 +480,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTARIT",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -376,10 +509,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTAREXT",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -393,10 +538,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTBIF",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -410,10 +567,22 @@ options = ["LIST", "MAP", "XREF", "RENT"]
 include = [
   "@@CRT1",
   "TSTBIFS",
-  "IRX#INIT", "IRX#TERM", "IRX#STOR", "IRX#ANCH",
-  "IRX#UID",  "IRX#MSID", "IRX#COND", "IRX#BIF",
-  "IRX#BIFS", "IRX#IO",   "IRX#LSTR", "IRX#TOKN",
-  "IRX#VPOL", "IRX#PARS", "IRX#CTRL", "IRX#EXEC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
   "IRX#ARIT",
 ]
 
@@ -466,6 +635,13 @@ version_files = ["VERSION"]
 
 [artifacts]
 headers = true
-header_files = ["irx.h", "irxanchr.h", "irxwkblk.h", "irxfunc.h",
-                "irxbif.h", "irxbifs.h", "irxcond.h"]
+header_files = [
+  "irx.h",
+  "irxanchr.h",
+  "irxwkblk.h",
+  "irxfunc.h",
+  "irxbif.h",
+  "irxbifs.h",
+  "irxcond.h",
+]
 loads = true

--- a/project.toml
+++ b/project.toml
@@ -64,7 +64,7 @@ include = ["IRXANCHR"]
 [[link.module]]
 name = "IRXTMPW"
 entry = "IRXTMPW"
-options = ["LIST", "MAP", "XREF", "AC=1", "REUS"]
+options = ["LIST", "MAP", "XREF", "AC=1", "RENT", "REUS"]
 include = ["IRXTMPW"]
 
 # ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`asm/irxanchr.asm`**: change free-slot sentinel from `X'FFFFFFFF'` to
  `X'00000000'` (NULL = free) for slots 3–63; designate slot 1 as default
  REXX environment, slot 2 as permanent sentinel; bump version to `C'0042'`
- **`asm/irxtmpw.asm`** (new): APF-authorized TSO TMP replacement that LOADs
  IRXANCHR into the Step-TCB JPQ before XCTLing to IKJEFT01, so the anchor
  survives XCTL and is visible to command subtasks via JPA lookup
- **`project.toml`**: add `REUS` to IRXANCHR, register IRXTMPW (`AC=1,REUS`),
  reformat include lists to one-per-line

Closes #61

## Test plan

- [ ] IRXANCHR assembles cleanly (IFOX00 RC=0)
- [ ] IRXTMPW assembles cleanly (IFOX00 RC=0)
- [ ] `irx_anchor_find_free_slot()` identifies free slots by `== NULL`
- [ ] All 1 156 cross-compile tests still green
- [ ] On MVS: IRXTMPW links into APF library, TSO session starts, `CALL TSTANCH` passes