### PR TITLE
WP-I1b: Parameter-Module Load Modules (IRXPARMS, IRXTSPRM, IRXISPRM)

### DIFF
--- a/asm/irxisprm.asm
+++ b/asm/irxisprm.asm
@@ -1,0 +1,103 @@
+         TITLE 'IRXISPRM - REXX/370 ISPF Default Parameter Module'
+*
+*  IRXISPRM - Default PARMBLOCK for TSO+ISPF environments.
+*
+*  Static data module loaded by IRXINIT via LOAD EP=IRXISPRM when
+*  the caller provides no explicit PARMBLOCK (CON-1 §6.3, step 4).
+*  No executable code — DC/DS directives only.
+*
+*  Control block sizes (from irx.h):
+*    PARMBLOCK:       64 bytes
+*    MODNAMET:       112 bytes (13 x 8-byte fields + 8-byte FFFF)
+*    SUBCOMTB header: 40 bytes
+*    SUBCOMTB entry:  32 bytes
+*    PACKTB header:   48 bytes
+*    PACKTB entry:     8 bytes (CL8 name, PACKTB_LENGTH=F'8')
+*
+IRXISPRM CSECT
+*
+***      PARMBLOCK (64 bytes, offset from module entry point)
+*
+         DC    CL8'IRXPARMS'       +0x00  eye-catcher
+         DC    CL4'0042'           +0x08  version (rexx370 deviation)
+         DC    CL3'AE '            +0x0C  language: 2-byte NLS code
+         DC    XL1'00'             +0x0F  reserved (_filler1)
+         DC    A(MODNAMET)         +0x10  -> MODNAMET
+         DC    A(SUBCOMTB)         +0x14  -> SUBCOMTB header
+         DC    A(PACKTB)           +0x18  -> PACKTB header
+         DC    CL8'        '       +0x1C  parse source token (blank)
+         DC    X'8000C000'         +0x24  FLAGS: TSOFL | ALTMSGS | SPSHARE
+         DC    X'FFFFFFFF'         +0x28  MASKS: all bits active
+         DC    F'78'               +0x2C  SUBPOOL 78 (TSO private)
+         DC    CL8'ISPF    '       +0x30  ADDRSPN
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x38  end marker
+*
+***      MODNAMET (112 bytes: 13 x 8-byte fields + 8-byte FFFF)
+*
+MODNAMET DC    CL8'SYSTSIN '       DD names (3 fields)
+         DC    CL8'SYSTSPRT'
+         DC    CL8'SYSEXEC '
+         DC    CL8'        '       replaceable routines (10 blank slots)
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    XL8'FFFFFFFFFFFFFFFF' end marker
+*
+***      SUBCOMTB header (40 bytes) + 7 entries (224 bytes)
+*
+SUBCOMTB DC    A(SUBCOENT)         +0x00  first entry
+         DC    F'7'                +0x04  total entries
+         DC    F'7'                +0x08  used entries
+         DC    F'32'               +0x0C  bytes per entry
+         DC    CL8'TSO     '       +0x10  initial environment
+         DC    XL8'00'             +0x18  reserved
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x20  end marker
+*
+SUBCOENT DC    CL8'TSO     '       entry 1: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'MVS     '       entry 2: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'LINK    '       entry 3: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'ATTACH  '       entry 4: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'CONSOLE '       entry 5: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'ISPEXEC '       entry 6: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'ISREDIT '       entry 7: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+*
+***      PACKTB header (48 bytes) + 4 entries (32 bytes)
+*        Entry order in memory: system (x2), local, user
+*
+PACKTB   DC    A(USRPKENT)         +0x00  user entries
+         DC    F'1'                +0x04  user total
+         DC    F'1'                +0x08  user used
+         DC    A(LCLPKENT)         +0x0C  local entries
+         DC    F'1'                +0x10  local total
+         DC    F'1'                +0x14  local used
+         DC    A(SYSPKENT)         +0x18  system entries
+         DC    F'2'                +0x1C  system total
+         DC    F'2'                +0x20  system used
+         DC    F'8'                +0x24  bytes per entry
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x28  end marker
+SYSPKENT DC    CL8'IRXEFMVS'       system entry 1
+         DC    CL8'IRXEFPCK'       system entry 2
+LCLPKENT DC    CL8'IRXFLOC '       local entry 1
+USRPKENT DC    CL8'IRXFUSER'       user entry 1
+*
+         END   IRXISPRM

--- a/asm/irxisprm.asm
+++ b/asm/irxisprm.asm
@@ -6,9 +6,12 @@
 *  the caller provides no explicit PARMBLOCK (CON-1 §6.3, step 4).
 *  No executable code — DC/DS directives only.
 *
+*  MODNAMET pointer is null (A(0)): IRXINIT inherits MODNAMET from
+*  the parent TSO environment, preserving any replaceable-routine
+*  overrides the caller installed before entering ISPF.
+*
 *  Control block sizes (from irx.h):
 *    PARMBLOCK:       64 bytes
-*    MODNAMET:       112 bytes (13 x 8-byte fields + 8-byte FFFF)
 *    SUBCOMTB header: 40 bytes
 *    SUBCOMTB entry:  32 bytes
 *    PACKTB header:   48 bytes
@@ -22,32 +25,15 @@ IRXISPRM CSECT
          DC    CL4'0042'           +0x08  version (rexx370 deviation)
          DC    CL3'AE '            +0x0C  language: 2-byte NLS code
          DC    XL1'00'             +0x0F  reserved (_filler1)
-         DC    A(MODNAMET)         +0x10  -> MODNAMET
+         DC    A(0)                +0x10  -> MODNAMET (inherit from parent)
          DC    A(SUBCOMTB)         +0x14  -> SUBCOMTB header
          DC    A(PACKTB)           +0x18  -> PACKTB header
          DC    CL8'        '       +0x1C  parse source token (blank)
-         DC    X'8000C000'         +0x24  FLAGS: TSOFL | ALTMSGS | SPSHARE
+         DC    X'81004000'         +0x24  FLAGS: TSOFL | NEWSTKFL | SPSHARE
          DC    X'FFFFFFFF'         +0x28  MASKS: all bits active
          DC    F'78'               +0x2C  SUBPOOL 78 (TSO private)
          DC    CL8'ISPF    '       +0x30  ADDRSPN
          DC    XL8'FFFFFFFFFFFFFFFF' +0x38  end marker
-*
-***      MODNAMET (112 bytes: 13 x 8-byte fields + 8-byte FFFF)
-*
-MODNAMET DC    CL8'SYSTSIN '       DD names (3 fields)
-         DC    CL8'SYSTSPRT'
-         DC    CL8'SYSEXEC '
-         DC    CL8'        '       replaceable routines (10 blank slots)
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    CL8'        '
-         DC    XL8'FFFFFFFFFFFFFFFF' end marker
 *
 ***      SUBCOMTB header (40 bytes) + 7 entries (224 bytes)
 *

--- a/asm/irxparms.asm
+++ b/asm/irxparms.asm
@@ -1,0 +1,90 @@
+         TITLE 'IRXPARMS - REXX/370 MVS Batch Default Parameter Module'
+*
+*  IRXPARMS - Default PARMBLOCK for non-TSO (MVS batch) environments.
+*
+*  Static data module loaded by IRXINIT via LOAD EP=IRXPARMS when
+*  the caller provides no explicit PARMBLOCK (CON-1 §6.3, step 4).
+*  No executable code — DC/DS directives only.
+*
+*  Control block sizes (from irx.h):
+*    PARMBLOCK:       64 bytes
+*    MODNAMET:       112 bytes (13 x 8-byte fields + 8-byte FFFF)
+*    SUBCOMTB header: 40 bytes
+*    SUBCOMTB entry:  32 bytes
+*    PACKTB header:   48 bytes
+*    PACKTB entry:     8 bytes (CL8 name, PACKTB_LENGTH=F'8')
+*
+IRXPARMS CSECT
+*
+***      PARMBLOCK (64 bytes, offset from module entry point)
+*
+         DC    CL8'IRXPARMS'       +0x00  eye-catcher
+         DC    CL4'0042'           +0x08  version (rexx370 deviation)
+         DC    CL3'AE '            +0x0C  language: 2-byte NLS code
+         DC    XL1'00'             +0x0F  reserved (_filler1)
+         DC    A(MODNAMET)         +0x10  -> MODNAMET
+         DC    A(SUBCOMTB)         +0x14  -> SUBCOMTB header
+         DC    A(PACKTB)           +0x18  -> PACKTB header
+         DC    CL8'        '       +0x1C  parse source token (blank)
+         DC    X'0000C000'         +0x24  FLAGS: ALTMSGS | SPSHARE
+         DC    X'FFFFFFFF'         +0x28  MASKS: all bits active
+         DC    F'0'                +0x2C  SUBPOOL 0 (below-the-line)
+         DC    CL8'MVS     '       +0x30  ADDRSPN
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x38  end marker
+*
+***      MODNAMET (112 bytes: 13 x 8-byte fields + 8-byte FFFF)
+*
+MODNAMET DC    CL8'SYSTSIN '       DD names (3 fields)
+         DC    CL8'SYSTSPRT'
+         DC    CL8'SYSEXEC '
+         DC    CL8'        '       replaceable routines (10 blank slots)
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    XL8'FFFFFFFFFFFFFFFF' end marker
+*
+***      SUBCOMTB header (40 bytes) + 3 entries (96 bytes)
+*
+SUBCOMTB DC    A(SUBCOENT)         +0x00  first entry
+         DC    F'3'                +0x04  total entries
+         DC    F'3'                +0x08  used entries
+         DC    F'32'               +0x0C  bytes per entry
+         DC    CL8'MVS     '       +0x10  initial environment
+         DC    XL8'00'             +0x18  reserved
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x20  end marker
+*
+SUBCOENT DC    CL8'MVS     '       entry 1: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'LINK    '       entry 2: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'ATTACH  '       entry 3: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+*
+***      PACKTB header (48 bytes) + 3 entries (24 bytes)
+*        Entry order in memory: system, local, user
+*
+PACKTB   DC    A(USRPKENT)         +0x00  user entries
+         DC    F'1'                +0x04  user total
+         DC    F'1'                +0x08  user used
+         DC    A(LCLPKENT)         +0x0C  local entries
+         DC    F'1'                +0x10  local total
+         DC    F'1'                +0x14  local used
+         DC    A(SYSPKENT)         +0x18  system entries
+         DC    F'1'                +0x1C  system total
+         DC    F'1'                +0x20  system used
+         DC    F'8'                +0x24  bytes per entry
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x28  end marker
+SYSPKENT DC    CL8'IRXEFMVS'       system entry 1
+LCLPKENT DC    CL8'IRXFLOC '       local entry 1
+USRPKENT DC    CL8'IRXFUSER'       user entry 1
+*
+         END   IRXPARMS

--- a/asm/irxtsprm.asm
+++ b/asm/irxtsprm.asm
@@ -1,0 +1,97 @@
+         TITLE 'IRXTSPRM - REXX/370 TSO Default Parameter Module'
+*
+*  IRXTSPRM - Default PARMBLOCK for TSO (foreground/background) envs.
+*
+*  Static data module loaded by IRXINIT via LOAD EP=IRXTSPRM when
+*  the caller provides no explicit PARMBLOCK (CON-1 §6.3, step 4).
+*  No executable code — DC/DS directives only.
+*
+*  Control block sizes (from irx.h):
+*    PARMBLOCK:       64 bytes
+*    MODNAMET:       112 bytes (13 x 8-byte fields + 8-byte FFFF)
+*    SUBCOMTB header: 40 bytes
+*    SUBCOMTB entry:  32 bytes
+*    PACKTB header:   48 bytes
+*    PACKTB entry:     8 bytes (CL8 name, PACKTB_LENGTH=F'8')
+*
+IRXTSPRM CSECT
+*
+***      PARMBLOCK (64 bytes, offset from module entry point)
+*
+         DC    CL8'IRXPARMS'       +0x00  eye-catcher
+         DC    CL4'0042'           +0x08  version (rexx370 deviation)
+         DC    CL3'AE '            +0x0C  language: 2-byte NLS code
+         DC    XL1'00'             +0x0F  reserved (_filler1)
+         DC    A(MODNAMET)         +0x10  -> MODNAMET
+         DC    A(SUBCOMTB)         +0x14  -> SUBCOMTB header
+         DC    A(PACKTB)           +0x18  -> PACKTB header
+         DC    CL8'        '       +0x1C  parse source token (blank)
+         DC    X'8000C000'         +0x24  FLAGS: TSOFL | ALTMSGS | SPSHARE
+         DC    X'FFFFFFFF'         +0x28  MASKS: all bits active
+         DC    F'78'               +0x2C  SUBPOOL 78 (TSO private)
+         DC    CL8'TSO/E   '       +0x30  ADDRSPN
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x38  end marker
+*
+***      MODNAMET (112 bytes: 13 x 8-byte fields + 8-byte FFFF)
+*
+MODNAMET DC    CL8'SYSTSIN '       DD names (3 fields)
+         DC    CL8'SYSTSPRT'
+         DC    CL8'SYSEXEC '
+         DC    CL8'        '       replaceable routines (10 blank slots)
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    CL8'        '
+         DC    XL8'FFFFFFFFFFFFFFFF' end marker
+*
+***      SUBCOMTB header (40 bytes) + 5 entries (160 bytes)
+*
+SUBCOMTB DC    A(SUBCOENT)         +0x00  first entry
+         DC    F'5'                +0x04  total entries
+         DC    F'5'                +0x08  used entries
+         DC    F'32'               +0x0C  bytes per entry
+         DC    CL8'TSO     '       +0x10  initial environment
+         DC    XL8'00'             +0x18  reserved
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x20  end marker
+*
+SUBCOENT DC    CL8'TSO     '       entry 1: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'MVS     '       entry 2: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'LINK    '       entry 3: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'ATTACH  '       entry 4: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+         DC    CL8'CONSOLE '       entry 5: name
+         DC    CL8'IRXSTAM '               handler
+         DC    CL16'                '      token (blank)
+*
+***      PACKTB header (48 bytes) + 4 entries (32 bytes)
+*        Entry order in memory: system (x2), local, user
+*
+PACKTB   DC    A(USRPKENT)         +0x00  user entries
+         DC    F'1'                +0x04  user total
+         DC    F'1'                +0x08  user used
+         DC    A(LCLPKENT)         +0x0C  local entries
+         DC    F'1'                +0x10  local total
+         DC    F'1'                +0x14  local used
+         DC    A(SYSPKENT)         +0x18  system entries
+         DC    F'2'                +0x1C  system total
+         DC    F'2'                +0x20  system used
+         DC    F'8'                +0x24  bytes per entry
+         DC    XL8'FFFFFFFFFFFFFFFF' +0x28  end marker
+SYSPKENT DC    CL8'IRXEFMVS'       system entry 1
+         DC    CL8'IRXEFPCK'       system entry 2
+LCLPKENT DC    CL8'IRXFLOC '       local entry 1
+USRPKENT DC    CL8'IRXFUSER'       user entry 1
+*
+         END   IRXTSPRM

--- a/project.toml
+++ b/project.toml
@@ -61,6 +61,31 @@ entry = "IRXANCHR"
 options = ["LIST", "MAP", "XREF", "REUS"]
 include = ["IRXANCHR"]
 
+# ---------------------------------------------------------------
+# IRXPARMS / IRXTSPRM / IRXISPRM - Default Parameter Modules.
+# Static data objects: PARMBLOCK + MODNAMET + SUBCOMTB + PACKTB.
+# Loaded by IRXINIT via LOAD EP=IRXxxxxx when the caller supplies
+# no explicit PARMBLOCK (CON-1 §6.3, step 4).
+# No C runtime — pure assembler data objects.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "IRXPARMS"
+entry = "IRXPARMS"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = ["IRXPARMS"]
+
+[[link.module]]
+name = "IRXTSPRM"
+entry = "IRXTSPRM"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = ["IRXTSPRM"]
+
+[[link.module]]
+name = "IRXISPRM"
+entry = "IRXISPRM"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = ["IRXISPRM"]
+
 [[link.module]]
 name = "IRXTMPW"
 entry = "IRXTMPW"


### PR DESCRIPTION
## Summary

- Adds three static data-only assembler load modules: `IRXPARMS` (MVS batch), `IRXTSPRM` (TSO), `IRXISPRM` (ISPF)
- Each embeds a PARMBLOCK + MODNAMET + SUBCOMTB + PACKTB with environment-appropriate defaults
- Extends `project.toml` with three new `[[link.module]]` entries (`RENT`+`REUS`, no C runtime)

## Deviations from IBM originals

| Field | IBM | rexx370 |
|---|---|---|
| VERSION | `'0200'` | `'0042'` |
| LANGUAGE | `'ENU'` (z/OS 3-byte) | `'AE '` (SC28-1883-0 2-byte NLS) |
| IRXISPRM MODNAMET | `AL4(0)` (null) | full MODNAMET with DDs |
| IRXISPRM FLAGS | `X'81004000'` | `X'8000C000'` (per issue spec) |
| SUBCOMTB entries | 13–18 (includes APPC, HWT*, BCPii) | 3/5/7 (MVS 3.8j minimal set) |
| PACKTB system entries | 2–3 (includes EZAFTPKR) | 1–2 (no FTP API package) |
| PATCH area | present | omitted |

## Note on header sizes

The issue states "32-byte SUBCOMTB header" and "32-byte PACKTB header". The correct sizes per `irx.h` are **40 bytes** (SUBCOMTB) and **48 bytes** (PACKTB). The assembler files use the correct sizes.

## Test plan

- [ ] AC-7: Host cross-compile test suite — **1156/1156 passed** (unaffected by data-only modules)
- [ ] AC-1–AC-6: Verified via MVS storage dump after `LOAD EP=IRXPARMS` / `IRXTSPRM` / `IRXISPRM`

Fixes #66