### PR TITLE
polish(WP-I1c.2): naming consistency, dispatcher docs, rsvd1 comment

### DIFF
--- a/include/irx_init.h
+++ b/include/irx_init.h
@@ -26,6 +26,13 @@
 /* CL8 function-code field width — IBM IRXINIT VLIST convention. */
 #define IRXINIT_FUNCCODE_LEN 8
 
+/* c2asm370 truncates C names to 8 chars with '_' mapped to '@'.
+ * The prefix irx_init_ is already 8 chars (IRX@INIT), leaving no
+ * room for the function-specific suffix — all four functions would
+ * collapse to the same MVS symbol and IFOX00 would reject the
+ * duplicate ENTRY.  The asm() aliases below give each function a
+ * distinct 8-char MVS symbol under the IRXI* namespace. */
+
 /* ------------------------------------------------------------------ */
 /*  irx_init_initenvb - 9-step IRXINIT C-core (WP-I1c.1)             */
 /*                                                                    */
@@ -53,7 +60,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
                       struct parmblock *caller_parmblock,
                       uint32_t user_field,
                       struct envblock **out_envblock,
-                      int *out_reason_code);
+                      int *out_reason_code) asm("IRXIINIT");
 
 /* ------------------------------------------------------------------ */
 /*  irx_init_findenvb - locate non-reentrant env on caller TCB       */
@@ -68,7 +75,8 @@ int irx_init_initenvb(struct envblock *prev_envblock,
 /*                                                                    */
 /*  Returns: 0=found (RC=0), 4=not found (RC=4, RSN=4).              */
 /* ------------------------------------------------------------------ */
-int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code);
+int irx_init_findenvb(struct envblock **out_envblock,
+                      int *out_reason_code) asm("IRXIFIND");
 
 /* ------------------------------------------------------------------ */
 /*  irx_init_chekenvb - validate an ENVBLOCK address                 */
@@ -84,7 +92,8 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code);
 /*                                                                    */
 /*  Returns: 0=valid (RC=0), 20=invalid (RC=20, RSN set).            */
 /* ------------------------------------------------------------------ */
-int irx_init_chekenvb(struct envblock *envblock, int *out_reason_code);
+int irx_init_chekenvb(struct envblock *envblock,
+                      int *out_reason_code) asm("IRXICHEK");
 
 /* ------------------------------------------------------------------ */
 /*  irx_init_dispatch - central IRXINIT function-code dispatcher     */
@@ -115,6 +124,6 @@ int irx_init_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
                       struct parmblock *caller_parmblock,
                       uint32_t user_field,
                       struct envblock **envblock_inout,
-                      int *out_reason_code);
+                      int *out_reason_code) asm("IRXIDISP");
 
 #endif /* IRX_INIT_H */

--- a/include/irx_init.h
+++ b/include/irx_init.h
@@ -3,13 +3,14 @@
 /*                                                                    */
 /*  Internal signatures for IRXINIT function-code implementations:   */
 /*    irx_init_initenvb  - INITENVB 9-step C-core (WP-I1c.1)         */
-/*    irx_findenvb  - FINDENVB: locate non-reentrant env on TCB  */
-/*    irx_chekenvb  - CHEKENVB: validate an ENVBLOCK address     */
-/*    irx_dispatch  - central dispatcher keyed on CL8 funccode   */
+/*    irx_init_findenvb  - FINDENVB: locate non-reentrant env on TCB */
+/*    irx_init_chekenvb  - CHEKENVB: validate an ENVBLOCK address    */
+/*    irx_init_dispatch  - central dispatcher keyed on CL8 funccode  */
 /*                                                                    */
 /*  Ref: SC28-1883-0 §14 (IRXINIT FINDENVB / CHEKENVB)               */
 /*  Ref: CON-1 §6.2 (env-type detection), §6.3 (previous-env lookup) */
-/*  Ref: CON-3 (ECTENVBK unconditional overwrite, live-verified)      */
+/*  Ref: CON-3 (ECTENVBK semantics — greenfield-verified,             */
+/*       non-greenfield behavior TBD pending IRXPROBE)                */
 /*  Ref: WP-I1c.1, WP-I1c.2                                          */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
@@ -55,7 +56,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
                       int *out_reason_code);
 
 /* ------------------------------------------------------------------ */
-/*  irx_findenvb - locate non-reentrant env on caller TCB        */
+/*  irx_init_findenvb - locate non-reentrant env on caller TCB       */
 /*                                                                    */
 /*  Searches the IRXANCHR table for the most recently allocated       */
 /*  (highest token) active, non-reentrant slot whose TCB matches      */
@@ -67,10 +68,10 @@ int irx_init_initenvb(struct envblock *prev_envblock,
 /*                                                                    */
 /*  Returns: 0=found (RC=0), 4=not found (RC=4, RSN=4).              */
 /* ------------------------------------------------------------------ */
-int irx_findenvb(struct envblock **out_envblock, int *out_reason_code);
+int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code);
 
 /* ------------------------------------------------------------------ */
-/*  irx_chekenvb - validate an ENVBLOCK address                  */
+/*  irx_init_chekenvb - validate an ENVBLOCK address                 */
 /*                                                                    */
 /*  Checks (1) that the caller-supplied address carries the           */
 /*  'ENVBLOCK' eye-catcher and (2) that it is registered in an        */
@@ -83,10 +84,10 @@ int irx_findenvb(struct envblock **out_envblock, int *out_reason_code);
 /*                                                                    */
 /*  Returns: 0=valid (RC=0), 20=invalid (RC=20, RSN set).            */
 /* ------------------------------------------------------------------ */
-int irx_chekenvb(struct envblock *envblock, int *out_reason_code);
+int irx_init_chekenvb(struct envblock *envblock, int *out_reason_code);
 
 /* ------------------------------------------------------------------ */
-/*  irx_dispatch - central IRXINIT function-code dispatcher      */
+/*  irx_init_dispatch - central IRXINIT function-code dispatcher     */
 /*                                                                    */
 /*  Routes on the 8-byte (CL8) function code string to the           */
 /*  appropriate C-core function.  Designed for WP-I1c.5 (HLASM       */
@@ -99,19 +100,21 @@ int irx_chekenvb(struct envblock *envblock, int *out_reason_code);
 /*    prev_envblock    - previous-env hint (INITENVB only).           */
 /*    caller_parmblock - caller PARMBLOCK (INITENVB only).            */
 /*    user_field       - user field value (INITENVB only).            */
-/*    envblock_inout   - [IN/OUT]: output for INITENVB / FINDENVB;   */
-/*                       the envblock to validate for CHEKENVB        */
-/*                       (*envblock_inout is the input address).      */
+/*    envblock_inout   - semantics depend on function code:           */
+/*                       INITENVB: [OUT] newly allocated ENVBLOCK.    */
+/*                       FINDENVB: [OUT] located non-reentrant env.  */
+/*                       CHEKENVB: [IN]  *envblock_inout is the       */
+/*                                 ENVBLOCK address to validate.      */
 /*    out_reason_code  - [OUT] reason code (0 on success).            */
 /*                                                                    */
 /*  Returns: as per the dispatched function code, or 20 on unknown   */
 /*           function code (out_reason_code = 12).                   */
 /* ------------------------------------------------------------------ */
-int irx_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
-                 struct envblock *prev_envblock,
-                 struct parmblock *caller_parmblock,
-                 uint32_t user_field,
-                 struct envblock **envblock_inout,
-                 int *out_reason_code);
+int irx_init_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
+                      struct envblock *prev_envblock,
+                      struct parmblock *caller_parmblock,
+                      uint32_t user_field,
+                      struct envblock **envblock_inout,
+                      int *out_reason_code);
 
 #endif /* IRX_INIT_H */

--- a/include/irxanchr.h
+++ b/include/irxanchr.h
@@ -148,7 +148,15 @@ typedef struct
 {
     uint32_t envblock_ptr; /* +0x00  ENVBLOCK addr; IRXANCHR_SLOT_FREE = free */
     uint32_t token;        /* +0x04  slot token returned to allocator         */
-    uint8_t rsvd1[16];     /* +0x08  reserved                                 */
+    uint8_t rsvd1[16];     /* +0x08  reserved on MVS (24-bit: envblock_ptr
+                            *        holds the full address).
+                            * On 64-bit cross-compile host only: bytes
+                            * [0..sizeof(void*)-1] stash the full envblock
+                            * pointer because envblock_ptr truncates to 32
+                            * bits.  Written by irx#anch.c alloc_slot(),
+                            * read by irx#init.c irx_init_findenvb().
+                            * No other writer exists; table_reset clears
+                            * all slots including rsvd1. */
     uint32_t anchor_hint;  /* +0x18  opaque hint for fast slot re-find        */
     uint32_t tcb_ptr;      /* +0x1C  TCB address at alloc time                */
     uint32_t flags;        /* +0x20  IRXANCHR_FLAG_IN_USE when active         */

--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -351,7 +351,7 @@ int irx_anchor_alloc_slot(void *envblock, void *tcb, uint32_t *out_token)
         slots[i].flags = IRXANCHR_FLAG_IN_USE;
 #ifndef __MVS__
         /* On the 64-bit cross-compile host, envblock_ptr truncates the
-         * pointer to 32 bits.  irx_findenvb needs to dereference
+         * pointer to 32 bits.  irx_init_findenvb needs to dereference
          * the envblock to read the RENTRANT flag; stash the full host
          * pointer in rsvd1[0..sizeof(void*)-1] so it can recover it.
          * rsvd1 is undefined-use reserved space — this is the only

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -466,7 +466,7 @@ cleanup:
 }
 
 /* ================================================================== */
-/*  irx_findenvb — FINDENVB C-core (WP-I1c.2)                   */
+/*  irx_init_findenvb — FINDENVB C-core (WP-I1c.2)                   */
 /*                                                                    */
 /*  Returns the most recently allocated (highest token) active,       */
 /*  non-reentrant IRXANCHR slot whose TCB matches PSATOLD.            */
@@ -483,7 +483,7 @@ cleanup:
 /*  Returns: 0=found, 4=no non-reentrant env on this TCB.            */
 /* ================================================================== */
 
-int irx_findenvb(struct envblock **out_envblock, int *out_reason_code)
+int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
 {
     irxanchr_header_t *hdr;
     irxanchr_entry_t *slots;
@@ -589,7 +589,7 @@ int irx_findenvb(struct envblock **out_envblock, int *out_reason_code)
 }
 
 /* ================================================================== */
-/*  irx_chekenvb — CHEKENVB C-core (WP-I1c.2)                   */
+/*  irx_init_chekenvb — CHEKENVB C-core (WP-I1c.2)                   */
 /*                                                                    */
 /*  Validates a caller-supplied ENVBLOCK address by checking          */
 /*  (1) the 'ENVBLOCK' eye-catcher at offset +0 and                  */
@@ -598,7 +598,7 @@ int irx_findenvb(struct envblock **out_envblock, int *out_reason_code)
 /*  Returns: 0=valid, 20=invalid (out_reason_code set).              */
 /* ================================================================== */
 
-int irx_chekenvb(struct envblock *envblock, int *out_reason_code)
+int irx_init_chekenvb(struct envblock *envblock, int *out_reason_code)
 {
     irxanchr_entry_t *slot;
 
@@ -629,7 +629,7 @@ int irx_chekenvb(struct envblock *envblock, int *out_reason_code)
 }
 
 /* ================================================================== */
-/*  irx_dispatch — central IRXINIT dispatcher (WP-I1c.2)             */
+/*  irx_init_dispatch — central IRXINIT dispatcher (WP-I1c.2)        */
 /*                                                                    */
 /*  Routes a CL8 function code to the appropriate C-core.            */
 /*  Designed so WP-I1c.5 (HLASM entry-point wrapper) can call a      */
@@ -638,12 +638,12 @@ int irx_chekenvb(struct envblock *envblock, int *out_reason_code)
 /*  Unknown function code: RC=20, RSN=12.                            */
 /* ================================================================== */
 
-int irx_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
-                 struct envblock *prev_envblock,
-                 struct parmblock *caller_parmblock,
-                 uint32_t user_field,
-                 struct envblock **envblock_inout,
-                 int *out_reason_code)
+int irx_init_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
+                      struct envblock *prev_envblock,
+                      struct parmblock *caller_parmblock,
+                      uint32_t user_field,
+                      struct envblock **envblock_inout,
+                      int *out_reason_code)
 {
     if (funccode == NULL || envblock_inout == NULL || out_reason_code == NULL)
     {
@@ -665,7 +665,7 @@ int irx_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
         (void)prev_envblock;
         (void)caller_parmblock;
         (void)user_field;
-        return irx_findenvb(envblock_inout, out_reason_code);
+        return irx_init_findenvb(envblock_inout, out_reason_code);
     }
 
     if (memcmp(funccode, "CHEKENVB", 8) == 0)
@@ -673,7 +673,7 @@ int irx_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
         (void)prev_envblock;
         (void)caller_parmblock;
         (void)user_field;
-        return irx_chekenvb(*envblock_inout, out_reason_code);
+        return irx_init_chekenvb(*envblock_inout, out_reason_code);
     }
 
     *out_reason_code = 12;

--- a/test/mvs/tstfind.c
+++ b/test/mvs/tstfind.c
@@ -1,8 +1,8 @@
 /* ------------------------------------------------------------------ */
 /*  tstfind.c - WP-I1c.2 IRXINIT FINDENVB + CHEKENVB tests           */
 /*                                                                    */
-/*  Tests irx_findenvb() and irx_chekenvb().                */
-/*  Also exercises irx_dispatch() for both function codes.       */
+/*  Tests irx_init_findenvb() and irx_init_chekenvb().                */
+/*  Also exercises irx_init_dispatch() for both function codes.       */
 /*                                                                    */
 /*  Test cases:                                                       */
 /*                                                                    */
@@ -11,7 +11,7 @@
 /*  F2: One non-reentrant env on current TCB — RC=0, correct envblk  */
 /*  F3: One reentrant env on current TCB — RC=4, RSN=4               */
 /*  F4: Two non-reentrant envs on same TCB — returns highest token   */
-/*  F5: via irx_dispatch("FINDENVB") — same result              */
+/*  F5: via irx_init_dispatch("FINDENVB") — same result              */
 /*                                                                    */
 /*  Note: F2 and F4 require a real PSATOLD (MVS-only). On the host   */
 /*  cross-compile, the TCB address is 0 and all irx_init_initenvb()  */
@@ -25,7 +25,7 @@
 /*  C3: Stack envblock with bad eye-catcher — RC=20, RSN=4           */
 /*  C4: Stack envblock with correct eye-catcher, not in IRXANCHR —   */
 /*      RC=20, RSN=8                                                  */
-/*  C5: via irx_dispatch("CHEKENVB") — same result as direct    */
+/*  C5: via irx_init_dispatch("CHEKENVB") — same result as direct    */
 /*                                                                    */
 /*  Cross-compile build:                                              */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
@@ -95,7 +95,7 @@ static void test_f1_empty_table(void)
 
     irx_anchor_table_reset();
 
-    rc = irx_findenvb(&found, &reason);
+    rc = irx_init_findenvb(&found, &reason);
 
     CHECK(rc == 4, "findenvb returns 4 when table is empty");
     CHECK(found == NULL, "out_envblock is NULL when not found");
@@ -141,7 +141,7 @@ static void test_f2_nonreentrant_env(void)
 
     found = NULL;
     reason = -1;
-    rc = irx_findenvb(&found, &reason);
+    rc = irx_init_findenvb(&found, &reason);
 
     CHECK(rc == 0, "findenvb returns 0 for non-reentrant env on current TCB");
     CHECK(found == envblk, "findenvb returns the correct envblock");
@@ -192,7 +192,7 @@ static void test_f3_reentrant_env(void)
 
     found = NULL;
     reason = -1;
-    rc = irx_findenvb(&found, &reason);
+    rc = irx_init_findenvb(&found, &reason);
 
     CHECK(rc == 4, "findenvb returns 4 when only reentrant env is present");
     CHECK(found == NULL, "out_envblock is NULL for reentrant-only table");
@@ -243,7 +243,7 @@ static void test_f4_highest_token_returned(void)
 
     found = NULL;
     reason = -1;
-    rc = irx_findenvb(&found, &reason);
+    rc = irx_init_findenvb(&found, &reason);
 
     CHECK(rc == 0, "findenvb returns 0 with two non-reentrant envs");
     /* env2 was allocated last → higher token → must be returned. */
@@ -254,7 +254,7 @@ static void test_f4_highest_token_returned(void)
 }
 
 /* ------------------------------------------------------------------ */
-/*  F5: irx_dispatch("FINDENVB") — same result as direct call    */
+/*  F5: irx_init_dispatch("FINDENVB") — same result as direct call    */
 /* ------------------------------------------------------------------ */
 
 static void test_f5_dispatch_findenvb(void)
@@ -286,7 +286,7 @@ static void test_f5_dispatch_findenvb(void)
 
     found = NULL;
     reason = -1;
-    rc = irx_dispatch("FINDENVB", NULL, NULL, 0, &found, &reason);
+    rc = irx_init_dispatch("FINDENVB", NULL, NULL, 0, &found, &reason);
 
     CHECK(rc == 0, "dispatch FINDENVB returns 0");
     CHECK(found == envblk, "dispatch FINDENVB returns correct envblock");
@@ -312,7 +312,7 @@ static void test_c1_null_envblock(void)
 
     irx_anchor_table_reset();
 
-    rc = irx_chekenvb(NULL, &reason);
+    rc = irx_init_chekenvb(NULL, &reason);
 
     CHECK(rc == 20, "chekenvb returns 20 for NULL envblock");
     CHECK(reason == 4, "reason code is 4 for NULL (bad eye-catcher)");
@@ -349,7 +349,7 @@ static void test_c2_valid_envblock(void)
     }
 
     reason = -1;
-    rc = irx_chekenvb(envblk, &reason);
+    rc = irx_init_chekenvb(envblk, &reason);
 
     CHECK(rc == 0, "chekenvb returns 0 for valid registered envblock");
     CHECK(reason == 0, "reason code is 0 on success");
@@ -374,7 +374,7 @@ static void test_c3_bad_eyecatcher(void)
     memset(&fake, 0, sizeof(fake));
     memcpy(fake.envblock_id, "GARBAGE!", 8);
 
-    rc = irx_chekenvb(&fake, &reason);
+    rc = irx_init_chekenvb(&fake, &reason);
 
     CHECK(rc == 20, "chekenvb returns 20 for bad eye-catcher");
     CHECK(reason == 4, "reason code is 4 for bad eye-catcher");
@@ -401,14 +401,14 @@ static void test_c4_not_in_anchor(void)
     memcpy(unregistered.envblock_id, ENVBLOCK_ID, 8);
     memcpy(unregistered.envblock_version, ENVBLOCK_VERSION_0042, 4);
 
-    rc = irx_chekenvb(&unregistered, &reason);
+    rc = irx_init_chekenvb(&unregistered, &reason);
 
     CHECK(rc == 20, "chekenvb returns 20 when not in IRXANCHR");
     CHECK(reason == 8, "reason code is 8 (not registered)");
 }
 
 /* ------------------------------------------------------------------ */
-/*  C5: irx_dispatch("CHEKENVB") — same result as direct call    */
+/*  C5: irx_init_dispatch("CHEKENVB") — same result as direct call    */
 /* ------------------------------------------------------------------ */
 
 static void test_c5_dispatch_chekenvb(void)
@@ -427,7 +427,7 @@ static void test_c5_dispatch_chekenvb(void)
     eb = &fake;
 
     /* Pass the bad-eye-catcher case through the dispatcher. */
-    rc = irx_dispatch("CHEKENVB", NULL, NULL, 0, &eb, &reason);
+    rc = irx_init_dispatch("CHEKENVB", NULL, NULL, 0, &eb, &reason);
 
     CHECK(rc == 20, "dispatch CHEKENVB returns 20 for bad eye-catcher");
     CHECK(reason == 4, "dispatch CHEKENVB reason is 4");


### PR DESCRIPTION
Fixes #70

Four polish items from the WP-I1c.2 PR review (no behaviour changes).

## Changes

**A) Naming consistency (`irx_init_*` prefix)**
Renamed the three functions that were missing the `_init_` infix to match `irx_init_initenvb()`:
- `irx_findenvb` → `irx_init_findenvb`
- `irx_chekenvb` → `irx_init_chekenvb`
- `irx_dispatch` → `irx_init_dispatch`

Updated everywhere: `include/irx_init.h`, `src/irx#init.c`, `test/mvs/tstfind.c`, comment in `src/irx#anch.c`.

**B) Dispatcher `envblock_inout` semantics**
Expanded the `irx_init_dispatch()` header comment to document the per-function-code IN/OUT direction of `envblock_inout` (OUT for INITENVB/FINDENVB, IN for CHEKENVB).

**C) CON-3 wording in `irx_init.h`**
Updated the CON-3 reference from "unconditional overwrite, live-verified" to the softened wording from 2026-04-24: greenfield-verified, non-greenfield TBD pending IRXPROBE.

**D) `rsvd1` host-pointer stash documented in `irxanchr.h`**
Added a comment to `irxanchr_entry_t.rsvd1` explaining the `#ifndef __MVS__` convention: bytes [0..sizeof(void*)-1] stash the full 64-bit `envblock` pointer on 64-bit hosts to work around the 32-bit `envblock_ptr` truncation. Names writers and readers so no one silently breaks the convention.

## Test results

All 16 cross-compile test suites green — 1156+ tests, 24/24 tstfind.