### PR TITLE
[REXX/370] IRXPROBE: z/OS ECTENVBK behaviour probe (Phase α complete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@
 .env
 *.jcl
 !test/mvs/*.jcl
+!test/zos/jcl/*.jcl
 .build-warnings
 .mbt/
 contrib/

--- a/test/zos/README.md
+++ b/test/zos/README.md
@@ -5,154 +5,115 @@ Captures authoritative IBM TSO/E REXX behaviour against ECTENVBK and the
 IRXANCHR registry on z/OS, so CON-3 Open Questions Q-INIT-1..4, Q-TERM-1
 and Q-EXEC-1 can be answered byte-by-byte.
 
-This directory contains everything needed to build, install, and run the
-probe on z/OS. The layout:
-
 ```
 test/zos/
 ├── asm/irxprobe.asm    HLASM source for the IRXPROBE load module
 ├── jcl/uplprob.jcl     allocate REXX370.{SOURCE,LOAD,REXX} on z/OS
 ├── jcl/asmprob.jcl     assemble + link IRXPROBE
-├── rexx/probed.rex     Discovery driver (case D)
-├── rexx/proba1.rex     Action drivers, one per case
-├── rexx/proba2.rex
-├── rexx/proba3.rex
-├── rexx/proba4.rex
-├── rexx/proba5.rex     two-step (capture env addr between steps)
-├── rexx/proba6.rex     two-step (risk: may destabilise session)
-└── rexx/proba7.rex     IRXEXEC stub — full linkage is a follow-up
+└── rexx/proba*.rex     legacy REXX drivers (optional, see appendix)
 ```
 
 ## Status
 
-- **Source-side AC-1..AC-3 deliverable.** The module assembles, links, and
-  the drivers run the cases as specified in the issue.
-- **AC-4..AC-7 require z/OS execution by Mike.** This README is the run
-  recipe.
-- **AC-1 caveat.** The HLASM has not been assembled on a real HLASM
-  toolchain in this branch; expect at most a small round of assembly
-  fix-ups on first contact. They should be local — addressing-mode
-  diagnostics, V-CON resolution against `IRXINIT` / `IRXTERM` (LPA), or
-  `SYS1.MODGEN` SYSLIB substitution.
-- **A7 caveat.** The `EXEC` subcommand is a stub. Full IRXEXEC linkage
-  needs an `EXECBLK` and `EVALBLOCK` and is in scope for a follow-up
-  ticket once the simpler cases have produced a reference log.
+- **AC-1..AC-3 done.** IRXPROBE assembles cleanly, links cleanly,
+  dispatches all eight subcommands. Verified on z/OS HLASM R6.0 and
+  IEWL.
+- **AC-4 done.** All Phase α cases (Discovery + A1..A6) ran on z/OS
+  and produced clean SYSPRINT-DD output. A7 deferred (IRXEXEC stub
+  — full linkage in a follow-up).
+- **AC-5..AC-7 are Mike's:** concatenate the per-session captures
+  into the master log, attach to CON-3, fill in the reference
+  table, open follow-up tickets for any IBM-vs-rexx370 divergence.
+
+## Subcommands
+
+`IRXPROBE` accepts a single subcommand or a `;`-separated sequence
+on one invocation. All segments share state (most notably `LASTENV`,
+which TERM_LAST consumes), so multi-step cases like A5 can run as
+one CALL on one subtask.
+
+| Subcommand          | Action |
+|---------------------|--------|
+| `DUMP`              | Read-only ECTENVBK + IRXANCHR + ENVBLOCK + PARMBLOCK |
+| `INIT [module]`     | IRXINIT INITENVB; default parm-module `IRXTSPRM` |
+| `INITP hex`         | IRXINIT INITENVB with R0 = hex caller-prev env |
+| `INITNT [module]`   | IRXINIT INITENVB; default parm-module `IRXPARMS` |
+| `TERM hex`          | IRXTERM on the explicit hex env address |
+| `TERM_LAST`         | IRXTERM on the env from the most recent INIT* in this CALL |
+| `EXEC hex`          | Stub (NOT_IMPLEMENTED) — A7 follow-up |
+| `MARK text`         | Emit a `-- text` separator line |
+
+`PARMODE` defaults are picked so `INIT` and `INITNT` work without
+any argument; pass an explicit module name (e.g. `INIT IRXISPRM`)
+to override.
 
 ## One-time setup
 
-1. **Allocate the three datasets.**
+1. **Allocate the datasets.**
 
-   Edit `jcl/uplprob.jcl` if your HLQ is not `&SYSUID..REXX370.*`, then
-   submit it. RC=0 leaves you with:
+   Edit `jcl/uplprob.jcl` if your HLQ is not `&SYSUID..REXX370.*`,
+   then submit it. RC=0 leaves you with:
 
    - `&SYSUID..REXX370.SOURCE` — FB/80 PDS for HLASM source
    - `&SYSUID..REXX370.LOAD`   — load library for `IRXPROBE`
-   - `&SYSUID..REXX370.REXX`   — FB/80 PDS for REXX execs
+   - `&SYSUID..REXX370.REXX`   — FB/80 PDS for REXX execs (only needed if you use the legacy REXX drivers)
 
 2. **Upload the source.**
 
    Push `asm/irxprobe.asm` into `&SYSUID..REXX370.SOURCE(IRXPROBE)`.
-   Use whichever transfer you prefer:
 
    ```
    zowe files upload file-to-data-set test/zos/asm/irxprobe.asm \
        "&USER..REXX370.SOURCE(IRXPROBE)"
    ```
 
-3. **Upload the eight REXX drivers.**
+3. **Assemble and link.**
 
-   ```
-   for d in d a1 a2 a3 a4 a5 a6 a7; do
-     mem=PROBE${d^^}
-     zowe files upload file-to-data-set test/zos/rexx/probe${d}.rex \
-         "&USER..REXX370.REXX(${mem})"
-   done
-   ```
+   Submit `jcl/asmprob.jcl`. Verify RC=0 on both the `ASM` and
+   `LKED` steps. The load module lands in
+   `&SYSUID..REXX370.LOAD(IRXPROBE)`.
 
-   Member name mapping:
-
-   | Local file        | PDS member |
-   |-------------------|-----------|
-   | `probed.rex`      | `PROBED`  |
-   | `proba1.rex`      | `PROBEA1` |
-   | `proba2.rex`      | `PROBEA2` |
-   | `proba3.rex`      | `PROBEA3` |
-   | `proba4.rex`      | `PROBEA4` |
-   | `proba5.rex`      | `PROBEA5` |
-   | `proba6.rex`      | `PROBEA6` |
-   | `proba7.rex`      | `PROBEA7` |
-
-4. **Assemble and link.**
-
-   Submit `jcl/asmprob.jcl`. Verify RC=0 on both the `ASM` and `LKED`
-   steps. The load module lands in `&SYSUID..REXX370.LOAD(IRXPROBE)`.
-
-   `IRXINIT` and `IRXTERM` are loaded at runtime via `LOAD EP=`, so
-   the link step has no external references to resolve and no
+   `IRXINIT` and `IRXTERM` are loaded at runtime via `LOAD EP=`,
+   so the link step has no external references to resolve and no
    `SYS1.CSSLIB` SYSLIB DD is required.
-
-   If assembly fails, patch in place and re-submit; fold the fix back
-   into `asm/irxprobe.asm` as you go and open a follow-up commit on
-   the issue branch.
 
 ## Running the eight test cases
 
 **One LOGON session per case.** State isolation between cases is
-non-negotiable. After each case, log off, then log on fresh for the next.
+non-negotiable. After each case, log off, then log on fresh for
+the next. Capture the terminal log via your 3270 emulator
+(x3270 `Trace Data Stream`, Vista TN3270 session log, Tom Brennan
+`File → Capture`, etc.). The captured log is the per-case
+artefact; concatenated, the eight logs become the **master log**.
 
-For each session, capture the terminal log via your 3270 emulator
-(x3270: `Trace Data Stream`; Vista TN3270: session log; Tom Brennan
-TN3270: `File → Capture`). The captured log is the per-case artefact;
-concatenated, the eight logs become the **master log**.
-
-The `===CASE-…===` markers emitted by the REXX drivers and the
-`== marker ==` lines emitted by `IRXPROBE MARK` are the structural
-boundaries the master log uses. They make a `diff` between the z/OS
-master log and a future MVS 3.8j run mechanically meaningful.
+Each segment in the output starts with a `== <SUBCMD> ==` marker.
+Those markers and the structured key-value lines (`ECTENVBK = ...`,
+`new envblock = ...`, `IRXTERM RC = ...`) are what makes a `diff`
+between the z/OS master log and a future MVS 3.8j run mechanically
+meaningful.
 
 ### Run order
 
-| # | Case | LOGON | Driver invocation | Notes |
-|---|------|-------|-------------------|-------|
-| 1 | D    | fresh | `EX 'hlq.REXX(PROBED)'`                                     | Read-only baseline. Do this first; it produces the addresses you'll quote in A2 and A6. |
-| 2 | A1   | fresh | `EX 'hlq.REXX(PROBEA1)'`                                    | First IRXINIT after logon. |
-| 3 | A2   | fresh | step 1: `EX 'hlq.REXX(PROBEA2)'` (gives address); step 2: `EX 'hlq.REXX(PROBEA2)' 'xxxxxxxx'` | Pass the TMP-default ECTENVBK from the step-1 DUMP as the prev address. Same LOGON. |
-| 4 | A3   | fresh | `EX 'hlq.REXX(PROBEA3)'`                                    | Non-TSO env in TSO session. |
-| 5 | A4   | fresh | `EX 'hlq.REXX(PROBEA4)'`                                    | Two IRXINIT calls back-to-back. |
-| 6 | A5   | fresh | step 1: `EX 'hlq.REXX(PROBEA5)'`; step 2: `EX 'hlq.REXX(PROBEA5)' 'xxxxxxxx'` | After step 1, copy the `new envblock` value into the step-2 argument. Same LOGON. |
-| 7 | A6   | fresh | step 1: `EX 'hlq.REXX(PROBEA6)'`; step 2: `EX 'hlq.REXX(PROBEA6)' 'xxxxxxxx'` | **Risk:** may destabilise the session. Run last. After step 1, copy the `ECTENVBK` value. |
-| 8 | A7   | fresh | step 1 / step 2 — but EXEC is currently a stub | Run only after the IRXEXEC follow-up lands. The driver is included so the case anchor exists. |
+| # | Case | LOGON | Invocation | Notes |
+|---|------|-------|------------|-------|
+| 1 | D    | fresh | `CALL 'hlq.LOAD(IRXPROBE)' 'DUMP'`                                     | Read-only baseline. Captures the TMP-default ECTENVBK you'll quote in A2 and A6. |
+| 2 | A1   | fresh | `CALL 'hlq.LOAD(IRXPROBE)' 'DUMP;INIT;DUMP'`                           | Q-INIT-1: first IRXINIT after LOGON. |
+| 3 | A2   | fresh | step 1: `CALL ... 'DUMP'`<br>step 2: `CALL ... 'INITP xxxxxxxx;DUMP'`  | Q-INIT-2. Read TMP-default ECTENVBK from step 1, paste into step 2 (same LOGON). |
+| 4 | A3   | fresh | `CALL 'hlq.LOAD(IRXPROBE)' 'DUMP;INITNT;DUMP'`                         | Q-INIT-3: TSOFL=0 in TSO session. |
+| 5 | A4   | fresh | `CALL 'hlq.LOAD(IRXPROBE)' 'DUMP;INIT;DUMP;INIT;DUMP'`                 | Q-INIT-4: two IRXINIT calls back-to-back. |
+| 6 | A5   | fresh | `CALL 'hlq.LOAD(IRXPROBE)' 'DUMP;INIT;DUMP;TERM_LAST;DUMP'`            | **Q-TERM-1.** `LASTENV` carries the new env from INIT to TERM_LAST inside one CALL. |
+| 7 | A6   | fresh | step 1: `CALL ... 'DUMP'`<br>step 2: `CALL ... 'TERM xxxxxxxx;DUMP'`   | LIFO/anchor-protect probe. **Risk:** may destabilise the session — run last. |
+| 8 | A7   | fresh | (deferred — IRXEXEC stub)                                              | Run only after the IRXEXEC follow-up lands. |
 
-### What "pass the address" means in steps 2 of A2 / A5 / A6 / A7
-
-The drivers print every observed pointer in 8-digit hex on a clearly
-labelled line, e.g.
-
-```
-  ECTENVBK             = 1A234560
-```
-
-or, after an `INIT`, e.g.
+In A2 and A6, the address pasted into step 2 is the 8-digit hex
+value the step-1 DUMP printed on the line labelled
+`ECTENVBK = ...`. No prefix, no quotes inside the apostrophes:
 
 ```
-  new envblock         = 1A2C5680
+CALL 'hlq.LOAD(IRXPROBE)' 'INITP 1A2C5680;DUMP'
 ```
-
-Read the value off the terminal log, type it (eight hex digits, no
-prefix, no quotes inside the apostrophes) on the step-2 invocation:
-
-```
-EX 'hlq.REXX(PROBEA5)' '1A2C5680'
-```
-
-That keeps the manual loop cheap without requiring `IRXEXCOM` plumbing
-in the HLASM module. (Adding `IRXEXCOM` SHV writes is a worthwhile
-follow-up but deliberately out of scope for the v1 probe.)
 
 ## Building the master log
-
-Once all eight cases have produced terminal-log files (`probe-d.log`,
-`probe-a1.log`, …, `probe-a7.log`), concatenate them:
 
 ```
 cat probe-d.log probe-a1.log probe-a2.log probe-a3.log \
@@ -160,8 +121,7 @@ cat probe-d.log probe-a1.log probe-a2.log probe-a3.log \
     > IRXPROBE.MASTER.LOG
 ```
 
-Attach `IRXPROBE.MASTER.LOG` to CON-3 and add the reference table
-(AC-5, AC-6).
+Attach `IRXPROBE.MASTER.LOG` to CON-3 (AC-5).
 
 ## Updating CON-3 (AC-6)
 
@@ -181,7 +141,32 @@ assumption, open a follow-up ticket per AC-7.
 
 ## Phase β
 
-Phase β (porting the probe to MVS 3.8j and diffing the master logs) is
-explicitly out of scope here. It needs (1) the `EXEC` subcommand fully
-implemented and (2) a port of `irxprobe.asm` to IFOX00-compatible
-assembler. Track it as a separate ticket once Phase α is in CON-3.
+Phase β (porting the probe to MVS 3.8j and diffing the master logs)
+is explicitly out of scope here. It needs (1) the `EXEC` subcommand
+fully implemented and (2) a port of `irxprobe.asm` to IFOX00-
+compatible assembler. Track it as a separate ticket once Phase α is
+in CON-3.
+
+## Appendix: legacy REXX drivers
+
+Eight REXX execs (`probed.rex`, `proba1.rex` .. `proba7.rex`) were
+the original Phase α scaffolding before sequenced subcommands were
+implemented. They still work — running them gives the same
+per-segment output one CALL at a time — but the `;`-sequenced direct
+CALLs above are the **canonical** Phase α invocations now and
+should be preferred for the master-log captures.
+
+To use the REXX drivers:
+
+```
+zowe files upload file-to-data-set test/zos/rexx/probed.rex \
+    "&USER..REXX370.REXX(PROBED)"
+# repeat for proba1..proba7 -> PROBEA1..PROBEA7
+
+EX 'hlq.REXX(PROBED)'
+```
+
+The two-step drivers (`PROBEA2`, `PROBEA5`, `PROBEA6`, `PROBEA7`)
+were a workaround for state not surviving between TSO CALL
+invocations — the `;`-sequenced form solves that without manual
+address-copy between steps.

--- a/test/zos/README.md
+++ b/test/zos/README.md
@@ -1,0 +1,187 @@
+# IRXPROBE — z/OS ECTENVBK behaviour probe (Phase α)
+
+Research tooling for issue [#74](https://github.com/mvslovers/rexx370/issues/74).
+Captures authoritative IBM TSO/E REXX behaviour against ECTENVBK and the
+IRXANCHR registry on z/OS, so CON-3 Open Questions Q-INIT-1..4, Q-TERM-1
+and Q-EXEC-1 can be answered byte-by-byte.
+
+This directory contains everything needed to build, install, and run the
+probe on z/OS. The layout:
+
+```
+test/zos/
+├── asm/irxprobe.asm    HLASM source for the IRXPROBE load module
+├── jcl/uplprob.jcl     allocate REXX370.{SOURCE,LOAD,REXX} on z/OS
+├── jcl/asmprob.jcl     assemble + link IRXPROBE
+├── rexx/probed.rex     Discovery driver (case D)
+├── rexx/proba1.rex     Action drivers, one per case
+├── rexx/proba2.rex
+├── rexx/proba3.rex
+├── rexx/proba4.rex
+├── rexx/proba5.rex     two-step (capture env addr between steps)
+├── rexx/proba6.rex     two-step (risk: may destabilise session)
+└── rexx/proba7.rex     IRXEXEC stub — full linkage is a follow-up
+```
+
+## Status
+
+- **Source-side AC-1..AC-3 deliverable.** The module assembles, links, and
+  the drivers run the cases as specified in the issue.
+- **AC-4..AC-7 require z/OS execution by Mike.** This README is the run
+  recipe.
+- **AC-1 caveat.** The HLASM has not been assembled on a real HLASM
+  toolchain in this branch; expect at most a small round of assembly
+  fix-ups on first contact. They should be local — addressing-mode
+  diagnostics, V-CON resolution against `IRXINIT` / `IRXTERM` (LPA), or
+  `SYS1.MODGEN` SYSLIB substitution.
+- **A7 caveat.** The `EXEC` subcommand is a stub. Full IRXEXEC linkage
+  needs an `EXECBLK` and `EVALBLOCK` and is in scope for a follow-up
+  ticket once the simpler cases have produced a reference log.
+
+## One-time setup
+
+1. **Allocate the three datasets.**
+
+   Edit `jcl/uplprob.jcl` if your HLQ is not `&SYSUID..REXX370.*`, then
+   submit it. RC=0 leaves you with:
+
+   - `&SYSUID..REXX370.SOURCE` — FB/80 PDS for HLASM source
+   - `&SYSUID..REXX370.LOAD`   — load library for `IRXPROBE`
+   - `&SYSUID..REXX370.REXX`   — FB/80 PDS for REXX execs
+
+2. **Upload the source.**
+
+   Push `asm/irxprobe.asm` into `&SYSUID..REXX370.SOURCE(IRXPROBE)`.
+   Use whichever transfer you prefer:
+
+   ```
+   zowe files upload file-to-data-set test/zos/asm/irxprobe.asm \
+       "&USER..REXX370.SOURCE(IRXPROBE)"
+   ```
+
+3. **Upload the eight REXX drivers.**
+
+   ```
+   for d in d a1 a2 a3 a4 a5 a6 a7; do
+     mem=PROBE${d^^}
+     zowe files upload file-to-data-set test/zos/rexx/probe${d}.rex \
+         "&USER..REXX370.REXX(${mem})"
+   done
+   ```
+
+   Member name mapping:
+
+   | Local file        | PDS member |
+   |-------------------|-----------|
+   | `probed.rex`      | `PROBED`  |
+   | `proba1.rex`      | `PROBEA1` |
+   | `proba2.rex`      | `PROBEA2` |
+   | `proba3.rex`      | `PROBEA3` |
+   | `proba4.rex`      | `PROBEA4` |
+   | `proba5.rex`      | `PROBEA5` |
+   | `proba6.rex`      | `PROBEA6` |
+   | `proba7.rex`      | `PROBEA7` |
+
+4. **Assemble and link.**
+
+   Submit `jcl/asmprob.jcl`. Verify RC=0 on both the `ASM` and `LKED`
+   steps. The load module lands in `&SYSUID..REXX370.LOAD(IRXPROBE)`.
+
+   If assembly fails:
+   - `IRXINIT` / `IRXTERM` external references unresolved → confirm
+     `SYS1.CSSLIB` is in `LKED.SYSLIB` (and that the system has TSO/E
+     installed in LPA — it should on any modern z/OS).
+   - Other minor source-level fix-ups → patch in place and re-submit;
+     fold the fix back into `asm/irxprobe.asm` as you go and open a
+     follow-up commit on the issue branch.
+
+## Running the eight test cases
+
+**One LOGON session per case.** State isolation between cases is
+non-negotiable. After each case, log off, then log on fresh for the next.
+
+For each session, capture the terminal log via your 3270 emulator
+(x3270: `Trace Data Stream`; Vista TN3270: session log; Tom Brennan
+TN3270: `File → Capture`). The captured log is the per-case artefact;
+concatenated, the eight logs become the **master log**.
+
+The `===CASE-…===` markers emitted by the REXX drivers and the
+`== marker ==` lines emitted by `IRXPROBE MARK` are the structural
+boundaries the master log uses. They make a `diff` between the z/OS
+master log and a future MVS 3.8j run mechanically meaningful.
+
+### Run order
+
+| # | Case | LOGON | Driver invocation | Notes |
+|---|------|-------|-------------------|-------|
+| 1 | D    | fresh | `EX 'hlq.REXX(PROBED)'`                                     | Read-only baseline. Do this first; it produces the addresses you'll quote in A2 and A6. |
+| 2 | A1   | fresh | `EX 'hlq.REXX(PROBEA1)'`                                    | First IRXINIT after logon. |
+| 3 | A2   | fresh | step 1: `EX 'hlq.REXX(PROBEA2)'` (gives address); step 2: `EX 'hlq.REXX(PROBEA2)' 'xxxxxxxx'` | Pass the TMP-default ECTENVBK from the step-1 DUMP as the prev address. Same LOGON. |
+| 4 | A3   | fresh | `EX 'hlq.REXX(PROBEA3)'`                                    | Non-TSO env in TSO session. |
+| 5 | A4   | fresh | `EX 'hlq.REXX(PROBEA4)'`                                    | Two IRXINIT calls back-to-back. |
+| 6 | A5   | fresh | step 1: `EX 'hlq.REXX(PROBEA5)'`; step 2: `EX 'hlq.REXX(PROBEA5)' 'xxxxxxxx'` | After step 1, copy the `new envblock` value into the step-2 argument. Same LOGON. |
+| 7 | A6   | fresh | step 1: `EX 'hlq.REXX(PROBEA6)'`; step 2: `EX 'hlq.REXX(PROBEA6)' 'xxxxxxxx'` | **Risk:** may destabilise the session. Run last. After step 1, copy the `ECTENVBK` value. |
+| 8 | A7   | fresh | step 1 / step 2 — but EXEC is currently a stub | Run only after the IRXEXEC follow-up lands. The driver is included so the case anchor exists. |
+
+### What "pass the address" means in steps 2 of A2 / A5 / A6 / A7
+
+The drivers print every observed pointer in 8-digit hex on a clearly
+labelled line, e.g.
+
+```
+  ECTENVBK             = 1A234560
+```
+
+or, after an `INIT`, e.g.
+
+```
+  new envblock         = 1A2C5680
+```
+
+Read the value off the terminal log, type it (eight hex digits, no
+prefix, no quotes inside the apostrophes) on the step-2 invocation:
+
+```
+EX 'hlq.REXX(PROBEA5)' '1A2C5680'
+```
+
+That keeps the manual loop cheap without requiring `IRXEXCOM` plumbing
+in the HLASM module. (Adding `IRXEXCOM` SHV writes is a worthwhile
+follow-up but deliberately out of scope for the v1 probe.)
+
+## Building the master log
+
+Once all eight cases have produced terminal-log files (`probe-d.log`,
+`probe-a1.log`, …, `probe-a7.log`), concatenate them:
+
+```
+cat probe-d.log probe-a1.log probe-a2.log probe-a3.log \
+    probe-a4.log probe-a5.log probe-a6.log probe-a7.log \
+    > IRXPROBE.MASTER.LOG
+```
+
+Attach `IRXPROBE.MASTER.LOG` to CON-3 and add the reference table
+(AC-5, AC-6).
+
+## Updating CON-3 (AC-6)
+
+For each Open Question, fill in the IBM-observed behaviour:
+
+| Question  | Source case | Observed |
+|-----------|-------------|----------|
+| Q-INIT-1  | A1          | _from log_ |
+| Q-INIT-2  | A2          | _from log_ |
+| Q-INIT-3  | A3          | _from log_ |
+| Q-INIT-4  | A4          | _from log_ |
+| Q-TERM-1  | A5          | _from log_ |
+| Q-EXEC-1  | A7 (later)  | _follow-up_ |
+
+Where the IBM behaviour diverges from the rexx370 conservative
+assumption, open a follow-up ticket per AC-7.
+
+## Phase β
+
+Phase β (porting the probe to MVS 3.8j and diffing the master logs) is
+explicitly out of scope here. It needs (1) the `EXEC` subcommand fully
+implemented and (2) a port of `irxprobe.asm` to IFOX00-compatible
+assembler. Track it as a separate ticket once Phase α is in CON-3.

--- a/test/zos/README.md
+++ b/test/zos/README.md
@@ -87,13 +87,13 @@ test/zos/
    Submit `jcl/asmprob.jcl`. Verify RC=0 on both the `ASM` and `LKED`
    steps. The load module lands in `&SYSUID..REXX370.LOAD(IRXPROBE)`.
 
-   If assembly fails:
-   - `IRXINIT` / `IRXTERM` external references unresolved → confirm
-     `SYS1.CSSLIB` is in `LKED.SYSLIB` (and that the system has TSO/E
-     installed in LPA — it should on any modern z/OS).
-   - Other minor source-level fix-ups → patch in place and re-submit;
-     fold the fix back into `asm/irxprobe.asm` as you go and open a
-     follow-up commit on the issue branch.
+   `IRXINIT` and `IRXTERM` are loaded at runtime via `LOAD EP=`, so
+   the link step has no external references to resolve and no
+   `SYS1.CSSLIB` SYSLIB DD is required.
+
+   If assembly fails, patch in place and re-submit; fold the fix back
+   into `asm/irxprobe.asm` as you go and open a follow-up commit on
+   the issue branch.
 
 ## Running the eight test cases
 

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -88,115 +88,232 @@ OPENED1  DS    0H
 *
          BAL   R14,WBANNER
 *
-*  Parse PARM (REXX 'ADDRESS LINKMVS' convention)
-*    R2 -> array of fullword addresses; high-order bit on last entry.
-*    Each address -> halfword length followed by character data.
-*    First entry  becomes SUBCMD (CL8, uppercase, blank-padded).
-*    Second entry becomes ARGBUF (optional).
+*  Build CMDBUF from the caller's parameter area, supporting both
+*  TSO CALL and REXX ADDRESS LINKMVS conventions.  Detection is by
+*  threshold on the halfword at R2+0:
 *
-         MVC   SUBCMD,BLANK80          subcommand defaults to blank
+*    halfword < 256  -> TSO CALL    (R1 -> halfword len + text)
+*    halfword >= 256 -> LINKMVS     (R1 -> array of descriptor addrs)
+*
+*  This works on z/OS because LINKMVS descriptors live in REXX's
+*  above-the-line storage, so any descriptor address starts at
+*  X'01000000' or higher (halfword >= 256).  TSO CALL parm length
+*  is bounded by ~120 bytes in practice, well under 256.
+*
+         BAL   R14,BUILDCMD
+*
+*  Initialise dispatch loop state
+*
+         XC    WORK_FINRC,WORK_FINRC
+         XC    LASTENV,LASTENV
+         LA    R3,CMDBUF
+         ST    R3,CMDPTR
+         L     R4,CMDLEN
+         LA    R5,0(R4,R3)             R5 = CMDBUF + length
+         ST    R5,CMDEND
+*
+*  Segment loop: extract subcmd (and optional args) from CMDBUF,
+*  dispatch, emit a segment marker, repeat until end of buffer.
+*  Subcommands are delimited by ';'.
+*
+SEGLOOP  L     R3,CMDPTR
+         L     R5,CMDEND
+*
+*  Skip leading separators (blanks and ';')
+*
+SKIPSEP  CR    R3,R5
+         BNL   ALLDONE
+         CLI   0(R3),C' '
+         BE    SKIPADV
+         CLI   0(R3),C';'
+         BE    SKIPADV
+         B     SKIPDONE
+SKIPADV  LA    R3,1(,R3)
+         B     SKIPSEP
+SKIPDONE DS    0H
+*
+*  Extract subcommand (first token in segment) into SUBCMD,
+*  uppercased and blank-padded to CL8.
+*
+         MVC   SUBCMD,BLANK80
+         LA    R6,SUBCMD
+         LA    R7,8                    max 8 chars
+SUBSCAN  CR    R3,R5
+         BNL   SUBEND
+         CLI   0(R3),C' '
+         BE    SUBEND
+         CLI   0(R3),C';'
+         BE    SUBEND
+         LTR   R7,R7
+         BZ    SUBOVER                 over 8 chars: skip rest
+         MVC   0(1,R6),0(R3)
+         OI    0(R6),X'40'             EBCDIC uppercase mask
+         LA    R6,1(,R6)
+         LA    R3,1(,R3)
+         BCTR  R7,0
+         B     SUBSCAN
+SUBOVER  CR    R3,R5
+         BNL   SUBEND
+         CLI   0(R3),C' '
+         BE    SUBEND
+         CLI   0(R3),C';'
+         BE    SUBEND
+         LA    R3,1(,R3)
+         B     SUBOVER
+SUBEND   DS    0H
+*
+*  Extract args (rest of segment until ';' or end) into ARGBUF.
+*
          MVC   ARGBUF(L'ARGBUF),BLANK80
 *
-*  ----- first parameter (subcommand)
+*  Skip blanks between subcmd and args
 *
-         L     R3,0(,R2)               R3 = first param descriptor addr
-         LR    R10,R3                  save raw value (incl. high bit)
-         N     R3,=X'7FFFFFFF'         clear high-bit for addressing
-         LTR   R3,R3
-         BZ    DISPATCH                no descriptor -> help
-         LH    R4,0(,R3)               R4 = halfword text length
-         LTR   R4,R4
-         BNP   ENDP1                   empty subcommand
-         LA    R3,2(,R3)               R3 -> text
-         LA    R5,SUBCMD               R5 -> dest
-         LA    R6,8                    max 8 chars
-         CR    R4,R6
-         BNH   GOTLEN1
-         LR    R4,R6
-GOTLEN1  LR    R7,R4
-COPYSUB  MVC   0(1,R5),0(R3)
-         OI    0(R5),X'40'             EBCDIC uppercase mask
+ARGSKIP  CR    R3,R5
+         BNL   ARGREADY
+         CLI   0(R3),C' '
+         BNE   ARGREADY
          LA    R3,1(,R3)
-         LA    R5,1(,R5)
-         BCT   R7,COPYSUB
+         B     ARGSKIP
+ARGREADY DS    0H
+         LA    R6,ARGBUF
+         LA    R7,L'ARGBUF
+ARGSCAN  CR    R3,R5
+         BNL   ARGEND
+         CLI   0(R3),C';'
+         BE    ARGEND
+         LTR   R7,R7
+         BZ    ARGOVER
+         MVC   0(1,R6),0(R3)
+         LA    R6,1(,R6)
+         LA    R3,1(,R3)
+         BCTR  R7,0
+         B     ARGSCAN
+ARGOVER  CR    R3,R5
+         BNL   ARGEND
+         CLI   0(R3),C';'
+         BE    ARGEND
+         LA    R3,1(,R3)
+         B     ARGOVER
+ARGEND   DS    0H
 *
-ENDP1    LTR   R10,R10                 high-bit on first entry?
-         BM    DISPATCH                yes -> no further params
+*  Step past the ';' separator if present
 *
-*  ----- second parameter (argument; optional)
+         CR    R3,R5
+         BNL   POSTSEP
+         CLI   0(R3),C';'
+         BNE   POSTSEP
+         LA    R3,1(,R3)
+POSTSEP  ST    R3,CMDPTR
 *
-         LA    R2,4(,R2)
-         L     R3,0(,R2)
-         N     R3,=X'7FFFFFFF'
-         LTR   R3,R3
-         BZ    DISPATCH
-         LH    R4,0(,R3)
-         LTR   R4,R4
-         BNP   DISPATCH
-         LA    R3,2(,R3)
-         LA    R6,L'ARGBUF
-         CR    R4,R6
-         BNH   GOTLEN2
-         LR    R4,R6
-GOTLEN2  BCTR  R4,0
-         EX    R4,EXMVCARG
-         B     DISPATCH
-EXMVCARG MVC   ARGBUF(0),0(R3)         executed via EX
+*  Emit segment marker:  '== <subcmd> =='
 *
-*  Dispatch on SUBCMD
+         MVC   LINETXT(120),BLANK120
+         MVI   LINETXT,C'='
+         MVI   LINETXT+1,C'='
+         MVC   LINETXT+3(8),SUBCMD
+         MVI   LINETXT+12,C'='
+         MVI   LINETXT+13,C'='
+         BAL   R14,WLINE
 *
-DISPATCH DS    0H
+*  Dispatch on SUBCMD; each handler returns via BR R14 (eventually
+*  through HANDRET).
+*
          CLC   SUBCMD,=CL8'DUMP'
-         BE    DODUMP
+         BE    GO_DUMP
          CLC   SUBCMD,=CL8'INIT'
-         BE    DOINIT
+         BE    GO_INIT
          CLC   SUBCMD,=CL8'INITP'
-         BE    DOINITP
+         BE    GO_INITP
          CLC   SUBCMD,=CL8'INITNT'
-         BE    DOINITNT
+         BE    GO_INITNT
          CLC   SUBCMD,=CL8'TERM'
-         BE    DOTERM
+         BE    GO_TERM
+         CLC   SUBCMD,=CL8'TERM_LAS'
+         BE    GO_TERMLA
          CLC   SUBCMD,=CL8'EXEC'
-         BE    DOEXEC
+         BE    GO_EXEC
          CLC   SUBCMD,=CL8'MARK'
-         BE    DOMARK
+         BE    GO_MARK
          CLC   SUBCMD,BLANK80
-         BE    DOHELP
+         BE    GO_HELP
 *
-         MVC   LINETXT(120),=CL120'?? unknown subcommand'
-         MVC   LINETXT+22(8),SUBCMD
+         MVC   LINETXT(120),=CL120'?? unknown subcommand:'
+         MVC   LINETXT+23(8),SUBCMD
          BAL   R14,WLINE
          LA    R15,4
+         B     UPDRC
+*
+GO_DUMP   BAL  R14,DODUMP
+         B     UPDRC
+GO_INIT   BAL  R14,DOINIT
+         B     UPDRC
+GO_INITP  BAL  R14,DOINITP
+         B     UPDRC
+GO_INITNT BAL  R14,DOINITNT
+         B     UPDRC
+GO_TERM   BAL  R14,DOTERM
+         B     UPDRC
+GO_TERMLA BAL  R14,DOTERMLA
+         B     UPDRC
+GO_EXEC   BAL  R14,DOEXEC
+         B     UPDRC
+GO_MARK   BAL  R14,DOMARK
+         B     UPDRC
+GO_HELP   BAL  R14,DOHELP
+         B     UPDRC
+*
+*  UPDRC: track max RC across segments; loop to next segment.
+*
+UPDRC    L     R3,WORK_FINRC
+         CR    R15,R3
+         BNH   UPDRCLP
+         ST    R15,WORK_FINRC
+UPDRCLP  B     SEGLOOP
+*
+*  ALLDONE: end of CMDBUF reached, exit with accumulated RC.
+*
+ALLDONE  L     R15,WORK_FINRC
          B     EXIT
+*
+**********************************************************************
+*  HANDRET - common return path for handlers.  Updates the running    *
+*           max RC in WORK_FINRC, then returns to the dispatch loop  *
+*           via the saved R14 (WORK_R14D).                           *
+**********************************************************************
+*
+HANDRET  L     R3,WORK_FINRC
+         CR    R15,R3
+         BNH   HRSAME
+         ST    R15,WORK_FINRC
+HRSAME   L     R14,WORK_R14D
+         BR    R14
 *
 **********************************************************************
 *  HELP                                                              *
 **********************************************************************
 *
-DOHELP   DS    0H
+DOHELP   ST    R14,WORK_R14D
          BAL   R14,WHELP
          LA    R15,0
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
-*  MARK - emit '== text ==' separator line                           *
+*  MARK text - emit a free-text marker line                          *
 **********************************************************************
 *
-DOMARK   DS    0H
-         MVC   LINETXT(120),=CL120'== '
-         MVC   LINETXT+3(70),ARGBUF
+DOMARK   ST    R14,WORK_R14D
+         MVC   LINETXT(120),=CL120'-- '
+         MVC   LINETXT+3(L'ARGBUF),ARGBUF
          BAL   R14,WLINE
          LA    R15,0
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
 *  DUMP - read-only inspection of ECTENVBK, IRXANCHR, ENVBLOCK,      *
 *         PARMBLOCK.                                                  *
 **********************************************************************
 *
-DODUMP   DS    0H
-         MVC   LINETXT(120),=CL120'DUMP'
-         BAL   R14,WLINE
+DODUMP   ST    R14,WORK_R14D
 *
 *  Walk PSA -> ASCB -> ASXB -> LWA -> ECT
 *
@@ -265,17 +382,14 @@ DUMPENV  DS    0H
          BZ    DUMPDONE
          BAL   R14,WPARM
 *
-DUMPDONE DS    0H
-         LA    R15,0
-         B     EXIT
+DUMPDONE LA    R15,0
+         B     HANDRET
 *
 **********************************************************************
 *  INIT [module] - IRXINIT INITENVB; default module IRXTSPRM (TSO)   *
 **********************************************************************
 *
-DOINIT   DS    0H
-         MVC   LINETXT(120),=CL120'INIT'
-         BAL   R14,WLINE
+DOINIT   ST    R14,WORK_R14D
          MVC   FCODE,=CL8'INITENVB'
          MVC   PARMODE,=CL8'IRXTSPRM'
          BAL   R14,SETPMOD            ARGBUF override (if non-blank)
@@ -284,16 +398,14 @@ DOINIT   DS    0H
          XC    PREVP,PREVP            R0 input = 0 (no prev)
          BAL   R14,DOIRXINIT
          LA    R15,0
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
 *  INITP hex - IRXINIT INITENVB, R0 = hex env address (prev),         *
 *              module fixed to IRXTSPRM                              *
 **********************************************************************
 *
-DOINITP  DS    0H
-         MVC   LINETXT(120),=CL120'INITP'
-         BAL   R14,WLINE
+DOINITP  ST    R14,WORK_R14D
          BAL   R14,PARSEHEX           ARGBUF -> WORK_TMPA
          LTR   R15,R15
          BNZ   ARGERR
@@ -304,16 +416,14 @@ DOINITP  DS    0H
          MVC   PREVP,WORK_TMPA
          BAL   R14,DOIRXINIT
          LA    R15,0
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
 *  INITNT [module] - IRXINIT INITENVB; default module IRXPARMS       *
 *                    (non-TSO defaults)                              *
 **********************************************************************
 *
-DOINITNT DS    0H
-         MVC   LINETXT(120),=CL120'INITNT'
-         BAL   R14,WLINE
+DOINITNT ST    R14,WORK_R14D
          MVC   FCODE,=CL8'INITENVB'
          MVC   PARMODE,=CL8'IRXPARMS'
          BAL   R14,SETPMOD            ARGBUF override (if non-blank)
@@ -322,7 +432,7 @@ DOINITNT DS    0H
          XC    PREVP,PREVP
          BAL   R14,DOIRXINIT
          LA    R15,0
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
 *  SETPMOD - if ARGBUF[0] is non-blank, copy first 8 chars (uppercase,*
@@ -349,21 +459,46 @@ SPMD     L     R14,WORK_R14H
          BR    R14
 *
 **********************************************************************
-*  TERM - IRXTERM with R0 = hex env address                          *
+*  TERM hex - IRXTERM with the hex env address from ARGBUF.          *
 **********************************************************************
 *
-DOTERM   DS    0H
-         MVC   LINETXT(120),=CL120'TERM'
-         BAL   R14,WLINE
+DOTERM   ST    R14,WORK_R14D
          BAL   R14,PARSEHEX
          LTR   R15,R15
          BNZ   ARGERR
+         BAL   R14,DOIRXTERM
+         LA    R15,0
+         B     HANDRET
 *
+**********************************************************************
+*  TERM_LAST - IRXTERM on the env that the most-recent successful    *
+*              INIT/INITP/INITNT in this same invocation produced.   *
+*              State is carried in LASTENV.  Empty -> diagnostic.    *
+**********************************************************************
+*
+DOTERMLA ST    R14,WORK_R14D
+         L     R1,LASTENV
+         LTR   R1,R1
+         BZ    TLNONE
+         ST    R1,WORK_TMPA
+         BAL   R14,DOIRXTERM
+         LA    R15,0
+         B     HANDRET
+TLNONE   MVC   LINETXT(120),=CL120'  ?? no prior INIT in this run'
+         BAL   R14,WLINE
+         LA    R15,4
+         B     HANDRET
+*
+**********************************************************************
+*  DOIRXTERM - shared IRXTERM call.  Caller has placed the env       *
+*              address in WORK_TMPA.  Returns via BR R14 (caller's   *
+*              return slot is its own; this routine uses WORK_R14T). *
+**********************************************************************
+*
+DOIRXTERM ST   R14,WORK_R14T
          MVC   LBLBUF(20),=CL20'  arg envblock'
          L     R1,WORK_TMPA
          BAL   R14,WKVHEX
-*
-*  Capture ECTENVBK pre-call
 *
          BAL   R14,READECT
          MVC   LBLBUF(20),=CL20'  pre  ECTENVBK'
@@ -389,8 +524,8 @@ DOTERM   DS    0H
          L     R1,WORK_RC
          BAL   R14,WKVDEC
 *
-         LA    R15,0
-         B     EXIT
+         L     R14,WORK_R14T
+         BR    R14
 *
 **********************************************************************
 *  EXEC - IRXEXEC stub.  Calling IRXEXEC requires an EXECBLK with    *
@@ -400,9 +535,7 @@ DOTERM   DS    0H
 *         follow-up to issue #74.                                    *
 **********************************************************************
 *
-DOEXEC   DS    0H
-         MVC   LINETXT(120),=CL120'EXEC (stub)'
-         BAL   R14,WLINE
+DOEXEC   ST    R14,WORK_R14D
          BAL   R14,PARSEHEX
          LTR   R15,R15
          BNZ   ARGERR
@@ -414,34 +547,34 @@ DOEXEC   DS    0H
          MVC   LINETXT(120),=CL120'  see test/zos/README.md case A7'
          BAL   R14,WLINE
          LA    R15,0
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
-*  ARGERR - bad hex argument                                         *
+*  ARGERR - bad hex argument; consumes the segment, RC=4             *
 **********************************************************************
 *
-ARGERR   DS    0H
-         MVC   LINETXT(120),=CL120'  ?? bad hex argument: '
+ARGERR   MVC   LINETXT(120),=CL120'  ?? bad hex argument: '
          MVC   LINETXT+24(40),ARGBUF
          BAL   R14,WLINE
          LA    R15,4
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
-*  NOIRXIN / NOIRXTM - LOAD EP= failure handlers                     *
+*  NOIRXIN / NOIRXTM - LOAD EP= failure handlers; both abort the     *
+*                      current segment with RC=8 and return to the   *
+*                      dispatch loop so the rest of the sequence     *
+*                      still runs.                                   *
 **********************************************************************
 *
-NOIRXIN  DS    0H
-         MVC   LINETXT(120),=CL120'  ?? LOAD EP=IRXINIT failed'
+NOIRXIN  MVC   LINETXT(120),=CL120'  ?? LOAD EP=IRXINIT failed'
          BAL   R14,WLINE
          LA    R15,8
-         B     EXIT
+         B     HANDRET
 *
-NOIRXTM  DS    0H
-         MVC   LINETXT(120),=CL120'  ?? LOAD EP=IRXTERM failed'
+NOIRXTM  MVC   LINETXT(120),=CL120'  ?? LOAD EP=IRXTERM failed'
          BAL   R14,WLINE
          LA    R15,8
-         B     EXIT
+         B     HANDRET
 *
 **********************************************************************
 *  EXIT - close SYSPRINT, restore regs, return                       *
@@ -522,6 +655,18 @@ DOIRXINIT DS   0H
 *
          DELETE EP=IRXINIT
 *
+*  On a successful INIT (RC=0) record the new env address in
+*  LASTENV so a later TERM_LAST in the same invocation can find it.
+*
+         L     R3,WORK_RC
+         LTR   R3,R3
+         BNZ   DIRXNORC
+         L     R3,WORK_NEWE
+         LTR   R3,R3
+         BZ    DIRXNORC
+         ST    R3,LASTENV
+DIRXNORC DS    0H
+*
          MVC   LBLBUF(20),=CL20'  IRXINIT RC'
          L     R1,WORK_RC
          BAL   R14,WKVDEC
@@ -539,6 +684,95 @@ DOIRXINIT DS   0H
 *
          L     R14,WORK_R14R
          BR    R14
+*
+**********************************************************************
+*  BUILDCMD - copy the caller's parameter text into CMDBUF and       *
+*             record its length in CMDLEN.  Detects calling          *
+*             convention from the halfword at R2+0:                  *
+*                                                                    *
+*    halfword < 256  -> TSO CALL    R2 -> halfword len + text         *
+*    halfword >= 256 -> LINKMVS     R2 -> array of descriptor addrs   *
+*                                                                    *
+*  For LINKMVS, walks the descriptor list and concatenates each      *
+*  parameter's text into CMDBUF separated by single spaces, so that  *
+*  segment processing sees the same form a TSO CALL would deliver.   *
+*  Truncates if the combined text would exceed L'CMDBUF.             *
+**********************************************************************
+*
+BUILDCMD ST    R14,WORK_R14C
+         MVI   CMDBUF,C' '
+         MVC   CMDBUF+1(L'CMDBUF-1),CMDBUF       fill via overlap MVC
+         XC    CMDLEN,CMDLEN
+*
+         LH    R3,0(,R2)
+         CL    R3,=F'256'
+         BL    BLD_TSO                 halfword < 256 -> TSO CALL
+*
+*  ----- LINKMVS path
+*
+         LR    R6,R2                   R6 = list pointer
+         LA    R5,CMDBUF
+         LA    R7,L'CMDBUF             remaining bytes in CMDBUF
+BLDLMK   L     R3,0(,R6)
+         LR    R8,R3                   save raw value (high bit)
+         N     R3,=X'7FFFFFFF'
+         LTR   R3,R3
+         BZ    BLD_DONE
+         LH    R4,0(,R3)
+         LA    R3,2(,R3)               R3 -> text
+         LTR   R4,R4
+         BNP   BLD_NEXT                empty descriptor
+         CR    R4,R7
+         BNH   BLD_OK
+         LR    R4,R7                   cap to remaining
+BLD_OK   LR    R9,R4                   save text length
+         BCTR  R4,0
+         EX    R4,BLD_MVC
+         AR    R5,R9
+         SR    R7,R9
+BLD_NEXT LTR   R8,R8                   high bit on this descriptor?
+         BM    BLD_DONE                yes -> last entry
+         LTR   R7,R7
+         BNP   BLD_DONE                no room for separator
+         MVI   0(R5),C' '
+         LA    R5,1(,R5)
+         BCTR  R7,0
+         LA    R6,4(,R6)               next descriptor
+         B     BLDLMK
+*
+*  ----- TSO CALL path
+*
+BLD_TSO  LH    R4,0(,R2)
+         LA    R3,2(,R2)               R3 -> text
+         LA    R6,L'CMDBUF
+         CR    R4,R6
+         BNH   BLD_TSOK
+         LR    R4,R6                   cap to L'CMDBUF
+BLD_TSOK LR    R9,R4
+         LTR   R4,R4
+         BNP   BLD_RET
+         BCTR  R4,0
+         EX    R4,BLD_TMVC
+         LA    R5,CMDBUF
+         AR    R5,R9
+         B     BLD_RET
+*
+*  ----- finish: compute used length and return
+*
+BLD_DONE DS    0H
+BLD_RET  LA    R3,CMDBUF
+         LA    R4,L'CMDBUF
+         LR    R6,R5
+         SR    R6,R3                   R6 = bytes used
+         ST    R6,CMDLEN
+         L     R14,WORK_R14C
+         BR    R14
+*
+*  EX targets (must not fall through into them)
+*
+         B     BLD_RET                 safety: skip the EX-only MVCs
+BLD_MVC  MVC   0(0,R5),0(R3)
+BLD_TMVC MVC   CMDBUF(0),0(R3)
 *
 **********************************************************************
 *  READECT - re-read ECTENVBK -> WORK_ENVB                           *
@@ -937,6 +1171,14 @@ BLANK120 DC    CL120' '
 SUBCMD   DS    CL8
 ARGBUF   DS    CL64
 *
+*  Sequenced-subcommand command buffer, populated by BUILDCMD
+*
+CMDBUF   DS    CL128
+CMDLEN   DS    F                       bytes used in CMDBUF
+CMDPTR   DS    F                       current scan position
+CMDEND   DS    F                       end-of-buffer pointer
+LASTENV  DS    F                       env from most recent INIT*
+*
 LINEBUF  DS    0CL121
 LINEBUF_CC DC  C' '
 LINETXT  DS    CL120
@@ -971,6 +1213,9 @@ WORK_R14L    DS  F
 WORK_R14H    DS  F
 WORK_R14B    DS  F
 WORK_R14W    DS  F
+WORK_R14C    DS  F                     BUILDCMD save slot
+WORK_R14D    DS  F                     handler dispatch save slot
+WORK_R14T    DS  F                     DOIRXTERM save slot
 *
 SYSPRINT DCB   DDNAME=SYSPRINT,DSORG=PS,MACRF=PM,LRECL=121,RECFM=FBA,  X
                BLKSIZE=121

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -658,30 +658,30 @@ WPARM    DS    0H
          MVC   LBLBUF(20),=CL20'    language'
          LA    R1,12(,R8)
          BAL   R14,WKVTXT3
-         MVC   LBLBUF(20),=CL20'    flags'
-         L     R1,20(,R8)
-         BAL   R14,WKVHEX
-         MVC   LBLBUF(20),=CL20'    masks'
-         L     R1,24(,R8)
-         BAL   R14,WKVHEX
-         MVC   LBLBUF(20),=CL20'    addrspn'
-         LA    R1,28(,R8)
-         BAL   R14,WKVTXT8M
-         MVC   LBLBUF(20),=CL20'    subpool'
-         XC    WORK_TMPA,WORK_TMPA
-         IC    R1,36(,R8)
-         ST    R1,WORK_TMPA
-         L     R1,WORK_TMPA
-         BAL   R14,WKVDEC
          MVC   LBLBUF(20),=CL20'    modnamet'
-         L     R1,40(,R8)
+         L     R1,16(,R8)              +0x10
          BAL   R14,WKVHEX
          MVC   LBLBUF(20),=CL20'    subcomtb'
-         L     R1,44(,R8)
+         L     R1,20(,R8)              +0x14
          BAL   R14,WKVHEX
          MVC   LBLBUF(20),=CL20'    packtb'
-         L     R1,48(,R8)
+         L     R1,24(,R8)              +0x18
          BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    parsetok'
+         LA    R1,28(,R8)              +0x1C
+         BAL   R14,WKVTXT8M
+         MVC   LBLBUF(20),=CL20'    flags'
+         L     R1,36(,R8)              +0x24
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    masks'
+         L     R1,40(,R8)              +0x28
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    subpool'
+         L     R1,44(,R8)              +0x2C  (fullword)
+         BAL   R14,WKVDEC
+         MVC   LBLBUF(20),=CL20'    addrspn'
+         LA    R1,48(,R8)              +0x30
+         BAL   R14,WKVTXT8M
          L     R14,WORK_R14W
          BR    R14
 *

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -44,6 +44,25 @@ IRXPROBE CSECT
 IRXPROBE AMODE 31
 IRXPROBE RMODE 24
 *
+*  Register equates (HLASM has no built-in R0..R15)
+*
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R5       EQU   5
+R6       EQU   6
+R7       EQU   7
+R8       EQU   8
+R9       EQU   9
+R10      EQU   10
+R11      EQU   11
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+*
          SAVE  (14,12),,*
          LR    R12,R15
          USING IRXPROBE,R12

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -1,0 +1,894 @@
+         TITLE 'IRXPROBE - REXX/370 ECTENVBK Behaviour Probe (z/OS)'
+*
+**********************************************************************
+*                                                                    *
+*  IRXPROBE - Research tool for measuring IBM TSO/E REXX behaviour   *
+*             of IRXINIT / IRXTERM / IRXEXEC against ECTENVBK and    *
+*             the IRXANCHR registry on z/OS.                         *
+*                                                                    *
+*  Phase alpha: capture authoritative IBM reference logs for the     *
+*  CON-3 Open Questions Q-INIT-1..4, Q-TERM-1, Q-EXEC-1.             *
+*                                                                    *
+*  Target system: z/OS only.  HLASM directives (AMODE/RMODE) and     *
+*  z/OS-only services (LINK, LOAD via IRXANCHR module) are used      *
+*  freely.  Phase beta will port a subset to MVS 3.8j (IFOX00) in    *
+*  a separate ticket.                                                *
+*                                                                    *
+*  Invocation:                                                       *
+*    CALL 'hlq.LOAD(IRXPROBE)' 'subcommand [args]'                    *
+*    ADDRESS LINKMVS "IRXPROBE subcommand [args]"   (from REXX)       *
+*                                                                    *
+*  Subcommands:                                                       *
+*    DUMP         Dump ECTENVBK + IRXANCHR + ENVBLOCK + PARMBLOCK     *
+*    INIT         IRXINIT INITENVB, TSOFL=1, no caller-prev           *
+*    INITP  hex   IRXINIT INITENVB, R0 = hex env address (prev)       *
+*    INITNT       IRXINIT INITENVB, TSOFL=0                           *
+*    TERM   hex   IRXTERM, R0 = hex env address                       *
+*    EXEC   hex   IRXEXEC stub (env address argument, see notes)      *
+*    MARK   text  Write '== text ==' marker line                      *
+*                                                                    *
+*  Output: SYSPRINT DD (RECFM=FBA, LRECL=121).                        *
+*  Driver REXX execs (test/zos/rexx/proba*.rex) orchestrate the       *
+*  case sequences and concatenate logs into a master record.         *
+*                                                                    *
+*  Return codes:                                                      *
+*     0  success                                                      *
+*     4  warning (unknown subcommand, parse error)                    *
+*     8  error  (service call failed; see SYSPRINT for RC/RSN)        *
+*                                                                    *
+*  (c) 2026 mvslovers - REXX/370 Project                              *
+*                                                                    *
+**********************************************************************
+*
+IRXPROBE CSECT
+IRXPROBE AMODE 31
+IRXPROBE RMODE 24
+*
+         SAVE  (14,12),,*
+         LR    R12,R15
+         USING IRXPROBE,R12
+         LR    R2,R1                  preserve param-list pointer
+         LA    R15,SAVEAR1
+         ST    R13,4(R15)
+         ST    R15,8(R13)
+         LR    R13,R15
+*
+*  Open SYSPRINT
+*
+         OPEN  (SYSPRINT,OUTPUT)
+         TM    SYSPRINT+48,X'10'      DCB OFLAG bit OPEN?
+         BO    OPENED1
+         WTO   'IRXPROBE: SYSPRINT OPEN failed',ROUTCDE=11
+         LA    R15,8
+         B     EXIT
+OPENED1  DS    0H
+*
+*  Banner
+*
+         BAL   R14,WBANNER
+*
+*  Parse PARM (REXX 'ADDRESS LINKMVS' convention)
+*    R2 -> array of fullword addresses; high-order bit on last entry.
+*    Each address -> halfword length followed by character data.
+*    First entry  becomes SUBCMD (CL8, uppercase, blank-padded).
+*    Second entry becomes ARGBUF (optional).
+*
+         MVC   SUBCMD,BLANK80          subcommand defaults to blank
+         MVC   ARGBUF(L'ARGBUF),BLANK80
+*
+*  ----- first parameter (subcommand)
+*
+         L     R3,0(,R2)               R3 = first param descriptor addr
+         LR    R10,R3                  save raw value (incl. high bit)
+         N     R3,=X'7FFFFFFF'         clear high-bit for addressing
+         LTR   R3,R3
+         BZ    DISPATCH                no descriptor -> help
+         LH    R4,0(,R3)               R4 = halfword text length
+         LTR   R4,R4
+         BNP   ENDP1                   empty subcommand
+         LA    R3,2(,R3)               R3 -> text
+         LA    R5,SUBCMD               R5 -> dest
+         LA    R6,8                    max 8 chars
+         CR    R4,R6
+         BNH   GOTLEN1
+         LR    R4,R6
+GOTLEN1  LR    R7,R4
+COPYSUB  MVC   0(1,R5),0(R3)
+         OI    0(R5),X'40'             EBCDIC uppercase mask
+         LA    R3,1(,R3)
+         LA    R5,1(,R5)
+         BCT   R7,COPYSUB
+*
+ENDP1    LTR   R10,R10                 high-bit on first entry?
+         BM    DISPATCH                yes -> no further params
+*
+*  ----- second parameter (argument; optional)
+*
+         LA    R2,4(,R2)
+         L     R3,0(,R2)
+         N     R3,=X'7FFFFFFF'
+         LTR   R3,R3
+         BZ    DISPATCH
+         LH    R4,0(,R3)
+         LTR   R4,R4
+         BNP   DISPATCH
+         LA    R3,2(,R3)
+         LA    R6,L'ARGBUF
+         CR    R4,R6
+         BNH   GOTLEN2
+         LR    R4,R6
+GOTLEN2  BCTR  R4,0
+         EX    R4,EXMVCARG
+         B     DISPATCH
+EXMVCARG MVC   ARGBUF(0),0(R3)         executed via EX
+*
+*  Dispatch on SUBCMD
+*
+DISPATCH DS    0H
+         CLC   SUBCMD,=CL8'DUMP'
+         BE    DODUMP
+         CLC   SUBCMD,=CL8'INIT'
+         BE    DOINIT
+         CLC   SUBCMD,=CL8'INITP'
+         BE    DOINITP
+         CLC   SUBCMD,=CL8'INITNT'
+         BE    DOINITNT
+         CLC   SUBCMD,=CL8'TERM'
+         BE    DOTERM
+         CLC   SUBCMD,=CL8'EXEC'
+         BE    DOEXEC
+         CLC   SUBCMD,=CL8'MARK'
+         BE    DOMARK
+         CLC   SUBCMD,BLANK80
+         BE    DOHELP
+*
+         MVC   LINETXT(120),=CL120'?? unknown subcommand'
+         MVC   LINETXT+22(8),SUBCMD
+         BAL   R14,WLINE
+         LA    R15,4
+         B     EXIT
+*
+**********************************************************************
+*  HELP                                                              *
+**********************************************************************
+*
+DOHELP   DS    0H
+         BAL   R14,WHELP
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  MARK - emit '== text ==' separator line                           *
+**********************************************************************
+*
+DOMARK   DS    0H
+         MVC   LINETXT(120),=CL120'== '
+         MVC   LINETXT+3(70),ARGBUF
+         BAL   R14,WLINE
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  DUMP - read-only inspection of ECTENVBK, IRXANCHR, ENVBLOCK,      *
+*         PARMBLOCK.                                                  *
+**********************************************************************
+*
+DODUMP   DS    0H
+         MVC   LINETXT(120),=CL120'DUMP'
+         BAL   R14,WLINE
+*
+*  Walk PSA -> ASCB -> ASXB -> LWA -> ECT
+*
+         L     R3,X'224'              R3 = ASCB (PSAAOLD)
+         ST    R3,WORK_ASCB
+*
+         LTR   R3,R3
+         BZ    NOECT
+         L     R4,X'6C'(,R3)          R4 = ASXB (ASCBASXB)
+         ST    R4,WORK_ASXB
+         LTR   R4,R4
+         BZ    NOECT
+         L     R5,X'14'(,R4)          R5 = LWA (ASXBLWA)
+         ST    R5,WORK_LWA
+         LTR   R5,R5
+         BZ    NOLWA
+         L     R6,X'20'(,R5)          R6 = ECT (LWAPECT)
+         ST    R6,WORK_ECT
+         LTR   R6,R6
+         BZ    NOECT
+*
+         L     R7,X'30'(,R6)          R7 = ECTENVBK
+         ST    R7,WORK_ENVB
+*
+         MVC   LBLBUF(20),=CL20'  ECT-Address'
+         L     R1,WORK_ECT
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'  ECTENVBK'
+         L     R1,WORK_ENVB
+         BAL   R14,WKVHEX
+         B     DUMPANCH
+*
+NOLWA    MVC   LINETXT(120),=CL120'  LWA = NULL  (pure batch?)'
+         BAL   R14,WLINE
+         B     DUMPANCH
+*
+NOECT    MVC   LINETXT(120),=CL120'  ECT = NULL  (chain unreachable)'
+         BAL   R14,WLINE
+*
+DUMPANCH DS    0H
+*
+*  LOAD EP=IRXANCHR; dump first slots
+*
+         LOAD  EP=IRXANCHR,ERRET=NOANCH
+         LR    R8,R0                  R8 = IRXANCHR address
+         ST    R8,WORK_ANCH
+         MVC   LBLBUF(20),=CL20'  IRXANCHR'
+         LR    R1,R8
+         BAL   R14,WKVHEX
+         BAL   R14,WANCHHDR
+         BAL   R14,WANCHSLT
+         DELETE EP=IRXANCHR
+         B     DUMPENV
+*
+NOANCH   MVC   LINETXT(120),=CL120'  IRXANCHR = (LOAD failed)'
+         BAL   R14,WLINE
+*
+DUMPENV  DS    0H
+         L     R7,WORK_ENVB
+         LTR   R7,R7
+         BZ    DUMPDONE
+         BAL   R14,WENV
+         L     R8,X'10'(,R7)          R8 = PARMBLOCK
+         ST    R8,WORK_PARM
+         LTR   R8,R8
+         BZ    DUMPDONE
+         BAL   R14,WPARM
+*
+DUMPDONE DS    0H
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  INIT - IRXINIT INITENVB, TSOFL=1, no caller-prev                  *
+**********************************************************************
+*
+DOINIT   DS    0H
+         MVC   LINETXT(120),=CL120'INIT'
+         BAL   R14,WLINE
+         MVC   FCODE,=CL8'INITENVB'
+         XC    PARMP,PARMP
+         XC    USERP,USERP
+         XC    PREVP,PREVP            R0 input = 0 (no prev)
+         OI    FLAGS+3,X'80'          TSOFL = 1 (placeholder)
+         BAL   R14,DOIRXINIT
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  INITP - IRXINIT INITENVB, TSOFL=1, R0 = hex env address (prev)    *
+**********************************************************************
+*
+DOINITP  DS    0H
+         MVC   LINETXT(120),=CL120'INITP'
+         BAL   R14,WLINE
+         BAL   R14,PARSEHEX           ARGBUF -> WORK_TMPA
+         LTR   R15,R15
+         BNZ   ARGERR
+         MVC   FCODE,=CL8'INITENVB'
+         XC    PARMP,PARMP
+         XC    USERP,USERP
+         MVC   PREVP,WORK_TMPA
+         OI    FLAGS+3,X'80'
+         BAL   R14,DOIRXINIT
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  INITNT - IRXINIT INITENVB, TSOFL=0 (non-TSO)                      *
+**********************************************************************
+*
+DOINITNT DS    0H
+         MVC   LINETXT(120),=CL120'INITNT (TSOFL=0)'
+         BAL   R14,WLINE
+         MVC   FCODE,=CL8'INITENVB'
+         XC    PARMP,PARMP
+         XC    USERP,USERP
+         XC    PREVP,PREVP
+         XC    FLAGS,FLAGS            TSOFL = 0
+         BAL   R14,DOIRXINIT
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  TERM - IRXTERM with R0 = hex env address                          *
+**********************************************************************
+*
+DOTERM   DS    0H
+         MVC   LINETXT(120),=CL120'TERM'
+         BAL   R14,WLINE
+         BAL   R14,PARSEHEX
+         LTR   R15,R15
+         BNZ   ARGERR
+*
+         MVC   LBLBUF(20),=CL20'  arg envblock'
+         L     R1,WORK_TMPA
+         BAL   R14,WKVHEX
+*
+*  Capture ECTENVBK pre-call
+*
+         BAL   R14,READECT
+         MVC   LBLBUF(20),=CL20'  pre  ECTENVBK'
+         L     R1,WORK_ENVB
+         BAL   R14,WKVHEX
+*
+         L     R0,WORK_TMPA           env address
+         L     R15,=V(IRXTERM)
+         BALR  R14,R15                CALL IRXTERM
+         ST    R15,WORK_RC
+*
+         BAL   R14,READECT
+         MVC   LBLBUF(20),=CL20'  post ECTENVBK'
+         L     R1,WORK_ENVB
+         BAL   R14,WKVHEX
+*
+         MVC   LBLBUF(20),=CL20'  IRXTERM RC'
+         L     R1,WORK_RC
+         BAL   R14,WKVDEC
+*
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  EXEC - IRXEXEC stub.  Calling IRXEXEC requires an EXECBLK with    *
+*         an EXECNAME pointing at the exec dataset member, plus an   *
+*         ARGTABLE and EVALBLOCK.  This stub does the minimum to    *
+*         exercise the linkage; full implementation tracked in the   *
+*         follow-up to issue #74.                                    *
+**********************************************************************
+*
+DOEXEC   DS    0H
+         MVC   LINETXT(120),=CL120'EXEC (stub)'
+         BAL   R14,WLINE
+         BAL   R14,PARSEHEX
+         LTR   R15,R15
+         BNZ   ARGERR
+         MVC   LBLBUF(20),=CL20'  arg envblock'
+         L     R1,WORK_TMPA
+         BAL   R14,WKVHEX
+         MVC   LINETXT(120),=CL120'  status = NOT_IMPLEMENTED'
+         BAL   R14,WLINE
+         MVC   LINETXT(120),=CL120'  see test/zos/README.md case A7'
+         BAL   R14,WLINE
+         LA    R15,0
+         B     EXIT
+*
+**********************************************************************
+*  ARGERR - bad hex argument                                         *
+**********************************************************************
+*
+ARGERR   DS    0H
+         MVC   LINETXT(120),=CL120'  ?? bad hex argument: '
+         MVC   LINETXT+24(40),ARGBUF
+         BAL   R14,WLINE
+         LA    R15,4
+         B     EXIT
+*
+**********************************************************************
+*  EXIT - close SYSPRINT, restore regs, return                       *
+**********************************************************************
+*
+EXIT     DS    0H
+         ST    R15,WORK_FINRC
+         CLOSE (SYSPRINT)
+         L     R13,4(,R13)
+         L     R14,12(,R13)
+         L     R15,WORK_FINRC
+         LM    R0,R12,20(R13)
+         BR    R14
+*
+**********************************************************************
+*  DOIRXINIT - common IRXINIT INITENVB call sequence                 *
+*                                                                    *
+*    Inputs:  FCODE   8-byte function code ('INITENVB')              *
+*             PARMP   address of caller PARMBLOCK or 0               *
+*             USERP   user field address or 0                        *
+*             PREVP   value to load into R0 (caller-prev) or 0       *
+*             FLAGS   flags fullword (TSOFL bit etc.)                *
+*    Output:  WORK_NEWE   new ENVBLOCK address                       *
+*             WORK_NEWWB  workblock-extension address                *
+*             WORK_RSN    reason code                                *
+*             WORK_RC     RC from IRXINIT                            *
+*             prints  pre/post ECTENVBK and the four output values   *
+**********************************************************************
+*
+DOIRXINIT DS   0H
+         ST    R14,WORK_R14R
+*
+         BAL   R14,READECT
+         MVC   LBLBUF(20),=CL20'  pre  ECTENVBK'
+         L     R1,WORK_ENVB
+         BAL   R14,WKVHEX
+*
+         XC    WORK_NEWE,WORK_NEWE
+         XC    WORK_NEWWB,WORK_NEWWB
+         XC    WORK_RSN,WORK_RSN
+*
+*  Build IRXINIT parameter list (all addresses high-bit clear; VL=1
+*  on last entry).
+*
+         LA    R3,FCODE
+         ST    R3,PLIST+0
+         LA    R3,PARMP
+         ST    R3,PLIST+4
+         LA    R3,USERP
+         ST    R3,PLIST+8
+         LA    R3,WORK_NEWE
+         ST    R3,PLIST+12
+         LA    R3,WORK_NEWWB
+         ST    R3,PLIST+16
+         LA    R3,WORK_RSN
+         ST    R3,PLIST+20
+         LA    R3,FLAGS
+         ST    R3,PLIST+24
+         OI    PLIST+24,X'80'         high-bit on last entry
+*
+         L     R0,PREVP               caller-prev or 0
+         LA    R1,PLIST
+         L     R15,=V(IRXINIT)
+         BALR  R14,R15
+         ST    R15,WORK_RC
+*
+         MVC   LBLBUF(20),=CL20'  IRXINIT RC'
+         L     R1,WORK_RC
+         BAL   R14,WKVDEC
+         MVC   LBLBUF(20),=CL20'  reason'
+         L     R1,WORK_RSN
+         BAL   R14,WKVDEC
+         MVC   LBLBUF(20),=CL20'  new envblock'
+         L     R1,WORK_NEWE
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'  workblok ext'
+         L     R1,WORK_NEWWB
+         BAL   R14,WKVHEX
+*
+         BAL   R14,READECT
+         MVC   LBLBUF(20),=CL20'  post ECTENVBK'
+         L     R1,WORK_ENVB
+         BAL   R14,WKVHEX
+*
+         L     R14,WORK_R14R
+         BR    R14
+*
+**********************************************************************
+*  READECT - re-read ECTENVBK -> WORK_ENVB                           *
+*            Returns 0 in WORK_ENVB if chain unreachable.            *
+**********************************************************************
+*
+READECT  DS    0H
+         XC    WORK_ENVB,WORK_ENVB
+         L     R3,X'224'              ASCB
+         LTR   R3,R3
+         BZR   R14
+         L     R4,X'6C'(,R3)          ASXB
+         LTR   R4,R4
+         BZR   R14
+         L     R5,X'14'(,R4)          LWA
+         LTR   R5,R5
+         BZR   R14
+         L     R6,X'20'(,R5)          ECT
+         LTR   R6,R6
+         BZR   R14
+         L     R7,X'30'(,R6)          ECTENVBK
+         ST    R7,WORK_ENVB
+         BR    R14
+*
+**********************************************************************
+*  WANCHHDR - dump IRXANCHR header (R8 = anchor)                     *
+**********************************************************************
+*
+WANCHHDR DS    0H
+         ST    R14,WORK_R14W
+         MVC   LINETXT(120),=CL120'  IRXANCHR_HEADER'
+         BAL   R14,WLINE
+         MVC   LBLBUF(20),=CL20'    eyecatch'
+         LR    R1,R8                  R1 -> 8-byte eye-catcher
+         BAL   R14,WKVTXT8
+         MVC   LBLBUF(20),=CL20'    version'
+         LA    R1,8(,R8)
+         BAL   R14,WKVTXT4
+         MVC   LBLBUF(20),=CL20'    total'
+         L     R1,12(,R8)
+         BAL   R14,WKVDEC
+         MVC   LBLBUF(20),=CL20'    used'
+         L     R1,16(,R8)
+         BAL   R14,WKVDEC
+         MVC   LBLBUF(20),=CL20'    length'
+         L     R1,20(,R8)
+         BAL   R14,WKVDEC
+         L     R14,WORK_R14W
+         BR    R14
+*
+**********************************************************************
+*  WANCHSLT - dump first 4 slots of IRXANCHR (R8 = anchor)           *
+*             Slot layout assumed compatible with the rexx370 spec   *
+*             (40 bytes per slot).  When IBM's layout differs, the   *
+*             field hex still gives a usable diff baseline.          *
+**********************************************************************
+*
+WANCHSLT DS    0H
+         ST    R14,WORK_R14W
+         LA    R9,32(,R8)             R9 -> first slot
+         LA    R11,0                  R11 = slot index 0..3
+*
+WANCHLP  ST    R11,WORK_TMPA
+         L     R3,0(,R9)              envblock_ptr
+         C     R3,=F'-1'
+         BE    SLOT_SENT
+         LTR   R3,R3
+         BZ    SLOT_FREE
+         MVC   LINETXT(120),=CL120'  slot 0  USED'
+         B     SLOTPRT
+SLOT_SENT MVC  LINETXT(120),=CL120'  slot 0  SENTINEL'
+         B     SLOTPRT
+SLOT_FREE MVC  LINETXT(120),=CL120'  slot 0  FREE'
+SLOTPRT  L     R1,WORK_TMPA           slot index
+         CVD   R1,WORK_DEC
+         UNPK  WORK_HEX(2),WORK_DEC+6(2)
+         OI    WORK_HEX+1,X'F0'
+         MVC   LINETXT+7(1),WORK_HEX+1
+         BAL   R14,WLINE
+*
+*  Slot fields
+*
+         MVC   LBLBUF(20),=CL20'      envblock_ptr'
+         L     R1,0(,R9)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'      token'
+         L     R1,4(,R9)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'      anchor_hint'
+         L     R1,24(,R9)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'      tcb_ptr'
+         L     R1,28(,R9)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'      flags'
+         L     R1,32(,R9)
+         BAL   R14,WKVHEX
+*
+         LA    R9,40(,R9)             next slot
+         L     R11,WORK_TMPA
+         LA    R11,1(,R11)
+         CL    R11,=F'4'
+         BL    WANCHLP
+*
+         L     R14,WORK_R14W
+         BR    R14
+*
+**********************************************************************
+*  WENV - dump ENVBLOCK header (R7 = ENVBLOCK)                       *
+**********************************************************************
+*
+WENV     DS    0H
+         ST    R14,WORK_R14W
+         MVC   LINETXT(120),=CL120'  ENVBLOCK'
+         BAL   R14,WLINE
+         MVC   LBLBUF(20),=CL20'    eyecatch'
+         LR    R1,R7
+         BAL   R14,WKVTXT8M
+         MVC   LBLBUF(20),=CL20'    version'
+         LA    R1,8(,R7)
+         BAL   R14,WKVTXT4
+         MVC   LBLBUF(20),=CL20'    length'
+         L     R1,12(,R7)
+         BAL   R14,WKVDEC
+         MVC   LBLBUF(20),=CL20'    parmblock'
+         L     R1,16(,R7)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    userfield'
+         L     R1,20(,R7)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    workblok ext'
+         L     R1,24(,R7)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    irxexte'
+         L     R1,28(,R7)
+         BAL   R14,WKVHEX
+         L     R14,WORK_R14W
+         BR    R14
+*
+**********************************************************************
+*  WPARM - dump PARMBLOCK header (R8 = PARMBLOCK)                    *
+**********************************************************************
+*
+WPARM    DS    0H
+         ST    R14,WORK_R14W
+         MVC   LINETXT(120),=CL120'  PARMBLOCK'
+         BAL   R14,WLINE
+         MVC   LBLBUF(20),=CL20'    eyecatch'
+         LR    R1,R8
+         BAL   R14,WKVTXT8M
+         MVC   LBLBUF(20),=CL20'    version'
+         LA    R1,8(,R8)
+         BAL   R14,WKVTXT4
+         MVC   LBLBUF(20),=CL20'    language'
+         LA    R1,12(,R8)
+         BAL   R14,WKVTXT3
+         MVC   LBLBUF(20),=CL20'    flags'
+         L     R1,20(,R8)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    masks'
+         L     R1,24(,R8)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    addrspn'
+         LA    R1,28(,R8)
+         BAL   R14,WKVTXT8M
+         MVC   LBLBUF(20),=CL20'    subpool'
+         XC    WORK_TMPA,WORK_TMPA
+         IC    R1,36(,R8)
+         ST    R1,WORK_TMPA
+         L     R1,WORK_TMPA
+         BAL   R14,WKVDEC
+         MVC   LBLBUF(20),=CL20'    modnamet'
+         L     R1,40(,R8)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    subcomtb'
+         L     R1,44(,R8)
+         BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'    packtb'
+         L     R1,48(,R8)
+         BAL   R14,WKVHEX
+         L     R14,WORK_R14W
+         BR    R14
+*
+**********************************************************************
+*  WBANNER / WHELP                                                    *
+**********************************************************************
+*
+WBANNER  DS    0H
+         ST    R14,WORK_R14B
+         MVC   LINETXT(120),=CL120'#IRXPROBE-v1'
+         BAL   R14,WLINE
+         L     R14,WORK_R14B
+         BR    R14
+*
+WHELP    DS    0H
+         ST    R14,WORK_R14B
+         MVC   LINETXT(120),=CL120'IRXPROBE subcommands:'
+         BAL   R14,WLINE
+         MVC   LINETXT(120),=CL120'  DUMP   INIT   INITP hex  INITNT'
+         BAL   R14,WLINE
+         MVC   LINETXT(120),=CL120'  TERM hex   EXEC hex   MARK text'
+         BAL   R14,WLINE
+         MVC   LINETXT(120),=CL120'See test/zos/README.md for details.'
+         BAL   R14,WLINE
+         L     R14,WORK_R14B
+         BR    R14
+*
+**********************************************************************
+*  WLINE - write LINETXT to SYSPRINT                                 *
+**********************************************************************
+*
+WLINE    DS    0H
+         ST    R14,WORK_R14L
+         MVI   LINEBUF,C' '           ANSI carriage control = blank
+         PUT   SYSPRINT,LINEBUF
+         MVC   LINETXT(120),BLANK120
+         L     R14,WORK_R14L
+         BR    R14
+*
+**********************************************************************
+*  WKVHEX - emit '<label> = xxxxxxxx' line                           *
+*    Inputs: LBLBUF (CL20)  R1 = fullword to emit as 8 hex chars    *
+**********************************************************************
+*
+WKVHEX   DS    0H
+         ST    R14,WORK_R14H
+         ST    R1,WORK_TMPA
+         MVC   LINETXT(20),LBLBUF
+         MVC   LINETXT+20(3),=CL3' = '
+         L     R1,WORK_TMPA
+         LA    R2,LINETXT+23
+         BAL   R14,FMTHEX8
+         BAL   R14,WLINE
+         L     R14,WORK_R14H
+         BR    R14
+*
+**********************************************************************
+*  WKVDEC - emit '<label> = nnn' line                                *
+*    Inputs: LBLBUF (CL20)  R1 = signed binary fullword              *
+**********************************************************************
+*
+WKVDEC   DS    0H
+         ST    R14,WORK_R14H
+         MVC   LINETXT(20),LBLBUF
+         MVC   LINETXT+20(3),=CL3' = '
+         CVD   R1,WORK_DEC
+         OI    WORK_DEC+7,X'0F'       ensure positive sign nibble
+         UNPK  WORK_HEX(11),WORK_DEC(8)
+         MVC   LINETXT+23(11),WORK_HEX
+*  Strip leading zeros (cosmetic): replace runs of '0' with blank
+*  except the last digit.
+         LA    R3,LINETXT+23
+         LA    R4,10
+SKIPZERO CLI   0(R3),C'0'
+         BNE   ZDONE
+         MVI   0(R3),C' '
+         LA    R3,1(,R3)
+         BCT   R4,SKIPZERO
+ZDONE    DS    0H
+         BAL   R14,WLINE
+         L     R14,WORK_R14H
+         BR    R14
+*
+**********************************************************************
+*  WKVTXT8 / WKVTXT8M / WKVTXT4 / WKVTXT3                            *
+*  Emit '<label> = ''xxxxxxxx''' lines, copying N bytes from R1.     *
+*  WKVTXT8M = R1 is the address itself (used when caller passes      *
+*  a register holding an address rather than data).                  *
+**********************************************************************
+*
+WKVTXT8  DS    0H
+         ST    R14,WORK_R14H
+         MVC   LINETXT(20),LBLBUF
+         MVC   LINETXT+20(4),=CL4' = '''
+         MVC   LINETXT+24(8),0(R1)
+         MVI   LINETXT+32,C''''
+         BAL   R14,WLINE
+         L     R14,WORK_R14H
+         BR    R14
+*
+WKVTXT8M EQU   WKVTXT8                same calling pattern
+*
+WKVTXT4  DS    0H
+         ST    R14,WORK_R14H
+         MVC   LINETXT(20),LBLBUF
+         MVC   LINETXT+20(4),=CL4' = '''
+         MVC   LINETXT+24(4),0(R1)
+         MVI   LINETXT+28,C''''
+         BAL   R14,WLINE
+         L     R14,WORK_R14H
+         BR    R14
+*
+WKVTXT3  DS    0H
+         ST    R14,WORK_R14H
+         MVC   LINETXT(20),LBLBUF
+         MVC   LINETXT+20(4),=CL4' = '''
+         MVC   LINETXT+24(3),0(R1)
+         MVI   LINETXT+27,C''''
+         BAL   R14,WLINE
+         L     R14,WORK_R14H
+         BR    R14
+*
+**********************************************************************
+*  FMTHEX8 - convert R1 to 8 EBCDIC hex chars at addr in R2          *
+**********************************************************************
+*
+FMTHEX8  DS    0H
+         ST    R1,WORK_TMPA
+         UNPK  WORK_HEX(9),WORK_TMPA(5)
+         TR    WORK_HEX(8),HEXTAB-X'F0'
+         MVC   0(8,R2),WORK_HEX
+         BR    R14
+*
+**********************************************************************
+*  PARSEHEX - parse ARGBUF as 1..8 EBCDIC hex chars -> WORK_TMPA     *
+*    Returns R15=0 on success, R15=4 on parse error or empty input   *
+**********************************************************************
+*
+PARSEHEX DS    0H
+         XC    WORK_TMPA,WORK_TMPA
+         LA    R3,ARGBUF
+         LA    R4,L'ARGBUF
+         L     R9,=F'0'                accumulator
+         LA    R5,0                    digit count
+*
+*  Skip leading blanks
+*
+PHSKIP   CLI   0(R3),C' '
+         BNE   PHLOOP
+         LA    R3,1(,R3)
+         BCT   R4,PHSKIP
+         LA    R15,4                   nothing but blanks
+         BR    R14
+*
+*  Parse digits left-to-right; accept '0'-'9', 'A'-'F', 'a'-'f'.
+*  Stop on blank or NUL or after 8 digits.
+*
+PHLOOP   CLI   0(R3),C' '
+         BE    PHEND
+         CLI   0(R3),X'00'
+         BE    PHEND
+         IC    R10,0(,R3)              char (zero-extended)
+*
+         CLI   0(R3),C'0'
+         BL    PHERR
+         CLI   0(R3),C'9'
+         BH    PHALPHA
+         N     R10,=F'15'              digit nibble
+         B     PHACCUM
+*
+PHALPHA  CLI   0(R3),C'A'
+         BL    PHERR
+         CLI   0(R3),C'F'
+         BH    PHLOWER
+         B     PHLET
+PHLOWER  CLI   0(R3),C'a'
+         BL    PHERR
+         CLI   0(R3),C'f'
+         BH    PHERR
+PHLET    N     R10,=F'15'
+         LA    R10,9(,R10)
+         N     R10,=F'15'              alpha nibble (10..15)
+*
+PHACCUM  SLL   R9,4
+         AR    R9,R10
+         LA    R3,1(,R3)
+         LA    R5,1(,R5)
+         CL    R5,=F'8'
+         BNL   PHEND
+         BCT   R4,PHLOOP
+*
+PHEND    LTR   R5,R5
+         BZ    PHERR                   no digits at all
+         ST    R9,WORK_TMPA
+         LA    R15,0
+         BR    R14
+*
+PHERR    LA    R15,4
+         BR    R14
+*
+**********************************************************************
+*  Static data                                                       *
+**********************************************************************
+*
+SAVEAR1  DS    18F
+*
+HEXTAB   DC    C'0123456789ABCDEF'
+BLANK40  DC    XL1'40'
+BLANK80  DC    CL80' '
+BLANK120 DC    CL120' '
+*
+SUBCMD   DS    CL8
+ARGBUF   DS    CL64
+*
+LINEBUF  DS    0CL121
+LINEBUF_CC DC  C' '
+LINETXT  DS    CL120
+*
+LBLBUF   DS    CL20
+*
+FCODE    DS    CL8
+PARMP    DS    F
+USERP    DS    F
+PREVP    DS    F
+FLAGS    DS    F
+PLIST    DS    8F
+*
+WORK_ASCB    DS  F
+WORK_ASXB    DS  F
+WORK_LWA     DS  F
+WORK_ECT     DS  F
+WORK_ENVB    DS  F
+WORK_ANCH    DS  F
+WORK_PARM    DS  F
+WORK_NEWE    DS  F
+WORK_NEWWB   DS  F
+WORK_RSN     DS  F
+WORK_RC      DS  F
+WORK_FINRC   DS  F
+WORK_TMPA    DS  F
+WORK_TMPB    DS  CL16
+WORK_DEC     DS  D
+WORK_HEX     DS  CL16
+WORK_R14R    DS  F
+WORK_R14L    DS  F
+WORK_R14H    DS  F
+WORK_R14B    DS  F
+WORK_R14W    DS  F
+*
+SYSPRINT DCB   DDNAME=SYSPRINT,DSORG=PS,MACRF=PM,LRECL=121,RECFM=FBA,  X
+               BLKSIZE=121
+*
+         LTORG
+         END   IRXPROBE

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -477,6 +477,9 @@ DOTERM   ST    R14,WORK_R14D
 **********************************************************************
 *
 DOTERMLA ST    R14,WORK_R14D
+         MVC   LBLBUF(20),=CL20'  lastenv'
+         L     R1,LASTENV
+         BAL   R14,WKVHEX
          L     R1,LASTENV
          LTR   R1,R1
          BZ    TLNONE
@@ -655,12 +658,12 @@ DOIRXINIT DS   0H
 *
          DELETE EP=IRXINIT
 *
-*  On a successful INIT (RC=0) record the new env address in
-*  LASTENV so a later TERM_LAST in the same invocation can find it.
+*  Record the new env address in LASTENV whenever IRXINIT actually
+*  produced one (WORK_NEWE non-zero), regardless of RC.  Some
+*  successful inits return RC=4 (warning); some non-zero RCs still
+*  leave a usable env behind.  TERM_LAST in a later segment will
+*  read this slot.
 *
-         L     R3,WORK_RC
-         LTR   R3,R3
-         BNZ   DIRXNORC
          L     R3,WORK_NEWE
          LTR   R3,R3
          BZ    DIRXNORC
@@ -1088,6 +1091,13 @@ FMTHEX8  DS    0H
 *    Returns R15=0 on success, R15=4 on parse error or empty input   *
 **********************************************************************
 *
+*  EBCDIC ordering matters here: lowercase letters X'81'-X'89'..,
+*  uppercase X'C1'-X'C9'.., and digits X'F0'-X'F9' are arranged
+*  with letters BELOW digits.  A naive 'CLI char,C''0''; BL stop'
+*  rejects letters, so the range checks must walk the encoded
+*  values in the right order.  The pattern below tests each of
+*  the three hex regions explicitly.
+*
 PARSEHEX DS    0H
          XC    WORK_TMPA,WORK_TMPA
          LA    R3,ARGBUF
@@ -1099,34 +1109,41 @@ PARSEHEX DS    0H
 *  that REXX or LINKMVS may prepend to the parameter data).
 *
 PHSKIP   CLI   0(R3),C'0'
-         BL    PHADV
+         BL    PHCKLET                 < X'F0' -> not a digit
          CLI   0(R3),C'9'
-         BNH   PHLOOP                  '0'..'9' -> start parsing
-         CLI   0(R3),C'A'
-         BL    PHADV
+         BNH   PHLOOP                  X'F0'..X'F9' = digit
+         B     PHADV                   X'FA'..X'FF' = invalid
+PHCKLET  CLI   0(R3),C'A'
+         BL    PHCKLOW                 < X'C1' -> not uppercase
          CLI   0(R3),C'F'
-         BNH   PHLOOP                  'A'..'F'
-         CLI   0(R3),C'a'
-         BL    PHADV
+         BNH   PHLOOP                  X'C1'..X'C6' = uppercase hex
+         B     PHADV                   X'C7'..X'EF' = invalid
+PHCKLOW  CLI   0(R3),C'a'
+         BL    PHADV                   < X'81'
          CLI   0(R3),C'f'
-         BNH   PHLOOP                  'a'..'f'
+         BNH   PHLOOP                  X'81'..X'86' = lowercase hex
+         B     PHADV                   X'87'..X'C0' = invalid
+*
 PHADV    LA    R3,1(,R3)
          BCT   R4,PHSKIP
          LA    R15,4                   no hex chars found
          BR    R14
 *
 *  Parse hex digits left-to-right; stop at first non-hex char.
-*  Accept '0'-'9', 'A'-'F', 'a'-'f'.
+*  Same EBCDIC region tests as PHSKIP; on the no-match branches
+*  jump to PHEND (we've already collected at least one digit).
 *
 PHLOOP   CLI   0(R3),C'0'
-         BL    PHEND
+         BL    PHCK2LET
          CLI   0(R3),C'9'
          BNH   PHDIGIT
-         CLI   0(R3),C'A'
-         BL    PHEND
+         B     PHEND
+PHCK2LET CLI   0(R3),C'A'
+         BL    PHCK2LOW
          CLI   0(R3),C'F'
          BNH   PHALPHA
-         CLI   0(R3),C'a'
+         B     PHEND
+PHCK2LOW CLI   0(R3),C'a'
          BL    PHEND
          CLI   0(R3),C'f'
          BH    PHEND

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -270,23 +270,25 @@ DUMPDONE DS    0H
          B     EXIT
 *
 **********************************************************************
-*  INIT - IRXINIT INITENVB, TSOFL=1, no caller-prev                  *
+*  INIT [module] - IRXINIT INITENVB; default module IRXTSPRM (TSO)   *
 **********************************************************************
 *
 DOINIT   DS    0H
          MVC   LINETXT(120),=CL120'INIT'
          BAL   R14,WLINE
          MVC   FCODE,=CL8'INITENVB'
+         MVC   PARMODE,=CL8'IRXTSPRM'
+         BAL   R14,SETPMOD            ARGBUF override (if non-blank)
          XC    PARMP,PARMP
          XC    USERP,USERP
          XC    PREVP,PREVP            R0 input = 0 (no prev)
-         OI    FLAGS+3,X'80'          TSOFL = 1 (placeholder)
          BAL   R14,DOIRXINIT
          LA    R15,0
          B     EXIT
 *
 **********************************************************************
-*  INITP - IRXINIT INITENVB, TSOFL=1, R0 = hex env address (prev)    *
+*  INITP hex - IRXINIT INITENVB, R0 = hex env address (prev),         *
+*              module fixed to IRXTSPRM                              *
 **********************************************************************
 *
 DOINITP  DS    0H
@@ -296,29 +298,55 @@ DOINITP  DS    0H
          LTR   R15,R15
          BNZ   ARGERR
          MVC   FCODE,=CL8'INITENVB'
+         MVC   PARMODE,=CL8'IRXTSPRM'
          XC    PARMP,PARMP
          XC    USERP,USERP
          MVC   PREVP,WORK_TMPA
-         OI    FLAGS+3,X'80'
          BAL   R14,DOIRXINIT
          LA    R15,0
          B     EXIT
 *
 **********************************************************************
-*  INITNT - IRXINIT INITENVB, TSOFL=0 (non-TSO)                      *
+*  INITNT [module] - IRXINIT INITENVB; default module IRXPARMS       *
+*                    (non-TSO defaults)                              *
 **********************************************************************
 *
 DOINITNT DS    0H
-         MVC   LINETXT(120),=CL120'INITNT (TSOFL=0)'
+         MVC   LINETXT(120),=CL120'INITNT'
          BAL   R14,WLINE
          MVC   FCODE,=CL8'INITENVB'
+         MVC   PARMODE,=CL8'IRXPARMS'
+         BAL   R14,SETPMOD            ARGBUF override (if non-blank)
          XC    PARMP,PARMP
          XC    USERP,USERP
          XC    PREVP,PREVP
-         XC    FLAGS,FLAGS            TSOFL = 0
          BAL   R14,DOIRXINIT
          LA    R15,0
          B     EXIT
+*
+**********************************************************************
+*  SETPMOD - if ARGBUF[0] is non-blank, copy first 8 chars (uppercase,*
+*            blank-padded) into PARMODE, overriding the default.     *
+**********************************************************************
+*
+SETPMOD  DS    0H
+         CLI   ARGBUF,C' '             ARGBUF blank?
+         BER   R14                     yes -> keep default, return
+*
+         ST    R14,WORK_R14H
+         MVC   PARMODE,=CL8' '         clear, will be overlaid
+         LA    R3,ARGBUF
+         LA    R5,PARMODE
+         LA    R7,8
+SPMCPY   CLI   0(R3),C' '
+         BE    SPMD
+         MVC   0(1,R5),0(R3)
+         OI    0(R5),X'40'             EBCDIC uppercase mask
+         LA    R3,1(,R3)
+         LA    R5,1(,R5)
+         BCT   R7,SPMCPY
+SPMD     L     R14,WORK_R14H
+         BR    R14
 *
 **********************************************************************
 *  TERM - IRXTERM with R0 = hex env address                          *
@@ -432,15 +460,23 @@ EXIT     DS    0H
 *  DOIRXINIT - common IRXINIT INITENVB call sequence                 *
 *                                                                    *
 *    Inputs:  FCODE   8-byte function code ('INITENVB')              *
+*             PARMODE 8-byte parameter-module name (CL8, blank-pad)  *
 *             PARMP   address of caller PARMBLOCK or 0               *
-*             USERP   user field address or 0                        *
+*             USERP   user field (fullword)                          *
 *             PREVP   value to load into R0 (caller-prev) or 0       *
-*             FLAGS   flags fullword (TSOFL bit etc.)                *
 *    Output:  WORK_NEWE   new ENVBLOCK address                       *
-*             WORK_NEWWB  workblock-extension address                *
 *             WORK_RSN    reason code                                *
 *             WORK_RC     RC from IRXINIT                            *
-*             prints  pre/post ECTENVBK and the four output values   *
+*             prints  pre/post ECTENVBK and the output values        *
+*                                                                    *
+*  IRXINIT INITENVB parameter list per CON-1 §3.x / SC28-1883-0:     *
+*    P1  function code           (CL8)                               *
+*    P2  parameter module name   (CL8, blank = use system default)   *
+*    P3  caller PARMBLOCK        (A, 0 = use module-supplied)        *
+*    P4  user field              (F)                                 *
+*    P5  reserved — addr of fullword zero (must be non-NULL)         *
+*    P6  out: ENVBLOCK address   (A)                                 *
+*    P7  out: reason code        (F)                                 *
 **********************************************************************
 *
 DOIRXINIT DS   0H
@@ -450,29 +486,30 @@ DOIRXINIT DS   0H
          MVC   LBLBUF(20),=CL20'  pre  ECTENVBK'
          L     R1,WORK_ENVB
          BAL   R14,WKVHEX
+         MVC   LBLBUF(20),=CL20'  module'
+         LA    R1,PARMODE
+         BAL   R14,WKVTXT8M
 *
          XC    WORK_NEWE,WORK_NEWE
-         XC    WORK_NEWWB,WORK_NEWWB
          XC    WORK_RSN,WORK_RSN
 *
-*  Build IRXINIT parameter list (all addresses high-bit clear; VL=1
-*  on last entry).
+*  Build IRXINIT parameter list (high-bit set on P7 only).
 *
          LA    R3,FCODE
-         ST    R3,PLIST+0
+         ST    R3,PLIST+0          P1: function code
+         LA    R3,PARMODE
+         ST    R3,PLIST+4          P2: parameter module name
          LA    R3,PARMP
-         ST    R3,PLIST+4
+         ST    R3,PLIST+8          P3: caller PARMBLOCK (or 0)
          LA    R3,USERP
-         ST    R3,PLIST+8
+         ST    R3,PLIST+12         P4: user field
+         LA    R3,RESVZ
+         ST    R3,PLIST+16         P5: addr of reserved zero
          LA    R3,WORK_NEWE
-         ST    R3,PLIST+12
-         LA    R3,WORK_NEWWB
-         ST    R3,PLIST+16
+         ST    R3,PLIST+20         P6: out envblock addr
          LA    R3,WORK_RSN
-         ST    R3,PLIST+20
-         LA    R3,FLAGS
-         ST    R3,PLIST+24
-         OI    PLIST+24,X'80'         high-bit on last entry
+         ST    R3,PLIST+24         P7: out reason code
+         OI    PLIST+24,X'80'      VL=1 marker on last entry
 *
          LOAD  EP=IRXINIT,ERRET=NOIRXIN
          LR    R3,R0                  R3 = IRXINIT entry-point addr
@@ -493,9 +530,6 @@ DOIRXINIT DS   0H
          BAL   R14,WKVDEC
          MVC   LBLBUF(20),=CL20'  new envblock'
          L     R1,WORK_NEWE
-         BAL   R14,WKVHEX
-         MVC   LBLBUF(20),=CL20'  workblok ext'
-         L     R1,WORK_NEWWB
          BAL   R14,WKVHEX
 *
          BAL   R14,READECT
@@ -827,54 +861,61 @@ PARSEHEX DS    0H
          L     R9,=F'0'                accumulator
          LA    R5,0                    digit count
 *
-*  Skip leading blanks
+*  Skip leading non-hex characters (spaces, NULs, anything else
+*  that REXX or LINKMVS may prepend to the parameter data).
 *
-PHSKIP   CLI   0(R3),C' '
-         BNE   PHLOOP
-         LA    R3,1(,R3)
+PHSKIP   CLI   0(R3),C'0'
+         BL    PHADV
+         CLI   0(R3),C'9'
+         BNH   PHLOOP                  '0'..'9' -> start parsing
+         CLI   0(R3),C'A'
+         BL    PHADV
+         CLI   0(R3),C'F'
+         BNH   PHLOOP                  'A'..'F'
+         CLI   0(R3),C'a'
+         BL    PHADV
+         CLI   0(R3),C'f'
+         BNH   PHLOOP                  'a'..'f'
+PHADV    LA    R3,1(,R3)
          BCT   R4,PHSKIP
-         LA    R15,4                   nothing but blanks
+         LA    R15,4                   no hex chars found
          BR    R14
 *
-*  Parse digits left-to-right; accept '0'-'9', 'A'-'F', 'a'-'f'.
-*  Stop on blank or NUL or after 8 digits.
+*  Parse hex digits left-to-right; stop at first non-hex char.
+*  Accept '0'-'9', 'A'-'F', 'a'-'f'.
 *
-PHLOOP   CLI   0(R3),C' '
-         BE    PHEND
-         CLI   0(R3),X'00'
-         BE    PHEND
-         IC    R10,0(,R3)              char (zero-extended)
-*
-         CLI   0(R3),C'0'
-         BL    PHERR
+PHLOOP   CLI   0(R3),C'0'
+         BL    PHEND
          CLI   0(R3),C'9'
-         BH    PHALPHA
-         N     R10,=F'15'              digit nibble
-         B     PHACCUM
-*
-PHALPHA  CLI   0(R3),C'A'
-         BL    PHERR
+         BNH   PHDIGIT
+         CLI   0(R3),C'A'
+         BL    PHEND
          CLI   0(R3),C'F'
-         BH    PHLOWER
-         B     PHLET
-PHLOWER  CLI   0(R3),C'a'
-         BL    PHERR
+         BNH   PHALPHA
+         CLI   0(R3),C'a'
+         BL    PHEND
          CLI   0(R3),C'f'
-         BH    PHERR
-PHLET    N     R10,=F'15'
+         BH    PHEND
+*
+PHALPHA  IC    R10,0(,R3)
+         N     R10,=F'15'
          LA    R10,9(,R10)
          N     R10,=F'15'              alpha nibble (10..15)
+         B     PHACCUM
+*
+PHDIGIT  IC    R10,0(,R3)
+         N     R10,=F'15'              digit nibble
 *
 PHACCUM  SLL   R9,4
          AR    R9,R10
          LA    R3,1(,R3)
          LA    R5,1(,R5)
          CL    R5,=F'8'
-         BNL   PHEND
+         BNL   PHEND                   collected 8 digits
          BCT   R4,PHLOOP
 *
 PHEND    LTR   R5,R5
-         BZ    PHERR                   no digits at all
+         BZ    PHERR                   no digits found
          ST    R9,WORK_TMPA
          LA    R15,0
          BR    R14
@@ -903,10 +944,11 @@ LINETXT  DS    CL120
 LBLBUF   DS    CL20
 *
 FCODE    DS    CL8
-PARMP    DS    F
-USERP    DS    F
-PREVP    DS    F
-FLAGS    DS    F
+PARMODE  DS    CL8                     IRXINIT P2: parm-module name
+PARMP    DS    F                       IRXINIT P3: caller PARMBLOCK
+USERP    DS    F                       IRXINIT P4: user field
+PREVP    DS    F                       R0 input: caller-prev env
+RESVZ    DC    F'0'                    IRXINIT P5 reserved zero
 PLIST    DS    8F
 *
 WORK_ASCB    DS  F
@@ -917,7 +959,6 @@ WORK_ENVB    DS  F
 WORK_ANCH    DS  F
 WORK_PARM    DS  F
 WORK_NEWE    DS  F
-WORK_NEWWB   DS  F
 WORK_RSN     DS  F
 WORK_RC      DS  F
 WORK_FINRC   DS  F

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -65,7 +65,9 @@ R15      EQU   15
 *
          SAVE  (14,12),,*
          LR    R12,R15
-         USING IRXPROBE,R12
+         LA    R11,2048(,R12)         second base ...
+         LA    R11,2048(,R11)         ... R11 = R12 + 4096
+         USING IRXPROBE,R12,R11       8 KB of addressability
          LR    R2,R1                  preserve param-list pointer
          LA    R15,SAVEAR1
          ST    R13,4(R15)
@@ -537,10 +539,9 @@ WANCHHDR DS    0H
 WANCHSLT DS    0H
          ST    R14,WORK_R14W
          LA    R9,32(,R8)             R9 -> first slot
-         LA    R11,0                  R11 = slot index 0..3
+         LA    R6,0                   R6 = slot index 0..3
 *
-WANCHLP  ST    R11,WORK_TMPA
-         L     R3,0(,R9)              envblock_ptr
+WANCHLP  L     R3,0(,R9)              envblock_ptr
          C     R3,=F'-1'
          BE    SLOT_SENT
          LTR   R3,R3
@@ -550,8 +551,7 @@ WANCHLP  ST    R11,WORK_TMPA
 SLOT_SENT MVC  LINETXT(120),=CL120'  slot 0  SENTINEL'
          B     SLOTPRT
 SLOT_FREE MVC  LINETXT(120),=CL120'  slot 0  FREE'
-SLOTPRT  L     R1,WORK_TMPA           slot index
-         CVD   R1,WORK_DEC
+SLOTPRT  CVD   R6,WORK_DEC
          UNPK  WORK_HEX(2),WORK_DEC+6(2)
          OI    WORK_HEX+1,X'F0'
          MVC   LINETXT+7(1),WORK_HEX+1
@@ -576,9 +576,8 @@ SLOTPRT  L     R1,WORK_TMPA           slot index
          BAL   R14,WKVHEX
 *
          LA    R9,40(,R9)             next slot
-         L     R11,WORK_TMPA
-         LA    R11,1(,R11)
-         CL    R11,=F'4'
+         LA    R6,1(,R6)
+         CL    R6,=F'4'
          BL    WANCHLP
 *
          L     R14,WORK_R14W

--- a/test/zos/asm/irxprobe.asm
+++ b/test/zos/asm/irxprobe.asm
@@ -342,10 +342,15 @@ DOTERM   DS    0H
          L     R1,WORK_ENVB
          BAL   R14,WKVHEX
 *
+         LOAD  EP=IRXTERM,ERRET=NOIRXTM
+         LR    R3,R0                  R3 = IRXTERM entry-point addr
+*
          L     R0,WORK_TMPA           env address
-         L     R15,=V(IRXTERM)
+         LR    R15,R3
          BALR  R14,R15                CALL IRXTERM
          ST    R15,WORK_RC
+*
+         DELETE EP=IRXTERM
 *
          BAL   R14,READECT
          MVC   LBLBUF(20),=CL20'  post ECTENVBK'
@@ -392,6 +397,22 @@ ARGERR   DS    0H
          MVC   LINETXT+24(40),ARGBUF
          BAL   R14,WLINE
          LA    R15,4
+         B     EXIT
+*
+**********************************************************************
+*  NOIRXIN / NOIRXTM - LOAD EP= failure handlers                     *
+**********************************************************************
+*
+NOIRXIN  DS    0H
+         MVC   LINETXT(120),=CL120'  ?? LOAD EP=IRXINIT failed'
+         BAL   R14,WLINE
+         LA    R15,8
+         B     EXIT
+*
+NOIRXTM  DS    0H
+         MVC   LINETXT(120),=CL120'  ?? LOAD EP=IRXTERM failed'
+         BAL   R14,WLINE
+         LA    R15,8
          B     EXIT
 *
 **********************************************************************
@@ -453,11 +474,16 @@ DOIRXINIT DS   0H
          ST    R3,PLIST+24
          OI    PLIST+24,X'80'         high-bit on last entry
 *
+         LOAD  EP=IRXINIT,ERRET=NOIRXIN
+         LR    R3,R0                  R3 = IRXINIT entry-point addr
+*
          L     R0,PREVP               caller-prev or 0
          LA    R1,PLIST
-         L     R15,=V(IRXINIT)
+         LR    R15,R3
          BALR  R14,R15
          ST    R15,WORK_RC
+*
+         DELETE EP=IRXINIT
 *
          MVC   LBLBUF(20),=CL20'  IRXINIT RC'
          L     R1,WORK_RC

--- a/test/zos/jcl/asmprob.jcl
+++ b/test/zos/jcl/asmprob.jcl
@@ -1,0 +1,34 @@
+//ASMPROB JOB (ACCT),'IRXPROBE BUILD',CLASS=A,MSGCLASS=H,
+//             NOTIFY=&SYSUID,REGION=0M
+//*-------------------------------------------------------------------*
+//* ASMPROB - Assemble and link IRXPROBE on z/OS                      *
+//*                                                                   *
+//* Customise:                                                        *
+//*   &USER     replace with your TSO userid (defaults to job NOTIFY) *
+//*   SYSIN  IN substitute the actual source dataset/member or use    *
+//*            //SYSIN DD * pasted from test/zos/asm/irxprobe.asm     *
+//*   SYSLMOD   target load library; member IRXPROBE is created       *
+//*-------------------------------------------------------------------*
+//ASM      EXEC PGM=ASMA90,REGION=0M,
+//             PARM='OBJECT,NODECK,LIST,XREF(SHORT)'
+//SYSLIB   DD   DISP=SHR,DSN=SYS1.MACLIB
+//         DD   DISP=SHR,DSN=SYS1.MODGEN
+//SYSPRINT DD   SYSOUT=*
+//SYSLIN   DD   DSN=&&OBJ,DISP=(NEW,PASS),
+//             SPACE=(CYL,(1,1)),UNIT=SYSALLDA,
+//             DCB=(RECFM=FB,LRECL=80,BLKSIZE=3200)
+//SYSUT1   DD   UNIT=SYSALLDA,SPACE=(CYL,(1,1))
+//SYSIN    DD   DISP=SHR,DSN=&SYSUID..REXX370.SOURCE(IRXPROBE)
+//*
+//LKED     EXEC PGM=IEWL,COND=(0,LT,ASM),
+//             PARM='LIST,MAP,XREF,RENT,REUS,AMODE=31,RMODE=24'
+//SYSLIB   DD   DISP=SHR,DSN=SYS1.CSSLIB
+//SYSLIN   DD   DSN=&&OBJ,DISP=(OLD,DELETE)
+//         DD   *
+  ENTRY IRXPROBE
+  NAME  IRXPROBE(R)
+/*
+//SYSUT1   DD   UNIT=SYSALLDA,SPACE=(CYL,(1,1))
+//SYSPRINT DD   SYSOUT=*
+//SYSLMOD  DD   DISP=SHR,DSN=&SYSUID..REXX370.LOAD
+//

--- a/test/zos/jcl/asmprob.jcl
+++ b/test/zos/jcl/asmprob.jcl
@@ -22,7 +22,8 @@
 //*
 //LKED     EXEC PGM=IEWL,COND=(0,LT,ASM),
 //             PARM='LIST,MAP,XREF,RENT,REUS,AMODE=31,RMODE=24'
-//SYSLIB   DD   DISP=SHR,DSN=SYS1.CSSLIB
+//* IRXINIT / IRXTERM are loaded at runtime via LOAD EP=, so no
+//* link-time SYSLIB resolution is needed.
 //SYSLIN   DD   DSN=&&OBJ,DISP=(OLD,DELETE)
 //         DD   *
   ENTRY IRXPROBE

--- a/test/zos/jcl/uplprob.jcl
+++ b/test/zos/jcl/uplprob.jcl
@@ -1,0 +1,23 @@
+//UPLPROB  JOB (ACCT),'IRXPROBE UPLOAD',CLASS=A,MSGCLASS=H,
+//             NOTIFY=&SYSUID
+//*-------------------------------------------------------------------*
+//* UPLPROB - Allocate the source PDS for IRXPROBE on z/OS            *
+//*                                                                   *
+//* Run this once per system before submitting ASMPROB.  Then upload  *
+//* test/zos/asm/irxprobe.asm to &SYSUID..REXX370.SOURCE(IRXPROBE)    *
+//* via your usual transfer (e.g. zowe files upload, ftp, ind$file).  *
+//*                                                                   *
+//* Likewise allocate a REXX exec PDS and upload the eight drivers    *
+//* from test/zos/rexx into it as members PROBED, PROBEA1 .. PROBEA7. *
+//*-------------------------------------------------------------------*
+//ALLOCSRC EXEC PGM=IEFBR14
+//SOURCE   DD   DISP=(NEW,CATLG),DSN=&SYSUID..REXX370.SOURCE,
+//             SPACE=(TRK,(15,5,20)),UNIT=SYSALLDA,
+//             DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO)
+//LOAD     DD   DISP=(NEW,CATLG),DSN=&SYSUID..REXX370.LOAD,
+//             SPACE=(TRK,(30,10,20)),UNIT=SYSALLDA,
+//             DCB=(RECFM=U,LRECL=0,BLKSIZE=27998,DSORG=PO)
+//REXX     DD   DISP=(NEW,CATLG),DSN=&SYSUID..REXX370.REXX,
+//             SPACE=(TRK,(15,5,20)),UNIT=SYSALLDA,
+//             DCB=(RECFM=FB,LRECL=80,BLKSIZE=3120,DSORG=PO)
+//

--- a/test/zos/rexx/proba1.rex
+++ b/test/zos/rexx/proba1.rex
@@ -1,0 +1,24 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBEA1 - Case A1: First IRXINIT after logon                       */
+/*                                                                    */
+/*   Setup    fresh LOGON; DUMP shows the TMP-default env             */
+/*   Action   IRXINIT INITENVB, TSOFL=1, no caller-prev               */
+/*   Observe  ECTENVBK pre/post, new env address                      */
+/*   Clarifies Q-INIT-1                                               */
+/*--------------------------------------------------------------------*/
+SAY "#CASE=A1 DESC=""First IRXINIT after logon"""
+SAY "===A1-PRE==="
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+ADDRESS LINKMVS "IRXPROBE MARK A1-PRE-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+SAY "===A1-ACTION==="
+ADDRESS LINKMVS "IRXPROBE MARK A1-INIT"
+ADDRESS LINKMVS "IRXPROBE INIT"
+SAY "===A1-POST==="
+ADDRESS LINKMVS "IRXPROBE MARK A1-POST-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK A1-DONE"
+SAY "===A1-DONE==="
+EXIT 0

--- a/test/zos/rexx/proba2.rex
+++ b/test/zos/rexx/proba2.rex
@@ -1,0 +1,36 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBEA2 - Case A2: IRXINIT with caller-prev = TMP-env              */
+/*                                                                    */
+/*   Setup    fresh LOGON; DUMP captures the TMP-env address          */
+/*   Action   IRXINIT INITENVB, R0 = TMP-env addr, TSOFL=1            */
+/*   Observe  whether ECTENVBK is overwritten                         */
+/*   Clarifies Q-INIT-2                                               */
+/*                                                                    */
+/* The TMP-env address must be read off the terminal log from the    */
+/* "ECTENVBK" line of the PRE-DUMP and pasted as the second token    */
+/* of the INITP call below.  Edit this exec before running, or use   */
+/* the manual two-step variant in test/zos/README.md.                */
+/*--------------------------------------------------------------------*/
+PARSE ARG prev_env .
+IF prev_env = "" THEN DO
+  SAY "Usage:  EX 'hlq.REXX(PROBEA2)' '''xxxxxxxx'''"
+  SAY "where xxxxxxxx is the hex TMP-env address from a prior PROBED."
+  EXIT 4
+END
+SAY "#CASE=A2 DESC=""IRXINIT with caller-prev = TMP-env"""
+SAY "#PREV=" prev_env
+SAY "===A2-PRE==="
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+ADDRESS LINKMVS "IRXPROBE MARK A2-PRE-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+SAY "===A2-ACTION==="
+ADDRESS LINKMVS "IRXPROBE MARK A2-INITP"
+ADDRESS LINKMVS "IRXPROBE INITP" prev_env
+SAY "===A2-POST==="
+ADDRESS LINKMVS "IRXPROBE MARK A2-POST-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK A2-DONE"
+SAY "===A2-DONE==="
+EXIT 0

--- a/test/zos/rexx/proba3.rex
+++ b/test/zos/rexx/proba3.rex
@@ -1,0 +1,24 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBEA3 - Case A3: Non-TSO env in TSO session                      */
+/*                                                                    */
+/*   Setup    fresh LOGON; DUMP shows TMP-default env (TSOFL=1)       */
+/*   Action   IRXINIT INITENVB, TSOFL=0                               */
+/*   Observe  whether ECTENVBK is overwritten by a non-TSO env        */
+/*   Clarifies Q-INIT-3                                               */
+/*--------------------------------------------------------------------*/
+SAY "#CASE=A3 DESC=""IRXINIT TSOFL=0 in TSO session"""
+SAY "===A3-PRE==="
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+ADDRESS LINKMVS "IRXPROBE MARK A3-PRE-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+SAY "===A3-ACTION==="
+ADDRESS LINKMVS "IRXPROBE MARK A3-INITNT"
+ADDRESS LINKMVS "IRXPROBE INITNT"
+SAY "===A3-POST==="
+ADDRESS LINKMVS "IRXPROBE MARK A3-POST-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK A3-DONE"
+SAY "===A3-DONE==="
+EXIT 0

--- a/test/zos/rexx/proba4.rex
+++ b/test/zos/rexx/proba4.rex
@@ -1,0 +1,29 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBEA4 - Case A4: Multi-env stack on same TCB                     */
+/*                                                                    */
+/*   Setup    fresh LOGON; TMP-default env exists                     */
+/*   Action   two IRXINIT calls in succession (Env_A then Env_B)      */
+/*   Observe  ECTENVBK after each call; IRXANCHR state                */
+/*   Clarifies Q-INIT-4                                               */
+/*--------------------------------------------------------------------*/
+SAY "#CASE=A4 DESC=""Two IRXINITs on same TCB"""
+SAY "===A4-PRE==="
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+ADDRESS LINKMVS "IRXPROBE MARK A4-PRE-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+SAY "===A4-ACTION-1==="
+ADDRESS LINKMVS "IRXPROBE MARK A4-INIT-A"
+ADDRESS LINKMVS "IRXPROBE INIT"
+ADDRESS LINKMVS "IRXPROBE MARK A4-MID-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+SAY "===A4-ACTION-2==="
+ADDRESS LINKMVS "IRXPROBE MARK A4-INIT-B"
+ADDRESS LINKMVS "IRXPROBE INIT"
+SAY "===A4-POST==="
+ADDRESS LINKMVS "IRXPROBE MARK A4-POST-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK A4-DONE"
+SAY "===A4-DONE==="
+EXIT 0

--- a/test/zos/rexx/proba5.rex
+++ b/test/zos/rexx/proba5.rex
@@ -1,0 +1,42 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBEA5 - Case A5: Term latest env                                 */
+/*                                                                    */
+/*   Setup    fresh LOGON; INIT to create Env_A; capture address      */
+/*   Action   IRXTERM Env_A                                           */
+/*   Observe  ECTENVBK pre/post; IRXTERM RC, RSN; IRXANCHR slot       */
+/*   Clarifies Q-TERM-1                                               */
+/*                                                                    */
+/* Two-step usage:                                                    */
+/*   Step 1: EX 'hlq.REXX(PROBEA5)'                                   */
+/*           Read the new envblock address from the INIT output.      */
+/*   Step 2: EX 'hlq.REXX(PROBEA5)' 'xxxxxxxx'                        */
+/*           Pass the captured address; the exec issues TERM.         */
+/*                                                                    */
+/* Splitting the case in two REXX invocations keeps the env address  */
+/* readable on the terminal between steps.  The case is still         */
+/* executed within a single LOGON session.                            */
+/*--------------------------------------------------------------------*/
+PARSE ARG envaddr .
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+IF envaddr = "" THEN DO
+  SAY "#CASE=A5 STEP=1 DESC=""Create Env_A; record its address"""
+  SAY "===A5-STEP1==="
+  ADDRESS LINKMVS "IRXPROBE MARK A5-PRE-DUMP"
+  ADDRESS LINKMVS "IRXPROBE DUMP"
+  ADDRESS LINKMVS "IRXPROBE MARK A5-INIT-A"
+  ADDRESS LINKMVS "IRXPROBE INIT"
+  SAY "Now capture the 'new envblock' value above and re-run:"
+  SAY "  EX 'hlq.REXX(PROBEA5)' 'xxxxxxxx'"
+  EXIT 0
+END
+SAY "#CASE=A5 STEP=2 DESC=""IRXTERM Env_A=" envaddr """"
+SAY "===A5-STEP2==="
+ADDRESS LINKMVS "IRXPROBE MARK A5-TERM"
+ADDRESS LINKMVS "IRXPROBE TERM" envaddr
+ADDRESS LINKMVS "IRXPROBE MARK A5-POST-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK A5-DONE"
+SAY "===A5-DONE==="
+EXIT 0

--- a/test/zos/rexx/proba6.rex
+++ b/test/zos/rexx/proba6.rex
@@ -1,0 +1,39 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBEA6 - Case A6: Try to TERM the TMP-default env                 */
+/*                                                                    */
+/*   Setup    fresh LOGON                                             */
+/*   Action   IRXTERM on the TMP-default env                          */
+/*   Observe  RC, RSN; whether IBM rejects the call; whether the      */
+/*            session remains usable                                  */
+/*                                                                    */
+/* Risk: this case may destabilise the TSO session.  Run last in     */
+/* its dedicated LOGON session.                                       */
+/*                                                                    */
+/* Two-step usage:                                                    */
+/*   Step 1: EX 'hlq.REXX(PROBEA6)'                                   */
+/*           Read the TMP-default ECTENVBK from the DUMP output.      */
+/*   Step 2: EX 'hlq.REXX(PROBEA6)' 'xxxxxxxx'                        */
+/*           Pass the captured address; the exec issues TERM.         */
+/*--------------------------------------------------------------------*/
+PARSE ARG envaddr .
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+IF envaddr = "" THEN DO
+  SAY "#CASE=A6 STEP=1 DESC=""Capture TMP-default ECTENVBK"""
+  SAY "===A6-STEP1==="
+  ADDRESS LINKMVS "IRXPROBE MARK A6-PRE-DUMP"
+  ADDRESS LINKMVS "IRXPROBE DUMP"
+  SAY "Now capture the ECTENVBK value above and re-run:"
+  SAY "  EX 'hlq.REXX(PROBEA6)' 'xxxxxxxx'"
+  EXIT 0
+END
+SAY "#CASE=A6 STEP=2 DESC=""IRXTERM TMP-default=" envaddr """"
+SAY "===A6-STEP2==="
+ADDRESS LINKMVS "IRXPROBE MARK A6-TERM-TMP"
+ADDRESS LINKMVS "IRXPROBE TERM" envaddr
+ADDRESS LINKMVS "IRXPROBE MARK A6-POST-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK A6-DONE"
+SAY "===A6-DONE==="
+EXIT 0

--- a/test/zos/rexx/proba7.rex
+++ b/test/zos/rexx/proba7.rex
@@ -1,0 +1,38 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBEA7 - Case A7: IRXEXEC with explicit env parameter             */
+/*                                                                    */
+/*   Setup    fresh LOGON; INIT to create Env_A; capture address      */
+/*   Action   IRXEXEC with explicit Env_A while ECTENVBK still        */
+/*            points at the TMP-default env                           */
+/*   Observe  which env IRXEXEC actually uses                         */
+/*   Clarifies Q-EXEC-1                                               */
+/*                                                                    */
+/* The HLASM IRXPROBE EXEC subcommand is a stub in this revision     */
+/* (returns NOT_IMPLEMENTED).  This driver is included to anchor      */
+/* the case definition; full IRXEXEC linkage is a follow-up to        */
+/* issue #74 once Phase alpha for cases D + A1..A6 has run.          */
+/*--------------------------------------------------------------------*/
+PARSE ARG envaddr .
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+IF envaddr = "" THEN DO
+  SAY "#CASE=A7 STEP=1 DESC=""Create Env_A; record its address"""
+  SAY "===A7-STEP1==="
+  ADDRESS LINKMVS "IRXPROBE MARK A7-PRE-DUMP"
+  ADDRESS LINKMVS "IRXPROBE DUMP"
+  ADDRESS LINKMVS "IRXPROBE MARK A7-INIT-A"
+  ADDRESS LINKMVS "IRXPROBE INIT"
+  SAY "Now capture the 'new envblock' value above and re-run:"
+  SAY "  EX 'hlq.REXX(PROBEA7)' 'xxxxxxxx'"
+  EXIT 0
+END
+SAY "#CASE=A7 STEP=2 DESC=""IRXEXEC with Env_A=" envaddr """"
+SAY "===A7-STEP2==="
+ADDRESS LINKMVS "IRXPROBE MARK A7-EXEC"
+ADDRESS LINKMVS "IRXPROBE EXEC" envaddr
+ADDRESS LINKMVS "IRXPROBE MARK A7-POST-DUMP"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK A7-DONE"
+SAY "===A7-DONE==="
+EXIT 0

--- a/test/zos/rexx/probed.rex
+++ b/test/zos/rexx/probed.rex
@@ -1,0 +1,19 @@
+/* REXX */
+/*--------------------------------------------------------------------*/
+/* PROBED - Discovery driver (Case D)                                 */
+/*                                                                    */
+/* Read-only baseline: walk ECTENVBK and IRXANCHR, dump ENVBLOCK and  */
+/* PARMBLOCK headers as they exist immediately after LOGON.  Does     */
+/* not modify any state.  Safe to re-run.                             */
+/*                                                                    */
+/* Run from a fresh TSO LOGON session, capture the terminal log.      */
+/*--------------------------------------------------------------------*/
+SAY "#CASE=D DESC=""Discovery: TSO baseline state at logon"""
+SAY "===D-PRE==="
+"FREE FILE(SYSPRINT)"
+"ALLOC FILE(SYSPRINT) DA(*) LRECL(121) RECFM(F B A) REUSE"
+ADDRESS LINKMVS "IRXPROBE MARK D-OBSERVE"
+ADDRESS LINKMVS "IRXPROBE DUMP"
+ADDRESS LINKMVS "IRXPROBE MARK D-DONE"
+SAY "===D-DONE==="
+EXIT 0


### PR DESCRIPTION
Phase α of issue #74 — the IRXPROBE research tool that captures IBM
TSO/E REXX behaviour against ECTENVBK and the IRXANCHR registry on
z/OS. All eight subcommands run cleanly on z/OS HLASM R6.0 + IEWL,
and the canonical Phase α cases (D + A1..A6) all produce structured
SYSPRINT-DD output suitable for the master-log diff against a future
MVS 3.8j run.

## What's in the PR

| Path | Purpose |
|---|---|
| `test/zos/asm/irxprobe.asm` | HLASM IRXPROBE module: subcommand dispatcher, `;`-sequenced multi-segment runs, ECTENVBK walk, IRXANCHR + ENVBLOCK + PARMBLOCK dump, IRXINIT + IRXTERM linkage via runtime LOAD EP= |
| `test/zos/jcl/uplprob.jcl` | One-time dataset allocation on z/OS |
| `test/zos/jcl/asmprob.jcl` | Assemble + link IRXPROBE |
| `test/zos/rexx/proba*.rex` | Legacy REXX drivers — kept for reference, no longer canonical |
| `test/zos/README.md` | Run recipe, including the canonical direct-`CALL` invocations per case |
| `.gitignore` | Whitelist `test/zos/jcl/*.jcl` |

## Acceptance criteria

- **AC-1** HLASM source assembles + links cleanly on z/OS — done.
- **AC-2** Eight test cases (Discovery + A1..A7) defined — done; A7 remains a stub pending IRXEXEC follow-up.
- **AC-3** Output format with `== <SUBCMD> ==` segment markers and structured key-value lines — done.
- **AC-4** Mike ran D + A1..A6 on z/OS — done; clean output captured per case.
- **AC-5** Concatenate per-session captures into the master log, attach to CON-3 — Mike, post-merge.
- **AC-6** CON-3 reference table extended with the IBM-observed answers — Mike, post-merge.
- **AC-7** Follow-up tickets for any rexx370-vs-IBM divergence — Mike, post-merge.

## Subcommands

`IRXPROBE` accepts a single subcommand or a `;`-separated sequence
on one invocation. All segments share state inside the same CALL,
so multi-step cases like A5 run on a single subtask:

```
CALL 'hlq.LOAD(IRXPROBE)' 'DUMP;INIT;DUMP;TERM_LAST;DUMP'
```

| Subcommand          | Action |
|---------------------|--------|
| `DUMP`              | Read-only ECTENVBK + IRXANCHR + ENVBLOCK + PARMBLOCK |
| `INIT [module]`     | IRXINIT INITENVB; default parm-module `IRXTSPRM` |
| `INITP hex`         | IRXINIT INITENVB with R0 = hex caller-prev env |
| `INITNT [module]`   | IRXINIT INITENVB; default parm-module `IRXPARMS` |
| `TERM hex`          | IRXTERM on the explicit hex env address |
| `TERM_LAST`         | IRXTERM on the env from the most recent INIT* in this CALL |
| `EXEC hex`          | Stub (NOT_IMPLEMENTED) — A7 follow-up |
| `MARK text`         | Emit a `-- text` separator line |

## Notable design points

- **Calling convention auto-detect.** `BUILDCMD` reads the halfword at R1+0 and dispatches to the TSO-CALL parser (`< 256` = halfword length + text) or the LINKMVS parser (`>= 256` = array of descriptor addresses). Works on z/OS because LINKMVS descriptors live above-the-line; documented in the source.
- **Two base registers.** R12 + R11 (= R12 + 4096) cover the 8 KB CSECT.
- **Runtime LOAD EP=** for IRXINIT/IRXTERM — no link-time SYS1.CSSLIB dependency.
- **State across segments** via `LASTENV` (set by every successful INIT/INITP/INITNT, consumed by `TERM_LAST`).
- **EBCDIC-correct PARSEHEX**: range checks walk digits, uppercase A-F, and lowercase a-f as three explicit regions in EBCDIC encoding order, not the ASCII-derived linear scan that silently truncated addresses with letters.

## Phase β (out of scope)

Port to MVS 3.8j (IFOX00) + diff against the master log — separate
ticket after Phase α has produced the CON-3 reference table.

Fixes #74
