### PR TITLE
fix(anchor): IRXANCHR slot flags only for TSO-attached envs (Phase α)

### DIFF
--- a/asm/irxanchr.asm
+++ b/asm/irxanchr.asm
@@ -20,7 +20,7 @@
 *    +0x08 16B  (reserved)
 *    +0x18  4B  ANCHOR_HINT
 *    +0x1C  4B  TCB_PTR
-*    +0x20  4B  FLAGS            0x40000000 = in-use
+*    +0x20  4B  FLAGS            0x40000000 = TSO-attached
 *    +0x24  4B  (reserved)
 *
 *  Slot 0 is a permanent sentinel and is never allocated by the API.

--- a/include/irxanchr.h
+++ b/include/irxanchr.h
@@ -105,8 +105,13 @@ void anch_push(struct envblock *new_env) asm("ANCHPUSH");
 #define IRXANCHR_SLOT_FREE     ((uint32_t)0x00000000U)
 #define IRXANCHR_SLOT_SENTINEL ((uint32_t)0xFFFFFFFFU)
 
-/* Flag bit set in the flags field when a slot is in use */
-#define IRXANCHR_FLAG_IN_USE ((uint32_t)0x40000000U)
+/* Top bit of the flags field — set when the slot represents a
+ * TSO-attached env (i.e. registered via ECTENVBK). For non-TSO envs
+ * (TSOFL=0) the flags field stays 0x00000000. Slot occupancy is
+ * determined by envblock_ptr (see IRXANCHR_SLOT_FREE / SLOT_SENTINEL),
+ * NOT by this bit. Verified against IBM TSO/E z/OS via IRXPROBE
+ * Phase α Case A1 vs A3 (CON-14). */
+#define IRXANCHR_FLAG_TSO_ATTACHED ((uint32_t)0x40000000U)
 
 /* ================================================================== */
 /*  Part 2: IRXANCHR Registry — Structs                               */
@@ -141,7 +146,7 @@ typedef struct
                             * all slots including rsvd1. */
     uint32_t anchor_hint;  /* +0x18  opaque hint for fast slot re-find        */
     uint32_t tcb_ptr;      /* +0x1C  TCB address at alloc time                */
-    uint32_t flags;        /* +0x20  IRXANCHR_FLAG_IN_USE when active         */
+    uint32_t flags;        /* +0x20  IRXANCHR_FLAG_TSO_ATTACHED for TSO envs  */
     uint32_t rsvd2;        /* +0x24  reserved                                 */
 } irxanchr_entry_t;
 
@@ -174,8 +179,12 @@ typedef char irxanchr_entry_flags_ofs_[(offsetof(irxanchr_entry_t, flags) == 32)
 /* ================================================================== */
 
 /* Claim a free slot; sets envblock_ptr, token, tcb_ptr, flags.
+ * is_tso=1 sets flags=IRXANCHR_FLAG_TSO_ATTACHED (TSO env); is_tso=0
+ * leaves flags=0x00000000 (non-TSO env). The flag does NOT track
+ * slot occupancy — that lives in envblock_ptr.
  * Returns 0 on success, non-zero if table full or invalid. */
-int irx_anchor_alloc_slot(void *envblock, void *tcb, uint32_t *out_token) asm("ANCHALOC");
+int irx_anchor_alloc_slot(void *envblock, void *tcb, int is_tso,
+                          uint32_t *out_token) asm("ANCHALOC");
 
 /* Release the slot for envblock (sets envblock_ptr = IRXANCHR_SLOT_FREE).
  * USED remains at high-watermark (never decremented).

--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -267,7 +267,8 @@ int irx_anchor_get_handle(irxanchr_header_t **out_anchor)
 
 /* ---- common registry functions ---- */
 
-int irx_anchor_alloc_slot(void *envblock, void *tcb, uint32_t *out_token)
+int irx_anchor_alloc_slot(void *envblock, void *tcb, int is_tso,
+                          uint32_t *out_token)
 {
     irxanchr_header_t *hdr;
     irxanchr_entry_t *slots;
@@ -321,10 +322,15 @@ int irx_anchor_alloc_slot(void *envblock, void *tcb, uint32_t *out_token)
         }
 
         /* Populate aux fields before bumping USED: a concurrent
-         * find_by_tcb scans 0..USED and must see a complete entry. */
+         * find_by_tcb scans 0..USED and must see a complete entry.
+         *
+         * flags=0x40000000 marks the slot as TSO-attached (verified
+         * IRXPROBE Phase α Case A1 vs A3, CON-14). Non-TSO envs leave
+         * flags=0x00000000 — slot occupancy is tracked via envblock_ptr,
+         * not via this bit. */
         slots[i].token = anchor_fetch_inc(counter) + 1U;
         slots[i].tcb_ptr = (uint32_t)(unsigned long)tcb;
-        slots[i].flags = IRXANCHR_FLAG_IN_USE;
+        slots[i].flags = is_tso ? IRXANCHR_FLAG_TSO_ATTACHED : 0U;
 #ifndef __MVS__
         /* On the 64-bit cross-compile host, envblock_ptr truncates the
          * pointer to 32 bits.  irx_init_findenvb needs to dereference

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -398,7 +398,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
 #endif
         uint32_t slot_token = 0;
         /* Ignore IRX_ANCHOR_RC_FULL — non-fatal, env remains usable. */
-        (void)irx_anchor_alloc_slot(envblk, tcb, &slot_token);
+        (void)irx_anchor_alloc_slot(envblk, tcb, is_tso, &slot_token);
     }
 
     /* ----------------------------------------------------------------
@@ -529,10 +529,9 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
         {
             continue;
         }
-        if (!(slots[i].flags & IRXANCHR_FLAG_IN_USE))
-        {
-            continue;
-        }
+        /* Slot occupancy is determined solely by envblock_ptr; the
+         * flags field marks TSO-attachment, not in-use status (CON-14
+         * IRXPROBE Phase α). FINDENVB walks both TSO and non-TSO envs. */
         if (slots[i].tcb_ptr != tcbptr)
         {
             continue;

--- a/test/mvs/tstansl.c
+++ b/test/mvs/tstansl.c
@@ -1,7 +1,7 @@
 /* ------------------------------------------------------------------ */
 /*  tstansl.c - IRXANCHR Slot-Management-API tests (WP-I1a.3)         */
 /*                                                                    */
-/*  Seven test cases pinning down the IBM-observed slot-allocation     */
+/*  Eight test cases pinning down the IBM-observed slot-allocation    */
 /*  behaviour:                                                        */
 /*    1. Alloc/find/free round-trip; USED stays at high-watermark      */
 /*    2. High-watermark never shrinks; next alloc uses N+1, not freed  */
@@ -10,6 +10,7 @@
 /*    5. Table-full: 62nd alloc succeeds, 63rd returns RC=FULL         */
 /*    6. find_by_tcb returns the highest-token entry for a TCB         */
 /*    7. get_handle returns RC=BAD_EYE on corrupt eye-catcher (host)   */
+/*    8. is_tso flag steers FLAGS field; lookup is flag-agnostic       */
 /*                                                                    */
 /*  Cross-compile build:                                              */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
@@ -96,7 +97,7 @@ static void test_1_round_trip(void)
     printf("--- Test 1: alloc/find/free round-trip\n");
     irx_anchor_table_reset();
 
-    rc = irx_anchor_alloc_slot(ENV(1), TCB(1), &tok);
+    rc = irx_anchor_alloc_slot(ENV(1), TCB(1), /*is_tso=*/1, &tok);
     CHECK(rc == IRX_ANCHOR_RC_OK, "T1: alloc slot returns OK");
     CHECK(tok == 1, "T1: first token is 1");
     CHECK(get_used() == 2, "T1: USED = 2 after first alloc");
@@ -107,8 +108,8 @@ static void test_1_round_trip(void)
     CHECK(e != NULL &&
               e->tcb_ptr == (uint32_t)(unsigned long)TCB(1),
           "T1: found slot has correct tcb_ptr");
-    CHECK(e != NULL && (e->flags & IRXANCHR_FLAG_IN_USE),
-          "T1: found slot has IN_USE flag");
+    CHECK(e != NULL && (e->flags & IRXANCHR_FLAG_TSO_ATTACHED),
+          "T1: TSO-attached slot has 0x40000000 flag");
 
     rc = irx_anchor_free_slot(ENV(1));
     CHECK(rc == IRX_ANCHOR_RC_OK, "T1: free_slot returns OK");
@@ -131,20 +132,20 @@ static void test_2_hwm_no_recycle(void)
     irx_anchor_table_reset();
     slots = get_slots();
 
-    irx_anchor_alloc_slot(ENV(2), TCB(1), &tok_a);
+    irx_anchor_alloc_slot(ENV(2), TCB(1), /*is_tso=*/1, &tok_a);
     CHECK(slots != NULL &&
               slots[1].envblock_ptr == (uint32_t)(unsigned long)ENV(2),
           "T2: env_A lands in slot 1");
     CHECK(get_used() == 2, "T2: USED = 2 after env_A");
 
     /* Slot 2 is a permanent sentinel — env_B must skip it → slot 3. */
-    irx_anchor_alloc_slot(ENV(3), TCB(1), &tok_b);
+    irx_anchor_alloc_slot(ENV(3), TCB(1), /*is_tso=*/1, &tok_b);
     CHECK(slots != NULL &&
               slots[3].envblock_ptr == (uint32_t)(unsigned long)ENV(3),
           "T2: env_B lands in slot 3 (slot 2 is sentinel)");
     CHECK(get_used() == 4, "T2: USED = 4 after env_B");
 
-    irx_anchor_alloc_slot(ENV(4), TCB(1), &tok_c);
+    irx_anchor_alloc_slot(ENV(4), TCB(1), /*is_tso=*/1, &tok_c);
     CHECK(slots != NULL &&
               slots[4].envblock_ptr == (uint32_t)(unsigned long)ENV(4),
           "T2: env_C lands in slot 4");
@@ -154,7 +155,7 @@ static void test_2_hwm_no_recycle(void)
     CHECK(get_used() == 5, "T2: USED stays 5 after freeing env_B");
 
     /* Append-only: next alloc starts at USED=5, not recycled slot 3. */
-    irx_anchor_alloc_slot(ENV(5), TCB(1), &tok_d);
+    irx_anchor_alloc_slot(ENV(5), TCB(1), /*is_tso=*/1, &tok_d);
     CHECK(slots != NULL &&
               slots[5].envblock_ptr == (uint32_t)(unsigned long)ENV(5),
           "T2: env_D lands in slot 5 (no recycling of freed slot 3)");
@@ -181,10 +182,10 @@ static void test_3_sentinel_integrity(void)
 
     /* Drive several alloc/free cycles so the scan passes both
      * sentinel positions at least once. */
-    irx_anchor_alloc_slot(ENV(10), TCB(1), &tok);
-    irx_anchor_alloc_slot(ENV(11), TCB(1), &tok);
+    irx_anchor_alloc_slot(ENV(10), TCB(1), /*is_tso=*/1, &tok);
+    irx_anchor_alloc_slot(ENV(11), TCB(1), /*is_tso=*/1, &tok);
     irx_anchor_free_slot(ENV(10));
-    irx_anchor_alloc_slot(ENV(12), TCB(1), &tok);
+    irx_anchor_alloc_slot(ENV(12), TCB(1), /*is_tso=*/1, &tok);
 
     CHECK(slots != NULL &&
               slots[0].envblock_ptr == IRXANCHR_SLOT_SENTINEL,
@@ -222,9 +223,9 @@ static void test_4_token_monotonic(void)
     printf("--- Test 4: token monotonicity\n");
     irx_anchor_table_reset();
 
-    irx_anchor_alloc_slot(ENV(20), TCB(1), &tok1);
+    irx_anchor_alloc_slot(ENV(20), TCB(1), /*is_tso=*/1, &tok1);
     irx_anchor_free_slot(ENV(20));
-    irx_anchor_alloc_slot(ENV(20), TCB(1), &tok2);
+    irx_anchor_alloc_slot(ENV(20), TCB(1), /*is_tso=*/1, &tok2);
 
     CHECK(tok2 > tok1,
           "T4: re-allocated slot gets strictly higher token");
@@ -247,7 +248,7 @@ static void test_5_table_full(void)
     /* Allocatable slots: 1, 3-63 = 62 slots. */
     for (i = 0; i < 62; i++)
     {
-        rc = irx_anchor_alloc_slot(ENV(100 + i), TCB(1), &tok);
+        rc = irx_anchor_alloc_slot(ENV(100 + i), TCB(1), /*is_tso=*/1, &tok);
         if (rc == IRX_ANCHOR_RC_OK)
         {
             filled++;
@@ -255,7 +256,7 @@ static void test_5_table_full(void)
     }
     CHECK(filled == 62, "T5: 62 allocations succeed (all non-sentinel slots)");
 
-    rc = irx_anchor_alloc_slot(ENV(200), TCB(1), &tok);
+    rc = irx_anchor_alloc_slot(ENV(200), TCB(1), /*is_tso=*/1, &tok);
     CHECK(rc == IRX_ANCHOR_RC_FULL,
           "T5: 63rd allocation returns RC=FULL");
 
@@ -276,9 +277,9 @@ static void test_6_find_by_tcb(void)
     printf("--- Test 6: find_by_tcb returns highest-token entry\n");
     irx_anchor_table_reset();
 
-    irx_anchor_alloc_slot(ENV(30), TCB(2), &tok1);
-    irx_anchor_alloc_slot(ENV(31), TCB(2), &tok2);
-    irx_anchor_alloc_slot(ENV(32), TCB(3), &tok3);
+    irx_anchor_alloc_slot(ENV(30), TCB(2), /*is_tso=*/1, &tok1);
+    irx_anchor_alloc_slot(ENV(31), TCB(2), /*is_tso=*/1, &tok2);
+    irx_anchor_alloc_slot(ENV(32), TCB(3), /*is_tso=*/1, &tok3);
 
     found = irx_anchor_find_by_tcb(TCB(2));
     CHECK(found != NULL, "T6: find_by_tcb(tcb2) returns non-NULL");
@@ -345,6 +346,49 @@ static void test_7_eyecatcher(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Test 8: is_tso parameter steers FLAGS; lookup is flag-agnostic     */
+/*                                                                    */
+/*  Per IRXPROBE Phase α (CON-14, Case A1 vs A3): the top bit of      */
+/*  the FLAGS field is set only for TSO-attached envs (TSOFL=1) and   */
+/*  cleared for non-TSO envs (TSOFL=0). Slot occupancy is determined  */
+/*  by envblock_ptr alone — find_by_envblock and find_by_tcb must     */
+/*  return both flag values.                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_8_is_tso_flag(void)
+{
+    uint32_t tok = 0;
+    irxanchr_entry_t *e;
+
+    printf("--- Test 8: is_tso flag steers FLAGS field\n");
+    irx_anchor_table_reset();
+
+    /* TSO-attached env → flag set. */
+    irx_anchor_alloc_slot(ENV(40), TCB(1), /*is_tso=*/1, &tok);
+    e = irx_anchor_find_by_envblock(ENV(40));
+    CHECK(e != NULL && e->flags == IRXANCHR_FLAG_TSO_ATTACHED,
+          "T8: is_tso=1 → flags == 0x40000000");
+
+    /* Non-TSO env → flag clear. */
+    irx_anchor_alloc_slot(ENV(41), TCB(1), /*is_tso=*/0, &tok);
+    e = irx_anchor_find_by_envblock(ENV(41));
+    CHECK(e != NULL && e->flags == 0U,
+          "T8: is_tso=0 → flags == 0x00000000");
+
+    /* Both env kinds findable via find_by_envblock. */
+    CHECK(irx_anchor_find_by_envblock(ENV(40)) != NULL,
+          "T8: find_by_envblock returns TSO-attached slot");
+    CHECK(irx_anchor_find_by_envblock(ENV(41)) != NULL,
+          "T8: find_by_envblock returns non-TSO slot");
+
+    /* find_by_tcb returns the highest-token entry regardless of flag —
+     * here the non-TSO env was allocated second, so it wins. */
+    e = irx_anchor_find_by_tcb(TCB(1));
+    CHECK(e != NULL && e->envblock_ptr == (uint32_t)(unsigned long)ENV(41),
+          "T8: find_by_tcb returns highest-token entry across flag values");
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main                                                               */
 /* ------------------------------------------------------------------ */
 
@@ -359,6 +403,7 @@ int main(void)
     test_5_table_full();
     test_6_find_by_tcb();
     test_7_eyecatcher();
+    test_8_is_tso_flag();
 
     printf("\n=== Results: passed=%d run=%d skipped=%d",
            tests_passed, tests_run, tests_skipped);

--- a/test/mvs/tstinit.c
+++ b/test/mvs/tstinit.c
@@ -13,6 +13,8 @@
 /*  T6: irxterm after irx_init_initenvb — returns 0                   */
 /*  T7: irxinit() compat wrapper — IRXEXTE fully wired (irxuid != 0)  */
 /*  T8: Bad prev_envblock eye-catcher — step 1 skip, falls through    */
+/*  T9: TSOFL=1 parmblock → IRXANCHR slot flags=0x40000000            */
+/*  T10: TSOFL=0 parmblock → IRXANCHR slot flags=0x00000000           */
 /*                                                                    */
 /*  Cross-compile build:                                              */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
@@ -197,8 +199,20 @@ static void test_t4_anchor_slot_alloc(void)
         CHECK(slot != NULL, "irx_anchor_find_by_envblock returns non-NULL slot");
         if (slot != NULL)
         {
-            CHECK((slot->flags & IRXANCHR_FLAG_IN_USE) != 0,
-                  "slot flag IN_USE is set");
+            /* On the cross-compile host anch_tso() returns 0 and no
+             * caller_parmblock was supplied, so is_tso=0. The default
+             * init path produces a non-TSO slot with flags=0. T9/T10
+             * cover the TSOFL-driven flag values explicitly. */
+#ifdef __MVS__
+            /* TSO foreground or batch — anch_tso() may report either.
+             * Verify the flag matches one of the two valid values. */
+            CHECK(slot->flags == 0U ||
+                      slot->flags == IRXANCHR_FLAG_TSO_ATTACHED,
+                  "slot flag is 0 or TSO_ATTACHED");
+#else
+            CHECK(slot->flags == 0U,
+                  "host non-TSO env: slot flags == 0");
+#endif
         }
 
         irxterm(envblk);
@@ -366,6 +380,94 @@ static void test_t8_bad_prev_eyecatcher(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  T9 / T10 helper: build a minimal valid PARMBLOCK with explicit    */
+/*  TSOFL bit. Mask byte 0 MSB selects tsofl as caller-overridden;    */
+/*  flag byte 0 MSB carries the desired value (1=TSO, 0=non-TSO).     */
+/* ------------------------------------------------------------------ */
+
+static void build_parmblock_with_tsofl(struct parmblock *pb, int tso)
+{
+    memset(pb, 0, sizeof(*pb));
+    memcpy(pb->parmblock_id, PARMBLOCK_ID, 8);
+    memcpy(pb->parmblock_version, PARMBLOCK_VERSION_0042, 4);
+    /* Use the bit-field accessors so layout differences between the
+     * MVS toolchain (MSB-first) and the cross-compile host (LSB-first)
+     * do not silently misroute the bit. The fields are signed 1-bit
+     * bit-fields, so -1 is the only representable "true" value (matches
+     * the convention in test/mvs/tstfind.c). */
+    pb->tsofl_mask = -1;
+    pb->tsofl = tso ? -1 : 0;
+    memset(pb->parmblock_addrspn, ' ', 8);
+    memset(pb->parmblock_ffff, 0xFF, 8);
+}
+
+/* ------------------------------------------------------------------ */
+/*  T9: TSOFL=1 → IRXANCHR slot flags == 0x40000000                   */
+/* ------------------------------------------------------------------ */
+
+static void test_t9_tsofl_set_flag(void)
+{
+    struct parmblock pb;
+    struct envblock *envblk = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- T9: TSOFL=1 → IRXANCHR slot TSO_ATTACHED ---\n");
+
+    irx_anchor_table_reset();
+    build_parmblock_with_tsofl(&pb, /*tso=*/1);
+
+    rc = irx_init_initenvb(NULL, &pb, 0, &envblk, &reason);
+    CHECK(rc == 0, "irx_init_initenvb returns 0");
+
+    if (envblk != NULL)
+    {
+        irxanchr_entry_t *slot = irx_anchor_find_by_envblock(envblk);
+        CHECK(slot != NULL, "T9: slot found");
+        if (slot != NULL)
+        {
+            CHECK(slot->flags == IRXANCHR_FLAG_TSO_ATTACHED,
+                  "T9: TSOFL=1 → flags == 0x40000000");
+        }
+
+        irxterm(envblk);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  T10: TSOFL=0 explicit → IRXANCHR slot flags == 0x00000000         */
+/* ------------------------------------------------------------------ */
+
+static void test_t10_tsofl_clear_flag(void)
+{
+    struct parmblock pb;
+    struct envblock *envblk = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- T10: TSOFL=0 → IRXANCHR slot non-TSO ---\n");
+
+    irx_anchor_table_reset();
+    build_parmblock_with_tsofl(&pb, /*tso=*/0);
+
+    rc = irx_init_initenvb(NULL, &pb, 0, &envblk, &reason);
+    CHECK(rc == 0, "irx_init_initenvb returns 0");
+
+    if (envblk != NULL)
+    {
+        irxanchr_entry_t *slot = irx_anchor_find_by_envblock(envblk);
+        CHECK(slot != NULL, "T10: slot found");
+        if (slot != NULL)
+        {
+            CHECK(slot->flags == 0U,
+                  "T10: TSOFL=0 → flags == 0x00000000");
+        }
+
+        irxterm(envblk);
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                               */
 /* ------------------------------------------------------------------ */
 
@@ -381,6 +483,8 @@ int main(void)
     test_t6_irxterm_after_initenvb();
     test_t7_irxinit_compat_wrapper();
     test_t8_bad_prev_eyecatcher();
+    test_t9_tsofl_set_flag();
+    test_t10_tsofl_clear_flag();
 
     printf("\n--- Results ---\n");
     printf("  Run:    %d\n", tests_run);


### PR DESCRIPTION
Fixes #76

## Summary

`irx_anchor_alloc_slot()` was unconditionally setting the slot FLAGS
field to `0x40000000`. IRXPROBE Phase α (TSK-192) verified that on
real IBM TSO/E z/OS the bit means **TSO-attached** (registered via
`ECTENVBK`), not in-use:

- TSOFL=1 env (Case A1) → `flags = 0x40000000`
- TSOFL=0 env (Case A3) → `flags = 0x00000000`

Slot occupancy is decided by `envblock_ptr` alone (`!= 0` and
`!= 0xFFFFFFFF`).

## Changes

- `irx_anchor_alloc_slot()` gains an `int is_tso` parameter; FLAGS is
  set to `IRXANCHR_FLAG_TSO_ATTACHED` only when `is_tso` is true.
- `irx_init_initenvb()` passes its already-computed `is_tso`
  (from PARMBLOCK TSOFL or `anch_tso()` autodetect).
- `IRXANCHR_FLAG_IN_USE` renamed to `IRXANCHR_FLAG_TSO_ATTACHED`
  and the doc comments updated to reflect actual semantics.
- `irx_init_findenvb()` no longer filters slots on the FLAGS bit
  (with the corrected semantics that filter would silently skip
  every non-TSO env). `envblock_ptr` and the eye-catcher check
  remain the authoritative occupancy signals.
- `asm/irxanchr.asm` slot-layout comment updated.

## Tests

- `tstansl` T8 (new): `is_tso=1` → `0x40000000`; `is_tso=0` →
  `0x00000000`; `find_by_envblock` / `find_by_tcb` both return
  slots regardless of flag value.
- `tstinit` T9/T10 (new): caller PARMBLOCK with TSOFL=1 / TSOFL=0
  produces matching slot flags via the IRXINIT path.
- `tstinit` T4 updated: host build defaults to non-TSO env, so
  the assertion now expects `flags == 0`. MVS branch accepts
  either value (both are valid depending on TSO foreground state).

All 19 host binaries green (1276 tests).

## Out of Scope

- IRXTERM ECTENVBK rollback (TSK-194, separate ticket).
- IRXINIT ECTENVBK overwrite semantics fix.
- Other bits in the 32-bit FLAGS field — only `0x40000000` has known
  semantics.

## Test plan

- [x] `bash run_tests.sh` (19 host binaries, all green)
- [ ] MVS rebuild after merge: `tstansl`, `tstinit`, `tstfind`, `tstterm`