### PR TITLE
fix(irxinit): TSOFL-conditional ECTENVBK semantics

### DIFF
--- a/project.toml
+++ b/project.toml
@@ -133,6 +133,24 @@ include = [
 "mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
+# IRXDBG - Debug / Inspection Tool.
+# Inspects IRXANCHR state, ECT/ECTENVBK slot, and ENVBLOCK fields.
+# Useful during WP-I1c development to verify IRXINIT/IRXTERM state.
+#
+# Invocation:
+#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ANCH'
+#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'CLEAR'
+#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ECT'
+#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ENV'
+#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ENV 18BC5C90'
+# ---------------------------------------------------------------
+[[link.module]]
+name = "IRXDBG"
+entry = "@@CRT0"
+options = ["LIST", "MAP", "XREF", "RENT"]
+include = ["@@CRT1", "IRXDBG", "IRX#ANCH"]
+
+# ---------------------------------------------------------------
 # IRX#HELO - "Hello World" demo standalone load module.
 # Runs an embedded REXX exec through irx_exec_run() that exercises
 # SAY, arithmetic, NUMERIC DIGITS, string BIFs (LENGTH / REVERSE /
@@ -184,14 +202,14 @@ include = [
 #
 # Exit code: 0 on success, 1 on any test failure.
 # ---------------------------------------------------------------
-# [[link.module]]
-# name = "TSTTOKN"
-# entry = "@@CRT0"
-# options = ["LIST", "MAP", "XREF", "RENT"]
-# include = ["@@CRT1", "TSTTOKN", "IRX#TOKN", "IRX#STOR"]
+[[link.module]]
+name = "TSTTOKN"
+entry = "@@CRT0"
+options = ["LIST", "MAP", "XREF", "RENT"]
+include = ["@@CRT1", "TSTTOKN", "IRX#TOKN", "IRX#STOR"]
 
-# [link.module.dep_includes]
-# "mvslovers/lstring370" = "*"
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
 # MVS test load modules (follow-ups to the TSTTOKN pilot).
@@ -278,29 +296,14 @@ include = [
 #
 # Exit code: 0 on success, 1 on any test failure.
 # ---------------------------------------------------------------
-# ---------------------------------------------------------------
-# IRXDBG - Debug / Inspection Tool.
-# Inspects IRXANCHR state, ECT/ECTENVBK slot, and ENVBLOCK fields.
-# Useful during WP-I1c development to verify IRXINIT/IRXTERM state.
-#
-# Invocation:
-#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ANCH'
-#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'CLEAR'
-#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ECT'
-#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ENV'
-#   TSO  :  CALL 'hlq.LOAD(IRXDBG)' 'ENV 18BC5C90'
-# ---------------------------------------------------------------
 [[link.module]]
-name = "IRXDBG"
+name = "TSTANSL"
 entry = "@@CRT0"
 options = ["LIST", "MAP", "XREF", "RENT"]
-include = ["@@CRT1", "IRXDBG", "IRX#ANCH"]
+include = ["@@CRT1", "TSTANSL", "IRX#ANCH"]
 
-# [[link.module]]
-# name = "TSTANSL"
-# entry = "@@CRT0"
-# options = ["LIST", "MAP", "XREF", "RENT"]
-# include = ["@@CRT1", "TSTANSL", "IRX#ANCH"]
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
 # TSTINIT - WP-I1c.1 IRXINIT INITENVB C-Core unit tests.

--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -139,13 +139,14 @@ void anch_push(struct envblock *new_env)
     new_env->envblock_ectptr = NULL;
 #endif
 
-    /* Read-mostly anchor per CON-1 §6.1: only claim the ECTENVBK
-     * slot when it is NULL. Any non-NULL value means another REXX
-     * (on MVS 3.8j that is typically a parallel BREXX environment,
-     * or an earlier rexx370 environment that is still live) already
-     * owns the anchor — leave it alone. The caller manages the new
-     * ENVBLOCK pointer explicitly via the IRXINIT return value, per
-     * SC28-1883-0 §15 for reentrant environments. */
+    /* DEPRECATED claim-if-NULL — no production callers (TSK-195).
+     *
+     * IRXPROBE Phase α (CON-14) showed IBM unconditionally overwrites
+     * ECTENVBK on TSOFL=1 IRXINIT, so the production path in
+     * irx_init_initenvb() step 8 / irxinit() host wrapper writes the
+     * slot directly. This helper retains its original claim-if-NULL
+     * shape only because legacy assembler glue (irx#anch.s) still
+     * exports the symbol; pending full removal in a future cleanup. */
     if (*slot == NULL)
     {
         *slot = new_env;

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -14,10 +14,12 @@
 /*  Ref: CON-1 §3.1 (ENVBLOCK), §3.2 (PARMBLOCK inheritance),         */
 /*       §3.8 (IRXEXTE), §6.2 (env-type detection),                   */
 /*       §6.3 (INITENVB algorithm)                                     */
-/*  Ref: CON-3 (ECTENVBK semantics — greenfield-verified,             */
-/*       non-greenfield behavior TBD pending IRXPROBE)                */
+/*  Ref: CON-3 (ECTENVBK semantics — TSOFL-conditional, IRXPROBE-     */
+/*       verified Phase α: TSOFL=1 unconditional overwrite,           */
+/*       TSOFL=0 leave slot untouched)                                 */
+/*  Ref: CON-14 (IRXPROBE Phase α actions A1/A3)                      */
 /*  Ref: CON-4 (VERSION='0042', SLOT_FREE=0x00)                       */
-/*  Ref: WP-I1c.1                                                     */
+/*  Ref: WP-I1c.1, TSK-195                                            */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
 /* ------------------------------------------------------------------ */
@@ -169,7 +171,8 @@ cleanup:
 /*   5. PARMBLOCK copy allocation and link                            */
 /*   6. IRXEXTE placeholder (zeroed; COUNT=IRXEXTE_ENTRY_COUNT)       */
 /*   7. IRXANCHR slot allocation                                      */
-/*   8. ECTENVBK claim-if-null (TSO only, MVS only; CON-3 TBD)        */
+/*   8. ECTENVBK unconditional overwrite when TSOFL=1 (MVS only;     */
+/*      IRXPROBE-verified Phase α, CON-14 cases A1/A3)               */
 /*   9. Return *out_envblock, reason_code=0                           */
 /*                                                                    */
 /*  Returns: 0=OK, 20=error (out_reason_code set)                    */
@@ -287,29 +290,21 @@ int irx_init_initenvb(struct envblock *prev_envblock,
      * TSOFL=1 → TSO environment. Detection hierarchy:
      *   - If the caller's parmblock had tsofl_mask set, respect it.
      *   - Otherwise auto-detect via anch_tso().
+     *
+     * The resolved is_tso value is reflected into pb_copy via the
+     * bitfield accessor in step 5 (not by byte-level OR'ing here).
+     * Byte-level writes against tsofl are platform-specific because
+     * the int bitfield ordering differs between MVS (MSB-first) and
+     * the cross-compile host (LSB-first); the bitfield accessor lays
+     * down the right bit on whichever platform is compiling.
      * ---------------------------------------------------------------- */
+    if (caller_parmblock != NULL && caller_parmblock->tsofl_mask)
     {
-        int explicit_tso = 0;
-        if (caller_parmblock != NULL && caller_parmblock->tsofl_mask)
-        {
-            explicit_tso = 1;
-            /* tsofl bit-field: MSB of flags byte 0. */
-            is_tso = (caller_parmblock->tsofl != 0) ? 1 : 0;
-        }
-        if (!explicit_tso)
-        {
-            is_tso = anch_tso();
-            /* Reflect auto-detected TSOFL back into the effective flags. */
-            if (is_tso)
-            {
-                /* Set MSB of flags byte 0 (tsofl is the MSB). */
-                eff_flags[0] |= 0x80;
-            }
-            else
-            {
-                eff_flags[0] &= (unsigned char)~0x80;
-            }
-        }
+        is_tso = (caller_parmblock->tsofl != 0) ? 1 : 0;
+    }
+    else
+    {
+        is_tso = anch_tso();
     }
 
     /* ----------------------------------------------------------------
@@ -357,6 +352,13 @@ int irx_init_initenvb(struct envblock *prev_envblock,
     memset(pb_copy->parmblock_addrspn, ' ', 8);
     memset(pb_copy->parmblock_ffff, 0xFF, 8);
 
+    /* Reflect the resolved TSOFL through the bitfield accessor so byte
+     * and bitfield views agree on both MVS (MSB-first) and host
+     * (LSB-first). Mask is set to mark the value as caller-honoured for
+     * any future inheritance lookup. Signed 1-bit field: -1 for true. */
+    pb_copy->tsofl_mask = -1;
+    pb_copy->tsofl = is_tso ? -1 : 0;
+
     envblk->envblock_parmblock = pb_copy;
 
     /* ----------------------------------------------------------------
@@ -402,17 +404,18 @@ int irx_init_initenvb(struct envblock *prev_envblock,
     }
 
     /* ----------------------------------------------------------------
-     * Step 8: ECTENVBK claim-if-null (TSO + MVS only).
+     * Step 8: ECTENVBK unconditional overwrite when TSOFL=1.
      *
-     * Conservative semantics pending IRXPROBE verification. CON-3
-     * greenfield observation showed IBM writes ECTENVBK on init, but
-     * the non-greenfield case (slot already set) is TBD. We claim
-     * the slot only when NULL to avoid trampling other environments.
-     * If IRXPROBE shows IBM does unconditional overwrite we can flip.
+     * IRXPROBE Phase α (TSK-192, CON-14) confirmed IBM writes
+     * ECTENVBK unconditionally when TSOFL=1 (case A1: pre 18B09C90 →
+     * post 18B7BC90 even though pre was non-NULL) and leaves it
+     * untouched when TSOFL=0 (case A3: pre and post identical, slot
+     * flags zero). This replaces the earlier conservative
+     * claim-if-null hold-out.
      *
-     * Not executed on host builds — anch_tso() always returns 0 on
-     * host, so is_tso is 0 anyway; the #ifdef also avoids the
-     * (ect + ECT_ENVBK_OFF) pointer math on a host-simulated address.
+     * Not executed on host builds — the host wrapper irxinit() does
+     * the equivalent simulation write after irx_init_initenvb returns
+     * (using pb_copy->tsofl which is platform-portable).
      * ---------------------------------------------------------------- */
 #ifdef __MVS__
     if (is_tso)
@@ -422,19 +425,12 @@ int irx_init_initenvb(struct envblock *prev_envblock,
         {
             struct envblock **slot =
                 (struct envblock **)((char *)ect + ECT_ENVBK_OFF);
-            if (*slot == NULL)
-            {
-                *slot = envblk;
-                envblk->envblock_ectptr = ect;
-            }
-            else
-            {
-                /* Slot occupied — record ECT for tracing but don't
-                 * overwrite the anchor. */
-                envblk->envblock_ectptr = ect;
-            }
+            *slot = envblk;
+            envblk->envblock_ectptr = ect;
         }
     }
+    /* TSOFL=0: ECTENVBK is intentionally not touched. The env is
+     * registered in the IRXANCHR table only — no TSO binding. */
 #endif
 
     /* ----------------------------------------------------------------
@@ -686,11 +682,12 @@ int irx_init_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
 /*  the full IRXEXTE (real function pointers), SUBCOMTB, internal     */
 /*  Work Block, and BIF registry required by the interpreter.         */
 /*                                                                    */
-/*  On host (non-MVS) builds, writes the simulated ECTENVBK slot if  */
-/*  it is currently NULL, preserving the read-mostly test semantics  */
-/*  expected by tstphas1 and tstanrm (anch_tso() returns 0 on host,  */
-/*  so irx_init_initenvb() step 8 is skipped — the host write here   */
-/*  stands in for it without calling the deprecated anch_push()).     */
+/*  On host (non-MVS) builds, mirrors the MVS step 8 contract on the */
+/*  simulated ECTENVBK slot: when the resolved env carries TSOFL=1   */
+/*  (read via pb->tsofl, portable across MVS MSB-first and host      */
+/*  LSB-first int bitfield ordering), the slot is overwritten        */
+/*  unconditionally — matching IBM behaviour verified by IRXPROBE     */
+/*  Phase α. TSOFL=0 leaves the slot untouched.                       */
 /*                                                                    */
 /*  Returns: 0=OK, 20=init error                                      */
 /* ================================================================== */
@@ -804,20 +801,23 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
         }
     }
 
-    /* Host-only: simulate ECTENVBK slot write for cross-compile tests.
-     * On MVS, irx_init_initenvb() step 8 handles ECTENVBK for TSO
-     * environments. On host, anch_tso() returns 0 so step 8 is skipped;
-     * this block writes the simulation slot with read-mostly semantics
-     * (claim-if-null) so tstphas1 and tstanrm continue to pass. */
+    /* Host-only: mirror MVS step 8 ECTENVBK semantics on the
+     * simulation slot. Read TSOFL via the bitfield accessor to stay
+     * portable across MVS (MSB-first) and host (LSB-first) int
+     * bitfield encodings — the byte view of parmblock_flags differs
+     * between platforms, but pb->tsofl always lands on the right bit
+     * for the compiling target. */
 #ifndef __MVS__
     {
-        /* ectenvbk_slot() lives in irx#anch.c; test programs define the
-         * _simulated_ectenvbk global that the host build reads. */
-        extern struct envblock **ectenvbk_slot(void);
-        struct envblock **slot = ectenvbk_slot();
-        if (slot != NULL && *slot == NULL)
+        struct parmblock *pb = (struct parmblock *)envblk->envblock_parmblock;
+        if (pb != NULL && pb->tsofl != 0)
         {
-            *slot = envblk;
+            extern struct envblock **ectenvbk_slot(void);
+            struct envblock **slot = ectenvbk_slot();
+            if (slot != NULL)
+            {
+                *slot = envblk;
+            }
         }
     }
 #endif

--- a/test/mvs/tstanrm.c
+++ b/test/mvs/tstanrm.c
@@ -1,45 +1,52 @@
 /* ------------------------------------------------------------------ */
-/*  tstanrm.c - Read-mostly ECTENVBK protection tests  */
+/*  tstanrm.c - ECTENVBK TSOFL-conditional anchor tests  */
 /*                                                                    */
-/*  CON-1 §6.1 defines three observable states the ECTENVBK slot can  */
-/*  be in, and a distinct read-mostly response to each. The tests     */
-/*  below pin down all three as a single self-contained artefact so   */
-/*  future reviewers can point at one file for the anchor contract:   */
+/*  IRXPROBE Phase α (TSK-192, CON-14) verified IBM's actual          */
+/*  IRXINIT/IRXTERM contract for the ECTENVBK slot:                    */
 /*                                                                    */
-/*    (a) Empty-slot baseline — IRXINIT claims the slot; IRXTERM      */
-/*        leaves ECTENVBK unchanged (CON-3: caller responsibility).   */
+/*    - TSOFL=1 IRXINIT  → ECTENVBK is overwritten unconditionally     */
+/*      with the new ENVBLOCK, regardless of the slot's prior value.   */
+/*    - TSOFL=0 IRXINIT  → ECTENVBK is left untouched.                 */
+/*    - IRXTERM (any TSOFL) → ECTENVBK is never modified (CON-3).      */
 /*                                                                    */
-/*    (b) BREXX-simulated non-NULL slot — another REXX owns the       */
-/*        anchor. IRXINIT must NOT overwrite it; IRXTERM leaves the   */
-/*        slot alone because it never pointed at our env.             */
+/*  The cases below pin down all four observables in one place so a   */
+/*  reviewer can point at this file as the executable contract:        */
 /*                                                                    */
-/*    (c) Own-env stacking — a first IRXINIT claimed the slot; a      */
-/*        second IRXINIT on top must not disturb it. IRXTERM on any   */
-/*        env never modifies ECTENVBK (CON-3) — the caller manages    */
-/*        ECTENVBK lifetime.                                          */
+/*    (a) Empty-slot baseline — TSOFL=1 IRXINIT writes the slot;       */
+/*        IRXTERM does not clear it (caller-managed lifetime).        */
 /*                                                                    */
-/*  An old push/pop implementation would fail cases (b) and (c);      */
-/*  read-mostly passes all three.                                     */
+/*    (b) Foreign-owned slot — a sentinel pre-seeded into ECTENVBK     */
+/*        is clobbered by TSOFL=1 IRXINIT (matches IBM behaviour).    */
+/*        IRXTERM leaves the new value in place.                      */
+/*                                                                    */
+/*    (c) Own-env stacking — a TSOFL=1 IRXINIT for `outer` claims     */
+/*        the slot; a second TSOFL=1 IRXINIT for `inner` overwrites   */
+/*        it. IRXTERM on either env is a CON-3 no-op at the anchor.   */
+/*                                                                    */
+/*    (d) Non-TSO no-op — TSOFL=0 IRXINIT must not touch the slot,    */
+/*        even when one is reachable. The pre-seeded sentinel must   */
+/*        survive the IRXINIT call.                                   */
+/*                                                                    */
+/*  An old read-mostly / claim-if-NULL implementation would fail      */
+/*  cases (b) and (c); the IBM-compatible TSOFL-conditional contract   */
+/*  passes all four. See TSK-195 for the change rationale.            */
 /*                                                                    */
 /*  Platform-aware seed helper                                        */
 /*  --------------------------                                        */
-/*  On MVS, production anch_push / anch_pop / anch_curr read and      */
-/*  write the real ECTENVBK slot via ectenvbk_slot() (which walks     */
-/*  PSA→ASCB→ASXB→LWA→ECT). The host-only `_simulated_ectenvbk`       */
-/*  global is unused on MVS. Cases (b) and (c) need to simulate a     */
-/*  non-NULL initial slot state; _test_set_anchor() below targets     */
-/*  whichever storage the production code actually reads, per         */
-/*  platform. Do not re-introduce direct `_simulated_ectenvbk = ...`  */
-/*  writes in Case (b) / Case (c) — they silently no-op on MVS and    */
-/*  make the test look like it passes on host while failing on MVS.   */
-/*  See CON-1 §6.1.                                                   */
+/*  On MVS, production code reads and writes the real ECTENVBK slot   */
+/*  via ectenvbk_slot() (which walks PSA→ASCB→ASXB→LWA→ECT). The      */
+/*  host-only `_simulated_ectenvbk` global is unused on MVS. Cases   */
+/*  that need to simulate a pre-existing slot state use               */
+/*  _test_set_anchor() below, which targets whichever storage the     */
+/*  production code actually reads, per platform. Do not re-introduce */
+/*  direct `_simulated_ectenvbk = ...` writes in cases (b) / (c) /    */
+/*  (d) — they silently no-op on MVS and make the test look like it   */
+/*  passes on host while failing on MVS. See CON-1 §6.1.              */
 /*                                                                    */
-/*  Cases that require a specific anchor state (seeding a sentinel,   */
-/*  asserting that irxinit claimed the slot, asserting lenient pop)   */
-/*  only run when anch_tso() is true — i.e. the TSO ECT chain is      */
-/*  reachable. In pure batch (EXEC PGM=... direct) the walk returns   */
-/*  NULL and anch_push / anch_pop reduce to local field updates, so   */
-/*  those assertions are skipped (tests_skipped) rather than failed.  */
+/*  Cases that require a specific anchor state only run when           */
+/*  ectenvbk_slot() returns non-NULL. In pure MVS batch (EXEC         */
+/*  PGM=... direct) the walk returns NULL, so those assertions are    */
+/*  skipped (tests_skipped) rather than failed.                       */
 /*                                                                    */
 /*  Cross-compile build (Linux/gcc):                                  */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
@@ -57,6 +64,7 @@
 /* ------------------------------------------------------------------ */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "irx.h"
 #include "irxanchr.h"
@@ -151,26 +159,42 @@ static struct envblock *_test_get_anchor(void)
 #endif
 }
 
+/* Build a parmblock with the requested TSOFL value, mirroring the
+ * helper in tstinit.c. Bitfield writes lay down the right bit on both
+ * MVS (MSB-first) and host (LSB-first) int bitfield encodings. */
+static void build_parmblock(struct parmblock *pb, int tso)
+{
+    memset(pb, 0, sizeof(*pb));
+    memcpy(pb->parmblock_id, PARMBLOCK_ID, 8);
+    memcpy(pb->parmblock_version, PARMBLOCK_VERSION_0042, 4);
+    pb->tsofl_mask = -1;
+    pb->tsofl = tso ? -1 : 0;
+    memset(pb->parmblock_addrspn, ' ', 8);
+    memset(pb->parmblock_ffff, 0xFF, 8);
+}
+
 /* ------------------------------------------------------------------ */
-/*  Case (a) — empty-slot baseline                                    */
+/*  Case (a) — empty-slot baseline (TSOFL=1)                          */
 /* ------------------------------------------------------------------ */
 
 static void case_a_empty_slot_baseline(void)
 {
     struct envblock *env = NULL;
+    struct parmblock pb;
     int rc;
 
-    printf("\n--- Case (a): empty-slot baseline ---\n");
+    printf("\n--- Case (a): empty-slot baseline (TSOFL=1) ---\n");
 
     _test_set_anchor(NULL);
     CHECK(anch_curr() == NULL, "precondition: anch_curr() == NULL");
 
-    rc = irxinit(NULL, &env);
+    build_parmblock(&pb, /*tso=*/1);
+    rc = irxinit(&pb, &env);
     CHECK(rc == 0, "irxinit returns 0");
     CHECK(env != NULL, "irxinit produced an ENVBLOCK");
     CHECK_IF_REACHABLE(
         CHECK(anch_curr() == env,
-              "slot claimed: anch_curr() == env (was NULL at push)"),
+              "TSOFL=1: slot written (anch_curr() == env)"),
         "slot claimed: anch_curr() == env");
 
     struct envblock *slot_before = anch_curr(); /* save before irxterm */
@@ -185,85 +209,91 @@ static void case_a_empty_slot_baseline(void)
 }
 
 /* ------------------------------------------------------------------ */
-/*  Case (b) — BREXX-simulated non-NULL slot                          */
+/*  Case (b) — foreign-owned slot, TSOFL=1 clobbers it                */
 /* ------------------------------------------------------------------ */
 
-static void case_b_simulated_brexx_owns_slot(void)
+static void case_b_foreign_slot_clobbered(void)
 {
     struct envblock *env = NULL;
+    struct parmblock pb;
     int rc;
 
-    printf("\n--- Case (b): BREXX-simulated non-NULL slot ---\n");
+    printf("\n--- Case (b): foreign-owned slot clobbered (TSOFL=1) ---\n");
 
-    /* Seed the real slot (TSO) or the host simulation variable. On
-     * batch MVS the slot is unreachable and the seed is a no-op —
-     * the dependent assertions below are gated behind anch_tso(). */
+    /* Seed the real slot (TSO) or the host simulation variable with a
+     * sentinel that simulates a different REXX (e.g. parallel BREXX)
+     * already owning the anchor. On batch MVS the slot is unreachable
+     * and the seed is a no-op — the dependent assertions below are
+     * gated through CHECK_IF_REACHABLE. */
     _test_set_anchor((struct envblock *)SENTINEL);
     CHECK_IF_REACHABLE(
         CHECK(anch_curr() == SENTINEL,
               "pre-seed: anch_curr() == SENTINEL"),
         "pre-seed: anch_curr() == SENTINEL");
 
-    rc = irxinit(NULL, &env);
+    build_parmblock(&pb, /*tso=*/1);
+    rc = irxinit(&pb, &env);
     CHECK(rc == 0, "irxinit returns 0");
     CHECK(env != NULL, "irxinit produced an ENVBLOCK");
     CHECK_IF_REACHABLE(
-        CHECK(anch_curr() == SENTINEL,
-              "slot NOT overwritten (read-mostly guard holds)"),
-        "slot NOT overwritten after irxinit");
+        CHECK(anch_curr() == env,
+              "TSOFL=1: foreign slot is overwritten with new env"),
+        "slot overwritten after TSOFL=1 irxinit");
     CHECK(env != (struct envblock *)SENTINEL,
           "returned env is distinct from the pre-existing anchor");
 
+    struct envblock *slot_before = anch_curr(); /* save before irxterm */
     rc = irxterm(env);
     CHECK(rc == 0, "irxterm returns 0");
     CHECK_IF_REACHABLE(
-        CHECK(anch_curr() == SENTINEL,
-              "slot still SENTINEL after irxterm (lenient pop)"),
-        "slot still SENTINEL after irxterm");
+        CHECK(anch_curr() == slot_before,
+              "slot unchanged by irxterm (CON-3 no-op)"),
+        "slot unchanged after irxterm");
 
-    /* Always run the post-cleanup restore: on MVS batch the slot was
-     * never touched, on host the simulation variable was, and the
-     * helper handles both. Keeps Case (c)'s precondition clean. */
+    /* Caller-side cleanup so Case (c) starts with a clean precondition. */
     _test_set_anchor(NULL);
     CHECK(anch_curr() == NULL, "post-cleanup: anch_curr() == NULL");
 }
 
 /* ------------------------------------------------------------------ */
-/*  Case (c) — own-env stacking                                       */
+/*  Case (c) — own-env stacking (TSOFL=1)                             */
 /* ------------------------------------------------------------------ */
 
 static void case_c_own_env_stacking(void)
 {
     struct envblock *outer = NULL;
     struct envblock *inner = NULL;
+    struct parmblock pb;
     int rc;
 
-    printf("\n--- Case (c): own-env stacking ---\n");
+    printf("\n--- Case (c): own-env stacking (TSOFL=1) ---\n");
 
     _test_set_anchor(NULL);
     CHECK(anch_curr() == NULL, "precondition: anch_curr() == NULL");
 
-    rc = irxinit(NULL, &outer);
+    build_parmblock(&pb, /*tso=*/1);
+
+    rc = irxinit(&pb, &outer);
     CHECK(rc == 0 && outer != NULL, "outer irxinit returned a valid env");
     CHECK_IF_REACHABLE(
         CHECK(anch_curr() == outer,
-              "outer claimed the slot (was NULL at push)"),
+              "TSOFL=1: outer claimed the slot"),
         "outer claimed the slot");
 
-    rc = irxinit(NULL, &inner);
+    rc = irxinit(&pb, &inner);
     CHECK(rc == 0 && inner != NULL, "inner irxinit returned a valid env");
     CHECK(inner != outer, "inner env is distinct from outer");
     CHECK_IF_REACHABLE(
-        CHECK(anch_curr() == outer,
-              "slot still outer (inner read-mostly-skipped the write)"),
-        "slot still outer after inner irxinit");
+        CHECK(anch_curr() == inner,
+              "TSOFL=1 stacking: inner overwrote outer in the slot"),
+        "slot now inner after stacked TSOFL=1 irxinit");
 
     rc = irxterm(inner);
     CHECK(rc == 0, "inner irxterm returns 0");
     CHECK_IF_REACHABLE(
-        CHECK(anch_curr() == outer,
-              "slot still outer (inner was not the holder; CON-3 no-op)"),
-        "slot still outer after inner irxterm");
+        CHECK(anch_curr() == inner,
+              "slot still inner after inner irxterm (CON-3 no-op)"),
+        "slot still inner after inner irxterm");
 
     struct envblock *slot_before = anch_curr(); /* save before outer irxterm */
     rc = irxterm(outer);
@@ -276,14 +306,51 @@ static void case_c_own_env_stacking(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Case (d) — non-TSO env (TSOFL=0) leaves the slot untouched        */
+/* ------------------------------------------------------------------ */
+
+static void case_d_non_tso_noop(void)
+{
+    struct envblock *env = NULL;
+    struct parmblock pb;
+    int rc;
+
+    printf("\n--- Case (d): non-TSO env, TSOFL=0 no-op ---\n");
+
+    _test_set_anchor((struct envblock *)SENTINEL);
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == SENTINEL,
+              "pre-seed: anch_curr() == SENTINEL"),
+        "pre-seed: anch_curr() == SENTINEL");
+
+    build_parmblock(&pb, /*tso=*/0);
+    rc = irxinit(&pb, &env);
+    CHECK(rc == 0, "irxinit returns 0");
+    CHECK(env != NULL, "irxinit produced an ENVBLOCK");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == SENTINEL,
+              "TSOFL=0: slot remains the sentinel (no anchor write)"),
+        "slot unchanged after TSOFL=0 irxinit");
+
+    rc = irxterm(env);
+    CHECK(rc == 0, "irxterm returns 0");
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == SENTINEL,
+              "TSOFL=0: slot still sentinel after irxterm"),
+        "slot still SENTINEL after irxterm");
+
+    _test_set_anchor(NULL);
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
 
 int main(void)
 {
-    printf("=== Read-mostly ECTENVBK protection tests (CON-1 §6.1) ===\n");
+    printf("=== ECTENVBK TSOFL-conditional anchor tests (TSK-195) ===\n");
     printf("    mode: %s\n", anch_tso() ? "TSO (ECT reachable)"
-                                        : "batch (no ECT — TSO-only "
+                                        : "batch (no ECT — slot-state "
                                           "assertions will skip)");
 
     /* Silence unused-function warning on host where _test_get_anchor
@@ -292,8 +359,9 @@ int main(void)
     (void)_test_get_anchor;
 
     case_a_empty_slot_baseline();
-    case_b_simulated_brexx_owns_slot();
+    case_b_foreign_slot_clobbered();
     case_c_own_env_stacking();
+    case_d_non_tso_noop();
 
     printf("\n=== Results: passed=%d run=%d skipped=%d",
            tests_passed, tests_run, tests_skipped);

--- a/test/mvs/tstinit.c
+++ b/test/mvs/tstinit.c
@@ -54,6 +54,7 @@ struct envblock **ectenvbk_slot(void);
 static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
+static int tests_skipped = 0;
 
 #define CHECK(cond, msg)                 \
     do                                   \
@@ -479,6 +480,27 @@ static struct envblock *const ECT_SENTINEL =
     (struct envblock *)(unsigned long)0xDEADBEEFUL;
 
 /* ------------------------------------------------------------------ */
+/*  T11–T13 share a slot-reachability gate: pure-batch MVS reaches    */
+/*  IRXINIT through tstall.jcl with no LWA (and therefore no ECT),    */
+/*  so ectenvbk_slot() returns NULL. The slot-state assertions below  */
+/*  cannot hold in that mode — emit SKIP and return early instead of  */
+/*  failing. Host and TSO-batch (IKJEFT01) always see a reachable     */
+/*  slot, so the assertions execute as before.                        */
+/* ------------------------------------------------------------------ */
+
+static int slot_reachable_or_skip(const char *test_label)
+{
+    if (ectenvbk_slot() != NULL)
+    {
+        return 1;
+    }
+    printf("  SKIP: %s (ECTENVBK slot unreachable — pure batch)\n",
+           test_label);
+    tests_skipped++;
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
 /*  T11: TSOFL=1 with a non-NULL ECTENVBK → slot is overwritten       */
 /*                                                                    */
 /*  IRXPROBE Phase α (CON-14 case A1) verified IBM writes ECTENVBK    */
@@ -496,16 +518,14 @@ static void test_t11_tsofl1_overwrites_slot(void)
     printf("\n--- T11: TSOFL=1 overwrites non-NULL ECTENVBK ---\n");
 
     irx_anchor_table_reset();
+    if (!slot_reachable_or_skip("T11"))
     {
-        struct envblock **slot = ectenvbk_slot();
-        CHECK(slot != NULL, "T11: ectenvbk_slot reachable on host");
-        if (slot != NULL)
-        {
-            *slot = ECT_SENTINEL;
-            CHECK(*slot == ECT_SENTINEL,
-                  "T11: pre-seed: slot holds sentinel");
-        }
+        return;
     }
+
+    struct envblock **slot = ectenvbk_slot();
+    *slot = ECT_SENTINEL;
+    CHECK(*slot == ECT_SENTINEL, "T11: pre-seed: slot holds sentinel");
 
     build_parmblock_with_tsofl(&pb, /*tso=*/1);
     rc = irxinit(&pb, &envblk);
@@ -514,20 +534,12 @@ static void test_t11_tsofl1_overwrites_slot(void)
 
     if (envblk != NULL)
     {
-        struct envblock **slot = ectenvbk_slot();
-        if (slot != NULL)
-        {
-            CHECK(*slot == envblk,
-                  "T11: slot was overwritten with new env");
-            CHECK(*slot != ECT_SENTINEL,
-                  "T11: sentinel is gone (unconditional overwrite)");
-        }
+        CHECK(*slot == envblk, "T11: slot was overwritten with new env");
+        CHECK(*slot != ECT_SENTINEL,
+              "T11: sentinel is gone (unconditional overwrite)");
         irxterm(envblk);
         /* Caller-side cleanup so later tests start clean. */
-        if (slot != NULL)
-        {
-            *slot = NULL;
-        }
+        *slot = NULL;
     }
 }
 
@@ -548,14 +560,13 @@ static void test_t12_tsofl0_leaves_slot(void)
     printf("\n--- T12: TSOFL=0 leaves ECTENVBK untouched ---\n");
 
     irx_anchor_table_reset();
+    if (!slot_reachable_or_skip("T12"))
     {
-        struct envblock **slot = ectenvbk_slot();
-        CHECK(slot != NULL, "T12: ectenvbk_slot reachable on host");
-        if (slot != NULL)
-        {
-            *slot = ECT_SENTINEL;
-        }
+        return;
     }
+
+    struct envblock **slot = ectenvbk_slot();
+    *slot = ECT_SENTINEL;
 
     build_parmblock_with_tsofl(&pb, /*tso=*/0);
     rc = irxinit(&pb, &envblk);
@@ -564,19 +575,11 @@ static void test_t12_tsofl0_leaves_slot(void)
 
     if (envblk != NULL)
     {
-        struct envblock **slot = ectenvbk_slot();
-        if (slot != NULL)
-        {
-            CHECK(*slot == ECT_SENTINEL,
-                  "T12: slot still sentinel (TSOFL=0 no-op)");
-            CHECK(*slot != envblk,
-                  "T12: slot does NOT point at the new env");
-        }
+        CHECK(*slot == ECT_SENTINEL,
+              "T12: slot still sentinel (TSOFL=0 no-op)");
+        CHECK(*slot != envblk, "T12: slot does NOT point at the new env");
         irxterm(envblk);
-        if (slot != NULL)
-        {
-            *slot = NULL;
-        }
+        *slot = NULL;
     }
 }
 
@@ -597,42 +600,26 @@ static void test_t13_stacked_tsofl1_latest_wins(void)
     printf("\n--- T13: stacked TSOFL=1 IRXINITs — latest wins ---\n");
 
     irx_anchor_table_reset();
+    if (!slot_reachable_or_skip("T13"))
     {
-        struct envblock **slot = ectenvbk_slot();
-        if (slot != NULL)
-        {
-            *slot = NULL;
-        }
+        return;
     }
+
+    struct envblock **slot = ectenvbk_slot();
+    *slot = NULL;
 
     build_parmblock_with_tsofl(&pb, /*tso=*/1);
 
     rc = irxinit(&pb, &first);
     CHECK(rc == 0 && first != NULL, "T13: first irxinit succeeded");
-
-    {
-        struct envblock **slot = ectenvbk_slot();
-        if (slot != NULL)
-        {
-            CHECK(*slot == first,
-                  "T13: slot holds first env after first irxinit");
-        }
-    }
+    CHECK(*slot == first, "T13: slot holds first env after first irxinit");
 
     rc = irxinit(&pb, &second);
     CHECK(rc == 0 && second != NULL, "T13: second irxinit succeeded");
     CHECK(second != first, "T13: second env is distinct from first");
-
-    {
-        struct envblock **slot = ectenvbk_slot();
-        if (slot != NULL)
-        {
-            CHECK(*slot == second,
-                  "T13: slot holds second env (latest IRXINIT wins)");
-            CHECK(*slot != first,
-                  "T13: first env is no longer in the slot");
-        }
-    }
+    CHECK(*slot == second,
+          "T13: slot holds second env (latest IRXINIT wins)");
+    CHECK(*slot != first, "T13: first env is no longer in the slot");
 
     if (second != NULL)
     {
@@ -642,13 +629,7 @@ static void test_t13_stacked_tsofl1_latest_wins(void)
     {
         irxterm(first);
     }
-    {
-        struct envblock **slot = ectenvbk_slot();
-        if (slot != NULL)
-        {
-            *slot = NULL;
-        }
-    }
+    *slot = NULL;
 }
 
 /* ------------------------------------------------------------------ */
@@ -674,9 +655,10 @@ int main(void)
     test_t13_stacked_tsofl1_latest_wins();
 
     printf("\n--- Results ---\n");
-    printf("  Run:    %d\n", tests_run);
-    printf("  Passed: %d\n", tests_passed);
-    printf("  Failed: %d\n", tests_failed);
+    printf("  Run:     %d\n", tests_run);
+    printf("  Passed:  %d\n", tests_passed);
+    printf("  Failed:  %d\n", tests_failed);
+    printf("  Skipped: %d\n", tests_skipped);
 
     if (tests_failed > 0)
     {

--- a/test/mvs/tstinit.c
+++ b/test/mvs/tstinit.c
@@ -15,6 +15,9 @@
 /*  T8: Bad prev_envblock eye-catcher — step 1 skip, falls through    */
 /*  T9: TSOFL=1 parmblock → IRXANCHR slot flags=0x40000000            */
 /*  T10: TSOFL=0 parmblock → IRXANCHR slot flags=0x00000000           */
+/*  T11: TSOFL=1 with non-NULL ECTENVBK → slot is overwritten         */
+/*  T12: TSOFL=0 with non-NULL ECTENVBK → slot is untouched           */
+/*  T13: Two stacked TSOFL=1 IRXINITs → slot points at the latest     */
 /*                                                                    */
 /*  Cross-compile build:                                              */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
@@ -468,6 +471,187 @@ static void test_t10_tsofl_clear_flag(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Sentinel for T11–T13: any value that cannot collide with a real   */
+/*  ENVBLOCK address returned by the host allocator.                  */
+/* ------------------------------------------------------------------ */
+
+static struct envblock *const ECT_SENTINEL =
+    (struct envblock *)(unsigned long)0xDEADBEEFUL;
+
+/* ------------------------------------------------------------------ */
+/*  T11: TSOFL=1 with a non-NULL ECTENVBK → slot is overwritten       */
+/*                                                                    */
+/*  IRXPROBE Phase α (CON-14 case A1) verified IBM writes ECTENVBK    */
+/*  unconditionally on TSOFL=1, regardless of the prior slot value.   */
+/*  This test pins the same behaviour for the irxinit() compat        */
+/*  wrapper (which exercises the host simulation slot).               */
+/* ------------------------------------------------------------------ */
+
+static void test_t11_tsofl1_overwrites_slot(void)
+{
+    struct parmblock pb;
+    struct envblock *envblk = NULL;
+    int rc;
+
+    printf("\n--- T11: TSOFL=1 overwrites non-NULL ECTENVBK ---\n");
+
+    irx_anchor_table_reset();
+    {
+        struct envblock **slot = ectenvbk_slot();
+        CHECK(slot != NULL, "T11: ectenvbk_slot reachable on host");
+        if (slot != NULL)
+        {
+            *slot = ECT_SENTINEL;
+            CHECK(*slot == ECT_SENTINEL,
+                  "T11: pre-seed: slot holds sentinel");
+        }
+    }
+
+    build_parmblock_with_tsofl(&pb, /*tso=*/1);
+    rc = irxinit(&pb, &envblk);
+    CHECK(rc == 0, "T11: irxinit returns 0");
+    CHECK(envblk != NULL, "T11: irxinit produced an ENVBLOCK");
+
+    if (envblk != NULL)
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            CHECK(*slot == envblk,
+                  "T11: slot was overwritten with new env");
+            CHECK(*slot != ECT_SENTINEL,
+                  "T11: sentinel is gone (unconditional overwrite)");
+        }
+        irxterm(envblk);
+        /* Caller-side cleanup so later tests start clean. */
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  T12: TSOFL=0 with a non-NULL ECTENVBK → slot is untouched         */
+/*                                                                    */
+/*  IRXPROBE Phase α (CON-14 case A3) verified IBM leaves ECTENVBK    */
+/*  alone on TSOFL=0 IRXINIT. The env is registered in IRXANCHR but   */
+/*  not bound to ECTENVBK.                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_t12_tsofl0_leaves_slot(void)
+{
+    struct parmblock pb;
+    struct envblock *envblk = NULL;
+    int rc;
+
+    printf("\n--- T12: TSOFL=0 leaves ECTENVBK untouched ---\n");
+
+    irx_anchor_table_reset();
+    {
+        struct envblock **slot = ectenvbk_slot();
+        CHECK(slot != NULL, "T12: ectenvbk_slot reachable on host");
+        if (slot != NULL)
+        {
+            *slot = ECT_SENTINEL;
+        }
+    }
+
+    build_parmblock_with_tsofl(&pb, /*tso=*/0);
+    rc = irxinit(&pb, &envblk);
+    CHECK(rc == 0, "T12: irxinit returns 0");
+    CHECK(envblk != NULL, "T12: irxinit produced an ENVBLOCK");
+
+    if (envblk != NULL)
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            CHECK(*slot == ECT_SENTINEL,
+                  "T12: slot still sentinel (TSOFL=0 no-op)");
+            CHECK(*slot != envblk,
+                  "T12: slot does NOT point at the new env");
+        }
+        irxterm(envblk);
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  T13: Two stacked TSOFL=1 IRXINITs → slot tracks the latest        */
+/*                                                                    */
+/*  Each TSOFL=1 IRXINIT performs an unconditional overwrite, so the  */
+/*  most recent caller wins — there is no "first claimant" guard.     */
+/* ------------------------------------------------------------------ */
+
+static void test_t13_stacked_tsofl1_latest_wins(void)
+{
+    struct parmblock pb;
+    struct envblock *first = NULL;
+    struct envblock *second = NULL;
+    int rc;
+
+    printf("\n--- T13: stacked TSOFL=1 IRXINITs — latest wins ---\n");
+
+    irx_anchor_table_reset();
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    build_parmblock_with_tsofl(&pb, /*tso=*/1);
+
+    rc = irxinit(&pb, &first);
+    CHECK(rc == 0 && first != NULL, "T13: first irxinit succeeded");
+
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            CHECK(*slot == first,
+                  "T13: slot holds first env after first irxinit");
+        }
+    }
+
+    rc = irxinit(&pb, &second);
+    CHECK(rc == 0 && second != NULL, "T13: second irxinit succeeded");
+    CHECK(second != first, "T13: second env is distinct from first");
+
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            CHECK(*slot == second,
+                  "T13: slot holds second env (latest IRXINIT wins)");
+            CHECK(*slot != first,
+                  "T13: first env is no longer in the slot");
+        }
+    }
+
+    if (second != NULL)
+    {
+        irxterm(second);
+    }
+    if (first != NULL)
+    {
+        irxterm(first);
+    }
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                               */
 /* ------------------------------------------------------------------ */
 
@@ -485,6 +669,9 @@ int main(void)
     test_t8_bad_prev_eyecatcher();
     test_t9_tsofl_set_flag();
     test_t10_tsofl_clear_flag();
+    test_t11_tsofl1_overwrites_slot();
+    test_t12_tsofl0_leaves_slot();
+    test_t13_stacked_tsofl1_latest_wins();
 
     printf("\n--- Results ---\n");
     printf("  Run:    %d\n", tests_run);

--- a/test/mvs/tstphas1.c
+++ b/test/mvs/tstphas1.c
@@ -54,11 +54,11 @@ static int tests_skipped = 0;
     } while (0)
 
 /* Assertions that check anch_curr() against a non-NULL ENVBLOCK only
- * hold when the ECTENVBK slot is reachable so anch_push can actually
- * write it. ectenvbk_slot() returns non-NULL on host (the slot is the
- * `_simulated_ectenvbk` global) and on MVS under TSO (the
- * PSA→ASCB→ASXB→LWA→ECT walk completes); it returns NULL on pure
- * batch. Skip rather than fail when unreachable. Assertions that
+ * hold when the ECTENVBK slot is reachable so the IRXINIT step-8
+ * write can actually land. ectenvbk_slot() returns non-NULL on host
+ * (the slot is the `_simulated_ectenvbk` global) and on MVS under TSO
+ * (the PSA→ASCB→ASXB→LWA→ECT walk completes); it returns NULL on
+ * pure batch. Skip rather than fail when unreachable. Assertions that
  * check anch_curr() == NULL hold in both modes and run
  * unconditionally. */
 #define CHECK_IF_REACHABLE(cond, msg)                            \
@@ -75,6 +75,23 @@ static int tests_skipped = 0;
         }                                                        \
     } while (0)
 
+/* Build a minimal valid PARMBLOCK with TSOFL=1, mirroring the helper
+ * in tstinit.c. The anchor write in IRXINIT only runs when the
+ * effective TSOFL bit is 1, so smoke tests that want to observe a
+ * slot write must opt in explicitly — anch_tso() returns 0 on the
+ * cross-compile host and pure-batch MVS, which would otherwise
+ * resolve TSOFL to 0. */
+static void build_tso_parmblock(struct parmblock *pb)
+{
+    memset(pb, 0, sizeof(*pb));
+    memcpy(pb->parmblock_id, PARMBLOCK_ID, 8);
+    memcpy(pb->parmblock_version, PARMBLOCK_VERSION_0042, 4);
+    pb->tsofl_mask = -1;
+    pb->tsofl = -1;
+    memset(pb->parmblock_addrspn, ' ', 8);
+    memset(pb->parmblock_ffff, 0xFF, 8);
+}
+
 /* ------------------------------------------------------------------ */
 /*  Test 1: Single environment lifecycle                              */
 /* ------------------------------------------------------------------ */
@@ -85,12 +102,16 @@ static void test_single_env(void)
     struct parmblock *pb;
     struct irxexte *exte;
     struct irx_wkblk_int *wkbi;
+    struct parmblock tso_pb;
     int rc;
 
     printf("\n--- Test 1: Single environment lifecycle ---\n");
 
-    /* IRXINIT */
-    rc = irxinit(NULL, &envblk);
+    /* IRXINIT with TSOFL=1 so the ECTENVBK anchor write fires
+     * (TSK-195 / IRXPROBE Phase α: TSOFL=1 → unconditional overwrite,
+     * TSOFL=0 → slot untouched). */
+    build_tso_parmblock(&tso_pb);
+    rc = irxinit(&tso_pb, &envblk);
     CHECK(rc == 0, "irxinit returns 0");
     CHECK(envblk != NULL, "envblock is not NULL");
 
@@ -169,11 +190,11 @@ static void test_single_env(void)
 /* ------------------------------------------------------------------ */
 /*  Test 2: Multiple concurrent environments                          */
 /*                                                                    */
-/*  Under the read-mostly anchor (CON-1 §6.1) only the first IRXINIT  */
-/*  claims ECTENVBK; later IRXINITs observe a non-NULL slot and       */
-/*  leave it alone. IRXTERM never modifies ECTENVBK (CON-3), so the   */
-/*  slot stays pinned to env1. The caller is responsible for          */
-/*  managing ECTENVBK lifetime.                                       */
+/*  Under the TSOFL-conditional contract (TSK-195, CON-14) every      */
+/*  TSOFL=1 IRXINIT unconditionally overwrites ECTENVBK. The slot     */
+/*  therefore tracks the most recent IRXINIT, not the first claimant. */
+/*  IRXTERM never touches ECTENVBK (CON-3 / SC28-1883-0 §14), so the  */
+/*  slot stays pinned to whoever last wrote it.                       */
 /* ------------------------------------------------------------------ */
 
 static void test_multiple_envs(void)
@@ -181,39 +202,42 @@ static void test_multiple_envs(void)
     struct envblock *env1 = NULL;
     struct envblock *env2 = NULL;
     struct envblock *env3 = NULL;
+    struct parmblock tso_pb;
     int rc;
 
     printf("\n--- Test 2: Multiple concurrent environments ---\n");
 
-    rc = irxinit(NULL, &env1);
+    build_tso_parmblock(&tso_pb);
+
+    rc = irxinit(&tso_pb, &env1);
     CHECK(rc == 0 && env1 != NULL, "env1 created");
 
-    rc = irxinit(NULL, &env2);
+    rc = irxinit(&tso_pb, &env2);
     CHECK(rc == 0 && env2 != NULL, "env2 created");
 
-    rc = irxinit(NULL, &env3);
+    rc = irxinit(&tso_pb, &env3);
     CHECK(rc == 0 && env3 != NULL, "env3 created");
 
-    /* Read-mostly: env1 got the slot, env2/env3 never touched it.
-     * The "still env1" checks below are TSO-only — see CHECK_IF_REACHABLE
-     * comment near the top of the file. */
-    CHECK_IF_REACHABLE(anch_curr() == env1,
-                       "anch_curr holds the first claimant (env1)");
+    /* TSOFL=1 unconditional overwrite: each IRXINIT replaces the
+     * slot, so the latest (env3) wins. */
+    CHECK_IF_REACHABLE(anch_curr() == env3,
+                       "anch_curr holds the most recent IRXINIT (env3)");
 
     CHECK(env1 != env2 && env2 != env3,
           "all envblocks are distinct");
 
-    /* Terminate in reverse order. env3 and env2 were never in the
-     * slot, so their terminates are no-ops at the anchor. */
+    /* Terminate in reverse order. CON-3: IRXTERM never touches
+     * ECTENVBK, so the slot stays pinned to env3 across all three
+     * irxterm calls. */
     rc = irxterm(env3);
     CHECK(rc == 0, "env3 terminated");
-    CHECK_IF_REACHABLE(anch_curr() == env1,
-                       "after env3 term, anchor still env1");
+    CHECK_IF_REACHABLE(anch_curr() == env3,
+                       "after env3 term, anchor still env3 (CON-3 no-op)");
 
     rc = irxterm(env2);
     CHECK(rc == 0, "env2 terminated");
-    CHECK_IF_REACHABLE(anch_curr() == env1,
-                       "after env2 term, anchor still env1");
+    CHECK_IF_REACHABLE(anch_curr() == env3,
+                       "after env2 term, anchor still env3 (CON-3 no-op)");
 
     struct envblock *slot_before = anch_curr(); /* save before env1 irxterm */
     rc = irxterm(env1);


### PR DESCRIPTION
Fixes #78

## Summary

IRXPROBE Phase α (TSK-192) verified that IBM's IRXINIT writes `ECTENVBK` unconditionally when TSOFL=1 and leaves the slot untouched when TSOFL=0. This PR replaces the conservative claim-if-NULL hold-out from WP-I1c.1 with the byte-correct contract.

## Changes

### `src/irx#init.c`
- **Step 8**: changes the MVS path from claim-if-NULL to unconditional `*slot = envblk` whenever `is_tso` is true. TSOFL=0 leaves the slot alone.
- **Host wrapper (`irxinit`)**: mirrors the new contract against the simulation slot, deriving `is_tso` from `pb->tsofl` (bitfield accessor) so it works on both MVS (MSB-first) and host (LSB-first) `int` bitfield encodings.
- **Step 3**: no longer touches `eff_flags[0]` directly. The resolved TSOFL is laid down on `pb_copy` via the bitfield write in step 5, eliminating the byte/bitfield mismatch on host.
- Header / step 8 doc updated to reference CON-14 / IRXPROBE Phase α.

### `src/irx#anch.c`
- `anch_push` body comment rewritten to reflect deprecation. The function is no longer called by production (TSK-195); the header (`include/irxanchr.h`) already marks it deprecated.

### Tests
- **`tstinit`**: adds T11–T13:
  - T11: TSOFL=1 overwrites a non-NULL `ECTENVBK`.
  - T12: TSOFL=0 leaves a non-NULL `ECTENVBK` untouched.
  - T13: two stacked TSOFL=1 IRXINITs — the most recent one wins.
- **`tstanrm`**: header rewritten around the new contract. Cases (a)–(c) re-encode IBM-compatible behaviour (foreign slot clobbered, stacking lets the inner env win), and a new case (d) pins the TSOFL=0 no-op.
- **`tstphas1`**: Test 1 / Test 2 now pass an explicit TSOFL=1 parmblock so the anchor-write assertions hold under the new contract. Test 2 doc reworded to match.

## Acceptance criteria

- AC-1 ✅ TSOFL=1 IRXINIT overwrites ECTENVBK on MVS and host.
- AC-2 ✅ TSOFL=0 IRXINIT leaves ECTENVBK unchanged on MVS and host.
- AC-3 ✅ Host suite 1300/1300 (was 1276 + a pre-existing order-dependent tstvpol failure that no longer reproduces).
- AC-4 ⏳ MVS run pending — needs `tstinit + tstfind + tstterm + tstphas1 + tstanrm` against a live system.
- AC-5 ✅ Step 8 / file-header / `anch_push` comments updated to reference CON-14 and the IRXPROBE-verified contract.

## Test plan

- [x] Build host test matrix (`gcc -std=gnu99 -Wall -Wextra`)
- [x] Run `tstphas1` (38/38), `tstanrm` (30/30), `tstinit` (65/65)
- [x] Run full host suite (1300/1300 PASS, 0 FAIL)
- [x] `clang-format --dry-run --Werror` clean on all 5 changed files
- [ ] MVS bring-up: `tstinit`, `tstfind`, `tstterm`, `tstphas1`, `tstanrm` against a live MVS 3.8j