### PR TITLE
feat(irxterm): ECTENVBK predecessor-stack rollback (re-apply #81)

### DIFF
--- a/include/irx_init.h
+++ b/include/irx_init.h
@@ -100,8 +100,9 @@ int irx_init_chekenvb(struct envblock *envblock,
 /*                                                                    */
 /*  Reverses irx_init_initenvb: releases IRXEXTE, PARMBLOCK copy,    */
 /*  IRXANCHR slot, and ENVBLOCK itself, in reverse-allocation order.  */
-/*  ECTENVBK is never touched (CON-3 / IBM-compatible per             */
-/*  SC28-1883-0 §14 — ECTENVBK management is caller responsibility). */
+/*  For TSO-attached envs, rolls ECTENVBK back to the predecessor     */
+/*  TSO-attached env (or NULL), provided we still own the slot        */
+/*  (CON-14 / IRXPROBE Phase alpha). Non-TSO envs: ECTENVBK unchanged.*/
 /*                                                                    */
 /*  Parameters:                                                       */
 /*    envblock        - ENVBLOCK to terminate; must be non-NULL and   */

--- a/include/irxanchr.h
+++ b/include/irxanchr.h
@@ -34,8 +34,15 @@
 /*     ECT  + ECTENVBK  (0x030) -> ENVBLOCK                           */
 /*                                                                    */
 /*  In batch any link in this chain can be NULL (LWA is typical);     */
-/*  the walk returns NULL and anch_push / anch_pop reduce to local    */
-/*  field updates on the ENVBLOCK.                                    */
+/*  the walk returns NULL and the anchor discipline reduces to local   */
+/*  field-only semantics on the ENVBLOCK.                             */
+/*                                                                    */
+/*  IRXTERM (TSOFL=1 env): rolls ECTENVBK back to the most recent     */
+/*  TSO-attached predecessor in the IRXANCHR table, or NULL if none.  */
+/*  IRXTERM (TSOFL=0 env): never writes ECTENVBK.                     */
+/*  The roll-back is guarded: ECTENVBK is only modified when it        */
+/*  currently points to the terminating env (coexistence safety).     */
+/*  Ref: IRXPROBE Phase α (CON-14), CON-1 §6.1.                      */
 /*                                                                    */
 /*  === Part 2: IRXANCHR Registry API ===                             */
 /*                                                                    */
@@ -194,6 +201,16 @@ int irx_anchor_free_slot(void *envblock) asm("ANCHFREE");
 /* Locate slot by envblock or tcb. Returns NULL if not found. */
 irxanchr_entry_t *irx_anchor_find_by_envblock(void *envblock) asm("ANCHFENV");
 irxanchr_entry_t *irx_anchor_find_by_tcb(void *tcb) asm("ANCHFTCB");
+
+/* Walk backwards from current_slot-1 to slot 0. Returns the first slot
+ * that is occupied by a TSO-attached env (envblock_ptr is USED and
+ * flags has IRXANCHR_FLAG_TSO_ATTACHED set). Returns NULL when no such
+ * predecessor exists.
+ *
+ * Used exclusively by irx_init_term() to compute the ECTENVBK rollback
+ * target (IRXPROBE Phase α, CON-14). */
+irxanchr_entry_t *irx_anchor_find_previous_used(
+    const irxanchr_entry_t *current_slot) asm("ANCHFPREV");
 
 /* LOAD EP=IRXANCHR wrapper; verifies eye-catcher.
  * Returns 0 on success, non-zero on load/validation failure. */

--- a/include/irxanchr.h
+++ b/include/irxanchr.h
@@ -210,7 +210,7 @@ irxanchr_entry_t *irx_anchor_find_by_tcb(void *tcb) asm("ANCHFTCB");
  * Used exclusively by irx_init_term() to compute the ECTENVBK rollback
  * target (IRXPROBE Phase α, CON-14). */
 irxanchr_entry_t *irx_anchor_find_previous_used(
-    const irxanchr_entry_t *current_slot) asm("ANCHFPREV");
+    const irxanchr_entry_t *current_slot) asm("ANCHFPRV");
 
 /* LOAD EP=IRXANCHR wrapper; verifies eye-catcher.
  * Returns 0 on success, non-zero on load/validation failure. */

--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -467,6 +467,43 @@ irxanchr_entry_t *irx_anchor_find_by_tcb(void *tcb)
     return best;
 }
 
+irxanchr_entry_t *irx_anchor_find_previous_used(const irxanchr_entry_t *current_slot)
+{
+    irxanchr_header_t *hdr;
+    irxanchr_entry_t *slots;
+    int i;
+
+    if (current_slot == NULL)
+    {
+        return NULL;
+    }
+
+    if (irx_anchor_get_handle(&hdr) != IRX_ANCHOR_RC_OK)
+    {
+        return NULL;
+    }
+
+    slots = (irxanchr_entry_t *)((char *)hdr + sizeof(irxanchr_header_t));
+
+    /* Walk backwards from the slot before current_slot. */
+    i = (int)(current_slot - slots) - 1;
+    for (; i >= 0; i--)
+    {
+        if (slots[i].envblock_ptr == IRXANCHR_SLOT_FREE ||
+            slots[i].envblock_ptr == IRXANCHR_SLOT_SENTINEL)
+        {
+            continue;
+        }
+        if (!(slots[i].flags & IRXANCHR_FLAG_TSO_ATTACHED))
+        {
+            continue; /* non-TSO env never wrote ECTENVBK */
+        }
+        return &slots[i];
+    }
+
+    return NULL;
+}
+
 void irx_anchor_table_reset(void)
 {
     irxanchr_header_t *hdr;

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -1,19 +1,21 @@
 /* ------------------------------------------------------------------ */
 /*  irx#term.c - IRXTERM: Terminate a Language Processor Environment  */
 /*                                                                    */
-/*  irx_init_term() — 5-step C-core (WP-I1c.3):                      */
+/*  irx_init_term() — 6-step C-core:                                  */
 /*    1. Validate eye-catcher                                         */
-/*    2. IRXANCHR slot lookup (idempotency guard)                     */
+/*    2. IRXANCHR slot lookup (idempotency guard); save slot ptr      */
 /*    3. Free IRXEXTE + PARMBLOCK (reverse of INITENVB steps 6, 5)   */
-/*    4. Release IRXANCHR slot (ECTENVBK NOT touched — CON-3)         */
+/*    4a. Release IRXANCHR slot                                       */
+/*    4b. ECTENVBK rollback to predecessor (TSO-attached envs only;   */
+/*        only when we currently own the slot — CON-14, CON-1 §6.1)  */
 /*    5. Free ENVBLOCK itself                                         */
 /*                                                                    */
 /*  irxterm() — compat wrapper that frees wkbi / SUBCOMTB /          */
 /*  workblok_ext (Phase 2+ state) before delegating to irx_init_term. */
 /*                                                                    */
 /*  Ref: SC28-1883-0 §15 (IRXTERM)                                   */
-/*  Ref: CON-1 §6.4 (IRXTERM flow)                                   */
-/*  Ref: CON-3 (ECTENVBK unchanged on IRXTERM — caller responsibility) */
+/*  Ref: CON-1 §6.4 (IRXTERM flow), §6.1 (coexistence guard)        */
+/*  Ref: CON-14 / IRXPROBE Phase alpha (ECTENVBK predecessor rollback)*/
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
 /* ------------------------------------------------------------------ */
@@ -26,6 +28,9 @@
 #include "irxbif.h"
 #include "irxfunc.h"
 #include "irxwkblk.h"
+
+/* Forward-declare the ECTENVBK slot accessor from irx#anch.c. */
+struct envblock **ectenvbk_slot(void);
 
 /* Internal helper: free via irxstor, NULL-safe. */
 static void stor_free(void **ptr, struct envblock *envblk)
@@ -42,32 +47,33 @@ static void stor_free(void **ptr, struct envblock *envblk)
 
 int irx_init_term(struct envblock *envblock, int *out_reason_code)
 {
-    int reason = 0;
+    irxanchr_entry_t *my_slot;
+    int my_is_tso;
     void *p;
 
     /* Step 1: Validate eye-catcher. */
     if (envblock == NULL ||
         memcmp(envblock->envblock_id, ENVBLOCK_ID, 8) != 0)
     {
-        reason = 4;
         if (out_reason_code != NULL)
         {
-            *out_reason_code = reason;
+            *out_reason_code = 4;
         }
         return 20;
     }
 
     /* Step 2: IRXANCHR slot lookup — idempotency guard.
-     * If the slot is already free (double-term), return RC=20 RSN=4. */
-    if (irx_anchor_find_by_envblock(envblock) == NULL)
+     * Save the slot pointer; step 4b uses it after slot free. */
+    my_slot = irx_anchor_find_by_envblock(envblock);
+    if (my_slot == NULL)
     {
-        reason = 4;
         if (out_reason_code != NULL)
         {
-            *out_reason_code = reason;
+            *out_reason_code = 4;
         }
         return 20;
     }
+    my_is_tso = (my_slot->flags & IRXANCHR_FLAG_TSO_ATTACHED) != 0;
 
     /* Step 3: Free IRXEXTE, then PARMBLOCK — reverse of INITENVB
      * steps 6 and 5.  IRXEXTE freed first so irxstor can still read
@@ -75,9 +81,37 @@ int irx_init_term(struct envblock *envblock, int *out_reason_code)
     stor_free((void **)&envblock->envblock_irxexte, envblock);
     stor_free((void **)&envblock->envblock_parmblock, envblock);
 
-    /* Step 4: Release IRXANCHR slot.
-     * ECTENVBK is NOT touched — CON-3 / SC28-1883-0 §14. */
+    /* Step 4a: Release IRXANCHR slot (envblock_ptr set to SLOT_FREE).
+     * my_slot still points into the table — the pointer itself is valid
+     * for find_previous_used even though envblock_ptr is now zeroed. */
     irx_anchor_free_slot(envblock);
+
+    /* Step 4b: ECTENVBK predecessor rollback (TSO-attached envs only).
+     * Guard: only write the slot when it currently points at us — this
+     * prevents clobbering a foreign anchor in BREXX/370 coexistence or
+     * out-of-order TERM scenarios (CON-1 §6.1, CON-14). */
+    if (my_is_tso)
+    {
+        struct envblock **ect_slot = ectenvbk_slot();
+        if (ect_slot != NULL && *ect_slot == envblock)
+        {
+            irxanchr_entry_t *prev = irx_anchor_find_previous_used(my_slot);
+            if (prev != NULL)
+            {
+#ifndef __MVS__
+                void *full_ptr = NULL;
+                memcpy(&full_ptr, prev->rsvd1, sizeof(void *));
+                *ect_slot = (struct envblock *)full_ptr;
+#else
+                *ect_slot = (struct envblock *)(unsigned long)prev->envblock_ptr;
+#endif
+            }
+            else
+            {
+                *ect_slot = NULL;
+            }
+        }
+    }
 
     /* Step 5: Free ENVBLOCK itself (no envblock context for this free). */
     p = envblock;

--- a/test/mvs/tstanch.c
+++ b/test/mvs/tstanch.c
@@ -7,20 +7,17 @@
 /*  content through printf (crent370 maps to PUTLINE/WTO depending on */
 /*  how the module is invoked).                                       */
 /*                                                                    */
-/*  Verifies the read-mostly ECTENVBK anchor described in CON-1 §6.1  */
-/*  end-to-end, starting from an empty slot (state (a)):              */
-/*   - IRXINIT sees ECTENVBK == NULL and claims it.                   */
-/*   - envblock_ectptr is populated with the ECT address so later     */
-/*     reflection routines have a cheap back-pointer.                 */
-/*   - IRXTERM clears ECTENVBK because we are still the holder.       */
-/*  In batch (ECT not reachable) the slot is never written; IRXINIT   */
-/*  and IRXTERM still succeed with local-field-only semantics.        */
+/*  Verifies the TSOFL-conditional ECTENVBK contract (CON-14):        */
+/*   - TSOFL=1 IRXINIT overwrites ECTENVBK unconditionally.           */
+/*     IRXTERM rolls it back to predecessor (NULL for single env).    */
+/*   - TSOFL=0 IRXINIT leaves ECTENVBK untouched.                    */
+/*     IRXTERM does not touch ECTENVBK.                               */
+/*   - In batch (ECT not reachable) IRXINIT and IRXTERM succeed with  */
+/*     local-field-only semantics; ECTENVBK is never written.         */
 /*                                                                    */
 /*  Exit codes:                                                       */
 /*     0 — anchor behavior observed correct                           */
-/*     8 — anchor semantics violation (slot written despite           */
-/*         non-NULL, slot not cleared after pop, or batch path did    */
-/*         not reach the expected zero-field state)                   */
+/*     8 — anchor semantics violation                                 */
 /*    16 — IRXINIT or IRXTERM failed                                  */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
@@ -115,22 +112,28 @@ int main(void)
 
     if (anch_walk() != NULL)
     {
-        /* TSO-ish path: slot was empty at entry, so read-mostly
-         * claimed it. Our env must now be the anchor. */
-        if (initial_anchor == NULL && anch_curr() != env)
+        if (anch_tso())
         {
-            printf("FAIL: ECTENVBK was not claimed for our envblock\n");
-            exit_rc = RC_ANCHOR_BROKEN;
+            /* TSO: IRXINIT unconditionally overwrites ECTENVBK (CON-14). */
+            if (anch_curr() != env)
+            {
+                printf("FAIL: TSO IRXINIT did not install env in ECTENVBK\n");
+                exit_rc = RC_ANCHOR_BROKEN;
+            }
         }
-        if (initial_anchor != NULL && anch_curr() != initial_anchor)
+        else
         {
-            printf("FAIL: ECTENVBK was overwritten despite non-NULL slot\n");
-            exit_rc = RC_ANCHOR_BROKEN;
+            /* Non-TSO: IRXINIT must not touch ECTENVBK (CON-14). */
+            if (anch_curr() != initial_anchor)
+            {
+                printf("FAIL: non-TSO IRXINIT modified ECTENVBK\n");
+                exit_rc = RC_ANCHOR_BROKEN;
+            }
         }
     }
     else
     {
-        /* Batch path: no ECT; local-only push, slot stays untouched. */
+        /* Batch path: no ECT reachable; local-only semantics. */
         if (env->envblock_ectptr != NULL)
         {
             printf("FAIL: batch envblock_ectptr is non-NULL\n");
@@ -153,14 +156,21 @@ int main(void)
 
     dump_state("after irxterm", NULL);
 
-    /* After pop: slot must equal the initial_anchor. Either we
-     * claimed and then cleared (initial was NULL), or we never
-     * wrote it to begin with (initial was non-NULL) — in both
-     * cases the slot is back to its entry value. */
-    if (anch_curr() != initial_anchor)
+    /* After IRXTERM the slot must be at the expected post-term value.
+     *
+     * TSO path: IRXINIT wrote the slot; IRXTERM rolls back to the
+     * predecessor TSO-attached env in IRXANCHR (NULL for this single-env
+     * test since we started from an empty table).
+     *
+     * Non-TSO / batch: neither IRXINIT nor IRXTERM touched the slot;
+     * it remains at initial_anchor. */
     {
-        printf("FAIL: ECTENVBK not back at its initial value\n");
-        exit_rc = RC_ANCHOR_BROKEN;
+        struct envblock *expected = anch_tso() ? NULL : initial_anchor;
+        if (anch_curr() != expected)
+        {
+            printf("FAIL: ECTENVBK not at expected value after IRXTERM\n");
+            exit_rc = RC_ANCHOR_BROKEN;
+        }
     }
 
     if (exit_rc == 0)

--- a/test/mvs/tstanrm.c
+++ b/test/mvs/tstanrm.c
@@ -7,7 +7,8 @@
 /*    - TSOFL=1 IRXINIT  → ECTENVBK is overwritten unconditionally     */
 /*      with the new ENVBLOCK, regardless of the slot's prior value.   */
 /*    - TSOFL=0 IRXINIT  → ECTENVBK is left untouched.                 */
-/*    - IRXTERM (any TSOFL) → ECTENVBK is never modified (CON-3).      */
+/*    - TSOFL=1 IRXTERM → rolls ECTENVBK back to predecessor TSO env,  */
+/*      or NULL if none (TSK-194). TSOFL=0 IRXTERM → untouched.        */
 /*                                                                    */
 /*  The cases below pin down all four observables in one place so a   */
 /*  reviewer can point at this file as the executable contract:        */
@@ -17,11 +18,11 @@
 /*                                                                    */
 /*    (b) Foreign-owned slot — a sentinel pre-seeded into ECTENVBK     */
 /*        is clobbered by TSOFL=1 IRXINIT (matches IBM behaviour).    */
-/*        IRXTERM leaves the new value in place.                      */
+/*        IRXTERM rolls ECTENVBK to NULL (no TSO predecessor in table).*/
 /*                                                                    */
 /*    (c) Own-env stacking — a TSOFL=1 IRXINIT for `outer` claims     */
 /*        the slot; a second TSOFL=1 IRXINIT for `inner` overwrites   */
-/*        it. IRXTERM on either env is a CON-3 no-op at the anchor.   */
+/*        it. IRXTERM on inner rolls back to outer; outer to NULL.    */
 /*                                                                    */
 /*    (d) Non-TSO no-op — TSOFL=0 IRXINIT must not touch the slot,    */
 /*        even when one is reachable. The pre-seeded sentinel must   */
@@ -197,15 +198,13 @@ static void case_a_empty_slot_baseline(void)
               "TSOFL=1: slot written (anch_curr() == env)"),
         "slot claimed: anch_curr() == env");
 
-    struct envblock *slot_before = anch_curr(); /* save before irxterm */
     rc = irxterm(env);
     CHECK(rc == 0, "irxterm returns 0");
-    /* CON-3: IRXTERM does not touch ECTENVBK. The slot retains its
-     * pre-term value regardless of whether we were the holder. */
-    CHECK(anch_curr() == slot_before,
-          "ECTENVBK unchanged after irxterm (CON-3)");
-    /* Caller-side cleanup. */
-    _test_set_anchor(NULL);
+    /* TSK-194: single-env IRXTERM rolls ECTENVBK back to NULL (no predecessor). */
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == NULL,
+              "TSO IRXTERM rolls ECTENVBK back to NULL"),
+        "TSO IRXTERM rolls ECTENVBK back to NULL");
 }
 
 /* ------------------------------------------------------------------ */
@@ -242,17 +241,14 @@ static void case_b_foreign_slot_clobbered(void)
     CHECK(env != (struct envblock *)SENTINEL,
           "returned env is distinct from the pre-existing anchor");
 
-    struct envblock *slot_before = anch_curr(); /* save before irxterm */
     rc = irxterm(env);
     CHECK(rc == 0, "irxterm returns 0");
+    /* TSK-194: IRXTERM rolls back to predecessor in IRXANCHR (NULL —
+     * the foreign sentinel was never registered, so no predecessor). */
     CHECK_IF_REACHABLE(
-        CHECK(anch_curr() == slot_before,
-              "slot unchanged by irxterm (CON-3 no-op)"),
-        "slot unchanged after irxterm");
-
-    /* Caller-side cleanup so Case (c) starts with a clean precondition. */
-    _test_set_anchor(NULL);
-    CHECK(anch_curr() == NULL, "post-cleanup: anch_curr() == NULL");
+        CHECK(anch_curr() == NULL,
+              "TSO IRXTERM rolls ECTENVBK to NULL (no TSO predecessor)"),
+        "TSO IRXTERM rolls ECTENVBK to NULL");
 }
 
 /* ------------------------------------------------------------------ */
@@ -290,19 +286,19 @@ static void case_c_own_env_stacking(void)
 
     rc = irxterm(inner);
     CHECK(rc == 0, "inner irxterm returns 0");
+    /* TSK-194: inner irxterm rolls ECTENVBK back to outer (predecessor). */
     CHECK_IF_REACHABLE(
-        CHECK(anch_curr() == inner,
-              "slot still inner after inner irxterm (CON-3 no-op)"),
-        "slot still inner after inner irxterm");
+        CHECK(anch_curr() == outer,
+              "inner irxterm rolls ECTENVBK back to outer"),
+        "inner irxterm rolls back to outer");
 
-    struct envblock *slot_before = anch_curr(); /* save before outer irxterm */
     rc = irxterm(outer);
     CHECK(rc == 0, "outer irxterm returns 0");
-    /* CON-3: IRXTERM does not touch ECTENVBK. */
-    CHECK(anch_curr() == slot_before,
-          "ECTENVBK unchanged after outer irxterm (CON-3)");
-    /* Caller-side cleanup. */
-    _test_set_anchor(NULL);
+    /* TSK-194: outer irxterm rolls ECTENVBK back to NULL (no predecessor). */
+    CHECK_IF_REACHABLE(
+        CHECK(anch_curr() == NULL,
+              "outer irxterm rolls ECTENVBK back to NULL"),
+        "outer irxterm rolls back to NULL");
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/mvs/tstphas1.c
+++ b/test/mvs/tstphas1.c
@@ -173,18 +173,11 @@ static void test_single_env(void)
                        "anch_curr returns our envblock");
 
     /* IRXTERM */
-    struct envblock *slot_before = anch_curr(); /* save before irxterm */
     rc = irxterm(envblk);
     CHECK(rc == 0, "irxterm returns 0");
-    /* CON-3: IRXTERM does not modify ECTENVBK (SC28-1883-0 §14). */
-    CHECK(anch_curr() == slot_before,
-          "ECTENVBK unchanged after irxterm (CON-3)");
-    /* Caller-side cleanup so Test 2 starts with a clean slot. */
-    struct envblock **slot = ectenvbk_slot();
-    if (slot != NULL)
-    {
-        *slot = NULL;
-    }
+    /* TSK-194: single-env IRXTERM rolls ECTENVBK back to NULL (no predecessor). */
+    CHECK_IF_REACHABLE(anch_curr() == NULL,
+                       "TSO IRXTERM rolls ECTENVBK back to NULL (greenfield)");
 }
 
 /* ------------------------------------------------------------------ */
@@ -193,8 +186,8 @@ static void test_single_env(void)
 /*  Under the TSOFL-conditional contract (TSK-195, CON-14) every      */
 /*  TSOFL=1 IRXINIT unconditionally overwrites ECTENVBK. The slot     */
 /*  therefore tracks the most recent IRXINIT, not the first claimant. */
-/*  IRXTERM never touches ECTENVBK (CON-3 / SC28-1883-0 §14), so the  */
-/*  slot stays pinned to whoever last wrote it.                       */
+/*  IRXTERM (TSK-194) rolls ECTENVBK back to the predecessor TSO-     */
+/*  attached env in IRXANCHR, or to NULL if none remains.             */
 /* ------------------------------------------------------------------ */
 
 static void test_multiple_envs(void)
@@ -226,31 +219,22 @@ static void test_multiple_envs(void)
     CHECK(env1 != env2 && env2 != env3,
           "all envblocks are distinct");
 
-    /* Terminate in reverse order. CON-3: IRXTERM never touches
-     * ECTENVBK, so the slot stays pinned to env3 across all three
-     * irxterm calls. */
+    /* Terminate in reverse order. TSK-194: IRXTERM rolls ECTENVBK back
+     * to the predecessor TSO-attached env in IRXANCHR, or NULL. */
     rc = irxterm(env3);
     CHECK(rc == 0, "env3 terminated");
-    CHECK_IF_REACHABLE(anch_curr() == env3,
-                       "after env3 term, anchor still env3 (CON-3 no-op)");
+    CHECK_IF_REACHABLE(anch_curr() == env2,
+                       "after env3 term, anchor rolls back to env2");
 
     rc = irxterm(env2);
     CHECK(rc == 0, "env2 terminated");
-    CHECK_IF_REACHABLE(anch_curr() == env3,
-                       "after env2 term, anchor still env3 (CON-3 no-op)");
+    CHECK_IF_REACHABLE(anch_curr() == env1,
+                       "after env2 term, anchor rolls back to env1");
 
-    struct envblock *slot_before = anch_curr(); /* save before env1 irxterm */
     rc = irxterm(env1);
     CHECK(rc == 0, "env1 terminated");
-    /* CON-3: IRXTERM does not modify ECTENVBK. */
-    CHECK(anch_curr() == slot_before,
-          "ECTENVBK unchanged after env1 irxterm (CON-3)");
-    /* Caller-side cleanup so Test 3 starts with a clean slot. */
-    struct envblock **slot = ectenvbk_slot();
-    if (slot != NULL)
-    {
-        *slot = NULL;
-    }
+    CHECK_IF_REACHABLE(anch_curr() == NULL,
+                       "after env1 term, anchor rolls back to NULL");
 }
 
 /* ------------------------------------------------------------------ */

--- a/test/mvs/tstterm.c
+++ b/test/mvs/tstterm.c
@@ -516,6 +516,10 @@ static void test_t11_failure_ectenvbk_unchanged(void)
         return;
     }
 
+    /* Re-seed: TSOFL=1 IRXINIT overwrote the slot with envblk.
+     * Restore the sentinel so we can verify the failure path leaves it untouched. */
+    *slot = sentinel;
+
     /* Free the slot so irx_init_term's idempotency guard triggers. */
     irx_anchor_free_slot(envblk);
 

--- a/test/mvs/tstterm.c
+++ b/test/mvs/tstterm.c
@@ -1,7 +1,7 @@
 /* ------------------------------------------------------------------ */
 /*  tstterm.c - WP-I1c.3 IRXTERM C-Core Tests                        */
 /*                                                                    */
-/*  Tests irx_init_term() (5-step C-core) and the irxterm()           */
+/*  Tests irx_init_term() (6-step C-core) and the irxterm()           */
 /*  compatibility wrapper.                                            */
 /*                                                                    */
 /*  Test cases:                                                       */
@@ -10,9 +10,12 @@
 /*  T3: bad eye-catcher — RC=20, RSN=4                                */
 /*  T4: IRXANCHR slot freed — find_by_envblock returns NULL           */
 /*  T5: idempotency — IRXANCHR slot freed after irx_init_term         */
-/*  T6: ECTENVBK unchanged after irx_init_term (CON-3)                */
+/*  T6: non-TSO env — ECTENVBK unchanged after irx_init_term         */
 /*  T7: irxterm() compat wrapper via irx_init_initenvb path — RC=0   */
 /*  T8: irxterm() compat wrapper via irxinit() path (with wkbi)      */
+/*  T9: TSO single env — IRXTERM rolls ECTENVBK back to NULL          */
+/*  T10: TSO two-env stack — IRXTERM rolls ECTENVBK back to outer    */
+/*  T11: IRXTERM failure — ECTENVBK unchanged (AC-7)                  */
 /*                                                                    */
 /*  Cross-compile build:                                              */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
@@ -47,6 +50,31 @@ struct envblock **ectenvbk_slot(void);
 static int tests_run = 0;
 static int tests_passed = 0;
 static int tests_failed = 0;
+static int tests_skipped = 0;
+
+/* Return 1 if the ECTENVBK slot is reachable, 0 (and emit SKIP) if not. */
+static int slot_reachable_or_skip(const char *label)
+{
+    if (ectenvbk_slot() != NULL)
+    {
+        return 1;
+    }
+    printf("  SKIP: %s (ECTENVBK slot unreachable — pure batch)\n", label);
+    tests_skipped++;
+    return 0;
+}
+
+/* Build a minimal PARMBLOCK with a caller-controlled TSOFL value.
+ * tso=1 makes IRXINIT treat the env as TSO-attached; tso=0 leaves it
+ * non-TSO so ECTENVBK is never written. */
+static void build_parmblock_with_tsofl(struct parmblock *pb, int tso)
+{
+    memset(pb, 0, sizeof(*pb));
+    memcpy(pb->parmblock_id, PARMBLOCK_ID, 8);
+    memcpy(pb->parmblock_version, PARMBLOCK_VERSION_0042, 4);
+    pb->tsofl_mask = -1;
+    pb->tsofl = tso ? -1 : 0;
+}
 
 #define CHECK(cond, msg)                 \
     do                                   \
@@ -347,12 +375,173 @@ static void test_t8_irxterm_full_init(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  T9: TSO single env — IRXTERM rolls ECTENVBK back to NULL          */
+/*                                                                    */
+/*  Allocate a TSO-attached env, seed ECTENVBK with it, terminate.   */
+/*  No predecessor in IRXANCHR → rollback target is NULL.             */
+/* ------------------------------------------------------------------ */
+
+static void test_t9_tso_rollback_to_null(void)
+{
+    struct parmblock pb;
+    struct envblock *envblk = NULL;
+    struct envblock **slot;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- T9: TSO single env — IRXTERM rolls ECTENVBK to NULL ---\n");
+
+    irx_anchor_table_reset();
+    if (!slot_reachable_or_skip("T9"))
+    {
+        return;
+    }
+
+    slot = ectenvbk_slot();
+    *slot = NULL;
+
+    build_parmblock_with_tsofl(&pb, /*tso=*/1);
+    rc = irx_init_initenvb(NULL, &pb, 0, &envblk, &reason);
+    if (rc != 0 || envblk == NULL)
+    {
+        printf("  SKIP: T9 (irx_init_initenvb failed)\n");
+        return;
+    }
+
+    /* Simulate IRXINIT having written ECTENVBK for this TSO env. */
+    *slot = envblk;
+    CHECK(*slot == envblk, "T9: pre-term: ECTENVBK points at our env");
+
+    reason = -1;
+    rc = irx_init_term(envblk, &reason);
+
+    CHECK(rc == 0, "T9: irx_init_term returns 0");
+    CHECK(*slot == NULL, "T9: ECTENVBK rolled back to NULL (no predecessor)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  T10: TSO two-env stack — IRXTERM rolls ECTENVBK back to outer     */
+/*                                                                    */
+/*  Allocate outer (TSO), then inner (TSO). IRXTERM on inner must     */
+/*  restore ECTENVBK to the outer env.                                */
+/* ------------------------------------------------------------------ */
+
+static void test_t10_tso_rollback_to_outer(void)
+{
+    struct parmblock pb;
+    struct envblock *outer = NULL;
+    struct envblock *inner = NULL;
+    struct envblock **slot;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- T10: TSO two-env stack — IRXTERM rolls to outer ---\n");
+
+    irx_anchor_table_reset();
+    if (!slot_reachable_or_skip("T10"))
+    {
+        return;
+    }
+
+    slot = ectenvbk_slot();
+    *slot = NULL;
+
+    build_parmblock_with_tsofl(&pb, /*tso=*/1);
+    rc = irx_init_initenvb(NULL, &pb, 0, &outer, &reason);
+    if (rc != 0 || outer == NULL)
+    {
+        printf("  SKIP: T10 (outer irx_init_initenvb failed)\n");
+        return;
+    }
+    *slot = outer;
+
+    build_parmblock_with_tsofl(&pb, /*tso=*/1);
+    rc = irx_init_initenvb(NULL, &pb, 0, &inner, &reason);
+    if (rc != 0 || inner == NULL)
+    {
+        printf("  SKIP: T10 (inner irx_init_initenvb failed)\n");
+        irx_init_term(outer, NULL);
+        *slot = NULL;
+        return;
+    }
+    *slot = inner;
+
+    CHECK(*slot == inner, "T10: pre-term: ECTENVBK points at inner env");
+
+    reason = -1;
+    rc = irx_init_term(inner, &reason);
+
+    CHECK(rc == 0, "T10: irx_init_term(inner) returns 0");
+    CHECK(*slot == outer, "T10: ECTENVBK rolled back to outer env");
+
+    /* Cleanup. */
+    irx_init_term(outer, NULL);
+    *slot = NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/*  T11: IRXTERM failure — ECTENVBK unchanged (AC-7)                  */
+/*                                                                    */
+/*  Calling irx_init_term on an envblock not in IRXANCHR (double-free  */
+/*  or invalid) must leave ECTENVBK untouched.                        */
+/* ------------------------------------------------------------------ */
+
+static void test_t11_failure_ectenvbk_unchanged(void)
+{
+    struct parmblock pb;
+    struct envblock *envblk = NULL;
+    struct envblock *const sentinel =
+        (struct envblock *)(unsigned long)0xDEAD0003UL;
+    struct envblock **slot;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- T11: IRXTERM failure — ECTENVBK unchanged (AC-7) ---\n");
+
+    irx_anchor_table_reset();
+    if (!slot_reachable_or_skip("T11"))
+    {
+        return;
+    }
+
+    slot = ectenvbk_slot();
+    *slot = sentinel;
+
+    build_parmblock_with_tsofl(&pb, /*tso=*/1);
+    rc = irx_init_initenvb(NULL, &pb, 0, &envblk, &reason);
+    if (rc != 0 || envblk == NULL)
+    {
+        printf("  SKIP: T11 (irx_init_initenvb failed)\n");
+        *slot = NULL;
+        return;
+    }
+
+    /* Free the slot so irx_init_term's idempotency guard triggers. */
+    irx_anchor_free_slot(envblk);
+
+    reason = -1;
+    rc = irx_init_term(envblk, &reason);
+
+    CHECK(rc == 20, "T11: irx_init_term returns 20 (not registered)");
+    CHECK(*slot == sentinel, "T11: ECTENVBK unchanged on failure (AC-7)");
+
+    /* Cleanup: envblk was allocated but its IRXANCHR slot is already
+     * free; free the ENVBLOCK storage directly to avoid a memory leak.
+     * irx_init_term would do this, but it returned 20 so it did not. */
+    *slot = NULL;
+    {
+        void *p = envblk;
+        irxstor(RXSMFRE, 0, &p, NULL);
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                               */
 /* ------------------------------------------------------------------ */
 
 int main(void)
 {
-    printf("TSTTERM: WP-I1c.3 IRXTERM C-Core\n");
+    printf("TSTTERM: IRXTERM C-Core\n");
 
     test_t1_basic_term();
     test_t2_null_envblock();
@@ -362,11 +551,15 @@ int main(void)
     test_t6_ectenvbk_unchanged();
     test_t7_irxterm_minimal_init();
     test_t8_irxterm_full_init();
+    test_t9_tso_rollback_to_null();
+    test_t10_tso_rollback_to_outer();
+    test_t11_failure_ectenvbk_unchanged();
 
     printf("\n--- Results ---\n");
     printf("  Run:    %d\n", tests_run);
     printf("  Passed: %d\n", tests_passed);
     printf("  Failed: %d\n", tests_failed);
+    printf("  Skipped: %d\n", tests_skipped);
 
     if (tests_failed > 0)
     {


### PR DESCRIPTION
Re-applies the commits from PR #81 which were lost when PR #79 was squash-merged onto the same parent commit (90933c0), overwriting the #81 squash.

Cherry-picks applied cleanly onto current main (b95a58e):
- `ae8d60b` feat(irxterm): ECTENVBK predecessor-stack rollback (issue #80)
- `400a283` fix(irxanchr): shorten ANCHFPRV alias to 8 chars (was ANCHFPREV=9)
- `e1222be` test: update IRXTERM assertions from CON-3 no-op to TSK-194 rollback

## What this adds

- `irx_anchor_find_previous_used()` in `irx#anch.c` — backwards walk through IRXANCHR to find the most recent TSO-attached predecessor slot
- `irx_init_term()` step 4b — rolls ECTENVBK back to predecessor (or NULL) when terminating a TSO-attached env; guarded by `*ect_slot == envblock` for coexistence safety
- Tests: T9/T10/T11 in `tstterm.c`; rollback assertions in `tstphas1.c` and `tstanrm.c`

Host test suite: tstphas1 38/38, tstterm 26/26, tstanrm 29/29.

Fixes #80