### PR TITLE
[REXX/370] WP-I1c.5: HLASM Entry-Point Wrappers (IRXINIT, IRXTERM)

### DIFF
--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -68,8 +68,6 @@ R15      EQU   15
          PRINT GEN
 *
 IRXINIT  CSECT
-IRXINIT  AMODE 24
-IRXINIT  RMODE 24
 *
 *  --- standard MVS entry linkage ---
          STM   R14,R12,12(R13)     save caller R14-R12 in caller SA

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -75,8 +75,17 @@ IRXINIT  CSECT
          USING *,R12
 *
 *  Capture caller-supplied registers needed across the wrapper body.
+*  R10 must be set BEFORE the NULL-R1 check below — the NULLPLST
+*  early-exit restores caller R0 from R10 and would otherwise fault.
          LR    R10,R0              R10 = previous-env hint (R0 in)
          LR    R11,R1              R11 = caller VLIST address
+*
+*  Defensive NULL check: a caller passing R1=0 (no parm list at all)
+*  must not provoke an S0C5 in PARSELP and must not leak the workarea
+*  we are about to GETMAIN. Bail before any allocation; we cannot
+*  reach a REASON slot either, so just return RC=20 with R0 intact.
+         LTR   R11,R11             VLIST pointer NULL?
+         BZ    NULLPLST            yes -> early exit, no GETMAIN
 *
 *  --- allocate dynamic workarea (DSA + locals + C-call plist) ---
          LA    R0,WALEN
@@ -115,16 +124,21 @@ PARSELP  L     R6,0(,R3)           raw VLIST entry (addr | maybe VL)
          LA    R4,4(,R4)
          BCT   R2,PARSELP
 *
-*  Walked all 7 slots without seeing the VL marker.
+*  Walked all 7 slots without seeing the VL marker. The slot-7
+*  WPARMS entry was filled from VLIST[6], which is past the caller's
+*  actual list end and therefore undefined. We MUST NOT treat it as
+*  a REASON-slot address — go to ERREARLY (no reason write).
          LA    R15,20
-         B     SETRSN
+         B     ERREARLY
 *
 PARSEVL  EQU   *
 *  VL marker found; R2 = remaining count (must be 1 if on slot 7).
          CH    R2,=H'1'
          BE    FCCHK
+*  VL on the wrong slot — caller list is short. WPARMS+24 was never
+*  filled (or holds a stale value); no usable REASON slot reachable.
          LA    R15,20
-         B     SETRSN
+         B     ERREARLY
 *
 FCCHK    EQU   *
 *  --- validate function code: exact CL8, no trailing blanks ---
@@ -136,7 +150,9 @@ FCCHK    EQU   *
          CLC   0(8,R2),=CL8'CHEKENVB'
          BE    BUILDC
 *
-*  Unknown function code (incl. trailing blanks).
+*  Unknown function code (incl. trailing blanks). Slot 7 was reached
+*  via the normal VL-marker path, so WPARMS+24 holds the caller's
+*  REASON slot address and is safe to write through.
          LA    R15,20
          B     SETRSN
 *
@@ -157,13 +173,18 @@ BUILDC   EQU   *
          L     R2,WPREV            R2 = previous-env hint
          ST    R2,WCPLIST+4
 *
-         L     R2,WPARMS+4         R2 = addr of PARMMOD slot
-         L     R3,0(,R2)           R3 = caller parmblock value
-         ST    R3,WCPLIST+8
+*  P2 (Parameters-Module-Name, WPARMS+4) is ignored for now —
+*  MODNAMET-resolution lands with WP-I1c.4. The caller's PARMBLOCK
+*  pointer per SC28-1883-0 §14 lives in P3 (In-Storage Parm List
+*  Address) at WPARMS+8, and the user field is P4 at WPARMS+12.
 *
-         L     R2,WPARMS+8         R2 = addr of USERFLD slot
+         L     R2,WPARMS+8         R2 = addr of P3 (parmblock ptr slot)
+         L     R3,0(,R2)           R3 = caller PARMBLOCK pointer
+         ST    R3,WCPLIST+8        -> caller_parmblock argument
+*
+         L     R2,WPARMS+12        R2 = addr of P4 (user field slot)
          L     R3,0(,R2)           R3 = user_field value
-         ST    R3,WCPLIST+12
+         ST    R3,WCPLIST+12       -> user_field argument
 *
          L     R2,WPARMS+20        R2 = addr of ENVBLK slot
          ST    R2,WCPLIST+16
@@ -193,19 +214,27 @@ FAILR0   EQU   *
          B     EPILOG
 *
 SETRSN   EQU   *
-*  --- error path: write RSN=1 to caller REASON slot if available ---
+*  --- error path WITH reason write ---------------------------------
 *
-*  WPARMS+24 holds the caller REASON slot address only when slot 7
-*  was reached during parsing. The "no VL marker anywhere" path
-*  walks all 7 slots and stores their addresses, so WPARMS+24 is
-*  valid there. The "VL on wrong slot" path bails before reaching
-*  slot 7 and leaves WPARMS+24 untouched (=0); skip the write.
+*  Reached only via FCCHK (function code mismatch after the VLIST
+*  parser saw the VL marker on slot 7). WPARMS+24 therefore holds
+*  the caller's REASON slot address and can be written safely.
          LR    R3,R15              R3 = RC (20)
          LR    R4,R10              R4 = caller's original R0
-         L     R7,WPARMS+24
-         LTR   R7,R7
-         BZ    EPILOG
+         L     R7,WPARMS+24        caller REASON slot address
          MVC   0(4,R7),=F'1'       reason code 1
+         B     EPILOG
+*
+ERREARLY EQU   *
+*  --- error path WITHOUT reason write -------------------------------
+*
+*  Used by the two VLIST-shape failures ("walked all 7 without VL"
+*  and "VL on wrong slot") where WPARMS+24 cannot be trusted to
+*  hold a real caller REASON slot address. R15 is already set; we
+*  return RC=20 with R0 restored to the caller's original R0.
+         LR    R3,R15              R3 = RC (20)
+         LR    R4,R10              R4 = caller's original R0
+*  Fall through to EPILOG.
 *
 EPILOG   EQU   *
 *  R3 = output RC, R4 = output R0 — both in safe regs (1..12).
@@ -220,6 +249,17 @@ EPILOG   EQU   *
          LR    R15,R3              R15 = output RC
 *
 *  Restore R14 and R1-R12 from caller SA (preserve our R0 / R15).
+         L     R14,12(,R13)
+         LM    R1,R12,24(R13)
+         BR    R14
+*
+NULLPLST DS    0H
+*  Caller passed R1=0 — no VLIST, no REASON slot reachable. We have
+*  not allocated a workarea yet, so just restore caller R14/R1-R12
+*  from the still-current caller SA (R13 unchanged) and return with
+*  R0 = caller's original R0 (saved into R10 above) and R15 = 20.
+         LA    R15,20              RC=20
+         LR    R0,R10              caller's original R0
          L     R14,12(,R13)
          LM    R1,R12,24(R13)
          BR    R14

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -1,0 +1,239 @@
+         TITLE 'IRXINIT - REXX/370 IRXINIT Entry Point Wrapper'
+*
+*  IRXINIT - HLASM entry-point wrapper for the IRXINIT Programming
+*            Service (SC28-1883-0 §14).
+*
+*  Parses the caller VLIST, validates the high-bit endmarker on the
+*  last parameter, extracts the CL8 function code, and delegates to
+*  the C-core dispatcher irx_init_dispatch (asm() alias IRXIDISP,
+*  CON-4) which routes on the function code to one of:
+*
+*    INITENVB  -> irx_init_initenvb()  (alias IRXIINIT)
+*    FINDENVB  -> irx_init_findenvb()  (alias IRXIFIND)
+*    CHEKENVB  -> irx_init_chekenvb()  (alias IRXICHEK)
+*
+*  Calling convention (per SC28-1883-0):
+*
+*    CALL IRXINIT,(FCODE,PARMMOD,USERFLD,WKBLKEXT,RESERVED,         *
+*                  ENVBLK,REASON),VL
+*
+*  Each VLIST slot is a 4-byte address pointing at the parameter
+*  value. The address of the LAST slot has its high-order bit set
+*  to mark the end of the variable-length list.
+*
+*  R0  (in)  optional previous-env hint (passed to dispatcher)
+*  R0  (out) ENVBLOCK on success, original R0 on failure
+*  R15 (out) return code: 0 = ok, 4 = no env (FINDENVB),
+*            20 = error (RSN written to caller REASON slot)
+*
+*  Built as a separate load module (entry IRXINIT). The C-core
+*  (irx#init.c, irx#anch.c, ...) is NCAL-linked into the same
+*  load module via project.toml include list.
+*
+*  Known gap (deferred): the crent370 C runtime (CLIBCRT per-TCB
+*  control block) is normally initialized by the @@CRT0 entry on
+*  module load. Because the OS branches directly to IRXINIT here,
+*  __crtset() is not yet called. The first call into the C-core
+*  will hit calloc() with an uninitialized heap unless either
+*    (a) a runtime-bootstrap call (__crtset / @@CRTSET) is added
+*        in this prologue, or
+*    (b) irxstor() switches subpool 0 to GETMAIN on MVS.
+*  See WP-I1c.5e follow-up; the structural wrapper logic below is
+*  correct and stays valid once the bootstrap path is added.
+*
+*  Ref: SC28-1883-0 §14 (IRXINIT Programming Service)
+*  Ref: WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83
+*  Ref: CON-1 §6.3 (INITENVB algorithm)
+*  Ref: CON-4 (asm() aliases)
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R5       EQU   5
+R6       EQU   6
+R7       EQU   7
+R8       EQU   8
+R9       EQU   9
+R10      EQU   10
+R11      EQU   11
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+IRXINIT  CSECT
+IRXINIT  AMODE 24
+IRXINIT  RMODE 24
+*
+*  --- standard MVS entry linkage ---
+         STM   R14,R12,12(R13)     save caller R14-R12 in caller SA
+         BALR  R12,0
+         USING *,R12
+*
+*  Capture caller-supplied registers needed across the wrapper body.
+         LR    R10,R0              R10 = previous-env hint (R0 in)
+         LR    R11,R1              R11 = caller VLIST address
+*
+*  --- allocate dynamic workarea (DSA + locals + C-call plist) ---
+         LA    R0,WALEN
+         GETMAIN RU,LV=(0)
+         LR    R8,R1               R8 = workarea ptr (saved for FREE)
+*
+*  Chain save areas: caller SA <-> our DSA. WSAVE is at offset 0
+*  of the DSECT, so WSAVE+4 = offset 4 in our DSA.
+         ST    R13,4(,R1)          our DSA back-chain = caller SA
+         ST    R1,8(,R13)          caller forward     = our DSA
+         LR    R13,R1
+         USING WAREA,R13
+*
+*  Zero the workarea fields that the SETRSN path inspects so we can
+*  reliably distinguish "slot address parsed" from "slot never seen".
+*  GETMAIN does not zero-fill (subpool 0, RU); WPARMS / WCPLIST start
+*  with whatever was in storage.
+         XC    WPARMS(28),WPARMS    7F  = 28 bytes
+         XC    WCPLIST(24),WCPLIST  6F  = 24 bytes
+*
+*  Stash the caller-supplied previous-env hint for the C-call.
+         ST    R10,WPREV
+*
+*  --- parse VLIST: 7 entries, high-bit endmarker on slot 7 ---
+         LA    R2,7                expected slot count (countdown)
+         LR    R3,R11              R3 = current caller VLIST entry
+         LA    R4,WPARMS           R4 = our local parsed-addr array
+*
+PARSELP  L     R6,0(,R3)           raw VLIST entry (addr | maybe VL)
+         LR    R7,R6
+         N     R7,=X'7FFFFFFF'     clear VL bit -> bare address
+         ST    R7,0(,R4)
+         LTR   R6,R6               VL bit (sign bit) set?
+         BM    PARSEVL             yes -> end of list
+         LA    R3,4(,R3)
+         LA    R4,4(,R4)
+         BCT   R2,PARSELP
+*
+*  Walked all 7 slots without seeing the VL marker.
+         LA    R15,20
+         B     SETRSN
+*
+PARSEVL  EQU   *
+*  VL marker found; R2 = remaining count (must be 1 if on slot 7).
+         CH    R2,=H'1'
+         BE    FCCHK
+         LA    R15,20
+         B     SETRSN
+*
+FCCHK    EQU   *
+*  --- validate function code: exact CL8, no trailing blanks ---
+         L     R2,WPARMS+0         R2 = address of FCODE
+         CLC   0(8,R2),=CL8'INITENVB'
+         BE    BUILDC
+         CLC   0(8,R2),=CL8'FINDENVB'
+         BE    BUILDC
+         CLC   0(8,R2),=CL8'CHEKENVB'
+         BE    BUILDC
+*
+*  Unknown function code (incl. trailing blanks).
+         LA    R15,20
+         B     SETRSN
+*
+BUILDC   EQU   *
+*  --- build C-call plist for IRXIDISP -----------------------------
+*
+*    irx_init_dispatch(funccode, prev_envblock, caller_parmblock,
+*                      user_field, envblock_inout, out_reason_code)
+*
+*  PDPCLIB calling convention (verified via __crt0.asm CTHREAD,
+*  per WP-I1c.5 Q-WRAP-1 RESOLVED): values go directly in plist
+*  slots; pointer args are 4-byte addresses; in/out and out args
+*  are addresses of caller storage.
+*
+         L     R2,WPARMS+0         R2 = addr of CL8 funccode
+         ST    R2,WCPLIST+0
+*
+         L     R2,WPREV            R2 = previous-env hint
+         ST    R2,WCPLIST+4
+*
+         L     R2,WPARMS+4         R2 = addr of PARMMOD slot
+         L     R3,0(,R2)           R3 = caller parmblock value
+         ST    R3,WCPLIST+8
+*
+         L     R2,WPARMS+8         R2 = addr of USERFLD slot
+         L     R3,0(,R2)           R3 = user_field value
+         ST    R3,WCPLIST+12
+*
+         L     R2,WPARMS+20        R2 = addr of caller ENVBLK slot
+         ST    R2,WCPLIST+16        (in/out for CHEKENVB; out otherwise)
+*
+         L     R2,WPARMS+24        R2 = addr of caller REASON slot
+         ST    R2,WCPLIST+20
+*
+*  --- call irx_init_dispatch ---
+         LA    R1,WCPLIST
+         L     R15,=V(IRXIDISP)
+         BALR  R14,R15
+*
+*  R15 = RC; the C-core has written *envblock_inout and *reason
+*  through the addresses we passed.
+*
+         LR    R3,R15              R3 = RC (preserved across teardown)
+         LTR   R3,R3
+         BNZ   FAILR0              non-zero RC -> R0 stays as caller's
+*
+*  Success: R0 = new ENVBLOCK from caller's slot.
+         L     R7,WPARMS+20
+         L     R4,0(,R7)           R4 = new ENVBLOCK
+         B     EPILOG
+*
+FAILR0   EQU   *
+         L     R4,WPREV            R4 = caller's original R0
+         B     EPILOG
+*
+SETRSN   EQU   *
+*  --- error path: write RSN=1 to caller REASON slot if available ---
+*
+*  WPARMS+24 holds the caller REASON slot address only when slot 7
+*  was reached during parsing. The "no VL marker anywhere" path
+*  walks all 7 slots and stores their addresses, so WPARMS+24 is
+*  valid there. The "VL on wrong slot" path bails before reaching
+*  slot 7 and leaves WPARMS+24 untouched (=0); skip the write.
+         LR    R3,R15              R3 = RC (20)
+         LR    R4,R10              R4 = caller's original R0
+         L     R7,WPARMS+24
+         LTR   R7,R7
+         BZ    EPILOG
+         MVC   0(4,R7),=F'1'       reason code 1
+*
+EPILOG   EQU   *
+*  R3 = output RC, R4 = output R0 — both in safe regs (1..12).
+*  Tear down: restore R13, FREEMAIN, set outputs, return.
+*
+         L     R13,WSAVE+4         R13 = caller SA (back chain in DSA)
+*
+         LA    R0,WALEN
+         FREEMAIN RU,LV=(0),A=(8)
+*
+         LR    R0,R4               R0  = output ENVBLOCK / original
+         LR    R15,R3              R15 = output RC
+*
+*  Restore R14 and R1-R12 from caller SA (preserve our R0 / R15).
+         L     R14,12(,R13)
+         LM    R1,R12,24(,R13)
+         BR    R14
+*
+         LTORG
+*
+*  --- workarea DSECT --------------------------------------------------
+WAREA    DSECT
+WSAVE    DS    18F                 standard 72-byte save area
+WPREV    DS    F                   saved R0 in (previous-env hint)
+WPARMS   DS    7F                  bare addresses parsed from VLIST
+WCPLIST  DS    6F                  parameter list for IRXIDISP call
+WALEN    EQU   *-WAREA
+*
+         END   IRXINIT

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -165,8 +165,8 @@ BUILDC   EQU   *
          L     R3,0(,R2)           R3 = user_field value
          ST    R3,WCPLIST+12
 *
-         L     R2,WPARMS+20        R2 = addr of caller ENVBLK slot
-         ST    R2,WCPLIST+16        (in/out for CHEKENVB; out otherwise)
+         L     R2,WPARMS+20        R2 = addr of ENVBLK slot
+         ST    R2,WCPLIST+16
 *
          L     R2,WPARMS+24        R2 = addr of caller REASON slot
          ST    R2,WCPLIST+20
@@ -221,12 +221,12 @@ EPILOG   EQU   *
 *
 *  Restore R14 and R1-R12 from caller SA (preserve our R0 / R15).
          L     R14,12(,R13)
-         LM    R1,R12,24(,R13)
+         LM    R1,R12,24(R13)
          BR    R14
 *
          LTORG
 *
-*  --- workarea DSECT --------------------------------------------------
+*  --- workarea DSECT ---
 WAREA    DSECT
 WSAVE    DS    18F                 standard 72-byte save area
 WPREV    DS    F                   saved R0 in (previous-env hint)

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -1,0 +1,134 @@
+         TITLE 'IRXTERM - REXX/370 IRXTERM Entry Point Wrapper'
+*
+*  IRXTERM - HLASM entry-point wrapper for the IRXTERM Programming
+*            Service (SC28-1883-0 §15).
+*
+*  Delegates to the C-core irx_init_term (asm() alias IRXITERM,
+*  CON-4) which performs the 5-step teardown: validate eye-catcher,
+*  IRXANCHR slot lookup, free IRXEXTE/PARMBLOCK, release slot, roll
+*  ECTENVBK back to predecessor for TSO envs, and free the ENVBLOCK.
+*
+*  Calling convention (per SC28-1883-0):
+*
+*    CALL IRXTERM           (no parameter list)
+*
+*  R0  (in)  ENVBLOCK to terminate (NOT in a parameter list)
+*  R0  (out) predecessor ENVBLOCK on success (read back from
+*            ECTENVBK after the C-core rolled it back), or the
+*            original R0 unchanged on failure
+*  R15 (out) return code: 0 = ok, 20 = bad ENVBLOCK
+*
+*  Built as a separate load module (entry IRXTERM). The C-core
+*  (irx#term.c, irx#anch.c, ...) is NCAL-linked into the same
+*  load module via project.toml include list.
+*
+*  Known gap (deferred): same crent370 C-runtime bootstrap concern
+*  as IRXINIT — see asm/irxinit.asm prologue. WP-I1c.5e follow-up.
+*
+*  Ref: SC28-1883-0 §15 (IRXTERM Programming Service)
+*  Ref: WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83
+*  Ref: CON-1 §6.4 (IRXTERM flow)
+*  Ref: CON-14 / IRXPROBE Phase α (ECTENVBK predecessor rollback)
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R8       EQU   8
+R10      EQU   10
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+IRXTERM  CSECT
+IRXTERM  AMODE 24
+IRXTERM  RMODE 24
+*
+*  --- standard MVS entry linkage ---
+         STM   R14,R12,12(R13)     save caller R14-R12 in caller SA
+         BALR  R12,0
+         USING *,R12
+*
+*  Capture R0 in (the ENVBLOCK to terminate).
+         LR    R10,R0              R10 = caller R0 (envblock)
+*
+*  --- allocate dynamic workarea ---
+         LA    R0,WALEN
+         GETMAIN RU,LV=(0)
+         LR    R8,R1               R8 = workarea ptr
+*
+*  Chain save areas: caller SA <-> our DSA. WSAVE is at offset 0
+*  of the DSECT, so WSAVE+4 = offset 4 in our DSA.
+         ST    R13,4(,R1)          our DSA back-chain = caller SA
+         ST    R1,8(,R13)          caller forward     = our DSA
+         LR    R13,R1
+         USING WAREA,R13
+*
+*  --- build C-call plist for IRXITERM -----------------------------
+*
+*    irx_init_term(envblock, &reason_code)
+*
+*  PDPCLIB convention: IN ENVBLOCK pointer goes directly in plist
+*  slot 0 (value, not pointer-to-pointer); OUT reason takes the
+*  address of the local WREASON cell.
+*
+         ST    R10,WCPLIST+0       envblock value
+         LA    R2,WREASON
+         ST    R2,WCPLIST+4
+*
+         LA    R1,WCPLIST
+         L     R15,=V(IRXITERM)
+         BALR  R14,R15
+*
+*  R15 = RC; *WREASON now holds the reason code. We discard the
+*  reason — IBM IRXTERM has no caller-visible reason slot, R15 is
+*  the only output channel.
+*
+         LR    R3,R15              R3 = RC (preserved through teardown)
+         LTR   R3,R3
+         BNZ   FAILR0              non-zero RC -> R0 stays as original
+*
+*  Success: read predecessor from ECTENVBK via anch_curr(). The
+*  C-core has already rolled the slot back (TSO envs only); for
+*  non-TSO envs the slot is unchanged and anch_curr returns
+*  whatever was there before — which is the right answer for the
+*  caller too.
+         LA    R1,WCPLIST          minimal plist (no args)
+         L     R15,=V(ANCHCURR)
+         BALR  R14,R15
+         LR    R4,R15              R4 = predecessor envblock or NULL
+         B     EPILOG
+*
+FAILR0   EQU   *
+         LR    R4,R10              R4 = original R0 (saved at entry)
+*
+EPILOG   EQU   *
+*  R3 = RC, R4 = R0 output. Tear down workarea and return.
+         L     R13,WSAVE+4         R13 = caller SA
+*
+         LA    R0,WALEN
+         FREEMAIN RU,LV=(0),A=(8)
+*
+         LR    R0,R4               R0  = output ENVBLOCK / original
+         LR    R15,R3              R15 = RC
+*
+         L     R14,12(,R13)
+         LM    R1,R12,24(,R13)
+         BR    R14
+*
+         LTORG
+*
+*  --- workarea DSECT ----------------------------------------------
+WAREA    DSECT
+WSAVE    DS    18F                 standard 72-byte save area
+WCPLIST  DS    2F                  C-call plist for IRXITERM
+WREASON  DS    F                   reason-code OUT cell (discarded)
+WALEN    EQU   *-WAREA
+*
+         END   IRXTERM

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -117,7 +117,7 @@ EPILOG   EQU   *
          LR    R15,R3              R15 = RC
 *
          L     R14,12(,R13)
-         LM    R1,R12,24(,R13)
+         LM    R1,R12,24(R13)
          BR    R14
 *
          LTORG

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -47,8 +47,6 @@ R15      EQU   15
          PRINT GEN
 *
 IRXTERM  CSECT
-IRXTERM  AMODE 24
-IRXTERM  RMODE 24
 *
 *  --- standard MVS entry linkage ---
          STM   R14,R12,12(R13)     save caller R14-R12 in caller SA

--- a/include/irxfunc.h
+++ b/include/irxfunc.h
@@ -30,8 +30,14 @@
  *   envblock_ptr- Output: pointer to created ENVBLOCK
  *
  * Returns: 0=OK, 20=init error, 28=storage error
+ *
+ * MVS symbol: IRXINITC. The HLASM entry-point wrapper in
+ * asm/irxinit.asm owns the bare IRXINIT symbol (it is the
+ * IBM-spec Programming Service entry point and dispatches to
+ * irx_init_dispatch). The compat wrapper here installs the
+ * Phase 2+ state (BIFs, SUBCOMTB, wkbi) on top of that.
  */
-int irxinit(void *parms, struct envblock **envblock_ptr);
+int irxinit(void *parms, struct envblock **envblock_ptr) asm("IRXINITC");
 
 /* IRXTERM - Terminate a Language Processor Environment
  * Frees all storage associated with the environment and pops it
@@ -41,8 +47,12 @@ int irxinit(void *parms, struct envblock **envblock_ptr);
  *   envblock_ptr - Pointer to ENVBLOCK to terminate
  *
  * Returns: 0=OK, 20=term error
+ *
+ * MVS symbol: IRXTERMC. The HLASM IRXTERM Programming Service
+ * entry point lives in asm/irxterm.asm; this is the Phase 2+
+ * teardown compat wrapper.
  */
-int irxterm(struct envblock *envblock_ptr);
+int irxterm(struct envblock *envblock_ptr) asm("IRXTERMC");
 
 /* --- Storage Management Replaceable Routine --- */
 

--- a/project.toml
+++ b/project.toml
@@ -118,7 +118,21 @@ include = [
   "IRX#ANCH",
   "IRX#UID",
   "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
+  "IRX#ARIT",
 ]
+
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
 # IRXTERM - HLASM Entry-Point Wrapper for the IRXTERM Programming
@@ -141,7 +155,21 @@ include = [
   "IRX#ANCH",
   "IRX#UID",
   "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
+  "IRX#ARIT",
 ]
+
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
 # TSTANCH - ENVBLOCK anchor smoketest pseudomodule

--- a/project.toml
+++ b/project.toml
@@ -93,6 +93,57 @@ options = ["LIST", "MAP", "XREF", "AC=1", "RENT", "REUS"]
 include = ["IRXTMPW"]
 
 # ---------------------------------------------------------------
+# IRXINIT - HLASM Entry-Point Wrapper for the IRXINIT Programming
+#          Service (SC28-1883-0 §14). Parses the caller VLIST,
+#          extracts the function code, and delegates to the C-core
+#          dispatcher irx_init_dispatch (asm() alias IRXIDISP).
+#
+# Built as a separate load module (per IBM convention IRXINIT and
+# IRXTERM are independent load modules). The wrapper is the entry
+# point; the C-core (IRX#INIT, IRX#TERM, IRX#STOR, IRX#ANCH,
+# IRX#UID, IRX#MSID) is NCAL-linked into the same load module so
+# the BALR R14,R15 to =V(IRXIDISP) resolves.
+#
+# WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "IRXINIT"
+entry = "IRXINIT"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = [
+  "IRXINIT",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+]
+
+# ---------------------------------------------------------------
+# IRXTERM - HLASM Entry-Point Wrapper for the IRXTERM Programming
+#          Service (SC28-1883-0 §15). Reads R0=ENVBLOCK, calls the
+#          C-core irx_init_term (asm() alias IRXITERM), and reads
+#          back ECTENVBK via anch_curr (alias ANCHCURR) to return
+#          the predecessor envblock in R0.
+#
+# WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "IRXTERM"
+entry = "IRXTERM"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = [
+  "IRXTERM",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+]
+
+# ---------------------------------------------------------------
 # TSTANCH - ENVBLOCK anchor smoketest pseudomodule
 # Runs in TSO (CALL 'TSTANCH') or Batch (EXEC PGM=TSTANCH).
 # Pulls in the full phase-1/phase-2 object set so IRXINIT and


### PR DESCRIPTION
Fixes #83.

## Summary

Adds the two HLASM entry-point wrappers requested by WP-I1c.5: `asm/irxinit.asm` and `asm/irxterm.asm`, plus the `project.toml` link entries that build them into separate load modules. The wrappers translate the SC28-1883-0 calling convention (VLIST with high-bit endmarker for IRXINIT, R0=envblock for IRXTERM) into the PDPCLIB plist convention used by the C-core (`irx_init_dispatch` / `irx_init_term` via the CON-4 asm() aliases `IRXIDISP` / `IRXITERM` / `ANCHCURR`).

## Latest update — TSK-202 fix-up commit

Code review on the structural wrapper landed three concrete bugs that needed fixing before this PR can leave Draft. All three are scoped strictly to `asm/irxinit.asm`; the dispatcher architecture and `project.toml` link entries are unchanged. The architecture-mismatch concern raised in review was a false positive — see the CON-1 §14.2 update of 27.04. — and `irx_init_dispatch` (CON-4 alias `IRXIDISP`) remains the correct dispatch path.

| AC | Status | Notes |
|----|--------|-------|
| AC-1  | covered | BUILDC reads `WPARMS+8` for `caller_parmblock` (was wrongly `WPARMS+4`). |
| AC-2  | covered | BUILDC reads `WPARMS+12` for `user_field` (was wrongly `WPARMS+8`). |
| AC-3  | covered | `LTR R11,R11 / BZ NULLPLST` before GETMAIN; NULLPLST early-exit returns RC=20 with caller R0 intact, no workarea allocated, no leak. |
| AC-4  | covered | "Walked all 7 slots without VL" path now branches to `ERREARLY` (no reason write) — `WPARMS+24` was filled from `VLIST[6]` past the caller's list end and is undefined. |
| AC-5  | covered | "VL marker on wrong slot" path now branches to `ERREARLY` (no reason write) — `WPARMS+24` was never reached / is the XC-zeroed default. |
| AC-6  | covered | Function-code mismatch after slot 7 reached normally still branches to `SETRSN` (writes RSN=1 to caller REASON slot); `WPARMS+24` is known-valid on that path. |
| AC-7  | pending | HLASM clean assembly under IFOX00 — needs `mbt build --target IRXINIT` on MVS. |
| AC-8  | pending | Linker output (NCAL link of IRXINIT load module) — needs MVS submission. |
| AC-9  | covered | Host C-test matrix re-run after the fix-up: 15 binaries, **1192 tests green** (`tstphas1` 38, `tsttokn` 70, `tstlstr` 50, `tstvpol` 47, `tstprsr` 39, `tstsay` 27, `tstctrl` 62, `tstparse` 74, `tstproc` 53, `tsthelo` 16, `tstanrm` 29, `tstarit` 128, `tstarext` 113, `tstbif` 29, `tstbifs` 417). The asm-only changes don't touch C, so this is a sanity check rather than a behavioural verification of the wrapper. |
| AC-10 | covered | This PR description rewrite. |

Refs:
- TSK-202: <https://www.notion.so/34f3d993878781beb4dafec371e7327b>
- CON-1 §14.2 (architecture clarification — `irx_init_dispatch` is the correct path)
- TSK-200 (CLIBCRT bootstrap) and TSK-201 (`irxinit()` refactor) remain separate PRs.

## Known gap — runtime bootstrap (deferred)

The crent370 C-runtime allocates its per-TCB `CLIBCRT` control block via the `@@CRT0` startup path. Because the OS branches directly to `IRXINIT` / `IRXTERM` here (entry-point convention requires it), `__crtset()` never runs, so the first call into the C-core's `irxstor()` will hit `calloc()` against an uninitialized heap.

Two ways to close this — both out of scope for #83 and tracked as TSK-200:

1. Call `__crtset` (asm symbol `@@CRTSET`) in the wrapper prologue, before the `BALR R14,R15` to `IRXIDISP` / `IRXITERM`. Idempotent on the same TCB.
2. Switch `irxstor()` subpool 0 to `GETMAIN` / `FREEMAIN` on MVS (already implemented for subpool > 0). This avoids the heap entirely and matches the IBM convention more closely.

The wrapper logic in this PR is structurally correct and stays valid once either path lands. The MVS test JCL files are intentionally not included — shipping unverifiable test scaffolding now would be misleading.

## Test plan

- [x] All 15 host C-tests build cleanly with the unchanged C source set — 1192/1192 passed (asm-only changes, sanity check).
- [ ] **On MVS (after TSK-200 bootstrap)**: `mbt build --target IRXINIT` and `--target IRXTERM` produce the load modules.
- [ ] **On MVS (after TSK-200 bootstrap)**: HLASM caller invokes `CALL IRXINIT,(INITENVB,...)` and gets `R15=0`, `R0`=new ENVBLOCK, OUT slots populated.
- [ ] **On MVS (after TSK-200 bootstrap)**: `CALL IRXTERM` with `R0`=valid envblock returns `R15=0` and `R0`=predecessor (or 0).
- [ ] **On MVS**: VLIST without endmarker → `R15=20` and **no** reason write to a garbage address (TSK-202 AC-4); function-code mismatch → `R15=20 RSN=1` written to caller REASON slot (TSK-202 AC-6); R1=0 → `R15=20`, no GETMAIN, no leak (TSK-202 AC-3).

## Refs

- Notion TSK-198 (parent): <https://www.notion.so/34f3d99387878183a09ef003248cd4fe>
- Notion TSK-202 (this fix-up): <https://www.notion.so/34f3d993878781beb4dafec371e7327b>
- SC28-1883-0 §14 (IRXINIT) / §15 (IRXTERM)
- CON-1 §6.3 / §6.4 (init / term flow); §14.2 update on dispatcher architecture
- CON-4 (asm() aliases IRXIINIT / IRXIFIND / IRXICHEK / IRXIDISP / IRXITERM / ANCHCURR)
