### PR TITLE
[REXX/370] WP-I1c.5e: PDP-DSA stack layout in IRXINIT/IRXTERM + irxstor GETMAIN

### DIFF
--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -68,8 +68,6 @@ R15      EQU   15
          PRINT GEN
 *
 IRXINIT  CSECT
-IRXINIT  AMODE 24
-IRXINIT  RMODE 24
 *
 *  --- standard MVS entry linkage ---
          STM   R14,R12,12(R13)     save caller R14-R12 in caller SA

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -75,8 +75,17 @@ IRXINIT  CSECT
          USING *,R12
 *
 *  Capture caller-supplied registers needed across the wrapper body.
+*  R10 must be set BEFORE the NULL-R1 check below — the NULLPLST
+*  early-exit restores caller R0 from R10 and would otherwise fault.
          LR    R10,R0              R10 = previous-env hint (R0 in)
          LR    R11,R1              R11 = caller VLIST address
+*
+*  Defensive NULL check: a caller passing R1=0 (no parm list at all)
+*  must not provoke an S0C5 in PARSELP and must not leak the workarea
+*  we are about to GETMAIN. Bail before any allocation; we cannot
+*  reach a REASON slot either, so just return RC=20 with R0 intact.
+         LTR   R11,R11             VLIST pointer NULL?
+         BZ    NULLPLST            yes -> early exit, no GETMAIN
 *
 *  --- allocate dynamic workarea (DSA + locals + C-call plist) ---
          LA    R0,WALEN
@@ -115,16 +124,21 @@ PARSELP  L     R6,0(,R3)           raw VLIST entry (addr | maybe VL)
          LA    R4,4(,R4)
          BCT   R2,PARSELP
 *
-*  Walked all 7 slots without seeing the VL marker.
+*  Walked all 7 slots without seeing the VL marker. The slot-7
+*  WPARMS entry was filled from VLIST[6], which is past the caller's
+*  actual list end and therefore undefined. We MUST NOT treat it as
+*  a REASON-slot address — go to ERREARLY (no reason write).
          LA    R15,20
-         B     SETRSN
+         B     ERREARLY
 *
 PARSEVL  EQU   *
 *  VL marker found; R2 = remaining count (must be 1 if on slot 7).
          CH    R2,=H'1'
          BE    FCCHK
+*  VL on the wrong slot — caller list is short. WPARMS+24 was never
+*  filled (or holds a stale value); no usable REASON slot reachable.
          LA    R15,20
-         B     SETRSN
+         B     ERREARLY
 *
 FCCHK    EQU   *
 *  --- validate function code: exact CL8, no trailing blanks ---
@@ -136,7 +150,9 @@ FCCHK    EQU   *
          CLC   0(8,R2),=CL8'CHEKENVB'
          BE    BUILDC
 *
-*  Unknown function code (incl. trailing blanks).
+*  Unknown function code (incl. trailing blanks). Slot 7 was reached
+*  via the normal VL-marker path, so WPARMS+24 holds the caller's
+*  REASON slot address and is safe to write through.
          LA    R15,20
          B     SETRSN
 *
@@ -157,13 +173,18 @@ BUILDC   EQU   *
          L     R2,WPREV            R2 = previous-env hint
          ST    R2,WCPLIST+4
 *
-         L     R2,WPARMS+4         R2 = addr of PARMMOD slot
-         L     R3,0(,R2)           R3 = caller parmblock value
-         ST    R3,WCPLIST+8
+*  P2 (Parameters-Module-Name, WPARMS+4) is ignored for now —
+*  MODNAMET-resolution lands with WP-I1c.4. The caller's PARMBLOCK
+*  pointer per SC28-1883-0 §14 lives in P3 (In-Storage Parm List
+*  Address) at WPARMS+8, and the user field is P4 at WPARMS+12.
 *
-         L     R2,WPARMS+8         R2 = addr of USERFLD slot
+         L     R2,WPARMS+8         R2 = addr of P3 (parmblock ptr slot)
+         L     R3,0(,R2)           R3 = caller PARMBLOCK pointer
+         ST    R3,WCPLIST+8        -> caller_parmblock argument
+*
+         L     R2,WPARMS+12        R2 = addr of P4 (user field slot)
          L     R3,0(,R2)           R3 = user_field value
-         ST    R3,WCPLIST+12
+         ST    R3,WCPLIST+12       -> user_field argument
 *
          L     R2,WPARMS+20        R2 = addr of ENVBLK slot
          ST    R2,WCPLIST+16
@@ -193,19 +214,27 @@ FAILR0   EQU   *
          B     EPILOG
 *
 SETRSN   EQU   *
-*  --- error path: write RSN=1 to caller REASON slot if available ---
+*  --- error path WITH reason write ---------------------------------
 *
-*  WPARMS+24 holds the caller REASON slot address only when slot 7
-*  was reached during parsing. The "no VL marker anywhere" path
-*  walks all 7 slots and stores their addresses, so WPARMS+24 is
-*  valid there. The "VL on wrong slot" path bails before reaching
-*  slot 7 and leaves WPARMS+24 untouched (=0); skip the write.
+*  Reached only via FCCHK (function code mismatch after the VLIST
+*  parser saw the VL marker on slot 7). WPARMS+24 therefore holds
+*  the caller's REASON slot address and can be written safely.
          LR    R3,R15              R3 = RC (20)
          LR    R4,R10              R4 = caller's original R0
-         L     R7,WPARMS+24
-         LTR   R7,R7
-         BZ    EPILOG
+         L     R7,WPARMS+24        caller REASON slot address
          MVC   0(4,R7),=F'1'       reason code 1
+         B     EPILOG
+*
+ERREARLY EQU   *
+*  --- error path WITHOUT reason write -------------------------------
+*
+*  Used by the two VLIST-shape failures ("walked all 7 without VL"
+*  and "VL on wrong slot") where WPARMS+24 cannot be trusted to
+*  hold a real caller REASON slot address. R15 is already set; we
+*  return RC=20 with R0 restored to the caller's original R0.
+         LR    R3,R15              R3 = RC (20)
+         LR    R4,R10              R4 = caller's original R0
+*  Fall through to EPILOG.
 *
 EPILOG   EQU   *
 *  R3 = output RC, R4 = output R0 — both in safe regs (1..12).
@@ -220,6 +249,17 @@ EPILOG   EQU   *
          LR    R15,R3              R15 = output RC
 *
 *  Restore R14 and R1-R12 from caller SA (preserve our R0 / R15).
+         L     R14,12(,R13)
+         LM    R1,R12,24(R13)
+         BR    R14
+*
+NULLPLST DS    0H
+*  Caller passed R1=0 — no VLIST, no REASON slot reachable. We have
+*  not allocated a workarea yet, so just restore caller R14/R1-R12
+*  from the still-current caller SA (R13 unchanged) and return with
+*  R0 = caller's original R0 (saved into R10 above) and R15 = 20.
+         LA    R15,20              RC=20
+         LR    R0,R10              caller's original R0
          L     R14,12(,R13)
          LM    R1,R12,24(R13)
          BR    R14

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -30,16 +30,18 @@
 *  (irx#init.c, irx#anch.c, ...) is NCAL-linked into the same
 *  load module via project.toml include list.
 *
-*  Known gap (deferred): the crent370 C runtime (CLIBCRT per-TCB
-*  control block) is normally initialized by the @@CRT0 entry on
-*  module load. Because the OS branches directly to IRXINIT here,
-*  __crtset() is not yet called. The first call into the C-core
-*  will hit calloc() with an uninitialized heap unless either
-*    (a) a runtime-bootstrap call (__crtset / @@CRTSET) is added
-*        in this prologue, or
-*    (b) irxstor() switches subpool 0 to GETMAIN on MVS.
-*  See WP-I1c.5e follow-up; the structural wrapper logic below is
-*  correct and stays valid once the bootstrap path is added.
+*  Bootstrap design: this wrapper pre-allocates a WPOOL stack pool
+*  inside its workarea and shapes the workarea as a PDP-DSA so
+*  c2asm370-compiled callees can use their PDPPRLG bump-allocator
+*  prologue (which reads DSANAB at offset +76 of the caller DSA).
+*  irxstor() routes all storage through GETMAIN/FREEMAIN on MVS so
+*  the CLIBCRT C-runtime is not on the call path — @@CRT0 is not
+*  required for the dispatch to succeed.
+*
+*  Caveat: crent370 getmain() calls wtof() on its failure path,
+*  which IS CLIBCRT-dependent; a getmain failure here (very
+*  unlikely on a healthy system) would crash secondarily trying
+*  to log. Acceptable tail risk on the bootstrap path. See #85.
 *
 *  Ref: SC28-1883-0 §14 (IRXINIT Programming Service)
 *  Ref: WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83
@@ -87,22 +89,33 @@ IRXINIT  CSECT
          LTR   R11,R11             VLIST pointer NULL?
          BZ    NULLPLST            yes -> early exit, no GETMAIN
 *
-*  --- allocate dynamic workarea (DSA + locals + C-call plist) ---
-         LA    R0,WALEN
+*  --- allocate dynamic workarea (PDP-DSA + locals + WPOOL) -------
+*  WALEN ~ 8 KB so we cannot use LA (12-bit displacement); load via
+*  literal pool instead. Subpool 0 (RU form) and no zero-fill.
+         L     R0,=A(WALEN)
          GETMAIN RU,LV=(0)
          LR    R8,R1               R8 = workarea ptr (saved for FREE)
 *
-*  Chain save areas: caller SA <-> our DSA. WSAVE is at offset 0
-*  of the DSECT, so WSAVE+4 = offset 4 in our DSA.
+*  Chain DSAs: caller SA <-> our DSA. WDPREV = +4 (= old WSAVE+4).
          ST    R13,4(,R1)          our DSA back-chain = caller SA
          ST    R1,8(,R13)          caller forward     = our DSA
          LR    R13,R1
          USING WAREA,R13
 *
+*  --- initialize PDP-DSA fields the c2asm370 callees inspect ----
+*
+*  PDPPRLG (callee prologue) reads DSANAB at +76 of OUR DSA as the
+*  bump-allocator base. WDFLAGS (+0) and WDLWA (+72) must be zero
+*  per the PDP convention. R14-R12 (+12..+68) are written by the
+*  callee's SAVE-equivalent on entry.
+         XC    WDFLAGS(4),WDFLAGS  DSAFLAGS = 0
+         XC    WDLWA(4),WDLWA      DSALWA   = 0
+         LA    R0,WPOOL            R0 = start of stack pool
+         ST    R0,WDNAB            DSANAB   = WPOOL
+*
 *  Zero the workarea fields that the SETRSN path inspects so we can
 *  reliably distinguish "slot address parsed" from "slot never seen".
-*  GETMAIN does not zero-fill (subpool 0, RU); WPARMS / WCPLIST start
-*  with whatever was in storage.
+*  GETMAIN RU does not zero-fill; WPARMS / WCPLIST start with junk.
          XC    WPARMS(28),WPARMS    7F  = 28 bytes
          XC    WCPLIST(24),WCPLIST  6F  = 24 bytes
 *
@@ -240,9 +253,10 @@ EPILOG   EQU   *
 *  R3 = output RC, R4 = output R0 — both in safe regs (1..12).
 *  Tear down: restore R13, FREEMAIN, set outputs, return.
 *
-         L     R13,WSAVE+4         R13 = caller SA (back chain in DSA)
+         L     R13,WDPREV          R13 = caller SA (back chain in DSA)
 *
-         LA    R0,WALEN
+*  WALEN ~ 8 KB so the LA form does not fit; use literal pool.
+         L     R0,=A(WALEN)
          FREEMAIN RU,LV=(0),A=(8)
 *
          LR    R0,R4               R0  = output ENVBLOCK / original
@@ -266,12 +280,43 @@ NULLPLST DS    0H
 *
          LTORG
 *
-*  --- workarea DSECT ---
+*  --- workarea DSECT (PDP-DSA shape) ------------------------------
+*
+*  Offsets +0..+79 follow pdptop.copy exactly so c2asm370 callees
+*  (PDPPRLG prologue) can chain through OUR DSA correctly. The
+*  18F save area at +0..+71 maps onto the standard MVS save-area
+*  offsets used by SAVE/RETURN, and WDLWA / WDNAB extend it to
+*  the 80-byte PDP DSA. WPOOL provides the bump-allocator pool
+*  for nested c2asm370 frames; 8 KB covers ~25-50 frames @ ~150-300
+*  bytes each, well above the deepest IRXINIT call chain.
 WAREA    DSECT
-WSAVE    DS    18F                 standard 72-byte save area
+WDFLAGS  DS    F                   +0  DSAFLAGS (must be 0)
+WDPREV   DS    F                   +4  DSAPREV  (back chain)
+WDNEXT   DS    F                   +8  DSANEXT  (forward chain)
+WDR14    DS    F                   +12 caller R14 (set by SAVE)
+WDR15    DS    F                   +16 caller R15
+WDR0     DS    F                   +20 caller R0
+WDR1     DS    F                   +24 caller R1
+WDR2     DS    F                   +28 caller R2
+WDR3     DS    F                   +32 caller R3
+WDR4     DS    F                   +36 caller R4
+WDR5     DS    F                   +40 caller R5
+WDR6     DS    F                   +44 caller R6
+WDR7     DS    F                   +48 caller R7
+WDR8     DS    F                   +52 caller R8
+WDR9     DS    F                   +56 caller R9
+WDR10    DS    F                   +60 caller R10
+WDR11    DS    F                   +64 caller R11
+WDR12    DS    F                   +68 caller R12
+WDLWA    DS    F                   +72 DSALWA  (must be 0)
+WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
+*  Wrapper-local storage (after the PDP-DSA proper).
 WPREV    DS    F                   saved R0 in (previous-env hint)
 WPARMS   DS    7F                  bare addresses parsed from VLIST
 WCPLIST  DS    6F                  parameter list for IRXIDISP call
+*  Stack pool for nested c2asm370 PDPPRLG frames.
+WPOOL    DS    2048F               8 KB scratchpad
+WPOOLEND EQU   *
 WALEN    EQU   *-WAREA
 *
          END   IRXINIT

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -1,0 +1,239 @@
+         TITLE 'IRXINIT - REXX/370 IRXINIT Entry Point Wrapper'
+*
+*  IRXINIT - HLASM entry-point wrapper for the IRXINIT Programming
+*            Service (SC28-1883-0 §14).
+*
+*  Parses the caller VLIST, validates the high-bit endmarker on the
+*  last parameter, extracts the CL8 function code, and delegates to
+*  the C-core dispatcher irx_init_dispatch (asm() alias IRXIDISP,
+*  CON-4) which routes on the function code to one of:
+*
+*    INITENVB  -> irx_init_initenvb()  (alias IRXIINIT)
+*    FINDENVB  -> irx_init_findenvb()  (alias IRXIFIND)
+*    CHEKENVB  -> irx_init_chekenvb()  (alias IRXICHEK)
+*
+*  Calling convention (per SC28-1883-0):
+*
+*    CALL IRXINIT,(FCODE,PARMMOD,USERFLD,WKBLKEXT,RESERVED,         *
+*                  ENVBLK,REASON),VL
+*
+*  Each VLIST slot is a 4-byte address pointing at the parameter
+*  value. The address of the LAST slot has its high-order bit set
+*  to mark the end of the variable-length list.
+*
+*  R0  (in)  optional previous-env hint (passed to dispatcher)
+*  R0  (out) ENVBLOCK on success, original R0 on failure
+*  R15 (out) return code: 0 = ok, 4 = no env (FINDENVB),
+*            20 = error (RSN written to caller REASON slot)
+*
+*  Built as a separate load module (entry IRXINIT). The C-core
+*  (irx#init.c, irx#anch.c, ...) is NCAL-linked into the same
+*  load module via project.toml include list.
+*
+*  Known gap (deferred): the crent370 C runtime (CLIBCRT per-TCB
+*  control block) is normally initialized by the @@CRT0 entry on
+*  module load. Because the OS branches directly to IRXINIT here,
+*  __crtset() is not yet called. The first call into the C-core
+*  will hit calloc() with an uninitialized heap unless either
+*    (a) a runtime-bootstrap call (__crtset / @@CRTSET) is added
+*        in this prologue, or
+*    (b) irxstor() switches subpool 0 to GETMAIN on MVS.
+*  See WP-I1c.5e follow-up; the structural wrapper logic below is
+*  correct and stays valid once the bootstrap path is added.
+*
+*  Ref: SC28-1883-0 §14 (IRXINIT Programming Service)
+*  Ref: WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83
+*  Ref: CON-1 §6.3 (INITENVB algorithm)
+*  Ref: CON-4 (asm() aliases)
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R5       EQU   5
+R6       EQU   6
+R7       EQU   7
+R8       EQU   8
+R9       EQU   9
+R10      EQU   10
+R11      EQU   11
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+IRXINIT  CSECT
+IRXINIT  AMODE 24
+IRXINIT  RMODE 24
+*
+*  --- standard MVS entry linkage ---
+         STM   R14,R12,12(R13)     save caller R14-R12 in caller SA
+         BALR  R12,0
+         USING *,R12
+*
+*  Capture caller-supplied registers needed across the wrapper body.
+         LR    R10,R0              R10 = previous-env hint (R0 in)
+         LR    R11,R1              R11 = caller VLIST address
+*
+*  --- allocate dynamic workarea (DSA + locals + C-call plist) ---
+         LA    R0,WALEN
+         GETMAIN RU,LV=(0)
+         LR    R8,R1               R8 = workarea ptr (saved for FREE)
+*
+*  Chain save areas: caller SA <-> our DSA. WSAVE is at offset 0
+*  of the DSECT, so WSAVE+4 = offset 4 in our DSA.
+         ST    R13,4(,R1)          our DSA back-chain = caller SA
+         ST    R1,8(,R13)          caller forward     = our DSA
+         LR    R13,R1
+         USING WAREA,R13
+*
+*  Zero the workarea fields that the SETRSN path inspects so we can
+*  reliably distinguish "slot address parsed" from "slot never seen".
+*  GETMAIN does not zero-fill (subpool 0, RU); WPARMS / WCPLIST start
+*  with whatever was in storage.
+         XC    WPARMS(28),WPARMS    7F  = 28 bytes
+         XC    WCPLIST(24),WCPLIST  6F  = 24 bytes
+*
+*  Stash the caller-supplied previous-env hint for the C-call.
+         ST    R10,WPREV
+*
+*  --- parse VLIST: 7 entries, high-bit endmarker on slot 7 ---
+         LA    R2,7                expected slot count (countdown)
+         LR    R3,R11              R3 = current caller VLIST entry
+         LA    R4,WPARMS           R4 = our local parsed-addr array
+*
+PARSELP  L     R6,0(,R3)           raw VLIST entry (addr | maybe VL)
+         LR    R7,R6
+         N     R7,=X'7FFFFFFF'     clear VL bit -> bare address
+         ST    R7,0(,R4)
+         LTR   R6,R6               VL bit (sign bit) set?
+         BM    PARSEVL             yes -> end of list
+         LA    R3,4(,R3)
+         LA    R4,4(,R4)
+         BCT   R2,PARSELP
+*
+*  Walked all 7 slots without seeing the VL marker.
+         LA    R15,20
+         B     SETRSN
+*
+PARSEVL  EQU   *
+*  VL marker found; R2 = remaining count (must be 1 if on slot 7).
+         CH    R2,=H'1'
+         BE    FCCHK
+         LA    R15,20
+         B     SETRSN
+*
+FCCHK    EQU   *
+*  --- validate function code: exact CL8, no trailing blanks ---
+         L     R2,WPARMS+0         R2 = address of FCODE
+         CLC   0(8,R2),=CL8'INITENVB'
+         BE    BUILDC
+         CLC   0(8,R2),=CL8'FINDENVB'
+         BE    BUILDC
+         CLC   0(8,R2),=CL8'CHEKENVB'
+         BE    BUILDC
+*
+*  Unknown function code (incl. trailing blanks).
+         LA    R15,20
+         B     SETRSN
+*
+BUILDC   EQU   *
+*  --- build C-call plist for IRXIDISP -----------------------------
+*
+*    irx_init_dispatch(funccode, prev_envblock, caller_parmblock,
+*                      user_field, envblock_inout, out_reason_code)
+*
+*  PDPCLIB calling convention (verified via __crt0.asm CTHREAD,
+*  per WP-I1c.5 Q-WRAP-1 RESOLVED): values go directly in plist
+*  slots; pointer args are 4-byte addresses; in/out and out args
+*  are addresses of caller storage.
+*
+         L     R2,WPARMS+0         R2 = addr of CL8 funccode
+         ST    R2,WCPLIST+0
+*
+         L     R2,WPREV            R2 = previous-env hint
+         ST    R2,WCPLIST+4
+*
+         L     R2,WPARMS+4         R2 = addr of PARMMOD slot
+         L     R3,0(,R2)           R3 = caller parmblock value
+         ST    R3,WCPLIST+8
+*
+         L     R2,WPARMS+8         R2 = addr of USERFLD slot
+         L     R3,0(,R2)           R3 = user_field value
+         ST    R3,WCPLIST+12
+*
+         L     R2,WPARMS+20        R2 = addr of caller ENVBLK slot
+         ST    R2,WCPLIST+16        (in/out for CHEKENVB; out otherwise)
+*
+         L     R2,WPARMS+24        R2 = addr of caller REASON slot
+         ST    R2,WCPLIST+20
+*
+*  --- call irx_init_dispatch ---
+         LA    R1,WCPLIST
+         L     R15,=V(IRXIDISP)
+         BALR  R14,R15
+*
+*  R15 = RC; the C-core has written *envblock_inout and *reason
+*  through the addresses we passed.
+*
+         LR    R3,R15              R3 = RC (preserved across teardown)
+         LTR   R3,R3
+         BNZ   FAILR0              non-zero RC -> R0 stays as caller's
+*
+*  Success: R0 = new ENVBLOCK from caller's slot.
+         L     R7,WPARMS+20
+         L     R4,0(,R7)           R4 = new ENVBLOCK
+         B     EPILOG
+*
+FAILR0   EQU   *
+         L     R4,WPREV            R4 = caller's original R0
+         B     EPILOG
+*
+SETRSN   EQU   *
+*  --- error path: write RSN=1 to caller REASON slot if available ---
+*
+*  WPARMS+24 holds the caller REASON slot address only when slot 7
+*  was reached during parsing. The "no VL marker anywhere" path
+*  walks all 7 slots and stores their addresses, so WPARMS+24 is
+*  valid there. The "VL on wrong slot" path bails before reaching
+*  slot 7 and leaves WPARMS+24 untouched (=0); skip the write.
+         LR    R3,R15              R3 = RC (20)
+         LR    R4,R10              R4 = caller's original R0
+         L     R7,WPARMS+24
+         LTR   R7,R7
+         BZ    EPILOG
+         MVC   0(4,R7),=F'1'       reason code 1
+*
+EPILOG   EQU   *
+*  R3 = output RC, R4 = output R0 — both in safe regs (1..12).
+*  Tear down: restore R13, FREEMAIN, set outputs, return.
+*
+         L     R13,WSAVE+4         R13 = caller SA (back chain in DSA)
+*
+         LA    R0,WALEN
+         FREEMAIN RU,LV=(0),A=(8)
+*
+         LR    R0,R4               R0  = output ENVBLOCK / original
+         LR    R15,R3              R15 = output RC
+*
+*  Restore R14 and R1-R12 from caller SA (preserve our R0 / R15).
+         L     R14,12(,R13)
+         LM    R1,R12,24(,R13)
+         BR    R14
+*
+         LTORG
+*
+*  --- workarea DSECT --------------------------------------------------
+WAREA    DSECT
+WSAVE    DS    18F                 standard 72-byte save area
+WPREV    DS    F                   saved R0 in (previous-env hint)
+WPARMS   DS    7F                  bare addresses parsed from VLIST
+WCPLIST  DS    6F                  parameter list for IRXIDISP call
+WALEN    EQU   *-WAREA
+*
+         END   IRXINIT

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -96,7 +96,8 @@ IRXINIT  CSECT
          GETMAIN RU,LV=(0)
          LR    R8,R1               R8 = workarea ptr (saved for FREE)
 *
-*  Chain DSAs: caller SA <-> our DSA. WDPREV = +4 (= old WSAVE+4).
+*  Chain DSAs: caller SA <-> our DSA. Offsets +4/+8 are hardcoded
+*  to WDPREV / WDNEXT in the WAREA DSECT — keep in sync.
          ST    R13,4(,R1)          our DSA back-chain = caller SA
          ST    R1,8(,R13)          caller forward     = our DSA
          LR    R13,R1
@@ -287,8 +288,8 @@ NULLPLST DS    0H
 *  18F save area at +0..+71 maps onto the standard MVS save-area
 *  offsets used by SAVE/RETURN, and WDLWA / WDNAB extend it to
 *  the 80-byte PDP DSA. WPOOL provides the bump-allocator pool
-*  for nested c2asm370 frames; 8 KB covers ~25-50 frames @ ~150-300
-*  bytes each, well above the deepest IRXINIT call chain.
+*  for nested c2asm370 frames; see the WPOOL block below for the
+*  sizing and zero-init rationale.
 WAREA    DSECT
 WDFLAGS  DS    F                   +0  DSAFLAGS (must be 0)
 WDPREV   DS    F                   +4  DSAPREV  (back chain)
@@ -314,9 +315,12 @@ WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
 WPREV    DS    F                   saved R0 in (previous-env hint)
 WPARMS   DS    7F                  bare addresses parsed from VLIST
 WCPLIST  DS    6F                  parameter list for IRXIDISP call
-*  Stack pool for nested c2asm370 PDPPRLG frames.
+*  Stack pool for nested c2asm370 PDPPRLG frames. Sized for typical
+*  IRXIDISP call depth (5-10 nested frames @ 88-300 bytes each); 8 KB
+*  has comfortable margin. Intentionally not zero-filled — c2asm370-
+*  emitted code SAVE-writes R14-R12 before reading any frame slot, so
+*  XC initialization would cost 8 KB without functional benefit.
 WPOOL    DS    2048F               8 KB scratchpad
-WPOOLEND EQU   *
 WALEN    EQU   *-WAREA
 *
          END   IRXINIT

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -165,8 +165,8 @@ BUILDC   EQU   *
          L     R3,0(,R2)           R3 = user_field value
          ST    R3,WCPLIST+12
 *
-         L     R2,WPARMS+20        R2 = addr of caller ENVBLK slot
-         ST    R2,WCPLIST+16        (in/out for CHEKENVB; out otherwise)
+         L     R2,WPARMS+20        R2 = addr of ENVBLK slot
+         ST    R2,WCPLIST+16
 *
          L     R2,WPARMS+24        R2 = addr of caller REASON slot
          ST    R2,WCPLIST+20
@@ -221,12 +221,12 @@ EPILOG   EQU   *
 *
 *  Restore R14 and R1-R12 from caller SA (preserve our R0 / R15).
          L     R14,12(,R13)
-         LM    R1,R12,24(,R13)
+         LM    R1,R12,24(R13)
          BR    R14
 *
          LTORG
 *
-*  --- workarea DSECT --------------------------------------------------
+*  --- workarea DSECT ---
 WAREA    DSECT
 WSAVE    DS    18F                 standard 72-byte save area
 WPREV    DS    F                   saved R0 in (previous-env hint)

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -22,8 +22,12 @@
 *  (irx#term.c, irx#anch.c, ...) is NCAL-linked into the same
 *  load module via project.toml include list.
 *
-*  Known gap (deferred): same crent370 C-runtime bootstrap concern
-*  as IRXINIT — see asm/irxinit.asm prologue. WP-I1c.5e follow-up.
+*  Bootstrap design: same as IRXINIT — workarea is a PDP-DSA with
+*  an embedded WPOOL stack pool so c2asm370 callees can run their
+*  PDPPRLG bump-allocator prologue. irxstor() uses GETMAIN on MVS,
+*  bypassing the CLIBCRT C-runtime. See asm/irxinit.asm prologue
+*  comment block and #85 for the full rationale and tail-risk
+*  caveat (wtof on the getmain failure path).
 *
 *  Ref: SC28-1883-0 §15 (IRXTERM Programming Service)
 *  Ref: WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83
@@ -56,17 +60,29 @@ IRXTERM  CSECT
 *  Capture R0 in (the ENVBLOCK to terminate).
          LR    R10,R0              R10 = caller R0 (envblock)
 *
-*  --- allocate dynamic workarea ---
-         LA    R0,WALEN
+*  --- allocate dynamic workarea (PDP-DSA + locals + WPOOL) -------
+*  WALEN ~ 8 KB so we cannot use LA (12-bit displacement); load via
+*  literal pool instead. Subpool 0 (RU form) and no zero-fill.
+         L     R0,=A(WALEN)
          GETMAIN RU,LV=(0)
          LR    R8,R1               R8 = workarea ptr
 *
-*  Chain save areas: caller SA <-> our DSA. WSAVE is at offset 0
-*  of the DSECT, so WSAVE+4 = offset 4 in our DSA.
+*  Chain DSAs: caller SA <-> our DSA. WDPREV = +4 (= old WSAVE+4).
          ST    R13,4(,R1)          our DSA back-chain = caller SA
          ST    R1,8(,R13)          caller forward     = our DSA
          LR    R13,R1
          USING WAREA,R13
+*
+*  --- initialize PDP-DSA fields the c2asm370 callees inspect ----
+*
+*  PDPPRLG (callee prologue) reads DSANAB at +76 of OUR DSA as the
+*  bump-allocator base. WDFLAGS (+0) and WDLWA (+72) must be zero
+*  per the PDP convention. R14-R12 (+12..+68) are written by the
+*  callee's SAVE-equivalent on entry.
+         XC    WDFLAGS(4),WDFLAGS  DSAFLAGS = 0
+         XC    WDLWA(4),WDLWA      DSALWA   = 0
+         LA    R0,WPOOL            R0 = start of stack pool
+         ST    R0,WDNAB            DSANAB   = WPOOL
 *
 *  --- build C-call plist for IRXITERM -----------------------------
 *
@@ -108,9 +124,10 @@ FAILR0   EQU   *
 *
 EPILOG   EQU   *
 *  R3 = RC, R4 = R0 output. Tear down workarea and return.
-         L     R13,WSAVE+4         R13 = caller SA
+         L     R13,WDPREV          R13 = caller SA (back chain in DSA)
 *
-         LA    R0,WALEN
+*  WALEN ~ 8 KB so the LA form does not fit; use literal pool.
+         L     R0,=A(WALEN)
          FREEMAIN RU,LV=(0),A=(8)
 *
          LR    R0,R4               R0  = output ENVBLOCK / original
@@ -122,11 +139,41 @@ EPILOG   EQU   *
 *
          LTORG
 *
-*  --- workarea DSECT ----------------------------------------------
+*  --- workarea DSECT (PDP-DSA shape) ------------------------------
+*
+*  Offsets +0..+79 follow pdptop.copy exactly so c2asm370 callees
+*  (PDPPRLG prologue) can chain through OUR DSA correctly. The
+*  18F save area at +0..+71 maps onto the standard MVS save-area
+*  offsets used by SAVE/RETURN, and WDLWA / WDNAB extend it to
+*  the 80-byte PDP DSA. WPOOL provides the bump-allocator pool
+*  for nested c2asm370 frames.
 WAREA    DSECT
-WSAVE    DS    18F                 standard 72-byte save area
+WDFLAGS  DS    F                   +0  DSAFLAGS (must be 0)
+WDPREV   DS    F                   +4  DSAPREV  (back chain)
+WDNEXT   DS    F                   +8  DSANEXT  (forward chain)
+WDR14    DS    F                   +12 caller R14 (set by SAVE)
+WDR15    DS    F                   +16 caller R15
+WDR0     DS    F                   +20 caller R0
+WDR1     DS    F                   +24 caller R1
+WDR2     DS    F                   +28 caller R2
+WDR3     DS    F                   +32 caller R3
+WDR4     DS    F                   +36 caller R4
+WDR5     DS    F                   +40 caller R5
+WDR6     DS    F                   +44 caller R6
+WDR7     DS    F                   +48 caller R7
+WDR8     DS    F                   +52 caller R8
+WDR9     DS    F                   +56 caller R9
+WDR10    DS    F                   +60 caller R10
+WDR11    DS    F                   +64 caller R11
+WDR12    DS    F                   +68 caller R12
+WDLWA    DS    F                   +72 DSALWA  (must be 0)
+WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
+*  Wrapper-local storage (after the PDP-DSA proper).
 WCPLIST  DS    2F                  C-call plist for IRXITERM
 WREASON  DS    F                   reason-code OUT cell (discarded)
+*  Stack pool for nested c2asm370 PDPPRLG frames.
+WPOOL    DS    2048F               8 KB scratchpad
+WPOOLEND EQU   *
 WALEN    EQU   *-WAREA
 *
          END   IRXTERM

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -1,0 +1,134 @@
+         TITLE 'IRXTERM - REXX/370 IRXTERM Entry Point Wrapper'
+*
+*  IRXTERM - HLASM entry-point wrapper for the IRXTERM Programming
+*            Service (SC28-1883-0 §15).
+*
+*  Delegates to the C-core irx_init_term (asm() alias IRXITERM,
+*  CON-4) which performs the 5-step teardown: validate eye-catcher,
+*  IRXANCHR slot lookup, free IRXEXTE/PARMBLOCK, release slot, roll
+*  ECTENVBK back to predecessor for TSO envs, and free the ENVBLOCK.
+*
+*  Calling convention (per SC28-1883-0):
+*
+*    CALL IRXTERM           (no parameter list)
+*
+*  R0  (in)  ENVBLOCK to terminate (NOT in a parameter list)
+*  R0  (out) predecessor ENVBLOCK on success (read back from
+*            ECTENVBK after the C-core rolled it back), or the
+*            original R0 unchanged on failure
+*  R15 (out) return code: 0 = ok, 20 = bad ENVBLOCK
+*
+*  Built as a separate load module (entry IRXTERM). The C-core
+*  (irx#term.c, irx#anch.c, ...) is NCAL-linked into the same
+*  load module via project.toml include list.
+*
+*  Known gap (deferred): same crent370 C-runtime bootstrap concern
+*  as IRXINIT — see asm/irxinit.asm prologue. WP-I1c.5e follow-up.
+*
+*  Ref: SC28-1883-0 §15 (IRXTERM Programming Service)
+*  Ref: WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83
+*  Ref: CON-1 §6.4 (IRXTERM flow)
+*  Ref: CON-14 / IRXPROBE Phase α (ECTENVBK predecessor rollback)
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R8       EQU   8
+R10      EQU   10
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+IRXTERM  CSECT
+IRXTERM  AMODE 24
+IRXTERM  RMODE 24
+*
+*  --- standard MVS entry linkage ---
+         STM   R14,R12,12(R13)     save caller R14-R12 in caller SA
+         BALR  R12,0
+         USING *,R12
+*
+*  Capture R0 in (the ENVBLOCK to terminate).
+         LR    R10,R0              R10 = caller R0 (envblock)
+*
+*  --- allocate dynamic workarea ---
+         LA    R0,WALEN
+         GETMAIN RU,LV=(0)
+         LR    R8,R1               R8 = workarea ptr
+*
+*  Chain save areas: caller SA <-> our DSA. WSAVE is at offset 0
+*  of the DSECT, so WSAVE+4 = offset 4 in our DSA.
+         ST    R13,4(,R1)          our DSA back-chain = caller SA
+         ST    R1,8(,R13)          caller forward     = our DSA
+         LR    R13,R1
+         USING WAREA,R13
+*
+*  --- build C-call plist for IRXITERM -----------------------------
+*
+*    irx_init_term(envblock, &reason_code)
+*
+*  PDPCLIB convention: IN ENVBLOCK pointer goes directly in plist
+*  slot 0 (value, not pointer-to-pointer); OUT reason takes the
+*  address of the local WREASON cell.
+*
+         ST    R10,WCPLIST+0       envblock value
+         LA    R2,WREASON
+         ST    R2,WCPLIST+4
+*
+         LA    R1,WCPLIST
+         L     R15,=V(IRXITERM)
+         BALR  R14,R15
+*
+*  R15 = RC; *WREASON now holds the reason code. We discard the
+*  reason — IBM IRXTERM has no caller-visible reason slot, R15 is
+*  the only output channel.
+*
+         LR    R3,R15              R3 = RC (preserved through teardown)
+         LTR   R3,R3
+         BNZ   FAILR0              non-zero RC -> R0 stays as original
+*
+*  Success: read predecessor from ECTENVBK via anch_curr(). The
+*  C-core has already rolled the slot back (TSO envs only); for
+*  non-TSO envs the slot is unchanged and anch_curr returns
+*  whatever was there before — which is the right answer for the
+*  caller too.
+         LA    R1,WCPLIST          minimal plist (no args)
+         L     R15,=V(ANCHCURR)
+         BALR  R14,R15
+         LR    R4,R15              R4 = predecessor envblock or NULL
+         B     EPILOG
+*
+FAILR0   EQU   *
+         LR    R4,R10              R4 = original R0 (saved at entry)
+*
+EPILOG   EQU   *
+*  R3 = RC, R4 = R0 output. Tear down workarea and return.
+         L     R13,WSAVE+4         R13 = caller SA
+*
+         LA    R0,WALEN
+         FREEMAIN RU,LV=(0),A=(8)
+*
+         LR    R0,R4               R0  = output ENVBLOCK / original
+         LR    R15,R3              R15 = RC
+*
+         L     R14,12(,R13)
+         LM    R1,R12,24(,R13)
+         BR    R14
+*
+         LTORG
+*
+*  --- workarea DSECT ----------------------------------------------
+WAREA    DSECT
+WSAVE    DS    18F                 standard 72-byte save area
+WCPLIST  DS    2F                  C-call plist for IRXITERM
+WREASON  DS    F                   reason-code OUT cell (discarded)
+WALEN    EQU   *-WAREA
+*
+         END   IRXTERM

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -117,7 +117,7 @@ EPILOG   EQU   *
          LR    R15,R3              R15 = RC
 *
          L     R14,12(,R13)
-         LM    R1,R12,24(,R13)
+         LM    R1,R12,24(R13)
          BR    R14
 *
          LTORG

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -47,8 +47,6 @@ R15      EQU   15
          PRINT GEN
 *
 IRXTERM  CSECT
-IRXTERM  AMODE 24
-IRXTERM  RMODE 24
 *
 *  --- standard MVS entry linkage ---
          STM   R14,R12,12(R13)     save caller R14-R12 in caller SA

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -67,7 +67,8 @@ IRXTERM  CSECT
          GETMAIN RU,LV=(0)
          LR    R8,R1               R8 = workarea ptr
 *
-*  Chain DSAs: caller SA <-> our DSA. WDPREV = +4 (= old WSAVE+4).
+*  Chain DSAs: caller SA <-> our DSA. Offsets +4/+8 are hardcoded
+*  to WDPREV / WDNEXT in the WAREA DSECT — keep in sync.
          ST    R13,4(,R1)          our DSA back-chain = caller SA
          ST    R1,8(,R13)          caller forward     = our DSA
          LR    R13,R1
@@ -146,7 +147,8 @@ EPILOG   EQU   *
 *  18F save area at +0..+71 maps onto the standard MVS save-area
 *  offsets used by SAVE/RETURN, and WDLWA / WDNAB extend it to
 *  the 80-byte PDP DSA. WPOOL provides the bump-allocator pool
-*  for nested c2asm370 frames.
+*  for nested c2asm370 frames; see the WPOOL block below for the
+*  sizing and zero-init rationale.
 WAREA    DSECT
 WDFLAGS  DS    F                   +0  DSAFLAGS (must be 0)
 WDPREV   DS    F                   +4  DSAPREV  (back chain)
@@ -171,9 +173,12 @@ WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
 *  Wrapper-local storage (after the PDP-DSA proper).
 WCPLIST  DS    2F                  C-call plist for IRXITERM
 WREASON  DS    F                   reason-code OUT cell (discarded)
-*  Stack pool for nested c2asm370 PDPPRLG frames.
+*  Stack pool for nested c2asm370 PDPPRLG frames. Sized for typical
+*  IRXIDISP call depth (5-10 nested frames @ 88-300 bytes each); 8 KB
+*  has comfortable margin. Intentionally not zero-filled — c2asm370-
+*  emitted code SAVE-writes R14-R12 before reading any frame slot, so
+*  XC initialization would cost 8 KB without functional benefit.
 WPOOL    DS    2048F               8 KB scratchpad
-WPOOLEND EQU   *
 WALEN    EQU   *-WAREA
 *
          END   IRXTERM

--- a/include/irxfunc.h
+++ b/include/irxfunc.h
@@ -30,8 +30,14 @@
  *   envblock_ptr- Output: pointer to created ENVBLOCK
  *
  * Returns: 0=OK, 20=init error, 28=storage error
+ *
+ * MVS symbol: IRXINITC. The HLASM entry-point wrapper in
+ * asm/irxinit.asm owns the bare IRXINIT symbol (it is the
+ * IBM-spec Programming Service entry point and dispatches to
+ * irx_init_dispatch). The compat wrapper here installs the
+ * Phase 2+ state (BIFs, SUBCOMTB, wkbi) on top of that.
  */
-int irxinit(void *parms, struct envblock **envblock_ptr);
+int irxinit(void *parms, struct envblock **envblock_ptr) asm("IRXINITC");
 
 /* IRXTERM - Terminate a Language Processor Environment
  * Frees all storage associated with the environment and pops it
@@ -41,8 +47,12 @@ int irxinit(void *parms, struct envblock **envblock_ptr);
  *   envblock_ptr - Pointer to ENVBLOCK to terminate
  *
  * Returns: 0=OK, 20=term error
+ *
+ * MVS symbol: IRXTERMC. The HLASM IRXTERM Programming Service
+ * entry point lives in asm/irxterm.asm; this is the Phase 2+
+ * teardown compat wrapper.
  */
-int irxterm(struct envblock *envblock_ptr);
+int irxterm(struct envblock *envblock_ptr) asm("IRXTERMC");
 
 /* --- Storage Management Replaceable Routine --- */
 

--- a/project.toml
+++ b/project.toml
@@ -118,7 +118,21 @@ include = [
   "IRX#ANCH",
   "IRX#UID",
   "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
+  "IRX#ARIT",
 ]
+
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
 # IRXTERM - HLASM Entry-Point Wrapper for the IRXTERM Programming
@@ -141,7 +155,21 @@ include = [
   "IRX#ANCH",
   "IRX#UID",
   "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
+  "IRX#ARIT",
 ]
+
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
 # TSTANCH - ENVBLOCK anchor smoketest pseudomodule

--- a/project.toml
+++ b/project.toml
@@ -93,6 +93,57 @@ options = ["LIST", "MAP", "XREF", "AC=1", "RENT", "REUS"]
 include = ["IRXTMPW"]
 
 # ---------------------------------------------------------------
+# IRXINIT - HLASM Entry-Point Wrapper for the IRXINIT Programming
+#          Service (SC28-1883-0 §14). Parses the caller VLIST,
+#          extracts the function code, and delegates to the C-core
+#          dispatcher irx_init_dispatch (asm() alias IRXIDISP).
+#
+# Built as a separate load module (per IBM convention IRXINIT and
+# IRXTERM are independent load modules). The wrapper is the entry
+# point; the C-core (IRX#INIT, IRX#TERM, IRX#STOR, IRX#ANCH,
+# IRX#UID, IRX#MSID) is NCAL-linked into the same load module so
+# the BALR R14,R15 to =V(IRXIDISP) resolves.
+#
+# WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "IRXINIT"
+entry = "IRXINIT"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = [
+  "IRXINIT",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+]
+
+# ---------------------------------------------------------------
+# IRXTERM - HLASM Entry-Point Wrapper for the IRXTERM Programming
+#          Service (SC28-1883-0 §15). Reads R0=ENVBLOCK, calls the
+#          C-core irx_init_term (asm() alias IRXITERM), and reads
+#          back ECTENVBK via anch_curr (alias ANCHCURR) to return
+#          the predecessor envblock in R0.
+#
+# WP-I1c.5 / TSK-198 / GitHub mvslovers/rexx370#83.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "IRXTERM"
+entry = "IRXTERM"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = [
+  "IRXTERM",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+]
+
+# ---------------------------------------------------------------
 # TSTANCH - ENVBLOCK anchor smoketest pseudomodule
 # Runs in TSO (CALL 'TSTANCH') or Batch (EXEC PGM=TSTANCH).
 # Pulls in the full phase-1/phase-2 object set so IRXINIT and

--- a/src/irx#stor.c
+++ b/src/irx#stor.c
@@ -4,12 +4,21 @@
 ** this routine. It is a replaceable routine — callers can install
 ** a custom implementation via the Module Name Table (MODNAMET).
 **
-** Default behaviour:
-**   Subpool 0 (or no specific subpool) → calloc/free (crent370 heap)
-**   Subpool > 0 (from PARMBLOCK)       → getmain/freemain (clibos.h)
+** Behaviour:
+**   MVS  → getmain/freemain (clibos.h) for ALL subpools, including 0.
+**          crent370 getmain() embeds an 8-byte prefix (subpool +
+**          length) so freemain() recovers them — no caller-side
+**          length tracking required. Bypassing the calloc/free path
+**          keeps irxstor independent of CLIBCRT, so the entry-point
+**          wrappers (asm/irxinit.asm, asm/irxterm.asm) can dispatch
+**          into the C-core without going through @@CRT0 first.
+**          Caveat: getmain() calls wtof() on its failure path, which
+**          IS CLIBCRT-dependent — see #85.
+**   Host → calloc/free (cross-compile / unit tests).
 **
 ** Ref: SC28-1883-0, Chapter 16 (Storage Management)
 ** Ref: Architecture Design v0.1.0, Section 5.5
+** Ref: GitHub mvslovers/rexx370#85
 */
 
 #include <stdlib.h>
@@ -37,6 +46,7 @@
 int irxstor(int function, int length, void **addr_ptr,
             struct envblock *envblock)
 {
+#ifdef __MVS__
     int subpool = 0;
 
     /* Determine subpool from PARMBLOCK if available */
@@ -48,6 +58,9 @@ int irxstor(int function, int length, void **addr_ptr,
             subpool = pb->parmblock_subpool;
         }
     }
+#else
+    (void)envblock;
+#endif
 
     switch (function)
     {
@@ -57,21 +70,20 @@ int irxstor(int function, int length, void **addr_ptr,
                 return 20;
             }
 #ifdef __MVS__
-            if (subpool > 0)
             {
-                /* Specific subpool: use GETMAIN R,LV=,SP= */
-                void *ptr = getmain((unsigned)length, subpool);
+                /* getmain() zero-fills internally and embeds the
+                 * subpool + length in an 8-byte prefix that
+                 * freemain() recovers, so no caller-side length
+                 * tracking is needed. */
+                void *ptr = getmain((unsigned)length, (unsigned)subpool);
                 if (ptr == NULL)
                 {
                     return 20;
                 }
-                memset(ptr, 0, (unsigned)length);
                 *addr_ptr = ptr;
             }
-            else
-#endif
+#else
             {
-                /* Default: crent370 heap (calloc zeros the memory) */
                 void *ptr = calloc(1, (size_t)length);
                 if (ptr == NULL)
                 {
@@ -79,6 +91,7 @@ int irxstor(int function, int length, void **addr_ptr,
                 }
                 *addr_ptr = ptr;
             }
+#endif
             return 0;
 
         case RXSMFRE:
@@ -87,15 +100,10 @@ int irxstor(int function, int length, void **addr_ptr,
                 return 20;
             }
 #ifdef __MVS__
-            if (subpool > 0)
-            {
-                freemain(*addr_ptr);
-            }
-            else
+            freemain(*addr_ptr);
+#else
+            free(*addr_ptr);
 #endif
-            {
-                free(*addr_ptr);
-            }
             *addr_ptr = NULL;
             return 0;
 


### PR DESCRIPTION
Closes #85.

## How to review this PR

This PR is **stacked on top of PR #84** (issue-83). The diff therefore contains 7 commits totalling ~600 lines, but only the **last two commits are new work for review**:

| Commit | Phase | Files | Lines |
|--------|-------|-------|-------|
| `28a6433` | **Phase 1 (review me)** | `asm/irxinit.asm`, `asm/irxterm.asm` | +122 / -30 |
| `2c959a9` | **Phase 2 (review me)** | `src/irx#stor.c` | +26 / -18 |
| `61f7167`, `3b73071`, `fa3252d`, `e0e44f6`, `1989b8d` | (from #84) | wrappers + project.toml + irxfunc.h | ~470 |

Recommend closing #84 as superseded on merge — the wrapper commits land here unmodified, so #84 has no remaining content of its own.

## Background

Code review of PR #84 (HLASM wrappers IRXINIT/IRXTERM) surfaced **two independent bootstrap defects** that prevent the wrappers from successfully calling into the c2asm370-compiled C-core. Both defects are addressed by this PR. The plan is laid out in #85.

### Defect 1 — wrapper DSA layout incompatible with c2asm370 callees (Phase 1)

c2asm370 emits a `PDPPRLG CINDEX=N,FRAME=NN,BASER=12,ENTRY=YES` prologue at the head of every C function. Verified against `crent370/maclib/pdpprlg.macro`:

```
SAVE  (14,12),,&FUNC      ; STM caller R14-R12 into caller's SA
LA    &BASER,0(,15)
L     15,76(,13)          ; ★ R15 = caller's DSANAB (bump pointer)
ST    13,4(,15)           ; new DSA's DSAPREV = caller R13
ST    15,8(,13)           ; caller's DSANEXT = new DSA addr
LR    13,15
LA    15,&FRAME(,15)
ST    15,76(13)           ; new DSANAB
```

PDPPRLG is a **bump-allocator**, not a GETMAIN — the caller must pre-allocate the stack pool and pass `DSANAB` at offset +76 of its DSA. Our wrappers declared `WSAVE DS 18F` (72-byte standard SA) followed by `WPREV` at +72 and `WPARMS` at +76, so PDPPRLG read `WPARMS+0` (the first parsed VLIST address — `FCODE`) as the bump pointer and then `ST 13,4(,15)` wrote our R13 into `FCODE+4`. Wild write into caller storage; deterministic data corruption or S0C4 on the first BALR to a c2asm370 function.

**Fix:** restructure `WAREA` in both wrappers to follow `pdptop.copy` exactly:

| Offset | Field | Notes |
|--------|-------|-------|
| +0  | DSAFLAGS | Initialized to 0 |
| +4  | DSAPREV  | Caller R13 (existing chain-up code, no change) |
| +8  | DSANEXT  | Our DSA addr (existing chain-up code, no change) |
| +12..+68 | DSAR14..DSAR12 | Written by callees' SAVE-equivalent on entry |
| +72 | DSALWA   | Initialized to 0 |
| +76 | DSANAB   | ★ Initialized to address of `WPOOL` |

Append an 8 KB `WPOOL DS 2048F` for nested c2asm370 frames. Estimated worst-case is ~10 frames × 150–300 bytes (1.5–3 KB), so 8 KB has comfortable margin. The 18F save area maps onto offsets +0..+71 of the DSA exactly, so the existing `ST R13,4(,R1)` / `ST R1,8(,R13)` chain-up keeps working unchanged.

`WALEN` now exceeds 4095 bytes, so `LA R0,WALEN` no longer fits the 12-bit displacement. Switched both GETMAIN and FREEMAIN call-ups to `L R0,=A(WALEN)` (literal pool).

The NULLPLST early-exit path (TSK-202 AC-3) remains correct: no GETMAIN, no DSA-init, no leak.

### Defect 2 — irxstor calloc path requires uninitialized CLIBCRT (Phase 2)

The wrappers branch the OS straight into IRXINIT/IRXTERM, so `@@CRT0` does not run and the crent370 per-TCB `CLIBCRT` block is uninitialized when `irxstor()` first executes. The pre-existing subpool-0 path through `calloc()` then crashes on the uninitialized heap.

**Fix:** route every RXSMGET / RXSMFRE through crent370's `getmain()` / `freemain()` on MVS, regardless of subpool. crent370's `getmain()` is a pure inline-asm wrapper around `GETMAIN RC,LV=,SP=` that pokes PSA/TCB for the PSW key, embeds an 8-byte prefix carrying subpool + length, and zero-fills the storage. The success path **does not depend on CLIBCRT**, so the dispatch can complete without `@@CRT0`. `freemain()` reads the prefix back, so no caller-side length tracking is needed.

The Host (`!__MVS__`) path stays on `calloc`/`free` for cross-compile tests.

**Caveat:** `getmain()`'s failure path calls `wtof()`, which IS CLIBCRT-dependent. A getmain failure on the bootstrap path (very unlikely on a healthy system) would crash secondarily trying to log. Acceptable tail risk; documented in `src/irx#stor.c` header.

## Acceptance Criteria

| AC | Status | Notes |
|----|--------|-------|
| AC-1 — `WAREA` declared as PDP-DSA in `asm/irxinit.asm` | covered | DSAFLAGS / DSAPREV / DSANEXT / R14..R12 / DSALWA / DSANAB explicit fields |
| AC-2 — 8 KB `WPOOL` stack pool in `WAREA` | covered | `WPOOL DS 2048F` |
| AC-3 — Wrapper prologue initializes `WDFLAGS=0`, `WDLWA=0`, `WDNAB=WPOOL` before first c2asm370 BALR | covered | After GETMAIN + chain-up, before any `BALR R14,R15` |
| AC-4 — NULLPLST defense remains functional | covered | Path unchanged; no GETMAIN, no DSA-init, no leak |
| AC-5 — `asm/irxterm.asm` analogously restructured | covered | Same DSA layout + 8 KB pool |
| AC-6 — `RXSMGET` calls `getmain()` unconditionally on MVS | covered | Subpool conditional dropped |
| AC-7 — `RXSMFRE` calls `freemain()` unconditionally on MVS | covered | Subpool conditional dropped |
| AC-8 — Host path unchanged | covered | calloc / free preserved under `#else` |
| AC-9 — IFOX00 clean assembly | **pending** | Needs `mbt build --target IRXINIT/IRXTERM` on MVS |
| AC-10 — NCAL link succeeds for both load modules | **pending** | Needs MVS submission |
| AC-11 — Host C-test matrix stays green | covered | **15 binaries / 1192 tests passed** (38+70+50+47+39+27+62+74+53+16+29+128+113+29+417), unchanged from #84 baseline |
| AC-12 — MVS smoketest of `CALL IRXINIT,(...)` returns clean | **pending** | Needs MVS test caller; arrives in a follow-up after #84 lands |

## Honesty caveats

- **Phase 1 has not been assembled.** The structural changes are correct against the PDPPRLG specification and `pdptop.copy` reference, but only IFOX00 + a real MVS run can confirm the load module binds and dispatches cleanly. Inheriting #84's pending status for AC-9 / AC-10 / AC-12.
- **Literal-pool reach for `=A(WALEN)`** is expected to fit (~720 bytes between BALR R12,0 and LTORG in irxinit.asm; well under 4095) but unverified until IFOX00 runs.
- **TST\* MVS load modules also link IRX#STOR.** Their MVS allocation path moves from calloc → getmain. On MVS they enter via `@@CRT0` so both paths *should* work; functionally equivalent (both zero-fill, both go through the 8-byte prefix), but the TST\* MVS rerun is expected to be a no-op and has not been verified.

## Test plan

- [x] All 15 host C-tests build and pass — 1192/1192
- [ ] **On MVS**: `mbt build --target IRXINIT` and `--target IRXTERM` produce load modules cleanly
- [ ] **On MVS**: HLASM caller invokes `CALL IRXINIT,(INITENVB,...)`, gets `R15=0`, `R0`=new ENVBLOCK, OUT slots populated, **no S0C4** (Phase 1 verification)
- [ ] **On MVS**: `CALL IRXTERM` with `R0`=valid envblock returns `R15=0` and `R0`=predecessor (or 0)
- [ ] **On MVS**: TST\* load modules still pass post-Phase-2 (expected no-op)

## Refs

- TSK-200 (Notion): https://www.notion.so/34f3d993878781b99b01c113966330ae
- Closes #85
- Supersedes #84 (commits incorporated unchanged; close on merge)
- TSK-202 (PR #84 fix-up commit `61f7167` — included)
- crent370: `src/clib/getmain.c`, `maclib/pdpprlg.macro`, `maclib/pdptop.copy`
- SC28-1883-0 §14 (IRXINIT) / §15 (IRXTERM)
- CON-1 §6.3 / §6.4 (init / term flow)