### PR TITLE
fix(anchor): anch_tso() fallback for HLASM-direct callers

### DIFF
--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -48,12 +48,8 @@ void *anch_walk(void)
 
 int anch_tso(void)
 {
-    CLIBPPA *ppa = __ppaget();
-    if (ppa == NULL)
-    {
-        return 0;
-    }
-    /* Both bits count as "TSO-capable": PPAFLAG_TSOFG is the TSO
+    /* Primary detection: crent370 CLIBPPA, populated by @@CRT0 startup.
+     * Both bits count as "TSO-capable": PPAFLAG_TSOFG is the TSO
      * foreground (ready-prompt / CALL); PPAFLAG_TSOBG is TSO
      * background (batch job driving IKJEFT01). Pure batch
      * (EXEC PGM=... directly) leaves both clear.
@@ -61,7 +57,21 @@ int anch_tso(void)
      * Note: the sibling CLIBCRT.crtflag bits carry the same names
      * but are never written by crent370 startup — detection lives
      * in the process-level CLIBPPA, not the per-task CLIBCRT. */
-    return (ppa->ppaflag & (PPAFLAG_TSOFG | PPAFLAG_TSOBG)) != 0;
+    CLIBPPA *ppa = __ppaget();
+    if (ppa != NULL)
+    {
+        return (ppa->ppaflag & (PPAFLAG_TSOFG | PPAFLAG_TSOBG)) != 0;
+    }
+
+    /* Fallback for HLASM-direct callers without crent370 startup
+     * (e.g. wrapper-direct entries via IRXTMPW, TINITVL test caller).
+     * Presence of an ECT in the PSA -> ASCB -> ASXB -> LWA -> ECT
+     * chain implies a TSO context regardless of which runtime the
+     * caller uses: TSO foreground populates ECT, TSO background
+     * (IKJEFT01) populates ECT, pure batch leaves LWA -> ECT NULL.
+     * This complements the CLIBPPA path conceptually — both bits
+     * (TSOFG and TSOBG) imply ECT presence. */
+    return anch_walk() != NULL;
 }
 
 /* Intentionally non-static: the test harness forward-declares this


### PR DESCRIPTION
## Summary

`anch_tso()` previously relied solely on crent370's `CLIBPPA` for TSO
detection. HLASM-direct callers (TINITVL today, IRXTMPW later) have no
`CLIBPPA`, get `__ppaget() == NULL`, and so see `anch_tso() == 0` even
when running under TSO READY. This propagates downstream: the env is
created without `IRXANCHR_FLAG_TSO_ATTACHED`, the slot reads
`flags=00000000`, and ECTENVBK semantics (Step 9 of `INITENVB`) never
take the TSO-attached path.

This change adds a fallback that uses `anch_walk() != NULL` when
CLIBPPA is unavailable. Presence of an ECT in `PSA → ASCB → ASXB →
LWA → ECT` implies a TSO context regardless of which runtime started
the process: TSO foreground populates ECT, TSO background (IKJEFT01)
populates ECT, pure batch leaves `LWA → ECT` NULL. The CLIBPPA path
remains the primary detection — the fallback only fires when CLIBPPA
is missing.

## Empirical evidence (before)

After `CALL TINITVL` under TSO READY, `irxdbg anch` showed:

```
Slot | envblock_ptr | token | tcb_ptr  | flags    | hint
   1 |        9CD70 |     1 |   9B7208 |        0 |    0
```

`flags=00000000` — should be `0x40000000` (`IRXANCHR_FLAG_TSO_ATTACHED`).

## Test plan

- [x] Host cross-compile: 15 binaries, 1193 tests green (no host-side
      regression — host `anch_tso()` returns 0 unconditionally and is
      unchanged)
- [x] MVS build: `IRX#ANCH` RC=0
- [x] MVS link: `IRXANCHR`, `IRXINIT`, `IRXTERM`, `IRXTMPW`,
      `TSTANCH` all RC=0
- [ ] Live verification on MVS (Mike):
      `irxdbg clear` → `call rexx370.v0r1m0d.load(tinitvl)` →
      `irxdbg anch` should show `flags=40000000` for the new slot

## Acceptance criteria

- AC-1: `anch_tso()` returns 1 for TSO-foreground HLASM-direct callers
- AC-2: `anch_tso()` returns 0 for pure batch jobs
  (`EXEC PGM=TINITVL`)
- AC-3: `anch_tso()` correct for crent370 C applications
  (primary path unchanged)
- AC-4: TINITVL re-run shows `flags=40000000` in the IRXANCHR slot
- AC-5: Host tests stay green ✓
- AC-6: MVS build assembles + links cleanly ✓
- AC-7: Source comment documents fallback rationale ✓

## Out of scope

- TINITVL slot leak (separate)
- TSK-199 RC=0/4 TCB-aware differentiation
- WP-I1c.6 IRXTMPW extension
- Refactoring `anch_walk()` itself

Closes #89