### PR TITLE
WP-I1c.6: keep IRXINIT load module resident in IRXTMPW

### DIFF
--- a/asm/irxtmpw.asm
+++ b/asm/irxtmpw.asm
@@ -33,10 +33,12 @@ IRXTMPW  CSECT
          LR    R8,R15
 *
 * --- try loading IRXANCHR ---
-         LOAD  EP=IRXANCHR,ERRET=DUMMY
+         LOAD  EP=IRXANCHR,ERRET=NOANCH
 *
 * --- restore registers for IKJEFT01 ---
-DUMMY    DS    0H
+NOANCH   DS    0H
+         LOAD  EP=IRXINIT,ERRET=NOINIT
+NOINIT   DS    0H
          LR    R0,R5
          LR    R1,R6
          LR    R14,R7


### PR DESCRIPTION
## Summary

Adds a second `LOAD EP=IRXINIT` in the IKJEFT01 TMP wrapper so the IRXINIT
load module stays resident on the step-TCB JPQ for the lifetime of the TSO
session. No matching DELETE — module is reclaimed when the step terminates.

## Why so small

A one-off diagnostic probe (deployed once, not for merge) WTO'd
"LWA EXISTS BUT NO ECT" during IRXTMPW execution. On MVS 3.8j the ECT is
created by IKJEFT01 itself, not by the logon manager, so a pre-XCTL TMP
wrapper sees the LWA but cannot reach an ECT. That collapses the originally
planned WP-I1c.6 (eager INITENVB inside IRXTMPW with TSOFL=1 and a
pre-populated ECTENVBK) to this single LOAD: the first REXX caller runs as
a TSO command subtask under its own ECT and performs INITENVB lazily;
JPA-lookup finds the already-resident IRXINIT.

## Consequence

The IRXEXTE default-routine pointers installed by #91 remain
dereferencable for the full session, satisfying the lifetime contract
documented in `src/irx#init.c` step 6 for TSO callers.

## Open follow-up

A cleaner mechanism for an eager default environment with TSOFL=1 and a
populated ECTENVBK at logon time (without depending on IKJEFT01 having
created the ECT) remains TBD.

## Test plan

- [x] Live-verified on MVS-CE by the author