### PR TITLE
WP-I1c.6: EXTRACT-based TSO environment detector (ISTSO)

### DIFF
--- a/asm/istso.asm
+++ b/asm/istso.asm
@@ -1,4 +1,4 @@
-         TITLE 'TSOENV - TSO Environment Detection'
+         TITLE 'ISTSO - TSO Environment Detection'
 *
 *  ISTSO - Determine whether the current task is running under TSO
 *          (foreground interactive or IKJEFTSR background).

--- a/asm/istso.asm
+++ b/asm/istso.asm
@@ -1,0 +1,88 @@
+         TITLE 'TSOENV - TSO Environment Detection'
+*
+*  ISTSO - Determine whether the current task is running under TSO
+*          (foreground interactive or IKJEFTSR background).
+*
+*  Entry:  Standard MVS linkage (R14=ret, R13=caller SA)
+*  Return: R15 = 0  batch (no TSO environment)
+*          R15 = 1  TSO environment detected
+*
+*  RENT/REUS: dynamic workarea allocated via GETMAIN RU.
+*  WEXTLST (EXTRACT MF=L in DSECT) and WEXTANS (2F answer area)
+*  both reside in the workarea.  MF=(E,WEXTLST) fills the parm
+*  list at runtime and issues SVC 9 -- no MVC of a static template
+*  is needed (pattern from crent370 @@CRT0 PPASETUP).
+*
+*  IMPORTANT: R15 is NOT tested after EXTRACT. The SVC does not
+*  set R15 reliably on MVS 3.8j (live-verified 2026-04-28 MVS-CE).
+*
+*  IMPORTANT: EXTRACT clobbers R0. The epilog restores R0 from the
+*  caller save area (offset +20) after FREEMAIN.
+*
+*  Ref: WP-I1c.6 / GitHub mvslovers/rexx370#93
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R9       EQU   9
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+ISTSO    CSECT
+         STM   R14,R12,12(R13)
+         BALR  R12,0
+         USING *,R12
+*
+* --- acquire dynamic workarea (RENT) ---
+         L     R0,=A(WALEN)
+         GETMAIN RU,LV=(0)
+         LR    R9,R1
+         ST    R13,4(,R1)
+         ST    R1,8(,R13)
+         LR    R13,R1
+         USING WAREA,R13
+*
+* --- EXTRACT: MF=E fills parm list + issues SVC 9 ---
+         EXTRACT WEXTANS,FIELDS=(TSO,PSB),MF=(E,WEXTLST)
+*        NOTE: R15 is NOT tested - SVC 9 does not set it reliably
+*
+* --- evaluate answer area ---
+         LM    R2,R3,WEXTANS         R2->TSO byte  R3->PSB (or 0)
+         TM    0(R2),X'80'           TSO foreground bit?
+         BO    YESTSO
+         LTR   R3,R3                 non-zero PSB = background TSO?
+         BNZ   YESTSO
+         LA    R4,0                  batch: return 0
+         B     EXIT
+YESTSO   LA    R4,1                  TSO: return 1
+EXIT     DS    0H
+         L     R13,WDPREV
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(9)
+         LR    R15,R4
+         L     R14,12(,R13)
+         L     R0,20(,R13)           restore R0 (EXTRACT clobbers it)
+         LM    R1,R12,24(R13)
+         BR    R14
+*
+         LTORG
+*
+* --- workarea DSECT ---
+WAREA    DSECT
+WDFLAGS  DS    F                  +0  reserved
+WDPREV   DS    F                  +4  back chain
+WDNEXT   DS    F                  +8  forward chain
+         DS    15F               +12..+71 R14-R12 save slots
+WEXTANS  DS    2F                 EXTRACT answer area: TSO+PSB ptrs
+WEXTLST  EXTRACT MF=L             EXTRACT parm list (sized by macro)
+WALEN    EQU   *-WAREA
+*
+         END   ISTSO

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -13,12 +13,11 @@ Reference: [Architecture Design v0.2.0](https://www.notion.so/3283d9938787811ba3
 |---|---|---|---|
 | WP-01 | Project skeleton + headers | 1 | DONE |
 | WP-02 | IRXSTOR, IRXUID, IRXMSGID | 1 | DONE |
-| WP-03 | ECTENVBK anchor (IRX#ANCH) | 1 | DONE — ECTENVBK read-mostly discipline per CON-1 §6.1 | 
-|   |   |   |(PR #45, PR #46 d868b46) |
+| WP-03 | ECTENVBK anchor (IRX#ANCH) | 1 | DONE — ECTENVBK read-mostly discipline per CON-1 §6.1 (PR #45, PR #46 d868b46) |
 | WP-04 | IRXINIT + IRXTERM | 1 | DONE |
 | WP-05 | Phase 1 smoke test | 1 | DONE (38/38) |
-| WP-06 | Anchor protection tests | 1 | DONE — Case-(a)/(b)/(c) verification |
-|   |   |   | in test/test_anchor_readmostly.c; PR #46 d868b46 |
+| WP-06 | Anchor protection tests | 1 | DONE — Case-(a)/(b)/(c) verification in test/test_anchor_readmostly.c; PR #46 d868b46 |
+| WP-I1c.6 | IRXTMPW IRXINIT residency + ISTSO TSO detector | 1 | DONE — LOAD EP=IRXINIT in IRXTMPW (PR #92); EXTRACT-based is_tso() wrapper for reliable TSO detection independent of ECT availability (PR #94) |
 | WP-10 | Tokenizer (IRX#TOKN) | 2 | DONE (70/70) — PR #2 |
 | WP-11b | LString adapter (IRX#LSTR) | 2 | DONE (50/50) — PR #4 |
 | WP-12 | Variable pool (IRX#VPOL) | 2 | DONE (47/47) — PR #6 |
@@ -30,12 +29,7 @@ Reference: [Architecture Design v0.2.0](https://www.notion.so/3283d9938787811ba3
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | DONE (128/128) — PR #24 |
 | WP-21a | String BIFs (IRXBIFS) | 3 | DONE (29/29 + 87/87) — PR #26 |
-| WP-21b | Misc BIFs | 3 | DONE — 23 BIFs across Phases | 
-|   |   |   |A (#28, registry), B (#30, IRXARITH API), | 
-|   |   |   | C (#36, numeric), D (#38, conversion), | 
-|   |   |   | E (#39, reflection), F (#42, environment); |
-|   |   |   | Phase H closes the work package. |
-|   |   |   | Suite: 1156 total across 14 cross-compile binaries |
+| WP-21b | Misc BIFs | 3 | DONE — 23 BIFs across Phases A (#28, registry), B (#30, IRXARITH API), C (#36, numeric), D (#38, conversion), E (#39, reflection), F (#42, environment); Phase H closes the work package. Suite: 1156 total across 14 cross-compile binaries |
 | WP-22 | Built-in misc functions | 3 | OPEN |
 | WP-23 | INTERPRET instruction | 3 | OPEN |
 | WP-30 | EXECIO command | 4 | OPEN |

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -13,10 +13,12 @@ Reference: [Architecture Design v0.2.0](https://www.notion.so/3283d9938787811ba3
 |---|---|---|---|
 | WP-01 | Project skeleton + headers | 1 | DONE |
 | WP-02 | IRXSTOR, IRXUID, IRXMSGID | 1 | DONE |
-| WP-03 | ECTENVBK anchor (IRX#ANCH) | 1 | DONE — ECTENVBK read-mostly discipline per CON-1 §6.1 (PR #45, PR #46 d868b46) |
+| WP-03 | ECTENVBK anchor (IRX#ANCH) | 1 | DONE — ECTENVBK read-mostly discipline per CON-1 §6.1 | 
+|   |   |   |(PR #45, PR #46 d868b46) |
 | WP-04 | IRXINIT + IRXTERM | 1 | DONE |
 | WP-05 | Phase 1 smoke test | 1 | DONE (38/38) |
-| WP-06 | Anchor protection tests | 1 | DONE — Case-(a)/(b)/(c) verification in test/test_anchor_readmostly.c; PR #46 d868b46 |
+| WP-06 | Anchor protection tests | 1 | DONE — Case-(a)/(b)/(c) verification |
+|   |   |   | in test/test_anchor_readmostly.c; PR #46 d868b46 |
 | WP-10 | Tokenizer (IRX#TOKN) | 2 | DONE (70/70) — PR #2 |
 | WP-11b | LString adapter (IRX#LSTR) | 2 | DONE (50/50) — PR #4 |
 | WP-12 | Variable pool (IRX#VPOL) | 2 | DONE (47/47) — PR #6 |
@@ -28,7 +30,12 @@ Reference: [Architecture Design v0.2.0](https://www.notion.so/3283d9938787811ba3
 | WP-18 | Hello World end-to-end (IRX#EXEC) | 2 | DONE (16/16) — PR #14 |
 | WP-20 | Arithmetic engine (IRXARITH) | 3 | DONE (128/128) — PR #24 |
 | WP-21a | String BIFs (IRXBIFS) | 3 | DONE (29/29 + 87/87) — PR #26 |
-| WP-21b | Misc BIFs | 3 | DONE — 23 BIFs across Phases A (#28, registry), B (#30, IRXARITH API), C (#36, numeric), D (#38, conversion), E (#39, reflection), F (#42, environment); Phase H closes the work package. Suite: 1156 total across 14 cross-compile binaries |
+| WP-21b | Misc BIFs | 3 | DONE — 23 BIFs across Phases | 
+|   |   |   |A (#28, registry), B (#30, IRXARITH API), | 
+|   |   |   | C (#36, numeric), D (#38, conversion), | 
+|   |   |   | E (#39, reflection), F (#42, environment); |
+|   |   |   | Phase H closes the work package. |
+|   |   |   | Suite: 1156 total across 14 cross-compile binaries |
 | WP-22 | Built-in misc functions | 3 | OPEN |
 | WP-23 | INTERPRET instruction | 3 | OPEN |
 | WP-30 | EXECIO command | 4 | OPEN |

--- a/include/irxenv.h
+++ b/include/irxenv.h
@@ -1,0 +1,10 @@
+#ifndef IRXENV_H
+#define IRXENV_H
+
+#ifdef __MVS__
+int is_tso(void) asm("ISTSO");
+#else
+int is_tso(void);
+#endif
+
+#endif /* IRXENV_H */

--- a/project.toml
+++ b/project.toml
@@ -93,6 +93,18 @@ options = ["LIST", "MAP", "XREF", "AC=1", "RENT", "REUS"]
 include = ["IRXTMPW"]
 
 # ---------------------------------------------------------------
+# ISTSO - EXTRACT-based TSO environment detector.
+# Returns 0 (batch) or 1 (TSO foreground/background) via R15.
+# Pure assembler NCAL member; TISTSO links it in for the live test.
+# WP-I1c.6 / GitHub mvslovers/rexx370#93.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "ISTSO"
+entry = "ISTSO"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = ["ISTSO"]
+
+# ---------------------------------------------------------------
 # IRXINIT - HLASM Entry-Point Wrapper for the IRXINIT Programming
 #          Service (SC28-1883-0 §14). Parses the caller VLIST,
 #          extracts the function code, and delegates to the C-core
@@ -888,6 +900,20 @@ name = "TTERMVL"
 entry = "TTERMVL"
 options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
 include = ["TTERMVL"]
+
+# ---------------------------------------------------------------
+# TISTSO - Live MVS test caller for ISTSO (EXTRACT-based TSO detect).
+# Pure HLASM; ISTSO is NCAL-linked in so L R15,=V(ISTSO) resolves.
+# Invocation:
+#   Batch : EXEC PGM=TISTSO  (see test/mvs/jcl/tistso.jcl)
+#   TSO   : CALL 'hlq.LOAD(TISTSO)'
+# WP-I1c.6 / GitHub mvslovers/rexx370#93.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "TISTSO"
+entry = "TISTSO"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = ["TISTSO", "ISTSO"]
 
 # ---------------------------------------------------------------
 # IRXJCL - Batch entry point (PGM=IRXJCL)

--- a/src/irx#env.c
+++ b/src/irx#env.c
@@ -1,0 +1,8 @@
+#ifndef __MVS__
+#include "irxenv.h"
+
+int is_tso(void)
+{
+    return 0;
+}
+#endif

--- a/test/mvs/asm/tistso.asm
+++ b/test/mvs/asm/tistso.asm
@@ -1,0 +1,99 @@
+         TITLE 'TISTSO - Standalone test caller for ISTSO'
+*
+*  TISTSO - Calls ISTSO (EXTRACT-based TSO detector) and reports
+*           the result to the operator console via WTO.
+*
+*  Return code (R15 to JCL):
+*     0  ISTSO returned 0 (batch - no TSO environment)
+*     1  ISTSO returned 1 (TSO environment detected)
+*
+*  Expected JESLOG output:
+*     Batch : TISTSO: NOT TSO (batch)
+*     TSO   : TISTSO: IS TSO
+*
+*  Ref: WP-I1c.6 / GitHub mvslovers/rexx370#93
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R3       EQU   3
+R8       EQU   8
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+TISTSO   CSECT
+         STM   R14,R12,12(R13)
+         BALR  R12,0
+         USING *,R12
+*
+* --- allocate dynamic workarea (RENT) ---
+         L     R0,=A(WALEN)
+         GETMAIN RU,LV=(0)
+         LR    R8,R1
+         ST    R13,4(,R1)
+         ST    R1,8(,R13)
+         LR    R13,R1
+         USING WAREA,R13
+*
+* --- call ISTSO ---
+         L     R15,=V(ISTSO)
+         BALR  R14,R15
+         LR    R3,R15                 save result (0=batch, 1=TSO)
+*
+* --- emit WTO based on result ---
+         LTR   R3,R3
+         BNZ   WTOYES
+*
+*  --- not TSO (batch) ---
+         MVC   WWTOSK(WTOSKLEN),WTOSKEL
+         MVC   WWTOSK+4(MSGLEN),NOMSG
+         WTO   MF=(E,WWTOSK)
+         B     EPILOG
+*
+*  --- TSO detected ---
+WTOYES   MVC   WWTOSK(WTOSKLEN),WTOSKEL
+         MVC   WWTOSK+4(MSGLEN),YESMSG
+         WTO   MF=(E,WWTOSK)
+*
+EPILOG   DS    0H
+         L     R13,WDPREV
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(8)
+         LR    R15,R3
+         L     R14,12(,R13)
+         LM    R1,R12,24(R13)
+         BR    R14
+*
+         LTORG
+*
+* --- WTO parameter list skeleton (hand-built for IFOX00 col-71 limit) ---
+*  Layout: AL2(total len) AL2(MCS flags) 23C' '
+WTOSKEL  DS    0H
+         DC    AL2(WTOEND-WTOSKEL)
+         DC    AL2(0)
+         DC    23C' '
+WTOEND   EQU   *
+WTOSKLEN EQU   *-WTOSKEL
+*
+* --- 23-char message templates (text portion of WPL) ---
+*    01234567890123456789012
+*    0         1         2
+YESMSG   DC    CL23'TISTSO: IS TSO'
+NOMSG    DC    CL23'TISTSO: NOT TSO (batch)'
+MSGLEN   EQU   23
+*
+* --- workarea DSECT ---
+WAREA    DSECT
+WDFLAGS  DS    F                 +0
+WDPREV   DS    F                 +4  back chain
+WDNEXT   DS    F                 +8  forward chain
+         DS    15F              +12..+71 R14-R12 save slots
+WWTOSK   DS    CL(WTOSKLEN)      WTO working area
+WALEN    EQU   *-WAREA
+*
+         END   TISTSO

--- a/test/mvs/jcl/tistso.jcl
+++ b/test/mvs/jcl/tistso.jcl
@@ -1,0 +1,22 @@
+//TISTSO   JOB (A),'ISTSO TEST',REGION=4M,
+//           CLASS=A,MSGCLASS=H,MSGLEVEL=(1,1),
+//           NOTIFY=IBMUSER
+//*---------------------------------------------------------------
+//* TISTSO - Live MVS test of ISTSO EXTRACT-based TSO detection.
+//*
+//* Expected in batch: step RC=0, JESLOG shows
+//*   'TISTSO: NOT TSO (batch)'
+//*
+//* From TSO: CALL 'IBMUSER.REXX370.V0R1M0D.LOAD(TISTSO)'
+//*   Expected: RC=1, console shows 'TISTSO: IS TSO'
+//*---------------------------------------------------------------
+//STEP1   EXEC PGM=TISTSO,REGION=4M
+//STEPLIB  DD DSN=IBMUSER.REXX370.V0R1M0D.LOAD,DISP=SHR
+//SYSPRINT DD SYSOUT=*
+//*
+//STEP2   EXEC PGM=IKJEFT01
+//SYSTSPRT DD SYSOUT=*
+//SYSTSIN  DD *
+  CALL 'IBMUSER.REXX370.V0R1M0D.LOAD(TISTSO)'
+/*
+


### PR DESCRIPTION
## Summary

- Introduces `ISTSO`, a reentrant HLASM wrapper around the MVS EXTRACT SVC (SVC 9) that detects TSO foreground/background vs. batch
- `EXTRACT MF=L` in the DSECT / `MF=(E,WEXTLST)` at runtime — same pattern as `crent370 @@CRT0`; no MVC of a static template needed
- R15 is NOT tested after EXTRACT (SVC 9 does not set it reliably on MVS 3.8j — verified live)
- Epilog restores R0 from caller save area (+20) after FREEMAIN (EXTRACT clobbers R0)
- Returns R15=0 (batch) or R15=1 (TSO foreground or IKJEFTSR background)

## Files

| File | Purpose |
|------|---------|
| `asm/istso.asm` | ISTSO CSECT — RENT/REUS, GETMAIN workarea, EXTRACT-based TSO detect |
| `include/irxenv.h` | `is_tso()` declaration with `asm("ISTSO")` alias on MVS, plain decl on host |
| `src/irx#env.c` | Host-only stub (entire file `#ifndef __MVS__`), returns 0 |
| `test/mvs/asm/tistso.asm` | Standalone HLASM test caller, WTO + step RC=0/1 |
| `test/mvs/jcl/tistso.jcl` | Batch JCL to run TISTSO |
| `project.toml` | `[[link.module]]` entries for ISTSO and TISTSO |

## Test plan

- [x] AC-5: 14 host cross-compile binaries pass (1156 tests green)
- [x] AC-6: TISTSO assembled and linked on MVS without errors
- [x] AC-7: `//EXEC PGM=TISTSO` in batch — step RC=0, SYSPRINT shows `TISTSO: NOT TSO (batch)`

Closes #93