### PR TITLE
refactor(anch): remove anch_tso(), migrate callers to is_tso()

### DIFF
--- a/include/irxanchr.h
+++ b/include/irxanchr.h
@@ -81,12 +81,6 @@
  * (typical in batch, where LWA is not established). */
 void *anch_walk(void) asm("ANCHWALK");
 
-/* TSO detection via crent370's CLIBPPA.ppaflag
- * (PPAFLAG_TSOFG for TSO foreground, PPAFLAG_TSOBG for TSO background
- * invoked via IKJEFT01). Returns 1 when either bit is set, 0 in pure
- * batch and on non-MVS builds. */
-int anch_tso(void) asm("ANCHISTS");
-
 /* Read ECTENVBK — the currently installed ENVBLOCK, or NULL when
  * the slot is empty or unreachable. */
 struct envblock *anch_curr(void) asm("ANCHCURR");

--- a/src/irx#anch.c
+++ b/src/irx#anch.c
@@ -15,7 +15,6 @@
 
 #ifdef __MVS__
 #include "clibos.h"
-#include "clibppa.h"
 
 /* Low-core / control-block offsets per IBM macros — see header.
  * Named after the IBM fields so reviewers can cross-check the walk
@@ -44,34 +43,6 @@ void *anch_walk(void)
     void *lwa = deref_at(asxb, ASXBLWA);
     void *ect = deref_at(lwa, LWAPECT);
     return ect;
-}
-
-int anch_tso(void)
-{
-    /* Primary detection: crent370 CLIBPPA, populated by @@CRT0 startup.
-     * Both bits count as "TSO-capable": PPAFLAG_TSOFG is the TSO
-     * foreground (ready-prompt / CALL); PPAFLAG_TSOBG is TSO
-     * background (batch job driving IKJEFT01). Pure batch
-     * (EXEC PGM=... directly) leaves both clear.
-     *
-     * Note: the sibling CLIBCRT.crtflag bits carry the same names
-     * but are never written by crent370 startup — detection lives
-     * in the process-level CLIBPPA, not the per-task CLIBCRT. */
-    CLIBPPA *ppa = __ppaget();
-    if (ppa != NULL)
-    {
-        return (ppa->ppaflag & (PPAFLAG_TSOFG | PPAFLAG_TSOBG)) != 0;
-    }
-
-    /* Fallback for HLASM-direct callers without crent370 startup
-     * (e.g. wrapper-direct entries via IRXTMPW, TINITVL test caller).
-     * Presence of an ECT in the PSA -> ASCB -> ASXB -> LWA -> ECT
-     * chain implies a TSO context regardless of which runtime the
-     * caller uses: TSO foreground populates ECT, TSO background
-     * (IKJEFT01) populates ECT, pure batch leaves LWA -> ECT NULL.
-     * This complements the CLIBPPA path conceptually — both bits
-     * (TSOFG and TSOBG) imply ECT presence. */
-    return anch_walk() != NULL;
 }
 
 /* Intentionally non-static: the test harness forward-declares this
@@ -108,11 +79,6 @@ void *anch_walk(void)
      * push/pop path expects non-NULL when a slot is available. We
      * return the slot's address as a sentinel. */
     return (void *)&_simulated_ectenvbk;
-}
-
-int anch_tso(void)
-{
-    return 0;
 }
 
 #endif /* __MVS__ */

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -385,7 +385,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
      *   - If the caller's parmblock had tsofl_mask set, respect it.
      *   - Otherwise auto-detect via is_tso().
      *
-     * The resolved is_tso value is reflected into pb_copy via the
+     * The resolved tso_flag value is reflected into pb_copy via the
      * bitfield accessor in step 5 (not by byte-level OR'ing here).
      * Byte-level writes against tsofl are platform-specific because
      * the int bitfield ordering differs between MVS (MSB-first) and

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -33,6 +33,7 @@
 #include "irxanchr.h"
 #include "irxbif.h"
 #include "irxbifs.h"
+#include "irxenv.h"
 #include "irxfunc.h"
 #include "irxio.h"
 #include "irxpars.h"
@@ -231,7 +232,7 @@ cleanup:
 /*      (caller hint → TCB anchor find → LOAD IRXTSPRM/IRXPARMS;      */
 /*      parent-TCB walk still stubbed — WP-I1c.2)                     */
 /*   2. PARMBLOCK build with flags/mask inheritance (CON-1 §3.2)      */
-/*   3. Env-type detection: TSOFL from parmblock or anch_tso()        */
+/*   3. Env-type detection: TSOFL from parmblock or is_tso()          */
 /*   4. ENVBLOCK allocation (VERSION='0042', 320 bytes on MVS;        */
 /*      subpool from eff_subpool via stack-local bootstrap parmblock) */
 /*   5. PARMBLOCK copy allocation and link                            */
@@ -255,7 +256,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
     struct parmblock *pb_copy = NULL;
     struct irxexte *exte = NULL;
     int reason = 0;
-    int is_tso = 0; /* avoid name clash with tsofl macro in irx.h */
+    int tso_flag = 0; /* resolved in step 3 via is_tso() or caller PARMBLOCK */
 
     /* Effective parmblock fields, computed in step 2. */
     unsigned char eff_flags[4];
@@ -333,7 +334,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
              * LOAD failure, fall back to hardcoded defaults. */
             int loaded = 0;
 #ifdef __MVS__
-            if (load_default_parmblock(anch_tso(),
+            if (load_default_parmblock(is_tso(),
                                        eff_flags, eff_masks,
                                        eff_language, &eff_subpool) == 0)
             {
@@ -382,7 +383,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
      *
      * TSOFL=1 → TSO environment. Detection hierarchy:
      *   - If the caller's parmblock had tsofl_mask set, respect it.
-     *   - Otherwise auto-detect via anch_tso().
+     *   - Otherwise auto-detect via is_tso().
      *
      * The resolved is_tso value is reflected into pb_copy via the
      * bitfield accessor in step 5 (not by byte-level OR'ing here).
@@ -393,11 +394,11 @@ int irx_init_initenvb(struct envblock *prev_envblock,
      * ---------------------------------------------------------------- */
     if (caller_parmblock != NULL && caller_parmblock->tsofl_mask)
     {
-        is_tso = (caller_parmblock->tsofl != 0) ? 1 : 0;
+        tso_flag = (caller_parmblock->tsofl != 0) ? 1 : 0;
     }
     else
     {
-        is_tso = anch_tso();
+        tso_flag = is_tso();
     }
 
     /* ----------------------------------------------------------------
@@ -478,7 +479,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
      * (LSB-first). Mask is set to mark the value as caller-honoured for
      * any future inheritance lookup. Signed 1-bit field: -1 for true. */
     pb_copy->tsofl_mask = -1;
-    pb_copy->tsofl = is_tso ? -1 : 0;
+    pb_copy->tsofl = tso_flag ? -1 : 0;
 
     envblk->envblock_parmblock = pb_copy;
 
@@ -557,7 +558,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
 #endif
         uint32_t slot_token = 0;
         /* Ignore IRX_ANCHOR_RC_FULL — non-fatal, env remains usable. */
-        (void)irx_anchor_alloc_slot(envblk, tcb, is_tso, &slot_token);
+        (void)irx_anchor_alloc_slot(envblk, tcb, tso_flag, &slot_token);
     }
 
     /* ----------------------------------------------------------------
@@ -575,7 +576,7 @@ int irx_init_initenvb(struct envblock *prev_envblock,
      * (using pb_copy->tsofl which is platform-portable).
      * ---------------------------------------------------------------- */
 #ifdef __MVS__
-    if (is_tso)
+    if (tso_flag)
     {
         void *ect = anch_walk();
         if (ect != NULL)

--- a/test/mvs/tstanch.c
+++ b/test/mvs/tstanch.c
@@ -27,6 +27,7 @@
 
 #include "irx.h"
 #include "irxanchr.h"
+#include "irxenv.h"
 #include "irxfunc.h"
 
 #ifdef __MVS__
@@ -76,7 +77,7 @@ static void dump_state(const char *label, struct envblock *env)
 {
     printf("  [%s]\n", label);
     printf("    ECTENVBK slot  = %p\n", (void *)anch_curr());
-    printf("    is_tso         = %d\n", anch_tso());
+    printf("    is_tso         = %d\n", is_tso());
     printf("    walk_to_ect    = %p\n", anch_walk());
     if (env != NULL)
     {
@@ -112,7 +113,7 @@ int main(void)
 
     if (anch_walk() != NULL)
     {
-        if (anch_tso())
+        if (is_tso())
         {
             /* TSO: IRXINIT unconditionally overwrites ECTENVBK (CON-14). */
             if (anch_curr() != env)
@@ -165,7 +166,7 @@ int main(void)
      * Non-TSO / batch: neither IRXINIT nor IRXTERM touched the slot;
      * it remains at initial_anchor. */
     {
-        struct envblock *expected = anch_tso() ? NULL : initial_anchor;
+        struct envblock *expected = is_tso() ? NULL : initial_anchor;
         if (anch_curr() != expected)
         {
             printf("FAIL: ECTENVBK not at expected value after IRXTERM\n");

--- a/test/mvs/tstanrm.c
+++ b/test/mvs/tstanrm.c
@@ -69,6 +69,7 @@
 
 #include "irx.h"
 #include "irxanchr.h"
+#include "irxenv.h"
 #include "irxfunc.h"
 
 #ifndef __MVS__
@@ -111,7 +112,7 @@ static int tests_skipped = 0;
  * (the slot is the simulation global, always present) and on MVS
  * under TSO (the PSA→ASCB→ASXB→LWA→ECT walk completes); false only
  * on pure MVS batch where LWA is NULL. Gating on slot reachability
- * — not on anch_tso() — keeps the host cross-compile counts
+ * — not on is_tso() — keeps the host cross-compile counts
  * unchanged while still skipping the four/seven assertions that
  * cannot hold under batch. */
 #define CHECK_IF_REACHABLE(stmt, msg)                      \
@@ -345,9 +346,9 @@ static void case_d_non_tso_noop(void)
 int main(void)
 {
     printf("=== ECTENVBK TSOFL-conditional anchor tests (TSK-195) ===\n");
-    printf("    mode: %s\n", anch_tso() ? "TSO (ECT reachable)"
-                                        : "batch (no ECT — slot-state "
-                                          "assertions will skip)");
+    printf("    mode: %s\n", is_tso() ? "TSO (ECT reachable)"
+                                      : "batch (no ECT — slot-state "
+                                        "assertions will skip)");
 
     /* Silence unused-function warning on host where _test_get_anchor
      * is not exercised by any case today. The helper is kept for

--- a/test/mvs/tstinit.c
+++ b/test/mvs/tstinit.c
@@ -220,7 +220,7 @@ static void test_t4_anchor_slot_alloc(void)
         if (slot != NULL)
         {
             /* On the cross-compile host is_tso() returns 0 and no
-             * caller_parmblock was supplied, so is_tso=0. The default
+             * caller_parmblock was supplied, so tso_flag=0. The default
              * init path produces a non-TSO slot with flags=0. T9/T10
              * cover the TSOFL-driven flag values explicitly. */
 #ifdef __MVS__

--- a/test/mvs/tstinit.c
+++ b/test/mvs/tstinit.c
@@ -219,12 +219,12 @@ static void test_t4_anchor_slot_alloc(void)
         CHECK(slot != NULL, "irx_anchor_find_by_envblock returns non-NULL slot");
         if (slot != NULL)
         {
-            /* On the cross-compile host anch_tso() returns 0 and no
+            /* On the cross-compile host is_tso() returns 0 and no
              * caller_parmblock was supplied, so is_tso=0. The default
              * init path produces a non-TSO slot with flags=0. T9/T10
              * cover the TSOFL-driven flag values explicitly. */
 #ifdef __MVS__
-            /* TSO foreground or batch — anch_tso() may report either.
+            /* TSO foreground or batch — is_tso() may report either.
              * Verify the flag matches one of the two valid values. */
             CHECK(slot->flags == 0U ||
                       slot->flags == IRXANCHR_FLAG_TSO_ATTACHED,

--- a/test/mvs/tstphas1.c
+++ b/test/mvs/tstphas1.c
@@ -19,6 +19,7 @@
 
 #include "irx.h"
 #include "irxanchr.h"
+#include "irxenv.h"
 #include "irxfunc.h"
 #include "irxwkblk.h"
 
@@ -78,7 +79,7 @@ static int tests_skipped = 0;
 /* Build a minimal valid PARMBLOCK with TSOFL=1, mirroring the helper
  * in tstinit.c. The anchor write in IRXINIT only runs when the
  * effective TSOFL bit is 1, so smoke tests that want to observe a
- * slot write must opt in explicitly — anch_tso() returns 0 on the
+ * slot write must opt in explicitly — is_tso() returns 0 on the
  * cross-compile host and pure-batch MVS, which would otherwise
  * resolve TSOFL to 0. */
 static void build_tso_parmblock(struct parmblock *pb)
@@ -287,9 +288,9 @@ static void test_uid_msgid(void)
 int main(void)
 {
     printf("=== REXX/370 Phase 1 Smoke Test ===\n");
-    printf("    mode: %s\n", anch_tso() ? "TSO (ECT reachable)"
-                                        : "batch (no ECT — anchor "
-                                          "checks will skip)");
+    printf("    mode: %s\n", is_tso() ? "TSO (ECT reachable)"
+                                      : "batch (no ECT — anchor "
+                                        "checks will skip)");
 
     test_single_env();
     test_multiple_envs();


### PR DESCRIPTION
Closes #95

## Summary

- `src/irx#anch.c`: removes `anch_tso()` entirely (both MVS CLIBPPA-based implementation and host stub)
- `include/irxanchr.h`: removes the `int anch_tso(void) asm("ANCHISTS");` declaration and its doc-comment block
- `src/irx#init.c`: migrates both call sites to `is_tso()`, adds `#include "irxenv.h"`, renames local `is_tso` → `tso_flag` to avoid collision with the newly visible `is_tso()` symbol, updates step-1d and step-3 doc-comments
- `test/mvs/tstanch.c`, `tstanrm.c`, `tstphas1.c`, `tstinit.c`: migrate all `anch_tso()` call sites and comment references; add `#include "irxenv.h"` where missing

## Background

`anch_tso()` had two paths: a CLIBPPA-based primary (only works for crent370 C callers with @@CRT0 startup) and an `anch_walk()`-based fallback (measures ECT *existence*, not TSO status). `is_tso()` (PR #94, `asm/istso.asm`) reads the TSO step indication directly from the TCB via EXTRACT and is reliable for all caller paths and timing windows.

As a side effect, step 1d in `irx_init_initenvb` no longer depends on caller-PARMBLOCK timing — `is_tso()` reads TCB state directly.

## Test results

- Host: 16/16 binaries, 1192+ tests green, no new warnings
- MVS: IRXINIT, TINITVL, TTERMVL build and run clean
- Sanity greps: `anch_tso`, `ANCHISTS` absent from src/, include/, asm/, test/

Part of the WP-I1c.6 TSO-detection refactor chain:
1. `is_tso()` HLASM wrapper — PR #94 ✓
2. **This PR** — migrate and remove `anch_tso()`
3. WP-I1c.6 Phase 2: IRXTMPW eager default-env-init (follow-up)