### PR TITLE
WP-I1c.6 Phase 2: eager INITENVB in IRXTMPW for default TSO env

### DIFF
--- a/asm/irxtmpw.asm
+++ b/asm/irxtmpw.asm
@@ -2,9 +2,12 @@
 *
 *  IRXTMPW - Try loading IRXANCHR so its CDE lives in
 *            the Step-TCB JPQ (survives XCTL, found by command
-*            subtasks via JPA lookup). XCTL to IKJEFT01.
+*            subtasks via JPA lookup). Attempt eager IRXINIT
+*            INITENVB to create a default TSO environment in
+*            IRXANCHR slot 1 before handing control to IKJEFT01.
+*            XCTL to IKJEFT01.
 *
-*  Must be link-edited AC(1),RENT and REUS into an APF-authorized 
+*  Must be link-edited AC(1),RENT and REUS into an APF-authorized
 *  library (e.g. SYS2.LINKLIB).
 *
 *  On entry: R1 = PARM pointer, R13 = caller SA, R14 = return.
@@ -13,11 +16,14 @@
          PRINT NOGEN
 R0       EQU   0
 R1       EQU   1
+R2       EQU   2
+R3       EQU   3
 R5       EQU   5
 R6       EQU   6
 R7       EQU   7
 R8       EQU   8
 R12      EQU   12
+R13      EQU   13
 R14      EQU   14
 R15      EQU   15
          PRINT GEN
@@ -35,10 +41,66 @@ IRXTMPW  CSECT
 * --- try loading IRXANCHR ---
          LOAD  EP=IRXANCHR,ERRET=NOANCH
 *
-* --- restore registers for IKJEFT01 ---
 NOANCH   DS    0H
          LOAD  EP=IRXINIT,ERRET=NOINIT
+*
+* --- eager INITENVB: capture EP, allocate workarea ---
+         LR    R2,R0              save IRXINIT EP (LOAD returns in R0)
+         L     R0,=A(WALEN)
+         GETMAIN RC,LV=(0)
+         LTR   R15,R15
+         BNZ   NOINIT             GETMAIN failed - skip INITENVB
+         LR    R3,R1              save workarea ptr for FREEMAIN
+         ST    R13,4(,R1)        backward chain (caller's R13)
+         ST    R1,8(,R13)        forward chain
+         LR    R13,R1
+         USING WAREA,R13
+*
+* --- clear output cells ---
+         XC    WENVOUT,WENVOUT
+         XC    WREASON,WREASON
+*
+* --- build INITENVB VLIST (SC28-1883-0 §14) ---
+*
+*  P3/P4/P5: VLIST slots hold ADDRESSES of fullwords containing
+*  the actual values. IRXINIT does L Rx,VLIST_slot then
+*  L Ry,0(,Rx) -- a literal zero in the slot would dereference
+*  PSA[0] and yield a non-NULL bogus pointer. Use RESZERO (a
+*  static F'0' in the CSECT) and store its address.
+         LA    R1,FCODE
+         ST    R1,WVLIST+0       P1: function code addr
+         LA    R1,PARMODE
+         ST    R1,WVLIST+4       P2: parm module name addr
+         LA    R1,RESZERO
+         ST    R1,WVLIST+8       P3: caller PARMBLOCK = addr of null word
+         ST    R1,WVLIST+12      P4: user field = addr of null word
+         ST    R1,WVLIST+16      P5: reserved = addr of null word
+         LA    R1,WENVOUT
+         ST    R1,WVLIST+20      P6: out ENVBLOCK addr
+         LA    R1,WREASON
+         O     R1,=X'80000000'   VL marker on last slot
+         ST    R1,WVLIST+24      P7: out reason addr (VL=1)
+*
+* --- call IRXINIT INITENVB ---
+         SR    R0,R0              no previous-env hint
+         LA    R1,WVLIST
+         LR    R15,R2
+         BALR  R14,R15
+*
+* --- WTO on success; proceed regardless ---
+         LTR   R15,R15
+         BNZ   INITDONE
+         WTO   'IRXTMPW: default REXX env initialized'
+*
+INITDONE DS    0H
+* --- restore R13 and release workarea ---
+         L     R13,WSAVE+4       R13 = caller SA (backward chain)
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(R3)
+         DROP  R13
+*
 NOINIT   DS    0H
+* --- restore registers for IKJEFT01 ---
          LR    R0,R5
          LR    R1,R6
          LR    R14,R7
@@ -47,5 +109,19 @@ NOINIT   DS    0H
 * --- give control to IKJEFT01 ---
          XCTL  EP=IKJEFT01
 *
+* --- read-only static data (RENT-safe) ---
+FCODE    DC    CL8'INITENVB'
+PARMODE  DC    CL8' '
+RESZERO  DC    F'0'
+*
          LTORG
+*
+* --- workarea DSECT ---
+WAREA    DSECT
+WSAVE    DS    18F               standard save area (+0..+71)
+WVLIST   DS    7F                INITENVB VLIST (+72..+99)
+WENVOUT  DS    F                 P6: out ENVBLOCK pointer (+100)
+WREASON  DS    F                 P7: out reason code (+104)
+WALEN    EQU   *-WAREA
+*
          END   IRXTMPW


### PR DESCRIPTION
## Summary

- `asm/irxtmpw.asm`: Insert `IRXINIT INITENVB` call between `LOAD EP=IRXINIT` and `XCTL EP=IKJEFT01` to create a default TSO environment in IRXANCHR slot 1 at logon time
- Workarea allocated via `GETMAIN RC` (conditional); all failure paths (GETMAIN, LOAD, INITENVB RC≠0) fall through to `XCTL EP=IKJEFT01` — TSO logon never blocked
- `RESZERO DC F'0'` added as static CSECT constant for P3/P4/P5 VLIST slots (see spec deviation note below)

## Spec deviation: VLIST P3/P4/P5

The task spec suggested `SR R1,R1; ST R1,WVLIST+8` for P3 (caller PARMBLOCK = NULL). `asm/irxinit.asm` BUILDC double-dereferences every VLIST slot (`L Rx,slot; L Ry,0(,Rx)`), so a literal 0 in the slot reads from PSA[0] (FLCIPSW, non-NULL) and passes a bogus pointer as `caller_parmblock`, causing a `parmblock_masks[]` S0C4. Fixed using the `tinitvl.asm` pattern: `LA R1,RESZERO; ST R1,WVLIST+8/12/16` where `RESZERO DC F'0'` is a read-only CSECT constant (RENT-safe).

## Acceptance criteria

- AC-1: Assembles cleanly with IFOX00, no MNOTE >=4, RENT/REUS preserved (no mutable static data)
- AC-2: `LOAD EP=IRXANCHR,ERRET=NOANCH` and `LOAD EP=IRXINIT,ERRET=NOINIT` unchanged
- AC-3: R5/R6/R7/R8 preserved across INITENVB (IRXINIT standard linkage restores R1–R12)
- AC-4: GETMAIN + FREEMAIN paired on success path, no leak
- AC-5: All failure paths still XCTL to IKJEFT01
- AC-6..AC-9: Live MVS logon test — needs user approval before deployment

Closes #97