### PR TITLE
feat: FINDENVB self-healing ECTENVBK cache + cross-subtask TSO discovery (#99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,7 @@ run tstparse    # PARSE instruction (WP-16)          (74/74)
 run tstproc     # PROCEDURE EXPOSE (WP-17)           (53/53)
 run tsthelo     # Hello-world end-to-end (WP-18)     (16/16)
 run tstanrm     # ECTENVBK anchor read-mostly        (24/24)
+run tstfind     # FINDENVB + CHEKENVB (WP-I1c.2)     (44/44)
 run tstarit     # Arithmetic engine (WP-20)          (128/128)
 run tstarext    # Direct IRXARITH API (WP-20 + B)    (113/113)
 run tstbif      # BIF registry (WP-21a)              (29/29)
@@ -392,7 +393,7 @@ Note: `TSTANCH` (the ENVBLOCK anchor smoketest) is linked on MVS as
 a standalone load module but is invoked from TSO/Batch — it does not
 have a runnable Linux cross-compile entry of its own.
 
-Full matrix: 14 binaries, **1156 tests green** as of WP-21b Phase H close-out.
+Full matrix: 15 binaries, **1200 tests green** as of WP-I1c.2 close-out.
 
 ## Work packages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,7 +360,7 @@ LSTRING_SRC="../lstring370/src/lstr#cor.c  ../lstring370/src/lstr#cvt.c \
              ../lstring370/src/lstr#sub.c  ../lstring370/src/lstr#wrd.c \
              ../lstring370/src/lstr#xlt.c"
 PHASE1_SRC="src/irx#init.c src/irx#term.c src/irx#stor.c \
-            src/irx#anch.c src/irx#uid.c  src/irx#msid.c \
+            src/irx#anch.c src/irx#env.c  src/irx#uid.c  src/irx#msid.c \
             src/irx#cond.c src/irx#bif.c  src/irx#bifs.c"
 PHASE2_SRC="src/irx#io.c   src/irx#lstr.c src/irx#tokn.c \
             src/irx#vpol.c src/irx#pars.c src/irx#ctrl.c"

--- a/src/irx#env.c
+++ b/src/irx#env.c
@@ -1,8 +1,15 @@
 #ifndef __MVS__
 #include "irxenv.h"
 
+/* Host-only simulation flag. Set to 1 in test harnesses to exercise
+ * Stage 1a / Stage 1b secondary in irx_init_findenvb(). Mirrors the
+ * _simulated_ectenvbk pattern in irx#anch.c. Default 0 means all
+ * cross-compile tests that do not touch this flag see is_tso() == 0,
+ * which matches the MVS batch / non-TSO behaviour they were written for. */
+int _simulated_is_tso = 0;
+
 int is_tso(void)
 {
-    return 0;
+    return _simulated_is_tso;
 }
 #endif

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -672,7 +672,7 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
 {
     irxanchr_header_t *hdr;
     irxanchr_entry_t *slots;
-    irxanchr_entry_t *best;
+    irxanchr_entry_t *best = NULL;
     uint32_t tcbptr;
     uint32_t i;
 
@@ -709,8 +709,11 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
      * token-max. Runs before the cache so a subtask that has its own
      * IRXINIT'd env hits this path directly and never reads the shared
      * ECTENVBK slot (which a sibling subtask's INITENVB may overwrite).
+     * Note: Stage 1b primary accepts both TSO and non-TSO envs
+     * — it's the caller's own env regardless of attach mode.
+     * Stages 1a and 1b secondary, by contrast, restrict to
+     * TSO-attached envs (default-env-discovery semantics).
      * ---------------------------------------------------------------- */
-    best = NULL;
     for (i = 0; i < hdr->used; i++)
     {
         struct envblock *eb;
@@ -775,6 +778,13 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
             if (cached_slot != NULL &&
                 (cached_slot->flags & IRXANCHR_FLAG_TSO_ATTACHED) != 0)
             {
+                /* Reentrant filter: defensive. In production paths this
+                 * branch is unreachable because INITENVB step 8 only
+                 * writes ECTENVBK when TSOFL=1, and a reentrant TSO env
+                 * is not produced by any current caller. Mirror Stage
+                 * 1b's filter regardless so the cache cannot leak a
+                 * reentrant env even if a future caller pattern reaches
+                 * that combination. */
                 struct parmblock *pb =
                     (struct parmblock *)cached_eb->envblock_parmblock;
                 if (pb == NULL || !pb->rentrant)
@@ -847,6 +857,10 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
             if (ect_slot != NULL)
             {
                 *ect_slot = eb;
+                /* envblock_ectptr backlink: MVS-only because on host
+                 * ectenvbk_slot points into the simulation buffer, not a
+                 * real ECT control block. Subsequent Stage 1a hits work
+                 * via *ect_slot regardless. */
 #ifdef __MVS__
                 eb->envblock_ectptr = (char *)ect_slot - ECT_ENVBK_OFF;
 #endif

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -56,6 +56,9 @@ typedef char envblock_size_is_320_[(sizeof(struct envblock) == 320) ? 1 : -1];
 /* ECT ENVBK slot offset inside the ECT control block (IBM SYS1.AMODGEN). */
 #define ECT_ENVBK_OFF 0x030
 
+/* Forward-declare the ECTENVBK slot accessor from irx#anch.c. */
+struct envblock **ectenvbk_slot(void);
+
 /* Default host command environment names (8 bytes each, EBCDIC-safe). */
 #define DEFAULT_HOSTENV_TSO  "TSO     "
 #define DEFAULT_HOSTENV_MVS  "MVS     "
@@ -620,28 +623,56 @@ cleanup:
 }
 
 /* ================================================================== */
-/*  irx_init_findenvb — FINDENVB C-core (WP-I1c.2)                   */
+/*  Static helpers shared by irx_init_findenvb                        */
+/* ================================================================== */
+
+/* Extract the envblock pointer stored in a slot.
+ * MVS (24-bit): stored uint32_t is the full address.
+ * 64-bit cross-compile host: alloc_slot stashed the untruncated pointer
+ * in rsvd1[0..sizeof(void*)-1] to avoid 32-bit truncation (irx#anch.c). */
+static struct envblock *extract_eb_from_slot(const irxanchr_entry_t *slot)
+{
+#ifdef __MVS__
+    return (struct envblock *)(unsigned long)slot->envblock_ptr;
+#else
+    void *full_ptr = NULL;
+    memcpy(&full_ptr, slot->rsvd1, sizeof(void *));
+    return (struct envblock *)full_ptr;
+#endif
+}
+
+/* Return non-zero when eb carries the correct ENVBLOCK eye-catcher. */
+static int envblock_is_valid(const struct envblock *eb)
+{
+    return eb != NULL && memcmp(eb->envblock_id, ENVBLOCK_ID, 8) == 0;
+}
+
+/* ================================================================== */
+/*  irx_init_findenvb — FINDENVB C-core (WP-I1c.2, WP-I1c.7)        */
 /*                                                                    */
-/*  Returns the most recently allocated (highest token) active,       */
-/*  non-reentrant IRXANCHR slot whose TCB matches PSATOLD.            */
+/*  Three-stage search for the best (highest-token) active,           */
+/*  non-reentrant ENVBLOCK visible to the calling TCB:                */
 /*                                                                    */
-/*  We iterate the table directly (rather than calling                */
-/*  irx_anchor_find_by_tcb) for two reasons:                          */
-/*    1. irx_anchor_find_by_tcb returns the highest-token entry       */
-/*       regardless of the RENTRANT flag; we need to skip reentrant   */
-/*       environments.                                                */
-/*    2. irx_anchor_find_by_tcb early-exits on NULL tcb, but on the  */
-/*       cross-compile host all slots record tcb_ptr=0 (PSATOLD is   */
-/*       unavailable), so the NULL guard would prevent host testing.  */
+/*  Stage 1b primary  — exact TCB match in IRXANCHR (existing logic). */
+/*                      Runs first so a subtask with its own          */
+/*                      IRXINIT'd env hits here without ever touching */
+/*                      the shared ECTENVBK slot.                     */
+/*  Stage 1a cache    — read ECTENVBK, validate eye-catcher and IRXANCHR */
+/*                      registration, accept if TSO-attached and      */
+/*                      non-reentrant.                                */
+/*  Stage 1b secondary — only under is_tso(): linear IRXANCHR scan for */
+/*                      any live TSO-attached non-reentrant slot.     */
+/*                      On match, populates ECTENVBK cache for future */
+/*                      Stage 1a fast-path.                           */
 /*                                                                    */
-/*  Returns: 0=found, 4=no non-reentrant env on this TCB.            */
+/*  Returns: 0=found, 4=not found (reason_code=4).                   */
 /* ================================================================== */
 
 int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
 {
     irxanchr_header_t *hdr;
     irxanchr_entry_t *slots;
-    irxanchr_entry_t *best = NULL;
+    irxanchr_entry_t *best;
     uint32_t tcbptr;
     uint32_t i;
 
@@ -673,6 +704,13 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
 
     slots = (irxanchr_entry_t *)((char *)hdr + sizeof(irxanchr_header_t));
 
+    /* ----------------------------------------------------------------
+     * Stage 1b primary: scan IRXANCHR for exact TCB match, non-reentrant,
+     * token-max. Runs before the cache so a subtask that has its own
+     * IRXINIT'd env hits this path directly and never reads the shared
+     * ECTENVBK slot (which a sibling subtask's INITENVB may overwrite).
+     * ---------------------------------------------------------------- */
+    best = NULL;
     for (i = 0; i < hdr->used; i++)
     {
         struct envblock *eb;
@@ -683,27 +721,13 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
         {
             continue;
         }
-        /* Slot occupancy is determined solely by envblock_ptr; the
-         * flags field marks TSO-attachment, not in-use status (CON-14
-         * IRXPROBE Phase α). FINDENVB walks both TSO and non-TSO envs. */
         if (slots[i].tcb_ptr != tcbptr)
         {
             continue;
         }
 
-        /* On MVS (24-bit), the stored uint32_t holds the full address.
-         * On the 64-bit cross-compile host, alloc_slot stashed the full
-         * pointer in rsvd1 to avoid truncation (see irx#anch.c). */
-#ifdef __MVS__
-        eb = (struct envblock *)(unsigned long)slots[i].envblock_ptr;
-#else
-        {
-            void *full_ptr = NULL;
-            memcpy(&full_ptr, slots[i].rsvd1, sizeof(void *));
-            eb = (struct envblock *)full_ptr;
-        }
-#endif
-        if (eb == NULL || memcmp(eb->envblock_id, ENVBLOCK_ID, 8) != 0)
+        eb = extract_eb_from_slot(&slots[i]);
+        if (!envblock_is_valid(eb))
         {
             continue;
         }
@@ -721,24 +745,120 @@ int irx_init_findenvb(struct envblock **out_envblock, int *out_reason_code)
         }
     }
 
-    if (best == NULL)
+    if (best != NULL)
     {
-        *out_reason_code = 4;
-        return 4;
+        *out_envblock = extract_eb_from_slot(best);
+        return 0;
     }
 
-    /* Return the envblock address using the same full-pointer recovery
-     * as used in the loop above to avoid 32-bit truncation on host. */
-#ifdef __MVS__
-    *out_envblock = (struct envblock *)(unsigned long)best->envblock_ptr;
-#else
+    /* ----------------------------------------------------------------
+     * Stage 1a cache: read ECTENVBK, validate eye-catcher, confirm the
+     * env is still live in IRXANCHR (guards against a freed env whose
+     * cache pointer was never cleared). Accept only non-reentrant,
+     * TSO-attached envs — the TSO-flag check guards against a cache
+     * entry placed by a non-default-env INITENVB caller.
+     * ectenvbk_slot() returns NULL in batch (LWA absent), so this stage
+     * is a natural no-op outside TSO without an explicit is_tso() guard.
+     * ---------------------------------------------------------------- */
     {
-        void *full_ptr = NULL;
-        memcpy(&full_ptr, best->rsvd1, sizeof(void *));
-        *out_envblock = (struct envblock *)full_ptr;
+        struct envblock **ect_slot = ectenvbk_slot();
+        if (ect_slot != NULL && *ect_slot != NULL)
+        {
+            struct envblock *cached_eb = *ect_slot;
+            irxanchr_entry_t *cached_slot = NULL;
+
+            if (envblock_is_valid(cached_eb))
+            {
+                cached_slot = irx_anchor_find_by_envblock(cached_eb);
+            }
+
+            if (cached_slot != NULL &&
+                (cached_slot->flags & IRXANCHR_FLAG_TSO_ATTACHED) != 0)
+            {
+                struct parmblock *pb =
+                    (struct parmblock *)cached_eb->envblock_parmblock;
+                if (pb == NULL || !pb->rentrant)
+                {
+                    *out_envblock = cached_eb;
+                    return 0;
+                }
+            }
+        }
     }
+
+    /* ----------------------------------------------------------------
+     * Stage 1b secondary: only under TSO. Accept any live, non-reentrant,
+     * TSO-attached slot (token-max). Used for cross-subtask default-env
+     * discovery when no own-TCB env exists and the cache is stale.
+     *
+     * On match, populate the ECTENVBK cache so the next FINDENVB call
+     * from any subtask hits Stage 1a directly.
+     *
+     * ECTENVBK is an AS-wide shared slot. In multi-subtask scenarios it
+     * may be overwritten by sibling INITENVB calls, which is why Stage 1b
+     * primary runs first — a caller with its own env reaches it via
+     * TCB-match without touching the cache. The cache exists for the
+     * default-env-discovery case where no own-TCB env exists yet.
+     * ---------------------------------------------------------------- */
+    if (is_tso())
+    {
+        irxanchr_entry_t *sec_best = NULL;
+
+        for (i = 0; i < hdr->used; i++)
+        {
+            struct envblock *eb;
+            struct parmblock *pb;
+
+            if (slots[i].envblock_ptr == IRXANCHR_SLOT_FREE ||
+                slots[i].envblock_ptr == IRXANCHR_SLOT_SENTINEL)
+            {
+                continue;
+            }
+            if (!(slots[i].flags & IRXANCHR_FLAG_TSO_ATTACHED))
+            {
+                continue;
+            }
+
+            eb = extract_eb_from_slot(&slots[i]);
+            if (!envblock_is_valid(eb))
+            {
+                continue;
+            }
+
+            pb = (struct parmblock *)eb->envblock_parmblock;
+            if (pb != NULL && pb->rentrant)
+            {
+                continue;
+            }
+
+            if (sec_best == NULL || slots[i].token > sec_best->token)
+            {
+                sec_best = &slots[i];
+            }
+        }
+
+        if (sec_best != NULL)
+        {
+            struct envblock *eb = extract_eb_from_slot(sec_best);
+            struct envblock **ect_slot = ectenvbk_slot();
+
+            /* Populate ECTENVBK cache and backlink so subsequent FINDENVB
+             * calls hit Stage 1a and IRXTERM rolls back to the correct ECT. */
+            if (ect_slot != NULL)
+            {
+                *ect_slot = eb;
+#ifdef __MVS__
+                eb->envblock_ectptr = (char *)ect_slot - ECT_ENVBK_OFF;
 #endif
-    return 0;
+            }
+
+            *out_envblock = eb;
+            return 0;
+        }
+    }
+
+    *out_reason_code = 4;
+    return 4;
 }
 
 /* ================================================================== */
@@ -940,7 +1060,6 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
         struct parmblock *pb = (struct parmblock *)envblk->envblock_parmblock;
         if (pb != NULL && pb->tsofl != 0)
         {
-            extern struct envblock **ectenvbk_slot(void);
             struct envblock **slot = ectenvbk_slot();
             if (slot != NULL)
             {

--- a/test/mvs/tstfind.c
+++ b/test/mvs/tstfind.c
@@ -52,6 +52,8 @@
 /* Simulated ECTENVBK slot for host cross-compile tests. */
 #ifndef __MVS__
 void *_simulated_ectenvbk = NULL;
+/* Host-only TSO simulation flag from irx#env.c. */
+extern int _simulated_is_tso;
 #endif
 
 /* Forward-declare the slot accessor from irx#anch.c. */
@@ -434,6 +436,347 @@ static void test_c5_dispatch_chekenvb(void)
 }
 
 /* ================================================================== */
+/*  F6–F10: Stage 1a cache + Stage 1b secondary (host only)          */
+/*                                                                    */
+/*  These tests control _simulated_is_tso and use direct             */
+/*  irx_anchor_alloc_slot calls with a fake (non-zero) TCB to make   */
+/*  Stage 1b primary miss, then exercise Stage 1a and Stage 1b       */
+/*  secondary. On MVS the same paths are exercised by real            */
+/*  multi-task scenarios (AC-12/AC-13 via irxdbg find).              */
+/* ================================================================== */
+
+#ifndef __MVS__
+
+/* Register a minimal valid ENVBLOCK in IRXANCHR with a fake non-zero TCB
+ * so Stage 1b primary will not match on host (current_tcb=0 ≠ fake_tcb).
+ * Caller provides a zeroed + eye-catchered fake_eb. Returns token on
+ * success, 0 on failure. */
+static uint32_t register_fake_env(struct envblock *eb, int is_tso_flag)
+{
+    void *fake_tcb = (void *)0x00DEAD00; /* non-zero; won't match host tcbptr=0 */
+    uint32_t token = 0;
+    int rc = irx_anchor_alloc_slot(eb, fake_tcb, is_tso_flag, &token);
+    return (rc == 0) ? token : 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  F6: Stage 1a cache hit                                            */
+/*                                                                    */
+/*  ECTENVBK is seeded with a valid TSO-flagged env whose tcb_ptr     */
+/*  does not match the host current_tcb (=0). Stage 1b primary misses */
+/*  (tcb mismatch). Stage 1a reads the cache, validates, returns.     */
+/* ------------------------------------------------------------------ */
+
+static void test_f6_stage1a_cache_hit(void)
+{
+    struct envblock fake_eb;
+    uint32_t token;
+    struct envblock *found = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- F6: findenvb Stage 1a cache hit ---\n");
+
+    irx_anchor_table_reset();
+    _simulated_is_tso = 0;
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    memset(&fake_eb, 0, sizeof(fake_eb));
+    memcpy(fake_eb.envblock_id, ENVBLOCK_ID, 8);
+    token = register_fake_env(&fake_eb, 1 /* TSO-flagged */);
+    if (token == 0)
+    {
+        printf("  SKIP: register_fake_env failed\n");
+        return;
+    }
+
+    /* Seed ECTENVBK cache directly. */
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = &fake_eb;
+        }
+    }
+
+    rc = irx_init_findenvb(&found, &reason);
+
+    CHECK(rc == 0, "F6: findenvb returns 0 via Stage 1a cache hit");
+    CHECK(found == &fake_eb, "F6: findenvb returns the cached envblock");
+    CHECK(reason == 0, "F6: reason code is 0");
+
+    irx_anchor_free_slot(&fake_eb);
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  F7: Stage 1a stale cache → Stage 1b secondary fallback            */
+/*                                                                    */
+/*  ECTENVBK points to an env with a valid eye-catcher that is NOT    */
+/*  registered in IRXANCHR (simulates a freed env). Stage 1a finds    */
+/*  the slot NULL from irx_anchor_find_by_envblock and falls through  */
+/*  to Stage 1b secondary, which finds the live TSO env and           */
+/*  repopulates the cache.                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_f7_stage1a_stale_cache(void)
+{
+    struct envblock fake_eb;
+    struct envblock stale_eb; /* valid eye-catcher, NOT in IRXANCHR */
+    uint32_t token;
+    struct envblock *found = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- F7: findenvb Stage 1a stale → Stage 1b secondary ---\n");
+
+    irx_anchor_table_reset();
+    _simulated_is_tso = 1;
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    memset(&fake_eb, 0, sizeof(fake_eb));
+    memcpy(fake_eb.envblock_id, ENVBLOCK_ID, 8);
+    token = register_fake_env(&fake_eb, 1);
+    if (token == 0)
+    {
+        printf("  SKIP: register_fake_env failed\n");
+        _simulated_is_tso = 0;
+        return;
+    }
+
+    /* Stale cache entry: correct eye-catcher but not in IRXANCHR. */
+    memset(&stale_eb, 0, sizeof(stale_eb));
+    memcpy(stale_eb.envblock_id, ENVBLOCK_ID, 8);
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = &stale_eb;
+        }
+    }
+
+    rc = irx_init_findenvb(&found, &reason);
+
+    CHECK(rc == 0, "F7: findenvb returns 0 after stale cache → Stage 1b secondary");
+    CHECK(found == &fake_eb, "F7: findenvb returns the valid TSO env");
+
+    /* Stage 1b secondary must have repopulated the cache. */
+    {
+        struct envblock **slot = ectenvbk_slot();
+        CHECK(slot != NULL && *slot == &fake_eb,
+              "F7: ECTENVBK repopulated after Stage 1b secondary");
+    }
+
+    irx_anchor_free_slot(&fake_eb);
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+    _simulated_is_tso = 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  F8: Stage 1b secondary — no cache, no TCB match                   */
+/*                                                                    */
+/*  ECTENVBK is NULL. Stage 1b primary misses (tcb mismatch). Stage   */
+/*  1a sees an empty cache. Stage 1b secondary finds the TSO-flagged  */
+/*  env and populates ECTENVBK.                                       */
+/* ------------------------------------------------------------------ */
+
+static void test_f8_stage1b_secondary_no_cache(void)
+{
+    struct envblock fake_eb;
+    uint32_t token;
+    struct envblock *found = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- F8: findenvb Stage 1b secondary — no cache ---\n");
+
+    irx_anchor_table_reset();
+    _simulated_is_tso = 1;
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    memset(&fake_eb, 0, sizeof(fake_eb));
+    memcpy(fake_eb.envblock_id, ENVBLOCK_ID, 8);
+    token = register_fake_env(&fake_eb, 1);
+    if (token == 0)
+    {
+        printf("  SKIP: register_fake_env failed\n");
+        _simulated_is_tso = 0;
+        return;
+    }
+
+    rc = irx_init_findenvb(&found, &reason);
+
+    CHECK(rc == 0, "F8: Stage 1b secondary returns 0");
+    CHECK(found == &fake_eb, "F8: Stage 1b secondary returns TSO env");
+
+    /* Verify cache was populated. */
+    {
+        struct envblock **slot = ectenvbk_slot();
+        CHECK(slot != NULL && *slot == &fake_eb,
+              "F8: ECTENVBK populated by Stage 1b secondary");
+    }
+
+    irx_anchor_free_slot(&fake_eb);
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+    _simulated_is_tso = 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  F9: Stage 1b secondary skips non-TSO env → RC=4                   */
+/*                                                                    */
+/*  Only a non-TSO-flagged env is in IRXANCHR. is_tso()=1 so Stage   */
+/*  1b secondary runs, but skips the slot (no IRXANCHR_FLAG_TSO_     */
+/*  ATTACHED). Result: RC=4.                                          */
+/* ------------------------------------------------------------------ */
+
+static void test_f9_stage1b_no_tso_env(void)
+{
+    struct envblock fake_eb;
+    uint32_t token;
+    struct envblock *found = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- F9: findenvb Stage 1b secondary — only non-TSO env ---\n");
+
+    irx_anchor_table_reset();
+    _simulated_is_tso = 1;
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    memset(&fake_eb, 0, sizeof(fake_eb));
+    memcpy(fake_eb.envblock_id, ENVBLOCK_ID, 8);
+    token = register_fake_env(&fake_eb, 0 /* is_tso=0 — no TSO flag */);
+    if (token == 0)
+    {
+        printf("  SKIP: register_fake_env failed\n");
+        _simulated_is_tso = 0;
+        return;
+    }
+
+    rc = irx_init_findenvb(&found, &reason);
+
+    CHECK(rc == 4, "F9: findenvb returns 4 when only non-TSO env present");
+    CHECK(found == NULL, "F9: out_envblock is NULL");
+    CHECK(reason == 4, "F9: reason code is 4");
+
+    irx_anchor_free_slot(&fake_eb);
+    _simulated_is_tso = 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  F10: Stage 1a hit after Stage 1b secondary populated cache        */
+/*                                                                    */
+/*  First FINDENVB takes Stage 1b secondary and populates ECTENVBK.  */
+/*  Second FINDENVB hits Stage 1a directly via the populated cache.   */
+/* ------------------------------------------------------------------ */
+
+static void test_f10_stage1a_after_1b_populate(void)
+{
+    struct envblock fake_eb;
+    uint32_t token;
+    struct envblock *found = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- F10: findenvb Stage 1a hit after Stage 1b secondary populate ---\n");
+
+    irx_anchor_table_reset();
+    _simulated_is_tso = 1;
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    memset(&fake_eb, 0, sizeof(fake_eb));
+    memcpy(fake_eb.envblock_id, ENVBLOCK_ID, 8);
+    token = register_fake_env(&fake_eb, 1);
+    if (token == 0)
+    {
+        printf("  SKIP: register_fake_env failed\n");
+        _simulated_is_tso = 0;
+        return;
+    }
+
+    /* First call: Stage 1b primary misses, Stage 1a misses (no cache),
+     * Stage 1b secondary finds fake_eb and populates ECTENVBK. */
+    rc = irx_init_findenvb(&found, &reason);
+    if (rc != 0 || found != &fake_eb)
+    {
+        printf("  SKIP: first findenvb did not take Stage 1b secondary path\n");
+        irx_anchor_free_slot(&fake_eb);
+        _simulated_is_tso = 0;
+        return;
+    }
+
+    /* Second call: same TCB mismatch, Stage 1a now hits via the cache
+     * populated by the first call's Stage 1b secondary. */
+    found = NULL;
+    reason = -1;
+    rc = irx_init_findenvb(&found, &reason);
+
+    CHECK(rc == 0, "F10: second findenvb returns 0 via Stage 1a cache");
+    CHECK(found == &fake_eb, "F10: second findenvb returns same envblock");
+    CHECK(reason == 0, "F10: reason code is 0");
+
+    irx_anchor_free_slot(&fake_eb);
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+    _simulated_is_tso = 0;
+}
+
+#endif /* !__MVS__ */
+
+/* ================================================================== */
 /*  main                                                               */
 /* ================================================================== */
 
@@ -452,6 +795,14 @@ int main(void)
     test_c3_bad_eyecatcher();
     test_c4_not_in_anchor();
     test_c5_dispatch_chekenvb();
+
+#ifndef __MVS__
+    test_f6_stage1a_cache_hit();
+    test_f7_stage1a_stale_cache();
+    test_f8_stage1b_secondary_no_cache();
+    test_f9_stage1b_no_tso_env();
+    test_f10_stage1a_after_1b_populate();
+#endif
 
     printf("\n--- Results ---\n");
     printf("  Run:    %d\n", tests_run);

--- a/test/mvs/tstfind.c
+++ b/test/mvs/tstfind.c
@@ -774,6 +774,125 @@ static void test_f10_stage1a_after_1b_populate(void)
     _simulated_is_tso = 0;
 }
 
+/* ------------------------------------------------------------------ */
+/*  F11: Stage 1b secondary token-max selection                       */
+/*                                                                    */
+/*  Two TSO-flagged envs, both non-reentrant, different tcb_ptr       */
+/*  (neither matches host current_tcb=0). Stage 1b secondary must    */
+/*  return the one with the higher token.                             */
+/* ------------------------------------------------------------------ */
+
+static void test_f11_stage1b_secondary_token_max(void)
+{
+    struct envblock env_a;
+    struct envblock env_b;
+    uint32_t token_a;
+    uint32_t token_b;
+    struct envblock *found = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- F11: Stage 1b secondary — token-max selection ---\n");
+
+    irx_anchor_table_reset();
+    _simulated_is_tso = 1;
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    memset(&env_a, 0, sizeof(env_a));
+    memcpy(env_a.envblock_id, ENVBLOCK_ID, 8);
+    token_a = register_fake_env(&env_a, 1);
+
+    memset(&env_b, 0, sizeof(env_b));
+    memcpy(env_b.envblock_id, ENVBLOCK_ID, 8);
+    token_b = register_fake_env(&env_b, 1);
+
+    if (token_a == 0 || token_b == 0)
+    {
+        printf("  SKIP: register_fake_env failed\n");
+        irx_anchor_free_slot(&env_a);
+        irx_anchor_free_slot(&env_b);
+        _simulated_is_tso = 0;
+        return;
+    }
+
+    /* env_b was allocated second and has a higher token. */
+    rc = irx_init_findenvb(&found, &reason);
+
+    CHECK(rc == 0, "F11: Stage 1b secondary returns 0 with two TSO envs");
+    CHECK(found == &env_b, "F11: Stage 1b secondary returns highest-token env");
+
+    irx_anchor_free_slot(&env_a);
+    irx_anchor_free_slot(&env_b);
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+    _simulated_is_tso = 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  F12: Stage 1b secondary skips reentrant TSO env                   */
+/*                                                                    */
+/*  A TSO-flagged env with rentrant=1 must be skipped by Stage 1b    */
+/*  secondary, just as Stage 1b primary skips reentrant envs.        */
+/* ------------------------------------------------------------------ */
+
+static void test_f12_stage1b_secondary_skips_reentrant(void)
+{
+    struct envblock rent_eb;
+    struct parmblock rent_pb;
+    uint32_t token;
+    struct envblock *found = NULL;
+    int reason = -1;
+    int rc;
+
+    printf("\n--- F12: Stage 1b secondary — skips reentrant TSO env ---\n");
+
+    irx_anchor_table_reset();
+    _simulated_is_tso = 1;
+    {
+        struct envblock **slot = ectenvbk_slot();
+        if (slot != NULL)
+        {
+            *slot = NULL;
+        }
+    }
+
+    memset(&rent_pb, 0, sizeof(rent_pb));
+    memcpy(rent_pb.parmblock_id, PARMBLOCK_ID, 8);
+    rent_pb.rentrant = -1;
+
+    memset(&rent_eb, 0, sizeof(rent_eb));
+    memcpy(rent_eb.envblock_id, ENVBLOCK_ID, 8);
+    rent_eb.envblock_parmblock = &rent_pb;
+
+    token = register_fake_env(&rent_eb, 1 /* TSO-flagged */);
+    if (token == 0)
+    {
+        printf("  SKIP: register_fake_env failed\n");
+        _simulated_is_tso = 0;
+        return;
+    }
+
+    rc = irx_init_findenvb(&found, &reason);
+
+    CHECK(rc == 4, "F12: Stage 1b secondary skips reentrant TSO env → RC=4");
+    CHECK(found == NULL, "F12: out_envblock is NULL");
+    CHECK(reason == 4, "F12: reason code is 4");
+
+    irx_anchor_free_slot(&rent_eb);
+    _simulated_is_tso = 0;
+}
+
 #endif /* !__MVS__ */
 
 /* ================================================================== */
@@ -802,6 +921,8 @@ int main(void)
     test_f8_stage1b_secondary_no_cache();
     test_f9_stage1b_no_tso_env();
     test_f10_stage1a_after_1b_populate();
+    test_f11_stage1b_secondary_token_max();
+    test_f12_stage1b_secondary_skips_reentrant();
 #endif
 
     printf("\n--- Results ---\n");


### PR DESCRIPTION
## Summary

- **3-stage FINDENVB** (`irx_init_findenvb` in `src/irx#init.c`):
  - **Stage 1b primary** — exact TCB match, non-reentrant, token-max. Runs first so a subtask with its own env returns immediately without touching the shared ECTENVBK slot.
  - **Stage 1a cache** — read ECTENVBK, validate eye-catcher, accept if TSO-attached and non-reentrant. Fast path for the common case where the default env is already anchored.
  - **Stage 1b secondary** — linear IRXANCHR scan for any live TSO-flagged non-reentrant slot, token-max. Only runs under `is_tso()`. On match, writes ECTENVBK and `envblock_ectptr` (shared cache back-link) so subsequent calls hit Stage 1a.
- **`_simulated_is_tso`** host-only flag in `src/irx#env.c` — allows cross-compile tests to exercise Stage 1a and Stage 1b secondary without a live TSO ECT.
- **`tstfind.c`** — new test binary, 44 checks covering all state-machine paths (F1-F12): empty table, non-reentrant/reentrant, token-max, FINDENVB dispatch, CHEKENVB, Stage 1a cache hit, stale-cache fallback, Stage 1b secondary with/without cache populate, non-TSO rejection, lazy-populate effectiveness, token-max selection, reentrant-skip.

## Ordering rationale

ECTENVBK is an AS-wide shared slot. In multi-subtask scenarios a sibling
subtask's INITENVB unconditionally overwrites it. Stage 1b primary runs first
so a subtask that already has its own env (TCB match in IRXANCHR) never reads
a potentially stale ECTENVBK value.

## Live MVS verification

Live MVS verification of the Stage-1b-secondary path is deferred — it will
be exercised implicitly when WP-CPS-09 (REXXCPS end-to-end) runs. Cross-compile
coverage of all state-machine paths (F1-F12) is the acceptance evidence for
this PR.

## Test plan

- [x] `gcc` cross-compile: 44/44 green (`tstfind`)
- [x] All 15 cross-compile binaries: 1200/1200 green
- [ ] MVS build: `mbt build --target IRX#INIT IRX#ENV TSTFIND` — to be verified post-merge in CI

Closes #99