### PR TITLE
feat(bifs): TIME and DATE built-in functions (WP-CPS-01)

### DIFF
--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -115,12 +115,12 @@ struct irx_wkblk_int
     void *wkbi_condinfo; /* -> condition information block */
 
     /* --- Time BIF stamps (WP-CPS-01) --------------------------------- */
-    /* Zero-initialized by irxstor(RXSMGET); zero == uninitialised.
-     * Stored as unsigned int hi/lo pairs for c2asm370 compatibility.  */
-    unsigned int wkbi_init_stamp_hi;  /* usec epoch at first TIME() call, hi */
-    unsigned int wkbi_init_stamp_lo;  /* usec epoch at first TIME() call, lo */
-    unsigned int wkbi_reset_stamp_hi; /* TIME('R') reference stamp, hi */
-    unsigned int wkbi_reset_stamp_lo; /* TIME('R') reference stamp, lo */
+    /* Zero-initialized by irxstor(RXSMGET); zero sec == uninitialised.
+     * Stored as (sec, usec) pairs to avoid 64-bit division on MVS.    */
+    unsigned int wkbi_init_stamp_sec;   /* epoch sec at first TIME() call */
+    unsigned int wkbi_init_stamp_usec;  /* usec part at first TIME() call */
+    unsigned int wkbi_reset_stamp_sec;  /* TIME('R') reference stamp, sec */
+    unsigned int wkbi_reset_stamp_usec; /* TIME('R') reference stamp, usec */
 
     /* --- Error Recovery --- */
     int wkbi_error_number;   /* Last REXX error number         */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -114,10 +114,13 @@ struct irx_wkblk_int
     int wkbi_condflags;  /* Active SIGNAL ON conditions    */
     void *wkbi_condinfo; /* -> condition information block */
 
-    /* --- Elapsed Time --- */
-    int wkbi_elapsed_hi;    /* Elapsed time clock (high word) */
-    int wkbi_elapsed_lo;    /* Elapsed time clock (low word)  */
-    int wkbi_elapsed_reset; /* Elapsed time reset flag        */
+    /* --- Time BIF stamps (WP-CPS-01) --------------------------------- */
+    /* Zero-initialized by irxstor(RXSMGET); zero == uninitialised.
+     * Stored as unsigned int hi/lo pairs for c2asm370 compatibility.  */
+    unsigned int wkbi_init_stamp_hi;  /* usec epoch at first TIME() call, hi */
+    unsigned int wkbi_init_stamp_lo;  /* usec epoch at first TIME() call, lo */
+    unsigned int wkbi_reset_stamp_hi; /* TIME('R') reference stamp, hi */
+    unsigned int wkbi_reset_stamp_lo; /* TIME('R') reference stamp, lo */
 
     /* --- Error Recovery --- */
     int wkbi_error_number;   /* Last REXX error number         */

--- a/project.toml
+++ b/project.toml
@@ -866,6 +866,35 @@ include = [
 [link.module.dep_includes]
 "mvslovers/lstring370" = "*"
 
+[[link.module]]
+name = "TSTTIM"
+entry = "@@CRT0"
+options = ["LIST", "MAP", "XREF", "RENT"]
+include = [
+  "@@CRT1",
+  "TSTTIM",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
+  "IRX#ARIT",
+]
+
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
+
 # ---------------------------------------------------------------
 # TINITVL - Live MVS test caller for IRXINIT INITENVB.
 # Pure HLASM caller (no C runtime, no @@CRT0). Drives IRXINIT

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -3042,6 +3042,361 @@ static int bif_errortext(struct irx_parser *p, int argc, PLstr *argv,
 }
 
 /* ================================================================== */
+/*  Time / Date BIFs (WP-CPS-01)                                      */
+/* ================================================================== */
+
+#ifdef __MVS__
+#include <time64.h>
+#else
+#include <stdint.h>
+#include <sys/time.h>
+#include <time.h>
+#endif
+
+#define USEC_PER_SEC  1000000ULL
+#define SECS_PER_HOUR 3600UL
+#define MINS_PER_HOUR 60UL
+#define SECS_PER_DAY  86400UL
+/* Jan 1, 0001 is day 1 (REXX base). Unix epoch 1970-01-01 is day
+ * 719163: 1969 complete years * 365 = 718685 + 492 leap years
+ * - 19 centuries + 4 quad-centuries + 1 (day-1 base) = 719163. */
+#define REXX_DAY1_TO_EPOCH 719163UL
+#define TM_YEAR_BASE       1900
+#define YEAR_MOD_CENTURY   100
+#define MONTHS_PER_YEAR    12
+#define HOURS_PER_HALF_DAY 12
+#define WEEKDAYS_PER_WEEK  7
+#define TIME_BUF_LEN       32
+
+static const char *s_month_abbr[MONTHS_PER_YEAR] = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+
+static const char *s_month_long[MONTHS_PER_YEAR] = {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"};
+
+static const char *s_weekday[WEEKDAYS_PER_WEEK] = {
+    "Sunday", "Monday", "Tuesday", "Wednesday",
+    "Thursday", "Friday", "Saturday"};
+
+/* Return current time as microseconds since Unix epoch; also fill
+ * tm_out (UTC) if non-NULL. Single call captures both so that the
+ * HH:MM:SS and fractional parts in TIME('L') are consistent. */
+static uint64_t irx_time_now(struct tm *tm_out)
+{
+#ifdef __MVS__
+    uint64_t us = (uint64_t)uclock64();
+    if (tm_out != NULL)
+    {
+        time64_t t;
+        t.u64 = us / USEC_PER_SEC;
+        struct tm *p = gmtime64(&t);
+        if (p != NULL)
+        {
+            *tm_out = *p;
+        }
+    }
+    return us;
+#else
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    if (tm_out != NULL)
+    {
+        time_t t = tv.tv_sec;
+        struct tm *p = gmtime(&t);
+        if (p != NULL)
+        {
+            *tm_out = *p;
+        }
+    }
+    return (uint64_t)tv.tv_sec * USEC_PER_SEC + (uint64_t)tv.tv_usec;
+#endif
+}
+
+static uint64_t stamp_load(unsigned int hi, unsigned int lo)
+{
+    return ((uint64_t)hi << 32) | (uint64_t)lo;
+}
+
+static void stamp_store(uint64_t us, unsigned int *hi, unsigned int *lo)
+{
+    *hi = (unsigned int)(us >> 32);
+    *lo = (unsigned int)(us & 0xFFFFFFFFU);
+}
+
+/* Parse the first character of the optional subform argument at argv[idx].
+ * Empty/absent/NULL -> default_sub. Validates against the `allowed` set.
+ * On invalid input raises SYNTAX 40.23 and returns '\0'. */
+static char parse_subform(struct irx_parser *p, int argc, PLstr *argv,
+                          int idx, const char *bif_name,
+                          const char *allowed, char default_sub)
+{
+    if (idx >= argc || argv[idx] == NULL || argv[idx]->len == 0)
+    {
+        return default_sub;
+    }
+    char c = (char)toupper((unsigned char)argv[idx]->pstr[0]);
+    const char *a = allowed;
+    while (*a)
+    {
+        if (*a == c)
+        {
+            return c;
+        }
+        a++;
+    }
+    char desc[64];
+    sprintf(desc, "%s: invalid subform '%c'", bif_name, c);
+    irx_cond_raise(p->envblock, SYNTAX_BAD_CALL, ERR40_OPTION_INVALID, desc);
+    return '\0';
+}
+
+/* TIME([subform]) — SC28-1883-0 §4.43 */
+static int bif_time(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
+{
+    char sub = parse_subform(p, argc, argv, 0, "TIME",
+                             "NERSMHLC", 'N');
+    if (sub == '\0')
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    struct irx_wkblk_int *wk = wkbi_from_parser(p);
+
+    /* Lazy-init the environment-level init_stamp on the first TIME call. */
+    uint64_t init_us = 0;
+    if (wk != NULL)
+    {
+        init_us = stamp_load(wk->wkbi_init_stamp_hi, wk->wkbi_init_stamp_lo);
+        if (init_us == 0)
+        {
+            init_us = irx_time_now(NULL);
+            stamp_store(init_us, &wk->wkbi_init_stamp_hi,
+                        &wk->wkbi_init_stamp_lo);
+            /* Seed reset_stamp to init_stamp so TIME('R') first call is 0. */
+            stamp_store(init_us, &wk->wkbi_reset_stamp_hi,
+                        &wk->wkbi_reset_stamp_lo);
+        }
+    }
+
+    struct tm tm_now;
+    memset(&tm_now, 0, sizeof(tm_now));
+    uint64_t now_us = irx_time_now(&tm_now);
+
+    char buf[TIME_BUF_LEN];
+    int n = 0;
+
+    switch (sub)
+    {
+        case 'N': /* HH:MM:SS */
+            n = sprintf(buf, "%02d:%02d:%02d",
+                        tm_now.tm_hour, tm_now.tm_min, tm_now.tm_sec);
+            break;
+
+        case 'E': /* elapsed since init_stamp (seconds.microseconds) */
+        {
+            uint64_t delta = (wk != NULL && init_us != 0)
+                                 ? (now_us - init_us)
+                                 : 0ULL;
+            unsigned long secs = (unsigned long)(delta / USEC_PER_SEC);
+            unsigned long usec = (unsigned long)(delta % USEC_PER_SEC);
+            n = sprintf(buf, "%lu.%06lu", secs, usec);
+            break;
+        }
+
+        case 'R': /* elapsed since reset_stamp; update reset_stamp */
+        {
+            uint64_t reset_us = (wk != NULL)
+                                    ? stamp_load(wk->wkbi_reset_stamp_hi,
+                                                 wk->wkbi_reset_stamp_lo)
+                                    : 0ULL;
+            uint64_t delta = (reset_us != 0) ? (now_us - reset_us) : 0ULL;
+            unsigned long secs = (unsigned long)(delta / USEC_PER_SEC);
+            unsigned long usec = (unsigned long)(delta % USEC_PER_SEC);
+            n = sprintf(buf, "%lu.%06lu", secs, usec);
+            if (wk != NULL)
+            {
+                stamp_store(now_us, &wk->wkbi_reset_stamp_hi,
+                            &wk->wkbi_reset_stamp_lo);
+            }
+            break;
+        }
+
+        case 'S': /* total seconds since midnight */
+            n = sprintf(buf, "%d",
+                        (int)(tm_now.tm_hour * (int)SECS_PER_HOUR +
+                              tm_now.tm_min * (int)MINS_PER_HOUR +
+                              tm_now.tm_sec));
+            break;
+
+        case 'M': /* total minutes since midnight */
+            n = sprintf(buf, "%d",
+                        (int)(tm_now.tm_hour * (int)MINS_PER_HOUR +
+                              tm_now.tm_min));
+            break;
+
+        case 'H': /* total hours since midnight */
+            n = sprintf(buf, "%d", tm_now.tm_hour);
+            break;
+
+        case 'L': /* HH:MM:SS.uuuuuu */
+        {
+            unsigned long usec = (unsigned long)(now_us % USEC_PER_SEC);
+            n = sprintf(buf, "%02d:%02d:%02d.%06lu",
+                        tm_now.tm_hour, tm_now.tm_min, tm_now.tm_sec, usec);
+            break;
+        }
+
+        case 'C': /* hh:mmXM (12-hour civil) */
+        {
+            int h12 = tm_now.tm_hour % HOURS_PER_HALF_DAY;
+            if (h12 == 0)
+            {
+                h12 = HOURS_PER_HALF_DAY;
+            }
+            const char *ampm = (tm_now.tm_hour < HOURS_PER_HALF_DAY)
+                                   ? "am"
+                                   : "pm";
+            n = sprintf(buf, "%d:%02d%s", h12, tm_now.tm_min, ampm);
+            break;
+        }
+
+        default:
+            return IRXPARS_SYNTAX;
+    }
+
+    if (n <= 0)
+    {
+        return IRXPARS_SYNTAX;
+    }
+    int lrc = Lfx(p->alloc, result, (size_t)n);
+    if (lrc != LSTR_OK)
+    {
+        return translate_lstr_rc(lrc);
+    }
+    memcpy(result->pstr, buf, (size_t)n);
+    result->len = (size_t)n;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+/* DATE([subform]) — SC28-1883-0 §4.7 */
+static int bif_date(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
+{
+    char sub = parse_subform(p, argc, argv, 0, "DATE",
+                             "NSEUDBDMWJ", 'N');
+    if (sub == '\0')
+    {
+        return IRXPARS_SYNTAX;
+    }
+
+    struct tm tm_now;
+    memset(&tm_now, 0, sizeof(tm_now));
+    uint64_t now_us = irx_time_now(&tm_now);
+    (void)now_us;
+
+    char buf[TIME_BUF_LEN];
+    int n = 0;
+
+    switch (sub)
+    {
+        case 'N': /* dd Mon yyyy */
+        {
+            int mon = tm_now.tm_mon;
+            if (mon < 0 || mon >= MONTHS_PER_YEAR)
+            {
+                mon = 0;
+            }
+            n = sprintf(buf, "%d %s %d",
+                        tm_now.tm_mday,
+                        s_month_abbr[mon],
+                        tm_now.tm_year + TM_YEAR_BASE);
+            break;
+        }
+
+        case 'S': /* yyyymmdd */
+            n = sprintf(buf, "%04d%02d%02d",
+                        tm_now.tm_year + TM_YEAR_BASE,
+                        tm_now.tm_mon + 1,
+                        tm_now.tm_mday);
+            break;
+
+        case 'E': /* dd/mm/yy */
+            n = sprintf(buf, "%02d/%02d/%02d",
+                        tm_now.tm_mday,
+                        tm_now.tm_mon + 1,
+                        tm_now.tm_year % YEAR_MOD_CENTURY);
+            break;
+
+        case 'U': /* mm/dd/yy */
+            n = sprintf(buf, "%02d/%02d/%02d",
+                        tm_now.tm_mon + 1,
+                        tm_now.tm_mday,
+                        tm_now.tm_year % YEAR_MOD_CENTURY);
+            break;
+
+        case 'B': /* days since Jan 1, 0001 (base date) */
+        {
+            unsigned long epoch_days =
+                (unsigned long)(now_us / USEC_PER_SEC / SECS_PER_DAY);
+            unsigned long base_days = epoch_days + REXX_DAY1_TO_EPOCH;
+            n = sprintf(buf, "%lu", base_days);
+            break;
+        }
+
+        case 'D': /* day-of-year (Julian ordinal, 1-based) */
+            n = sprintf(buf, "%d", tm_now.tm_yday + 1);
+            break;
+
+        case 'M': /* full month name */
+        {
+            int mon = tm_now.tm_mon;
+            if (mon < 0 || mon >= MONTHS_PER_YEAR)
+            {
+                mon = 0;
+            }
+            n = sprintf(buf, "%s", s_month_long[mon]);
+            break;
+        }
+
+        case 'W': /* full weekday name */
+        {
+            int wday = tm_now.tm_wday;
+            if (wday < 0 || wday >= WEEKDAYS_PER_WEEK)
+            {
+                wday = 0;
+            }
+            n = sprintf(buf, "%s", s_weekday[wday]);
+            break;
+        }
+
+        case 'J': /* yyddd (Julian date) */
+            n = sprintf(buf, "%02d%03d",
+                        tm_now.tm_year % YEAR_MOD_CENTURY,
+                        tm_now.tm_yday + 1);
+            break;
+
+        default:
+            return IRXPARS_SYNTAX;
+    }
+
+    if (n <= 0)
+    {
+        return IRXPARS_SYNTAX;
+    }
+    int lrc = Lfx(p->alloc, result, (size_t)n);
+    if (lrc != LSTR_OK)
+    {
+        return translate_lstr_rc(lrc);
+    }
+    memcpy(result->pstr, buf, (size_t)n);
+    result->len = (size_t)n;
+    result->type = LSTRING_TY;
+    return IRXPARS_OK;
+}
+
+/* ================================================================== */
 /*  Registration                                                      */
 /* ================================================================== */
 
@@ -3115,6 +3470,9 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"LINESIZE", 0, 0, bif_linesize},
     {"VALUE", 1, 3, bif_value},
     {"SOURCELINE", 0, 1, bif_sourceline},
+    /* Time / Date (WP-CPS-01) */
+    {"TIME", 0, 1, bif_time},
+    {"DATE", 0, 1, bif_date},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -3053,7 +3053,7 @@ static int bif_errortext(struct irx_parser *p, int argc, PLstr *argv,
 #include <time.h>
 #endif
 
-#define USEC_PER_SEC  1000000ULL
+#define USEC_PER_SEC  1000000UL
 #define SECS_PER_HOUR 3600UL
 #define MINS_PER_HOUR 60UL
 #define SECS_PER_DAY  86400UL
@@ -3080,27 +3080,33 @@ static const char *s_weekday[WEEKDAYS_PER_WEEK] = {
     "Sunday", "Monday", "Tuesday", "Wednesday",
     "Thursday", "Friday", "Saturday"};
 
-/* Return current time as microseconds since Unix epoch; also fill
- * tm_out (UTC) if non-NULL. Single call captures both so that the
- * HH:MM:SS and fractional parts in TIME('L') are consistent. */
-static uint64_t irx_time_now(struct tm *tm_out)
+/* Fill sec_out (seconds since Unix epoch) and usec_out (microseconds
+ * within the current second). Also fill tm_out (UTC) if non-NULL.
+ * Uses multiply+subtract instead of divide — no @@UDIVDI on MVS. */
+static void irx_time_now(struct tm *tm_out, unsigned int *sec_out,
+                         unsigned int *usec_out)
 {
 #ifdef __MVS__
-    uint64_t us = (uint64_t)uclock64();
+    clock64_t sec64 = clock64();
+    uint64_t us64 = (uint64_t)uclock64();
+    *sec_out = (unsigned int)sec64;
+    /* subtract multiply-result to get usec fraction (no 64-bit divide) */
+    *usec_out = (unsigned int)(us64 - (uint64_t)sec64 * (uint64_t)USEC_PER_SEC);
     if (tm_out != NULL)
     {
         time64_t t;
-        t.u64 = us / USEC_PER_SEC;
+        t.u64 = sec64;
         struct tm *p = gmtime64(&t);
         if (p != NULL)
         {
             *tm_out = *p;
         }
     }
-    return us;
 #else
     struct timeval tv;
     gettimeofday(&tv, NULL);
+    *sec_out = (unsigned int)tv.tv_sec;
+    *usec_out = (unsigned int)tv.tv_usec;
     if (tm_out != NULL)
     {
         time_t t = tv.tv_sec;
@@ -3110,19 +3116,7 @@ static uint64_t irx_time_now(struct tm *tm_out)
             *tm_out = *p;
         }
     }
-    return (uint64_t)tv.tv_sec * USEC_PER_SEC + (uint64_t)tv.tv_usec;
 #endif
-}
-
-static uint64_t stamp_load(unsigned int hi, unsigned int lo)
-{
-    return ((uint64_t)hi << 32) | (uint64_t)lo;
-}
-
-static void stamp_store(uint64_t us, unsigned int *hi, unsigned int *lo)
-{
-    *hi = (unsigned int)(us >> 32);
-    *lo = (unsigned int)(us & 0xFFFFFFFFU);
 }
 
 /* Parse the first character of the optional subform argument at argv[idx].
@@ -3165,24 +3159,29 @@ static int bif_time(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
     struct irx_wkblk_int *wk = wkbi_from_parser(p);
 
     /* Lazy-init the environment-level init_stamp on the first TIME call. */
-    uint64_t init_us = 0;
+    unsigned int init_sec = 0, init_usec = 0;
     if (wk != NULL)
     {
-        init_us = stamp_load(wk->wkbi_init_stamp_hi, wk->wkbi_init_stamp_lo);
-        if (init_us == 0)
+        init_sec = wk->wkbi_init_stamp_sec;
+        if (init_sec == 0)
         {
-            init_us = irx_time_now(NULL);
-            stamp_store(init_us, &wk->wkbi_init_stamp_hi,
-                        &wk->wkbi_init_stamp_lo);
-            /* Seed reset_stamp to init_stamp so TIME('R') first call is 0. */
-            stamp_store(init_us, &wk->wkbi_reset_stamp_hi,
-                        &wk->wkbi_reset_stamp_lo);
+            irx_time_now(NULL, &init_sec, &init_usec);
+            wk->wkbi_init_stamp_sec = init_sec;
+            wk->wkbi_init_stamp_usec = init_usec;
+            /* Seed reset_stamp so TIME('R') first call returns 0. */
+            wk->wkbi_reset_stamp_sec = init_sec;
+            wk->wkbi_reset_stamp_usec = init_usec;
+        }
+        else
+        {
+            init_usec = wk->wkbi_init_stamp_usec;
         }
     }
 
     struct tm tm_now;
     memset(&tm_now, 0, sizeof(tm_now));
-    uint64_t now_us = irx_time_now(&tm_now);
+    unsigned int now_sec = 0, now_usec = 0;
+    irx_time_now(&tm_now, &now_sec, &now_usec);
 
     char buf[TIME_BUF_LEN];
     int n = 0;
@@ -3196,29 +3195,49 @@ static int bif_time(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
 
         case 'E': /* elapsed since init_stamp (seconds.microseconds) */
         {
-            uint64_t delta = (wk != NULL && init_us != 0)
-                                 ? (now_us - init_us)
-                                 : 0ULL;
-            unsigned long secs = (unsigned long)(delta / USEC_PER_SEC);
-            unsigned long usec = (unsigned long)(delta % USEC_PER_SEC);
+            unsigned long secs = 0;
+            unsigned long usec = 0;
+            if (wk != NULL && init_sec != 0)
+            {
+                secs = (unsigned long)(now_sec - init_sec);
+                int ud = (int)now_usec - (int)init_usec;
+                if (ud < 0)
+                {
+                    secs--;
+                    ud += (int)USEC_PER_SEC;
+                }
+                usec = (unsigned long)ud;
+            }
             n = sprintf(buf, "%lu.%06lu", secs, usec);
             break;
         }
 
         case 'R': /* elapsed since reset_stamp; update reset_stamp */
         {
-            uint64_t reset_us = (wk != NULL)
-                                    ? stamp_load(wk->wkbi_reset_stamp_hi,
-                                                 wk->wkbi_reset_stamp_lo)
-                                    : 0ULL;
-            uint64_t delta = (reset_us != 0) ? (now_us - reset_us) : 0ULL;
-            unsigned long secs = (unsigned long)(delta / USEC_PER_SEC);
-            unsigned long usec = (unsigned long)(delta % USEC_PER_SEC);
+            unsigned int reset_sec = 0, reset_usec = 0;
+            if (wk != NULL)
+            {
+                reset_sec = wk->wkbi_reset_stamp_sec;
+                reset_usec = wk->wkbi_reset_stamp_usec;
+            }
+            unsigned long secs = 0;
+            unsigned long usec = 0;
+            if (reset_sec != 0)
+            {
+                secs = (unsigned long)(now_sec - reset_sec);
+                int ud = (int)now_usec - (int)reset_usec;
+                if (ud < 0)
+                {
+                    secs--;
+                    ud += (int)USEC_PER_SEC;
+                }
+                usec = (unsigned long)ud;
+            }
             n = sprintf(buf, "%lu.%06lu", secs, usec);
             if (wk != NULL)
             {
-                stamp_store(now_us, &wk->wkbi_reset_stamp_hi,
-                            &wk->wkbi_reset_stamp_lo);
+                wk->wkbi_reset_stamp_sec = now_sec;
+                wk->wkbi_reset_stamp_usec = now_usec;
             }
             break;
         }
@@ -3241,12 +3260,10 @@ static int bif_time(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
             break;
 
         case 'L': /* HH:MM:SS.uuuuuu */
-        {
-            unsigned long usec = (unsigned long)(now_us % USEC_PER_SEC);
-            n = sprintf(buf, "%02d:%02d:%02d.%06lu",
-                        tm_now.tm_hour, tm_now.tm_min, tm_now.tm_sec, usec);
+            n = sprintf(buf, "%02d:%02d:%02d.%06u",
+                        tm_now.tm_hour, tm_now.tm_min, tm_now.tm_sec,
+                        now_usec);
             break;
-        }
 
         case 'C': /* hh:mmXM (12-hour civil) */
         {
@@ -3293,8 +3310,9 @@ static int bif_date(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
 
     struct tm tm_now;
     memset(&tm_now, 0, sizeof(tm_now));
-    uint64_t now_us = irx_time_now(&tm_now);
-    (void)now_us;
+    unsigned int now_sec = 0, now_usec = 0;
+    irx_time_now(&tm_now, &now_sec, &now_usec);
+    (void)now_usec;
 
     char buf[TIME_BUF_LEN];
     int n = 0;
@@ -3339,7 +3357,7 @@ static int bif_date(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
         case 'B': /* days since Jan 1, 0001 (base date) */
         {
             unsigned long epoch_days =
-                (unsigned long)(now_us / USEC_PER_SEC / SECS_PER_DAY);
+                (unsigned long)(now_sec / (unsigned long)SECS_PER_DAY);
             unsigned long base_days = epoch_days + REXX_DAY1_TO_EPOCH;
             n = sprintf(buf, "%lu", base_days);
             break;

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -3302,7 +3302,7 @@ static int bif_time(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
 static int bif_date(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
 {
     char sub = parse_subform(p, argc, argv, 0, "DATE",
-                             "NSEUDBDMWJ", 'N');
+                             "NSEUBDMWJ", 'N');
     if (sub == '\0')
     {
         return IRXPARS_SYNTAX;

--- a/test/mvs/tsttim.c
+++ b/test/mvs/tsttim.c
@@ -1,0 +1,738 @@
+/* ------------------------------------------------------------------ */
+/*  tsttim.c - WP-CPS-01 TIME/DATE BIF unit tests                    */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -o /tmp/tsttim \                   */
+/*        test/mvs/tsttim.c \                                         */
+/*        'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \       */
+/*        'src/irx#anch.c' 'src/irx#env.c'  'src/irx#uid.c' \        */
+/*        'src/irx#msid.c' 'src/irx#cond.c' 'src/irx#bif.c' \        */
+/*        'src/irx#bifs.c' 'src/irx#io.c'   'src/irx#lstr.c' \       */
+/*        'src/irx#tokn.c' 'src/irx#vpol.c' 'src/irx#pars.c' \       */
+/*        'src/irx#ctrl.c' 'src/irx#exec.c' 'src/irx#arith.c' \      */
+/*        /path/to/liblstring.a                                        */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define VAR_BUF_LEN    32
+#define STRTOL_DECIMAL 10
+
+#include "irx.h"
+#include "irxbif.h"
+#include "irxcond.h"
+#include "irxfunc.h"
+#include "irxpars.h"
+#include "irxtokn.h"
+#include "irxvpool.h"
+#include "irxwkblk.h"
+#include "lstralloc.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Fixture                                                            */
+/* ------------------------------------------------------------------ */
+
+struct fixture
+{
+    struct envblock *env;
+    struct lstr_alloc *alloc;
+    struct irx_vpool *pool;
+};
+
+static int fixture_open(struct fixture *f)
+{
+    memset(f, 0, sizeof(*f));
+    if (irxinit(NULL, &f->env) != 0)
+    {
+        return -1;
+    }
+    f->alloc = lstr_default_alloc();
+    f->pool = vpool_create(f->alloc, NULL);
+    return (f->pool != NULL) ? 0 : -1;
+}
+
+static void fixture_close(struct fixture *f)
+{
+    if (f->pool != NULL)
+    {
+        vpool_destroy(f->pool);
+    }
+    if (f->env != NULL)
+    {
+        irxterm(f->env);
+    }
+    memset(f, 0, sizeof(*f));
+}
+
+static int run_src(struct fixture *f, const char *src)
+{
+    struct irx_token *tokens = NULL;
+    int count = 0;
+    struct irx_tokn_error tok_err;
+    struct irx_parser parser;
+    int rc;
+
+    rc = irx_tokn_run(NULL, src, (int)strlen(src), &tokens, &count,
+                      &tok_err);
+    if (rc != 0)
+    {
+        return -1;
+    }
+    rc = irx_pars_init(&parser, tokens, count, f->pool, f->alloc, f->env);
+    if (rc != IRXPARS_OK)
+    {
+        irx_tokn_free(NULL, tokens, count);
+        return rc;
+    }
+    rc = irx_pars_run(&parser);
+    irx_pars_cleanup(&parser);
+    irx_tokn_free(NULL, tokens, count);
+    return rc;
+}
+
+/* Return the stored length of variable `name`, or -1 if not found. */
+static int var_len(struct fixture *f, const char *name)
+{
+    Lstr key;
+    Lstr val;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    int rc = vpool_get(f->pool, &key, &val);
+    int len = (rc == VPOOL_OK) ? (int)val.len : -1;
+
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return len;
+}
+
+/* Return the character at 0-based `pos`, or '\0' on miss. */
+static int var_char_at(struct fixture *f, const char *name, int pos)
+{
+    Lstr key;
+    Lstr val;
+    int c = '\0';
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    int rc = vpool_get(f->pool, &key, &val);
+    if (rc == VPOOL_OK && pos >= 0 && pos < (int)val.len)
+    {
+        c = (int)(unsigned char)val.pstr[pos];
+    }
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return c;
+}
+
+/* Return 1 if variable starts with `prefix`, 0 otherwise. */
+static int var_starts_with(struct fixture *f, const char *name,
+                           const char *prefix)
+{
+    Lstr key;
+    Lstr val;
+    int ok = 0;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    int rc = vpool_get(f->pool, &key, &val);
+    if (rc == VPOOL_OK)
+    {
+        size_t plen = strlen(prefix);
+        ok = (val.len >= plen) &&
+             (memcmp(val.pstr, prefix, plen) == 0);
+        if (!ok)
+        {
+            printf("    %s = '%.*s' (expected prefix '%s')\n",
+                   name, (int)val.len, (const char *)val.pstr, prefix);
+        }
+    }
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return ok;
+}
+
+/* Return 1 if every character of variable `name` satisfies isdigit. */
+static int var_all_digits(struct fixture *f, const char *name)
+{
+    Lstr key;
+    Lstr val;
+    int ok = 0;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    int rc = vpool_get(f->pool, &key, &val);
+    if (rc == VPOOL_OK && val.len > 0)
+    {
+        ok = 1;
+        for (size_t i = 0; i < val.len; i++)
+        {
+            if (!isdigit((unsigned char)val.pstr[i]))
+            {
+                ok = 0;
+                break;
+            }
+        }
+        if (!ok)
+        {
+            printf("    %s = '%.*s' (expected all-digits)\n",
+                   name, (int)val.len, (const char *)val.pstr);
+        }
+    }
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return ok;
+}
+
+/* Return 1 if every character of variable `name` satisfies isalpha. */
+static int var_all_alpha(struct fixture *f, const char *name)
+{
+    Lstr key;
+    Lstr val;
+    int ok = 0;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    int rc = vpool_get(f->pool, &key, &val);
+    if (rc == VPOOL_OK && val.len > 0)
+    {
+        ok = 1;
+        for (size_t i = 0; i < val.len; i++)
+        {
+            if (!isalpha((unsigned char)val.pstr[i]))
+            {
+                ok = 0;
+                break;
+            }
+        }
+        if (!ok)
+        {
+            printf("    %s = '%.*s' (expected all-alpha)\n",
+                   name, (int)val.len, (const char *)val.pstr);
+        }
+    }
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return ok;
+}
+
+/* Return 1 if variable ends with `suffix`. */
+static int var_ends_with(struct fixture *f, const char *name,
+                         const char *suffix)
+{
+    Lstr key;
+    Lstr val;
+    int ok = 0;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    int rc = vpool_get(f->pool, &key, &val);
+    if (rc == VPOOL_OK)
+    {
+        size_t slen = strlen(suffix);
+        ok = (val.len >= slen) &&
+             (memcmp(val.pstr + val.len - slen, suffix, slen) == 0);
+        if (!ok)
+        {
+            printf("    %s = '%.*s' (expected suffix '%s')\n",
+                   name, (int)val.len, (const char *)val.pstr, suffix);
+        }
+    }
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return ok;
+}
+
+/* Parse variable as long integer; return 1 if in [lo, hi]. */
+static int var_in_range(struct fixture *f, const char *name, long lo, long hi)
+{
+    Lstr key;
+    Lstr val;
+    int ok = 0;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    Lscpy(f->alloc, &key, name);
+
+    int rc = vpool_get(f->pool, &key, &val);
+    if (rc == VPOOL_OK && val.len > 0)
+    {
+        char buf[VAR_BUF_LEN];
+        size_t copy = (val.len < sizeof(buf) - 1) ? val.len : sizeof(buf) - 1;
+        memcpy(buf, val.pstr, copy);
+        buf[copy] = '\0';
+        char *end = NULL;
+        errno = 0;
+        long v = strtol(buf, &end, STRTOL_DECIMAL);
+        ok = (v >= lo && v <= hi);
+        if (!ok)
+        {
+            printf("    %s = %ld (expected [%ld, %ld])\n",
+                   name, v, lo, hi);
+        }
+    }
+    Lfree(f->alloc, &key);
+    Lfree(f->alloc, &val);
+    return ok;
+}
+
+/* Check that running `src` raises a SYNTAX condition with want_code /
+ * want_subcode. want_subcode == 0 means "don't check subcode". */
+static int run_expect_fail(const char *src, int want_code,
+                           int want_subcode, const char *msg)
+{
+    struct fixture fx;
+    if (fixture_open(&fx) != 0)
+    {
+        return 0;
+    }
+    int rc = run_src(&fx, src);
+
+    int code = 0;
+    int subcode = 0;
+    struct irx_wkblk_int *wk =
+        (struct irx_wkblk_int *)fx.env->envblock_userfield;
+    if (wk != NULL && wk->wkbi_last_condition != NULL &&
+        wk->wkbi_last_condition->valid)
+    {
+        code = wk->wkbi_last_condition->code;
+        subcode = wk->wkbi_last_condition->subcode;
+    }
+
+    int ok = (rc != IRXPARS_OK) && (code == want_code) &&
+             (want_subcode == 0 || subcode == want_subcode);
+    if (!ok)
+    {
+        printf("    rc=%d code=%d subcode=%d (want rc!=0 code=%d sub=%d)\n",
+               rc, code, subcode, want_code, want_subcode);
+    }
+    CHECK(ok, msg);
+    fixture_close(&fx);
+    return ok;
+}
+
+/* Open fixture, run "x = EXPR", then execute CHECKS block accessing fx. */
+#define WITH_RESULT(expr, checks)                              \
+    do                                                         \
+    {                                                          \
+        struct fixture fx;                                     \
+        if (fixture_open(&fx) != 0)                            \
+        {                                                      \
+            CHECK(0, "fixture_open: " expr);                   \
+            break;                                             \
+        }                                                      \
+        int _rc = run_src(&fx, "x = " expr "\n");              \
+        if (_rc != IRXPARS_OK)                                 \
+        {                                                      \
+            printf("    parser rc=%d for: %s\n", _rc, (expr)); \
+            CHECK(0, "parse ok: " expr);                       \
+        }                                                      \
+        else                                                   \
+        {                                                      \
+            checks;                                            \
+        }                                                      \
+        fixture_close(&fx);                                    \
+    } while (0)
+
+/* ================================================================== */
+/*  TIME tests                                                         */
+/* ================================================================== */
+
+static void test_time_normal(void)
+{
+    printf("\n--- TIME: N (normal HH:MM:SS) ---\n");
+
+    WITH_RESULT("TIME()", {
+        CHECK(var_len(&fx, "X") == 8, "TIME() length 8");
+        CHECK(var_char_at(&fx, "X", 2) == ':', "TIME() colon at 2");
+        CHECK(var_char_at(&fx, "X", 5) == ':', "TIME() colon at 5");
+        CHECK(isdigit(var_char_at(&fx, "X", 0)), "TIME() digit 0");
+        CHECK(isdigit(var_char_at(&fx, "X", 1)), "TIME() digit 1");
+        CHECK(isdigit(var_char_at(&fx, "X", 3)), "TIME() digit 3");
+        CHECK(isdigit(var_char_at(&fx, "X", 4)), "TIME() digit 4");
+        CHECK(isdigit(var_char_at(&fx, "X", 6)), "TIME() digit 6");
+        CHECK(isdigit(var_char_at(&fx, "X", 7)), "TIME() digit 7");
+    });
+
+    WITH_RESULT("TIME('N')", {
+        CHECK(var_len(&fx, "X") == 8, "TIME('N') length 8");
+        CHECK(var_char_at(&fx, "X", 2) == ':', "TIME('N') colon at 2");
+        CHECK(var_char_at(&fx, "X", 5) == ':', "TIME('N') colon at 5");
+    });
+
+    /* Case insensitivity: first char only, lower case */
+    WITH_RESULT("TIME('n')", {
+        CHECK(var_len(&fx, "X") == 8, "TIME('n') length 8");
+        CHECK(var_char_at(&fx, "X", 2) == ':', "TIME('n') colon at 2");
+    });
+}
+
+static void test_time_elapsed(void)
+{
+    printf("\n--- TIME: E (elapsed) ---\n");
+
+    /* First call in a fresh env — elapsed should be < 1 second. */
+    WITH_RESULT("TIME('E')", {
+        int len = var_len(&fx, "X");
+        CHECK(len > 1, "TIME('E') non-empty");
+        CHECK(var_starts_with(&fx, "X", "0."), "TIME('E') first call < 1s");
+    });
+
+    /* Case insensitivity */
+    WITH_RESULT("TIME('e')", {
+        CHECK(var_starts_with(&fx, "X", "0."), "TIME('e') case insensitive");
+    });
+}
+
+static void test_time_reset(void)
+{
+    printf("\n--- TIME: R (reset elapsed) ---\n");
+
+    /* First call in fresh env — reset_stamp == init_stamp so delta ~ 0. */
+    WITH_RESULT("TIME('R')", {
+        CHECK(var_starts_with(&fx, "X", "0."), "TIME('R') first call < 1s");
+    });
+
+    /* Two calls in same env: second call measures delta since first reset. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "x = TIME('R')\n");
+            CHECK(rc == IRXPARS_OK, "TIME('R') first call ok");
+            rc = run_src(&fx, "y = TIME('R')\n");
+            CHECK(rc == IRXPARS_OK, "TIME('R') second call ok");
+            /* y must have the decimal-point format. */
+            CHECK(var_char_at(&fx, "Y", 1) == '.' ||
+                      var_char_at(&fx, "Y", 2) == '.',
+                  "TIME('R') second call has decimal point");
+            fixture_close(&fx);
+        }
+    }
+}
+
+static void test_time_seconds(void)
+{
+    printf("\n--- TIME: S (seconds since midnight) ---\n");
+
+    WITH_RESULT("TIME('S')", {
+        CHECK(var_all_digits(&fx, "X"), "TIME('S') all digits");
+        /* 0 <= S < 86400 */
+        CHECK(var_in_range(&fx, "X", 0L, 86399L), "TIME('S') in range");
+    });
+}
+
+static void test_time_minutes(void)
+{
+    printf("\n--- TIME: M (minutes since midnight) ---\n");
+
+    WITH_RESULT("TIME('M')", {
+        CHECK(var_all_digits(&fx, "X"), "TIME('M') all digits");
+        /* 0 <= M < 1440 */
+        CHECK(var_in_range(&fx, "X", 0L, 1439L), "TIME('M') in range");
+    });
+}
+
+static void test_time_hours(void)
+{
+    printf("\n--- TIME: H (hours since midnight) ---\n");
+
+    WITH_RESULT("TIME('H')", {
+        CHECK(var_all_digits(&fx, "X"), "TIME('H') all digits");
+        CHECK(var_in_range(&fx, "X", 0L, 23L), "TIME('H') in range");
+    });
+}
+
+static void test_time_long(void)
+{
+    printf("\n--- TIME: L (long HH:MM:SS.uuuuuu) ---\n");
+
+    WITH_RESULT("TIME('L')", {
+        /* HH:MM:SS.uuuuuu = 15 chars */
+        CHECK(var_len(&fx, "X") == 15, "TIME('L') length 15");
+        CHECK(var_char_at(&fx, "X", 2) == ':', "TIME('L') colon at 2");
+        CHECK(var_char_at(&fx, "X", 5) == ':', "TIME('L') colon at 5");
+        CHECK(var_char_at(&fx, "X", 8) == '.', "TIME('L') dot at 8");
+    });
+}
+
+static void test_time_civil(void)
+{
+    printf("\n--- TIME: C (civil 12-hour) ---\n");
+
+    WITH_RESULT("TIME('C')", {
+        int len = var_len(&fx, "X");
+        CHECK(len >= 6, "TIME('C') min length");
+        /* ends with am or pm */
+        int ends_am = var_ends_with(&fx, "X", "am");
+        int ends_pm = var_ends_with(&fx, "X", "pm");
+        CHECK(ends_am || ends_pm, "TIME('C') ends am or pm");
+    });
+}
+
+static void test_time_errors(void)
+{
+    printf("\n--- TIME: error paths ---\n");
+
+    run_expect_fail("x = TIME('Z')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID, "TIME bad subform 'Z'");
+    /* 'NX' first char is 'N' = valid; only first char matters per spec. */
+    run_expect_fail("x = TIME('ZX')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID, "TIME bad subform 'ZX'");
+}
+
+/* ================================================================== */
+/*  DATE tests                                                         */
+/* ================================================================== */
+
+static void test_date_normal(void)
+{
+    printf("\n--- DATE: N (dd Mon yyyy) ---\n");
+
+    WITH_RESULT("DATE()", {
+        int len = var_len(&fx, "X");
+        /* Shortest: "1 Jan 2000" = 10; longest: "31 Dec 2999" = 11 */
+        CHECK(len >= 10 && len <= 11, "DATE() length 10-11");
+    });
+
+    WITH_RESULT("DATE('N')", {
+        int len = var_len(&fx, "X");
+        CHECK(len >= 10 && len <= 11, "DATE('N') length 10-11");
+        /* Space at index 1 or 2 (1- or 2-digit day) */
+        int sp1 = var_char_at(&fx, "X", 1);
+        int sp2 = var_char_at(&fx, "X", 2);
+        CHECK(sp1 == ' ' || sp2 == ' ', "DATE('N') space after day");
+    });
+
+    /* Case insensitivity */
+    WITH_RESULT("DATE('n')", {
+        int len = var_len(&fx, "X");
+        CHECK(len >= 10 && len <= 11, "DATE('n') case insensitive");
+    });
+}
+
+static void test_date_standard(void)
+{
+    printf("\n--- DATE: S (yyyymmdd) ---\n");
+
+    WITH_RESULT("DATE('S')", {
+        CHECK(var_len(&fx, "X") == 8, "DATE('S') length 8");
+        CHECK(var_all_digits(&fx, "X"), "DATE('S') all digits");
+        /* Year part >= 2000 */
+        CHECK(var_in_range(&fx, "X", 20000101L, 29991231L),
+              "DATE('S') plausible year");
+    });
+}
+
+static void test_date_european(void)
+{
+    printf("\n--- DATE: E (dd/mm/yy) ---\n");
+
+    WITH_RESULT("DATE('E')", {
+        CHECK(var_len(&fx, "X") == 8, "DATE('E') length 8");
+        CHECK(var_char_at(&fx, "X", 2) == '/', "DATE('E') slash at 2");
+        CHECK(var_char_at(&fx, "X", 5) == '/', "DATE('E') slash at 5");
+        CHECK(isdigit(var_char_at(&fx, "X", 0)), "DATE('E') digit 0");
+        CHECK(isdigit(var_char_at(&fx, "X", 1)), "DATE('E') digit 1");
+        CHECK(isdigit(var_char_at(&fx, "X", 3)), "DATE('E') digit 3");
+        CHECK(isdigit(var_char_at(&fx, "X", 4)), "DATE('E') digit 4");
+        CHECK(isdigit(var_char_at(&fx, "X", 6)), "DATE('E') digit 6");
+        CHECK(isdigit(var_char_at(&fx, "X", 7)), "DATE('E') digit 7");
+    });
+}
+
+static void test_date_usa(void)
+{
+    printf("\n--- DATE: U (mm/dd/yy) ---\n");
+
+    WITH_RESULT("DATE('U')", {
+        CHECK(var_len(&fx, "X") == 8, "DATE('U') length 8");
+        CHECK(var_char_at(&fx, "X", 2) == '/', "DATE('U') slash at 2");
+        CHECK(var_char_at(&fx, "X", 5) == '/', "DATE('U') slash at 5");
+    });
+}
+
+static void test_date_base(void)
+{
+    printf("\n--- DATE: B (days since 1 Jan 0001) ---\n");
+
+    WITH_RESULT("DATE('B')", {
+        CHECK(var_all_digits(&fx, "X"), "DATE('B') all digits");
+        /* 2026-04-29 = day 739770 approx; any value > 700000 is plausible */
+        CHECK(var_in_range(&fx, "X", 700000L, 999999L),
+              "DATE('B') plausible base day");
+    });
+}
+
+static void test_date_day(void)
+{
+    printf("\n--- DATE: D (day of year, Julian ordinal) ---\n");
+
+    WITH_RESULT("DATE('D')", {
+        CHECK(var_all_digits(&fx, "X"), "DATE('D') all digits");
+        CHECK(var_in_range(&fx, "X", 1L, 366L), "DATE('D') 1..366");
+    });
+}
+
+static void test_date_month(void)
+{
+    printf("\n--- DATE: M (full month name) ---\n");
+
+    WITH_RESULT("DATE('M')", {
+        int len = var_len(&fx, "X");
+        /* Shortest: "May" = 3; longest: "September" = 9 */
+        CHECK(len >= 3 && len <= 9, "DATE('M') length 3-9");
+        CHECK(var_all_alpha(&fx, "X"), "DATE('M') all alpha");
+    });
+}
+
+static void test_date_weekday(void)
+{
+    printf("\n--- DATE: W (full weekday name) ---\n");
+
+    WITH_RESULT("DATE('W')", {
+        int len = var_len(&fx, "X");
+        /* Shortest: "Monday" = 6; longest: "Wednesday" = 9 */
+        CHECK(len >= 6 && len <= 9, "DATE('W') length 6-9");
+        CHECK(var_all_alpha(&fx, "X"), "DATE('W') all alpha");
+    });
+}
+
+static void test_date_julian(void)
+{
+    printf("\n--- DATE: J (yyddd Julian) ---\n");
+
+    WITH_RESULT("DATE('J')", {
+        CHECK(var_len(&fx, "X") == 5, "DATE('J') length 5");
+        CHECK(var_all_digits(&fx, "X"), "DATE('J') all digits");
+    });
+}
+
+static void test_date_errors(void)
+{
+    printf("\n--- DATE: error paths ---\n");
+
+    run_expect_fail("x = DATE('Z')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID, "DATE bad subform 'Z'");
+    /* 'SX' first char is 'S' = valid; only first char matters per spec. */
+    run_expect_fail("x = DATE('ZX')\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID, "DATE bad subform 'ZX'");
+}
+
+/* ================================================================== */
+/*  Env isolation                                                      */
+/* ================================================================== */
+
+static void test_env_isolation(void)
+{
+    printf("\n--- Env isolation: TIME('R') is per-env ---\n");
+
+    struct fixture fa;
+    struct fixture fb;
+
+    if (fixture_open(&fa) != 0)
+    {
+        CHECK(0, "iso: fixture_open(fa)");
+        return;
+    }
+    if (fixture_open(&fb) != 0)
+    {
+        CHECK(0, "iso: fixture_open(fb)");
+        fixture_close(&fa);
+        return;
+    }
+
+    /* Both envs are fresh; their first TIME('R') should be near 0. */
+    int rc = run_src(&fa, "a = TIME('R')\n");
+    CHECK(rc == IRXPARS_OK, "iso: env-a TIME('R') ok");
+
+    rc = run_src(&fb, "b = TIME('R')\n");
+    CHECK(rc == IRXPARS_OK, "iso: env-b TIME('R') ok");
+
+    /* Both should start with "0." — independent init_stamps. */
+    CHECK(var_starts_with(&fa, "A", "0."), "iso: env-a starts 0.");
+    CHECK(var_starts_with(&fb, "B", "0."), "iso: env-b starts 0.");
+
+    fixture_close(&fa);
+    fixture_close(&fb);
+}
+
+/* ================================================================== */
+/*  main                                                               */
+/* ================================================================== */
+
+int main(void)
+{
+    printf("=== WP-CPS-01: TIME/DATE BIFs ===\n");
+
+    test_time_normal();
+    test_time_elapsed();
+    test_time_reset();
+    test_time_seconds();
+    test_time_minutes();
+    test_time_hours();
+    test_time_long();
+    test_time_civil();
+    test_time_errors();
+
+    test_date_normal();
+    test_date_standard();
+    test_date_european();
+    test_date_usa();
+    test_date_base();
+    test_date_day();
+    test_date_month();
+    test_date_weekday();
+    test_date_julian();
+    test_date_errors();
+
+    test_env_isolation();
+
+    printf("\n=== %d/%d passed (%d failed) ===\n",
+           tests_passed, tests_run, tests_failed);
+    return tests_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Closes #101

## Summary

- Implements all TIME subforms: N E R S M H L C (SC28-1883-0 §4.43)
- Implements all DATE subforms: N S E U B D M W J (SC28-1883-0 §4.7)
- Per-environment elapsed-time state (`wkbi_init_stamp_*`, `wkbi_reset_stamp_*`) stored as `(sec, usec)` pairs in `irx_wkblk_int` — zero-initialized by `irxstor(RXSMGET)`, lazily set on first `TIME()` call
- Platform path: `clock64()` / `uclock64()` / `gmtime64()` on MVS; `gettimeofday()` / `gmtime()` on host
- New test binary `TSTTIM` (`test/mvs/tsttim.c`): 70 tests covering all subforms, case-insensitivity, elapsed isolation across envs, and SYNTAX error paths

## MVS assembly fix (cf74d02)

c2asm370 emits `=A(@@UDIVDI)` instead of `=V()` for 64-bit unsigned division/modulo, causing IFOX00 IFO188 severity-8 errors. Fixed by eliminating all 64-bit division and modulo:

- `clock64()` provides seconds directly — no division needed
- usec fraction via `uclock64() - sec64 * USEC_PER_SEC` (multiply + subtract, no helper)
- Elapsed time (TIME E/R) via borrow subtraction on 32-bit `(sec, usec)` pairs
- DATE('B') via `now_sec / SECS_PER_DAY` (32-bit division, no 64-bit helper)
- TIME('L') usec directly from `now_usec`, not `now_us % USEC_PER_SEC`

## Notes

DATE('B') computes days since the REXX base date (Jan 1, 0001)
from the UTC timestamp, not from local time. This is consistent
with the rest of the BIF (`gmtime64` / `gmtime` everywhere) and
matches what Hercules-MVS provides natively (no local TZ conversion
in the time path). If a future requirement adds local time support,
the change applies uniformly to all DATE subforms, not just 'B'.

## Test plan

- [x] Host cross-compile: 70/70 `tsttim` + 417/417 `tstbifs` green
- [x] MVS build: IRX#BIFS assembles RC=0 (was RC=8 before fix), all ASM steps RC=0
- [ ] MVS run: `CALL 'hlq.LOAD(TSTTIM)'` and `CALL 'hlq.LOAD(TSTBIFS)'`