### PR TITLE
cleanup(mvs): HLASM column-71 audit + irx#env.c MVS linker fix

### DIFF
--- a/asm/irxtmpw.asm
+++ b/asm/irxtmpw.asm
@@ -72,7 +72,7 @@ NOANCH   DS    0H
          LA    R1,PARMODE
          ST    R1,WVLIST+4       P2: parm module name addr
          LA    R1,RESZERO
-         ST    R1,WVLIST+8       P3: caller PARMBLOCK = addr of null word
+         ST    R1,WVLIST+8       P3: caller PARMBLK = addr of null word
          ST    R1,WVLIST+12      P4: user field = addr of null word
          ST    R1,WVLIST+16      P5: reserved = addr of null word
          LA    R1,WENVOUT

--- a/src/irx#env.c
+++ b/src/irx#env.c
@@ -12,4 +12,9 @@ int is_tso(void)
 {
     return _simulated_is_tso;
 }
+#else
+/* The real is_tso() lives in asm/istso.asm (CSECT ISTSO). An empty
+ * translation unit produces no ESD entries and breaks the NCAL linker;
+ * this dummy gives it something to see without affecting behaviour. */
+static int _irx_env_dummy = 0;
 #endif

--- a/test/mvs/asm/tistso.asm
+++ b/test/mvs/asm/tistso.asm
@@ -71,7 +71,7 @@ EPILOG   DS    0H
 *
          LTORG
 *
-* --- WTO parameter list skeleton (hand-built for IFOX00 col-71 limit) ---
+* --- WTO parameter list skeleton (hand-built for IFOX00 col-71) ---
 *  Layout: AL2(total len) AL2(MCS flags) 23C' '
 WTOSKEL  DS    0H
          DC    AL2(WTOEND-WTOSKEL)


### PR DESCRIPTION
## Summary

- **HLASM column-71 audit** across all `asm/` and `test/mvs/asm/` files (including full-line `*` comments — IFOX00 warns on those too): 2 lines shortened in 2 files
  - `asm/irxtmpw.asm:75` — remark `PARMBLOCK` → `PARMBLK` (73 → 71 chars)
  - `test/mvs/asm/tistso.asm:74` — comment shortened by removing redundant word "limit" (74 → 68 chars)
- **`src/irx#env.c` MVS linker fix**: empty translation unit under `#ifdef __MVS__` produced no ESD entries and caused IEWL to reject the object. Added `static int _irx_env_dummy = 0` dummy. Option ii (per-file exclude in project.toml) not available — mbt has no host_only flag at file granularity.
- Clock64/uclock64 race-reconcile originally planned for this cleanup is obsolete — PR #104 already rebuilt `irx_time_now` on pure `uclock64()`.

## Test plan

- [x] Host build: 16/16 binaries, 1236 tests green
- [x] MVS build: `TSTALLB` JOB01796 CC 0000