### PR TITLE
WP-CPS-03: ADDRESS() BIF + State Backing (TSK-215)

### DIFF
--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -164,6 +164,13 @@ struct irx_wkblk_int
     /* alongside wkbi_bif_registry above; add a new _reserved[] array */
     /* when a future WP needs another word.                           */
     unsigned int wkbi_random_seed;
+
+    /* --- ADDRESS state (WP-CPS-03) --------------------------------- */
+    /* 8-byte space-padded host command environment name, consistent
+     * with SUBCOMTB and PARMBLOCK conventions.  Seeded at env
+     * creation from pb->tsofl ("TSO     " or "MVS     "); write path
+     * follows in WP-CPS-05 (ADDRESS keyword).                        */
+    char wkbi_address[8];
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -3156,6 +3156,36 @@ static char parse_subform(struct irx_parser *p, int argc, PLstr *argv,
     return '\0';
 }
 
+/* ADDRESS() — SC28-1883-0 §4.3 (WP-CPS-03)
+ * Returns the name of the current default host command environment,
+ * trimmed of trailing spaces (e.g. "TSO", not "TSO     ").
+ * The 8-byte space-padded setting is stored in wkbi_address, seeded at
+ * env creation; write path follows in WP-CPS-05 (ADDRESS keyword). */
+static int bif_address(struct irx_parser *p, int argc, PLstr *argv,
+                       PLstr result)
+{
+    struct irx_wkblk_int *wk = wkbi_from_parser(p);
+    const char *addr = (wk != NULL) ? wk->wkbi_address : "MVS     ";
+
+    /* Trim trailing spaces: scan backward from byte 7. */
+    int len = 8;
+    while (len > 1 && addr[len - 1] == ' ')
+    {
+        len--;
+    }
+
+    int lrc = Lfx(p->alloc, result, (size_t)len);
+    if (lrc != LSTR_OK)
+    {
+        return translate_lstr_rc(lrc);
+    }
+    memcpy(result->pstr, addr, (size_t)len);
+    result->len = len;
+    (void)argc;
+    (void)argv;
+    return IRXPARS_OK;
+}
+
 /* TIME([subform]) — SC28-1883-0 §4.43 */
 static int bif_time(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
 {
@@ -3618,6 +3648,8 @@ static const struct irx_bif_entry g_bifstr_table[] = {
     {"DATE", 0, 1, bif_date},
     /* Trace (WP-CPS-02) */
     {"TRACE", 0, 1, bif_trace},
+    /* Address (WP-CPS-03) */
+    {"ADDRESS", 0, 0, bif_address},
     /* Sentinel */
     {"", 0, 0, NULL}};
 

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -220,6 +220,24 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
     wk->wkbi_sigl = 0;
     wk->wkbi_rc = 0;
 
+    /* Seed ADDRESS setting from pb->tsofl (WP-CPS-03).
+     * Using pb->tsofl honours any caller-supplied tsofl_mask rather
+     * than calling is_tso() again, which would override the caller's
+     * intent.  Under ISPF the default ADDRESS environment is still
+     * "TSO", not "ISPEXEC", so a plain TSOFL check is sufficient. */
+    {
+        struct parmblock *pb =
+            (struct parmblock *)envblk->envblock_parmblock;
+        if (pb != NULL && pb->tsofl)
+        {
+            memcpy(wk->wkbi_address, DEFAULT_HOSTENV_TSO, 8);
+        }
+        else
+        {
+            memcpy(wk->wkbi_address, DEFAULT_HOSTENV_MVS, 8);
+        }
+    }
+
     *wk_out = wk;
     return 0;
 

--- a/test/mvs/tstbifs.c
+++ b/test/mvs/tstbifs.c
@@ -1842,6 +1842,105 @@ static void test_phase_f_sourceline(void)
     }
 }
 
+/* Build a caller-supplied PARMBLOCK with tsofl=1 set. */
+static void build_tso_pb(struct parmblock *pb)
+{
+    memset(pb, 0, sizeof(*pb));
+    memcpy(pb->parmblock_id, PARMBLOCK_ID, 8);
+    memcpy(pb->parmblock_version, PARMBLOCK_VERSION_0042, 4);
+    pb->tsofl_mask = -1;
+    pb->tsofl = -1;
+    memset(pb->parmblock_addrspn, ' ', 8);
+    memset(pb->parmblock_ffff, 0xFF, 8);
+}
+
+/* Open a fixture using a TSO parmblock (tsofl=1). */
+static int fixture_open_tso(struct fixture *f)
+{
+    struct parmblock tso_pb;
+    build_tso_pb(&tso_pb);
+    memset(f, 0, sizeof(*f));
+    if (irxinit(&tso_pb, &f->env) != 0)
+    {
+        return -1;
+    }
+    f->alloc = irx_lstr_init(f->env);
+    if (f->alloc == NULL)
+    {
+        irxterm(f->env);
+        f->env = NULL;
+        return -1;
+    }
+    f->pool = vpool_create(f->alloc, NULL);
+    return (f->pool != NULL) ? 0 : -1;
+}
+
+static void test_cps03_address(void)
+{
+    printf("--- ADDRESS() BIF (WP-CPS-03) ---\n");
+
+    /* AC-1: Default env (no parmblock → is_tso()=0 on host) returns "MVS". */
+    EXPECT_OK("address()", "MVS", "ADDRESS() default is MVS on host");
+
+    /* AC-1: TSO env (tsofl=1) returns "TSO". */
+    {
+        struct fixture fx;
+        if (fixture_open_tso(&fx) != 0)
+        {
+            CHECK(0, "ADDRESS TSO: fixture_open_tso");
+        }
+        else
+        {
+            int rc = run_src(&fx, "x = address()\n");
+            CHECK(rc == IRXPARS_OK, "ADDRESS() TSO: parse ok");
+            CHECK(var_eq(&fx, "X", "TSO"), "ADDRESS() TSO: returns TSO");
+            fixture_close(&fx);
+        }
+    }
+
+    /* AC-2: Isolation — two concurrent envs each see their own setting. */
+    {
+        struct fixture fa;
+        struct fixture fb;
+        if (fixture_open(&fa) != 0)
+        {
+            CHECK(0, "ADDRESS isolation: fixture_open MVS");
+        }
+        else if (fixture_open_tso(&fb) != 0)
+        {
+            CHECK(0, "ADDRESS isolation: fixture_open_tso TSO");
+            fixture_close(&fa);
+        }
+        else
+        {
+            int rca = run_src(&fa, "x = address()\n");
+            int rcb = run_src(&fb, "x = address()\n");
+            CHECK(rca == IRXPARS_OK, "ADDRESS isolation: fa parse ok");
+            CHECK(rcb == IRXPARS_OK, "ADDRESS isolation: fb parse ok");
+            CHECK(var_eq(&fa, "X", "MVS"), "ADDRESS isolation: fa returns MVS");
+            CHECK(var_eq(&fb, "X", "TSO"), "ADDRESS isolation: fb returns TSO");
+            fixture_close(&fb);
+            fixture_close(&fa);
+        }
+    }
+
+    /* AC-3: Result is trimmed — length("TSO") is 3, not 8. */
+    {
+        struct fixture fx;
+        if (fixture_open_tso(&fx) != 0)
+        {
+            CHECK(0, "ADDRESS trim: fixture_open_tso");
+        }
+        else
+        {
+            int rc = run_src(&fx, "x = length(address())\n");
+            CHECK(rc == IRXPARS_OK, "ADDRESS trim: parse ok");
+            CHECK(var_eq(&fx, "X", "3"), "ADDRESS() trimmed length is 3");
+            fixture_close(&fx);
+        }
+    }
+}
+
 int main(void)
 {
     printf("=== WP-21a + WP-21b Phase C+D+E+F: BIFs ===\n");
@@ -1870,6 +1969,7 @@ int main(void)
     test_phase_f_sourceline();
     test_error_paths();
     test_find_phrase_cap();
+    test_cps03_address();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);


### PR DESCRIPTION
Closes #110

## Summary

- Adds `wkbi_address[8]` to `struct irx_wkblk_int` — 8-byte space-padded host command environment name, consistent with SUBCOMTB/PARMBLOCK conventions
- Seeds it in `init_wkblk_int` from `pb->tsofl` (`"TSO     "` or `"MVS     "`)
- Implements `bif_address` (0 args, returns trimmed current address setting)
- Registers as `{"ADDRESS", 0, 0, bif_address}` in `g_bifstr_table`
- 9 new tests in `test/mvs/tstbifs.c` covering AC-1 (TSO/MVS defaults), AC-2 (per-Env isolation), AC-3 (trim)

## Architecture decisions

**Storage layout — `char wkbi_address[8]` not `char *`**

A fixed 8-byte field avoids a separate `irxstor` call for a constant-width value and matches the `SUBCOMTB` and `PARMBLOCK` conventions that already use space-padded 8-byte fields throughout. The ADDRESS keyword (WP-CPS-05) will overwrite in place. No pointer indirection, no allocation failure path.

**Seeding from `pb->tsofl`, not `is_tso()`**

`is_tso()` probes the live TCB/PSCB chain. A caller that sets `tsofl_mask`/`tsofl` explicitly (e.g. test fixtures, ISPF subtask invocations) has already expressed intent about the host environment. Re-probing via `is_tso()` would silently override that intent. Using `pb->tsofl` is the correct contract: honour what the caller declared, not what the hardware says.

## MVS verification

Batch (RC=0): **426/426** — all ADDRESS() tests green, no regressions  
TSO (RC=1): 424/426 — expected; `fixture_open(NULL)` correctly picks up the live TSO context under IKJEFT01