### PR TITLE
feat(parser): WP-CPS-04 — TRACE keyword/instruction

### DIFF
--- a/include/irxbifs.h
+++ b/include/irxbifs.h
@@ -14,12 +14,25 @@
 #ifndef IRXBIFS_H
 #define IRXBIFS_H
 
+#include "lstring.h"
+
 struct envblock;
 struct irx_bif_registry;
+struct irx_parser;
 
 /* Register every built-in that ships with the core interpreter.
  * Returns IRX_BIF_OK on success or the first IRX_BIF_* error code. */
 int irx_bif_register_all(struct envblock *env,
                          struct irx_bif_registry *reg) asm("IRXBIFAL");
+
+/* Parse a TRACE option string (shared by bif_trace and kw_trace).
+ * Sets *letter_out (one of NAILRCFEO, upper-cased) and *toggle_out (0/1).
+ * "?L" form: toggle=1, letter=L. Plain "L..." form: toggle=0, letter=L.
+ * toggle is always written — plain "L" clears any prior toggle.
+ * Returns 0 on success; -1 on error (SYNTAX 40.23 already raised).
+ *
+ * asm() alias required: cross-module entry point, name > 8 chars. */
+int parse_trace_option(struct irx_parser *p, PLstr opt,
+                       char *letter_out, int *toggle_out) asm("IRXPTOPT");
 
 #endif /* IRXBIFS_H */

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -3464,8 +3464,8 @@ static int bif_date(struct irx_parser *p, int argc, PLstr *argv, PLstr result)
  * toggle is always written — plain "L" clears any prior toggle (no
  * sticky toggle; full replace semantics for Read-Modify-Write).
  * Returns 0 on success; -1 on error (SYNTAX 40.23 already raised). */
-static int parse_trace_option(struct irx_parser *p, PLstr opt,
-                              char *letter_out, int *toggle_out)
+int parse_trace_option(struct irx_parser *p, PLstr opt,
+                       char *letter_out, int *toggle_out)
 {
     const char *s = (const char *)opt->pstr;
     int n = (int)opt->len;

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -22,6 +22,7 @@
 #include "irx.h"
 #include "irxarith.h"
 #include "irxbif.h"
+#include "irxbifs.h"
 #include "irxctrl.h"
 #include "irxlstr.h"
 #include "irxpars.h"
@@ -3370,6 +3371,138 @@ static int kw_parse(struct irx_parser *p)
 }
 
 /* ------------------------------------------------------------------ */
+/*  TRACE keyword handler (WP-CPS-04)                                 */
+/*                                                                    */
+/*  TRACE                     Toggle wkbi_interactive; letter kept.   */
+/*  TRACE VALUE expr          Evaluate expr, validate, write both.    */
+/*  TRACE option              Token text as option string, validate.  */
+/*  TRACE number              Skip-form: consume, no-op.              */
+/*                                                                    */
+/*  Ref: SC28-1883-0 §6.13                                            */
+/* ------------------------------------------------------------------ */
+
+static int kw_trace(struct irx_parser *p)
+{
+    const struct irx_token *t;
+    struct irx_wkblk_int *wk = NULL;
+
+    if (p->envblock != NULL && p->envblock->envblock_userfield != NULL)
+    {
+        wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+    }
+
+    t = cur_tok(p);
+
+    /* Form 1: Toggle — bare TRACE with no argument.
+     * Per SC28-1883-0 §6.13: interactive debug is toggled; the trace
+     * option letter is unchanged. */
+    if (tok_ends_clause(t))
+    {
+        if (wk != NULL)
+        {
+            wk->wkbi_interactive ^= 1;
+        }
+        return IRXPARS_OK;
+    }
+
+    /* Form 2: VALUE — context-sensitive keyword followed by expression. */
+    if (sym_matches(t, "VALUE"))
+    {
+        Lstr expr_result;
+        char new_letter = '\0';
+        int new_toggle = 0;
+        int rc;
+
+        advance_tok(p);
+
+        if (tok_ends_clause(cur_tok(p)))
+        {
+            skip_to_clause_end(p);
+            return fail(p, IRXPARS_SYNTAX);
+        }
+
+        Lzeroinit(&expr_result);
+        rc = irx_pars_eval_expr(p, &expr_result);
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &expr_result);
+            return rc;
+        }
+
+        if (parse_trace_option(p, &expr_result, &new_letter, &new_toggle) != 0)
+        {
+            Lfree(p->alloc, &expr_result);
+            skip_to_clause_end(p);
+            return IRXPARS_SYNTAX;
+        }
+        Lfree(p->alloc, &expr_result);
+
+        if (wk != NULL)
+        {
+            wk->wkbi_trace = (int)new_letter;
+            wk->wkbi_interactive = new_toggle;
+        }
+        skip_to_clause_end(p);
+        return IRXPARS_OK;
+    }
+
+    /* Form 3: Skip-form — Number-Literal token (optionally signed).
+     * Skip-form (TRACE n) consumed but not enforced; statement tracer
+     * is not yet active so the skip count has no effect anyway. */
+    if (t->tok_type == TOK_NUMBER)
+    {
+        advance_tok(p);
+        skip_to_clause_end(p);
+        return IRXPARS_OK;
+    }
+    if ((tok_is_op_char(t, TOK_OPERATOR, '+') ||
+         tok_is_op_char(t, TOK_OPERATOR, '-')) &&
+        peek_tok(p, 1) != NULL &&
+        peek_tok(p, 1)->tok_type == TOK_NUMBER)
+    {
+        advance_tok(p); /* sign */
+        advance_tok(p); /* number */
+        skip_to_clause_end(p);
+        return IRXPARS_OK;
+    }
+
+    /* Form 4: String-form — Symbol or String literal.
+     * Token text is taken directly as the option string (not evaluated
+     * as a variable). 'trace I' and 'trace ''I''' are equivalent. */
+    {
+        Lstr opt;
+        char new_letter = '\0';
+        int new_toggle = 0;
+        int rc;
+
+        Lzeroinit(&opt);
+        rc = lstr_set_bytes(p->alloc, &opt,
+                            (const char *)t->tok_text, t->tok_length);
+        if (rc != LSTR_OK)
+        {
+            return fail(p, IRXPARS_NOMEM);
+        }
+        advance_tok(p);
+
+        if (parse_trace_option(p, &opt, &new_letter, &new_toggle) != 0)
+        {
+            Lfree(p->alloc, &opt);
+            skip_to_clause_end(p);
+            return IRXPARS_SYNTAX;
+        }
+        Lfree(p->alloc, &opt);
+
+        if (wk != NULL)
+        {
+            wk->wkbi_trace = (int)new_letter;
+            wk->wkbi_interactive = new_toggle;
+        }
+        skip_to_clause_end(p);
+        return IRXPARS_OK;
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /*  Keyword table (WP-13 registers no handlers)                       */
 /*                                                                    */
 /*  WP-14 adds SAY. WP-15 adds DO/IF/SELECT/CALL/RETURN/EXIT/SIGNAL. */
@@ -3398,6 +3531,7 @@ static const struct irx_keyword g_keyword_table[] = {
     {"ARG", kw_arg},
     {"PARSE", kw_parse},
     {"NUMERIC", kw_numeric},
+    {"TRACE", kw_trace},
     {NULL, NULL}};
 
 static const struct irx_keyword *find_keyword(const unsigned char *name,

--- a/test/mvs/tsttrace.c
+++ b/test/mvs/tsttrace.c
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------------ */
-/*  tsttrace.c - WP-CPS-02 TRACE() BIF unit tests                    */
+/*  tsttrace.c - WP-CPS-02 TRACE() BIF + WP-CPS-04 TRACE instruction  */
 /*                                                                    */
 /*  Cross-compile build (Linux/gcc):                                  */
 /*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
@@ -500,6 +500,261 @@ static void test_trace_empty_arg(void)
 }
 
 /* ================================================================== */
+/*  WP-CPS-04: TRACE instruction-form tests                           */
+/* ================================================================== */
+
+/* Read wkbi_trace/wkbi_interactive directly from the fixture. */
+static int wk_letter(struct fixture *f)
+{
+    struct irx_wkblk_int *wk =
+        (struct irx_wkblk_int *)f->env->envblock_userfield;
+    return (wk != NULL) ? wk->wkbi_trace : (int)TRACE_NORMAL;
+}
+
+static int wk_interactive(struct fixture *f)
+{
+    struct irx_wkblk_int *wk =
+        (struct irx_wkblk_int *)f->env->envblock_userfield;
+    return (wk != NULL) ? wk->wkbi_interactive : 0;
+}
+
+/* AC-1 + AC-5: String-form sets trace letter. */
+static void test_instr_string_form(void)
+{
+    printf("\n--- TRACE instr: string-form ---\n");
+
+    /* trace off -> 'O' */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace off\n");
+            CHECK(rc == IRXPARS_OK, "instr: 'trace off' executes");
+            CHECK(wk_letter(&fx) == 'O', "instr: 'trace off' sets 'O'");
+            fixture_close(&fx);
+        }
+    }
+
+    /* trace 'I' (string literal) -> 'I' */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace 'I'\n");
+            CHECK(rc == IRXPARS_OK, "instr: trace 'I' executes");
+            CHECK(wk_letter(&fx) == 'I', "instr: trace 'I' sets 'I'");
+            fixture_close(&fx);
+        }
+    }
+
+    /* trace I (bare symbol) -> 'I' */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace I\n");
+            CHECK(rc == IRXPARS_OK, "instr: trace I (symbol) executes");
+            CHECK(wk_letter(&fx) == 'I', "instr: trace I sets 'I'");
+            fixture_close(&fx);
+        }
+    }
+
+    /* trace A -> 'A'; verify via TRACE() BIF */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace A\n");
+            CHECK(rc == IRXPARS_OK, "instr: trace A executes");
+            rc = run_src(&fx, "x = TRACE()\n");
+            CHECK(rc == IRXPARS_OK && var_eq(&fx, "X", "A"),
+                  "instr: trace A verified via TRACE()");
+            fixture_close(&fx);
+        }
+    }
+}
+
+/* AC-2 + AC-3: VALUE-form evaluates expression. */
+static void test_instr_value_form(void)
+{
+    printf("\n--- TRACE instr: VALUE-form ---\n");
+
+    /* trace value 'A' -> 'A' */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace value 'A'\n");
+            CHECK(rc == IRXPARS_OK, "instr: trace value 'A' executes");
+            CHECK(wk_letter(&fx) == 'A', "instr: trace value 'A' sets 'A'");
+            fixture_close(&fx);
+        }
+    }
+
+    /* trace value tracevar; tracevar='Off' -> 'O' */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "tracevar = 'Off'\n");
+            CHECK(rc == IRXPARS_OK, "instr: set tracevar='Off'");
+            rc = run_src(&fx, "trace value tracevar\n");
+            CHECK(rc == IRXPARS_OK, "instr: trace value tracevar executes");
+            CHECK(wk_letter(&fx) == 'O',
+                  "instr: trace value tracevar sets 'O'");
+            fixture_close(&fx);
+        }
+    }
+
+    /* AC-4: trace value trace() round-trip */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace value 'E'\n");
+            CHECK(rc == IRXPARS_OK, "instr: set to 'E' first");
+            rc = run_src(&fx, "trace value trace()\n");
+            CHECK(rc == IRXPARS_OK, "instr: trace value trace() executes");
+            CHECK(wk_letter(&fx) == 'E',
+                  "instr: round-trip trace value trace() preserves 'E'");
+            fixture_close(&fx);
+        }
+    }
+}
+
+/* AC-6: Toggle-form flips wkbi_interactive; letter unchanged. */
+static void test_instr_toggle_form(void)
+{
+    printf("\n--- TRACE instr: toggle-form ---\n");
+
+    /* Default: interactive=0, letter='N'.
+     * After bare 'trace': interactive=1, letter='N'. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            CHECK(wk_interactive(&fx) == 0,
+                  "toggle: initial wkbi_interactive is 0");
+            CHECK(wk_letter(&fx) == 'N',
+                  "toggle: initial wkbi_trace is 'N'");
+
+            int rc = run_src(&fx, "trace\n");
+            CHECK(rc == IRXPARS_OK, "toggle: bare 'trace' executes");
+            CHECK(wk_interactive(&fx) == 1,
+                  "toggle: wkbi_interactive becomes 1");
+            CHECK(wk_letter(&fx) == 'N',
+                  "toggle: wkbi_trace unchanged after toggle");
+
+            /* Second toggle -> back to 0. */
+            rc = run_src(&fx, "trace\n");
+            CHECK(rc == IRXPARS_OK, "toggle: second 'trace' executes");
+            CHECK(wk_interactive(&fx) == 0,
+                  "toggle: wkbi_interactive back to 0");
+            CHECK(wk_letter(&fx) == 'N',
+                  "toggle: wkbi_trace still 'N' after two toggles");
+
+            fixture_close(&fx);
+        }
+    }
+
+    /* Toggle does not touch letter even when letter was changed. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace A\n");
+            CHECK(rc == IRXPARS_OK, "toggle: set letter to 'A'");
+            rc = run_src(&fx, "trace\n");
+            CHECK(rc == IRXPARS_OK, "toggle: bare trace after 'A'");
+            CHECK(wk_interactive(&fx) == 1,
+                  "toggle: interactive toggled to 1");
+            CHECK(wk_letter(&fx) == 'A',
+                  "toggle: letter 'A' unchanged");
+            fixture_close(&fx);
+        }
+    }
+}
+
+/* AC-7: Invalid option -> SYNTAX 40.23 from instruction form. */
+static void test_instr_errors(void)
+{
+    printf("\n--- TRACE instr: error paths ---\n");
+
+    run_expect_fail("trace X\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID, "instr: 'trace X' bad option");
+    run_expect_fail("trace value 'Z'\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID,
+                    "instr: 'trace value \"Z\"' bad option");
+    run_expect_fail("trace value '?'\n", SYNTAX_BAD_CALL,
+                    ERR40_OPTION_INVALID,
+                    "instr: 'trace value \"?\"' bare ? invalid");
+}
+
+/* AC-11: Skip-form is a no-op; no SYNTAX raised. */
+static void test_instr_skip_form(void)
+{
+    printf("\n--- TRACE instr: skip-form ---\n");
+
+    /* trace 0 -> no-op; letter unchanged. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace 0\n");
+            CHECK(rc == IRXPARS_OK, "skip: trace 0 no SYNTAX");
+            CHECK(wk_letter(&fx) == 'N', "skip: trace 0 letter unchanged");
+            fixture_close(&fx);
+        }
+    }
+
+    /* trace 5 -> no-op. */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace 5\n");
+            CHECK(rc == IRXPARS_OK, "skip: trace 5 no SYNTAX");
+            fixture_close(&fx);
+        }
+    }
+
+    /* trace -5 -> no-op (signed skip). */
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "trace -5\n");
+            CHECK(rc == IRXPARS_OK, "skip: trace -5 no SYNTAX");
+            CHECK(wk_letter(&fx) == 'N', "skip: trace -5 letter unchanged");
+            fixture_close(&fx);
+        }
+    }
+}
+
+/* AC-10: REXXCPS round-trip pattern. */
+static void test_instr_rexxcps_pattern(void)
+{
+    printf("\n--- TRACE instr: REXXCPS pattern ---\n");
+
+    {
+        struct fixture fx;
+        if (fixture_open(&fx) == 0)
+        {
+            int rc = run_src(&fx, "tracevar = 'Off'\n"
+                                  "trace value tracevar\n");
+            CHECK(rc == IRXPARS_OK, "rexxcps: set Off via variable");
+            CHECK(wk_letter(&fx) == 'O', "rexxcps: letter is 'O'");
+
+            rc = run_src(&fx, "trace value trace()\n");
+            CHECK(rc == IRXPARS_OK, "rexxcps: round-trip executes");
+            CHECK(wk_letter(&fx) == 'O', "rexxcps: round-trip preserves 'O'");
+
+            fixture_close(&fx);
+        }
+    }
+}
+
+/* ================================================================== */
 /*  main                                                               */
 /* ================================================================== */
 
@@ -514,6 +769,15 @@ int main(void)
     test_trace_errors();
     test_trace_isolation();
     test_trace_empty_arg();
+
+    printf("\n=== WP-CPS-04: TRACE instruction ===\n");
+
+    test_instr_string_form();
+    test_instr_value_form();
+    test_instr_toggle_form();
+    test_instr_errors();
+    test_instr_skip_form();
+    test_instr_rexxcps_pattern();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);


### PR DESCRIPTION
Closes #112

Notion: TSK-216 — https://app.notion.com/p/3513d99387878189accce2691fbb09af

## What

Implements the TRACE keyword instruction in `src/irx#pars.c`. Registers
`kw_trace` in `g_keyword_table`. Four forms per SC28-1883-0 §6.13:

| Form | Example | Behaviour |
|------|---------|-----------|
| Toggle | `TRACE` | Flips `wkbi_interactive` only; letter unchanged |
| VALUE | `TRACE VALUE expr` | Evaluates expr, validates, writes both fields |
| String | `TRACE Off` / `TRACE 'I'` | Token text as option, validates, writes both |
| Skip | `TRACE 5` / `TRACE -5` | Consumed, no-op (statement tracer inactive) |

## Architecture decisions

### 1. `parse_trace_option` visibility

**Option (a): remove `static`, declare in `include/irxbifs.h` with `asm()` alias `IRXPTOPT`.**

The function name is 20 chars — beyond the 8-char MVS external symbol
limit. The codebase consistently aliases every cross-module entry point
(`irx_arith_op → IRXARIOP`, `irx_cond_raise → IRXCRAIS`, etc.), so the
`asm()` alias is mandatory alongside the visibility change. Definition
stays in `src/irx#bifs.c`; callers include `irxbifs.h`.

### 2. Skip-form detection

`TRACE -5` tokenises as `TOK_OPERATOR('-')` + `TOK_NUMBER`. `kw_trace`
handles both the bare-number case (`TRACE 5`) and the signed case
(`TRACE -5` / `TRACE +3`) with a two-token peek, consumes them, and
returns `IRXPARS_OK`. No state is written. Source comment: *"Skip-form
(TRACE n) consumed but not enforced; statement tracer is not yet active
so the skip count has no effect anyway."*

## Toggle-form semantics (SC28-1883-0 §6.13)

Bare `TRACE` with no argument only flips `wkbi_interactive`; the trace
letter (`wkbi_trace`) is **not** touched. This differs from the BIF
form (`TRACE('?A')`) which does a full read-modify-write on both fields.

## Statement tracer

Intentionally not activated. Settings are parsed and written; no output
produced. Continuation of the WP-CPS-02 stub stance (AC-8).

## Changes

| File | Change |
|------|--------|
| `include/irxbifs.h` | Forward-declare `parse_trace_option` with `asm("IRXPTOPT")` |
| `src/irx#bifs.c` | Remove `static` from `parse_trace_option` |
| `src/irx#pars.c` | Add `kw_trace` handler + `{"TRACE", kw_trace}` in keyword table |
| `test/mvs/tsttrace.c` | 44 new instruction-form tests (AC-1 – AC-11) |

## Test results

Host (Linux/gcc) and MVS/TSO both: **97/97 passed (0 failed)**

Full suite: zero regressions across all 17 test binaries.