### PR TITLE
feat(WP-CPS-07): implement IRXLOAD programming service

### DIFF
--- a/asm/irxload.asm
+++ b/asm/irxload.asm
@@ -1,0 +1,234 @@
+         TITLE 'IRXLOAD - REXX/370 IRXLOAD Entry Point Wrapper'
+*
+*  IRXLOAD - HLASM entry-point wrapper for the IRXLOAD Programming
+*            Service (SC28-1883-0 §14).
+*
+*  Parses the caller VLIST, validates the high-bit endmarker on the
+*  last parameter, validates the CL8 function code, and delegates to
+*  the C-core dispatcher irx_load_dispatch (asm() alias IRXLDISP,
+*  CON-4) which routes on the function code to one of:
+*
+*    LOAD  -> irx_load_load()   (reads REXX source, builds INSTBLK)
+*    FREE  -> irx_load_free()   (releases INSTBLK and source pool)
+*
+*  Calling convention (per SC28-1883-0 §14 IRXLOAD):
+*
+*    CALL IRXLOAD,(FCODE,EXECBLK,INSTBLK,ENVBLK,RETCODE),VL
+*
+*  Each VLIST slot is a 4-byte address pointing at the parameter
+*  value. The address of the LAST slot has its high-order bit set
+*  to mark the end of the variable-length list.
+*
+*  P1  CL8    function code: 'LOAD    ' / 'FREE    '
+*  P2  A      EXECBLK pointer (LOAD: required; FREE: ignored)
+*  P3  A      INSTBLK pointer (LOAD: output; FREE: input to free)
+*  P4  A      ENVBLOCK pointer (NULL -> default subpool 0)
+*  P5  F      return code (output)
+*
+*  R15 (out) return code: 0=OK, 4=NOMEM, 8=NOTFOUND, 20=ERROR
+*
+*  Mirrors asm/irxinit.asm structure and PDP-DSA/WPOOL shape.
+*  See irxinit.asm for the rationale behind the bootstrap design
+*  (no @@CRT0 dependency, WPOOL as bump-allocator pool).
+*
+*  Ref: SC28-1883-0 §14 (IRXLOAD Programming Service)
+*  Ref: CON-4 (asm() aliases)
+*  Ref: WP-CPS-07 / TSK-219 / GitHub mvslovers/rexx370#116
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R5       EQU   5
+R6       EQU   6
+R7       EQU   7
+R8       EQU   8
+R9       EQU   9
+R10      EQU   10
+R11      EQU   11
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+IRXLOAD  CSECT
+*
+*  --- standard MVS entry linkage ---
+         STM   R14,R12,12(R13)     save caller R14-R12 in caller SA
+         BALR  R12,0
+         USING *,R12
+*
+         LR    R11,R1              R11 = caller VLIST address
+*
+*  Defensive NULL check: a caller passing R1=0 (no parm list at all)
+*  must not provoke an S0C5 in PARSELP and must not leak the workarea
+*  we are about to GETMAIN.
+         LTR   R11,R11             VLIST pointer NULL?
+         BZ    NULLPLST            yes -> early exit, no GETMAIN
+*
+*  --- allocate dynamic workarea (PDP-DSA + locals + WPOOL) ---------
+         L     R0,=A(WALEN)
+         GETMAIN RU,LV=(0)
+         LR    R8,R1               R8 = workarea ptr (saved for FREE)
+*
+*  Chain DSAs: caller SA <-> our DSA.
+         ST    R13,4(,R1)          our DSA back-chain = caller SA
+         ST    R1,8(,R13)          caller forward     = our DSA
+         LR    R13,R1
+         USING WAREA,R13
+*
+*  --- initialize PDP-DSA fields ---
+         XC    WDFLAGS(4),WDFLAGS  DSAFLAGS = 0
+         XC    WDLWA(4),WDLWA      DSALWA   = 0
+         LA    R0,WPOOL
+         ST    R0,WDNAB            DSANAB   = WPOOL
+*
+*  Zero WPARMS / WCPLIST so "slot never filled" is distinguishable.
+         XC    WPARMS(20),WPARMS    5F = 20 bytes
+         XC    WCPLIST(20),WCPLIST  5F = 20 bytes
+*
+*  --- parse VLIST: 5 entries, high-bit endmarker on slot 5 ----------
+         LA    R2,5                expected slot count (countdown)
+         LR    R3,R11              R3 = current caller VLIST entry
+         LA    R4,WPARMS           R4 = our local parsed-addr array
+*
+PARSELP  L     R6,0(,R3)           raw VLIST entry (addr | maybe VL)
+         LR    R7,R6
+         N     R7,=X'7FFFFFFF'     clear VL bit -> bare address
+         ST    R7,0(,R4)
+         LTR   R6,R6               VL bit (sign bit) set?
+         BM    PARSEVL             yes -> end of list
+         LA    R3,4(,R3)
+         LA    R4,4(,R4)
+         BCT   R2,PARSELP
+*
+*  All 5 slots walked without a VL marker — malformed list.
+         LA    R15,20
+         B     ERREARLY
+*
+PARSEVL  EQU   *
+*  VL found; R2 = remaining count (must be 1 for slot 5).
+         CH    R2,=H'1'
+         BE    FCCHK
+*  VL on wrong slot — short list; no usable P5 / retval slot.
+         LA    R15,20
+         B     ERREARLY
+*
+FCCHK    EQU   *
+*  --- validate function code ---
+         L     R2,WPARMS+0         R2 = addr of P1 (CL8 funccode)
+         CLC   0(8,R2),=CL8'LOAD'
+         BE    BUILDC
+         CLC   0(8,R2),=CL8'FREE'
+         BE    BUILDC
+*
+*  Unknown funccode. WPARMS+16 is valid (VL on slot 5), so write P5.
+         LA    R15,20
+         B     SETRSN
+*
+BUILDC   EQU   *
+*  --- build C-call plist for IRXLDISP ----------------------------
+*
+*    irx_load_dispatch(funccode, execblk, instblk_p, envblk, retval)
+*
+*  P1 funccode: pass address of CL8 string (WPARMS+0 content).
+         L     R2,WPARMS+0         R2 = addr of funccode CL8
+         ST    R2,WCPLIST+0
+*
+*  P2 execblk: deref once to get the EXECBLK pointer.
+         L     R2,WPARMS+4         R2 = addr of EXECBLK ptr slot
+         L     R3,0(,R2)           R3 = EXECBLK ptr (may be 0 for FREE)
+         ST    R3,WCPLIST+4
+*
+*  P3 instblk_p: pass address of P3 slot so C can write *instblk_p.
+         L     R2,WPARMS+8         R2 = addr of INSTBLK ptr slot
+         ST    R2,WCPLIST+8
+*
+*  P4 envblk: deref once to get the ENVBLOCK pointer.
+         L     R2,WPARMS+12        R2 = addr of ENVBLOCK ptr slot
+         L     R3,0(,R2)           R3 = ENVBLOCK ptr (may be 0)
+         ST    R3,WCPLIST+12
+*
+*  P5 retval: pass address of caller's return-code slot.
+         L     R2,WPARMS+16        R2 = addr of retval int slot
+         ST    R2,WCPLIST+16
+*
+*  --- call irx_load_dispatch ---
+         LA    R1,WCPLIST
+         L     R15,=V(IRXLDISP)
+         BALR  R14,R15
+*
+*  R15 = RC from C; C has already written *retval through WCPLIST+16.
+         LR    R3,R15              R3 = RC (preserved across teardown)
+         B     EPILOG
+*
+SETRSN   EQU   *
+*  --- error path with P5 write (bad funccode, VL on slot 5 valid) --
+         LR    R3,R15              R3 = RC (20)
+         L     R7,WPARMS+16        caller's retval slot address
+         MVC   0(4,R7),=F'20'      *retval = 20
+         B     EPILOG
+*
+ERREARLY EQU   *
+*  --- error path without P5 write (VLIST malformed) -----------------
+         LR    R3,R15              R3 = RC (20)
+*  Fall through to EPILOG.
+*
+EPILOG   EQU   *
+*  R3 = output RC.
+*  Restore R13, FREEMAIN workarea, set R15, restore caller registers.
+*
+         L     R13,WDPREV          R13 = caller SA
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(8)
+*
+         LR    R15,R3              R15 = output RC
+         L     R14,12(,R13)
+         LM    R0,R12,20(R13)      restore R0-R12 from caller SA
+         BR    R14
+*
+NULLPLST DS    0H
+*  Caller passed R1=0.  R13 still points at caller SA (no GETMAIN).
+         LA    R15,20
+         L     R14,12(,R13)
+         LM    R0,R12,20(R13)
+         BR    R14
+*
+         LTORG
+*
+*  --- workarea DSECT (PDP-DSA shape, mirrors irxinit.asm) ----------
+*
+WAREA    DSECT
+WDFLAGS  DS    F                   +0  DSAFLAGS (must be 0)
+WDPREV   DS    F                   +4  DSAPREV  (back chain)
+WDNEXT   DS    F                   +8  DSANEXT  (forward chain)
+WDR14    DS    F                   +12 caller R14
+WDR15    DS    F                   +16 caller R15
+WDR0     DS    F                   +20 caller R0
+WDR1     DS    F                   +24 caller R1
+WDR2     DS    F                   +28 caller R2
+WDR3     DS    F                   +32 caller R3
+WDR4     DS    F                   +36 caller R4
+WDR5     DS    F                   +40 caller R5
+WDR6     DS    F                   +44 caller R6
+WDR7     DS    F                   +48 caller R7
+WDR8     DS    F                   +52 caller R8
+WDR9     DS    F                   +56 caller R9
+WDR10    DS    F                   +60 caller R10
+WDR11    DS    F                   +64 caller R11
+WDR12    DS    F                   +68 caller R12
+WDLWA    DS    F                   +72 DSALWA  (must be 0)
+WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
+*  Wrapper-local storage.
+WPARMS   DS    5F                  bare addresses from 5-slot VLIST
+WCPLIST  DS    5F                  parameter list for IRXLDISP call
+*  Stack pool for nested c2asm370 PDPPRLG frames (see irxinit.asm).
+WPOOL    DS    2048F               8 KB scratchpad
+WALEN    EQU   *-WAREA
+*
+         END   IRXLOAD

--- a/include/irxinstb.h
+++ b/include/irxinstb.h
@@ -1,0 +1,22 @@
+#ifndef IRXINSTB_H
+#define IRXINSTB_H
+
+/* irxinstb.h - INSTBLK compile-time assertions
+**
+** The authoritative INSTBLK layout is in include/irx.h (struct instblk).
+** This header adds static size/layout checks that catch any drift.
+**
+** Ref: CON-1 §3.4 (INSTBLK byte-exact layout)
+** Ref: WP-CPS-07 / TSK-219 / GitHub mvslovers/rexx370#116
+*/
+
+#include "irx.h"
+
+/* INSTBLK header must be exactly 128 bytes on MVS (pointer = 4 bytes).
+ * Assertion is MVS-only: on 64-bit hosts the struct is larger due to
+ * pointer widening and different struct padding. */
+#ifdef __MVS__
+typedef char irxinstb_hdrlen_ok[(sizeof(struct instblk) == INSTBLK_HDRLEN) ? 1 : -1];
+#endif
+
+#endif /* IRXINSTB_H */

--- a/include/irxload.h
+++ b/include/irxload.h
@@ -1,0 +1,38 @@
+#ifndef IRXLOAD_H
+#define IRXLOAD_H
+
+/* irxload.h - IRXLOAD Programming Service interface
+**
+** Ref: SC28-1883-0 §14 (IRXLOAD Programming Service)
+** Ref: WP-CPS-07 / TSK-219 / GitHub mvslovers/rexx370#116
+*/
+
+#include "irx.h"
+
+/* Function codes (CL8, blank-padded). */
+#define IRXLOAD_FC_LOAD "LOAD    "
+#define IRXLOAD_FC_FREE "FREE    "
+
+/* Return codes. */
+#define IRXLOAD_OK       0  /* success */
+#define IRXLOAD_NOMEM    4  /* storage not available */
+#define IRXLOAD_NOTFOUND 8  /* member or DD not found */
+#define IRXLOAD_ERROR    20 /* invalid argument / bad eye-catcher */
+
+/* C-core dispatcher — called from asm/irxload.asm BUILDC section.
+ * The asm() alias makes the linker emit the symbol "IRXLDISP",
+ * which the =V(IRXLDISP) reference in the asm wrapper resolves to.
+ *
+ * funccode  - pointer to CL8 function code ('LOAD    ' or 'FREE    ')
+ * execblk   - EXECBLK identifying the exec (LOAD: required; FREE: ignored)
+ * instblk_p - LOAD: output INSTBLK pointer; FREE: pointer to be freed
+ * envblk    - owning ENVBLOCK (NULL → default subpool)
+ * retval    - output: return code written to caller's P5 slot
+ */
+int irx_load_dispatch(const char *funccode,
+                      struct execblk *execblk,
+                      struct instblk **instblk_p,
+                      struct envblock *envblk,
+                      int *retval) asm("IRXLDISP");
+
+#endif /* IRXLOAD_H */

--- a/project.toml
+++ b/project.toml
@@ -184,6 +184,28 @@ include = [
 "mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
+# IRXLOAD - HLASM Entry-Point Wrapper for the IRXLOAD Programming
+#           Service (SC28-1883-0 §14). Parses the 5-slot VLIST,
+#           validates the function code, and delegates to the
+#           C-core dispatcher irx_load_dispatch (asm() alias
+#           IRXLDISP) which routes LOAD/FREE sub-functions.
+#
+# LOAD builds an INSTBLK from REXX source in a PDS member.
+# FREE releases the INSTBLK and its source pool.
+#
+# WP-CPS-07 / TSK-219 / GitHub mvslovers/rexx370#116.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "IRXLOAD"
+entry = "IRXLOAD"
+options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
+include = [
+  "IRXLOAD",
+  "IRX#LOAD",
+  "IRX#STOR",
+]
+
+# ---------------------------------------------------------------
 # TSTANCH - ENVBLOCK anchor smoketest pseudomodule
 # Runs in TSO (CALL 'TSTANCH') or Batch (EXEC PGM=TSTANCH).
 # Pulls in the full phase-1/phase-2 object set so IRXINIT and
@@ -894,6 +916,31 @@ include = [
 
 [link.module.dep_includes]
 "mvslovers/lstring370" = "*"
+
+# ---------------------------------------------------------------
+# TSTLOAD - WP-CPS-07 IRXLOAD C-core unit tests.
+# Tests irx_load_dispatch() directly (bypasses the asm IRXLOAD
+# wrapper). Host build uses the filesystem backend; MVS build
+# tests the BSAM path with real DD allocations.
+#
+# Invocation:
+#   TSO    :  CALL 'hlq.LOAD(TSTLOAD)'
+#   Batch  :  EXEC PGM=TSTLOAD
+#
+# Expected: CC=0
+#
+# WP-CPS-07 / TSK-219 / GitHub mvslovers/rexx370#116.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "TSTLOAD"
+entry = "@@CRT0"
+options = ["LIST", "MAP", "XREF", "RENT"]
+include = [
+  "@@CRT1",
+  "TSTLOAD",
+  "IRX#LOAD",
+  "IRX#STOR",
+]
 
 # ---------------------------------------------------------------
 # TINITVL - Live MVS test caller for IRXINIT INITENVB.

--- a/src/irx#load.c
+++ b/src/irx#load.c
@@ -1,0 +1,602 @@
+/* irx#load.c - IRXLOAD C-core: LOAD and FREE function codes
+**
+** Implements the IRXLOAD Programming Service per SC28-1883-0 §14.
+**
+** LOAD: locates a REXX exec in a PDS (MVS: BSAM) or flat file (host),
+**       reads all source lines into an INSTBLK, and returns a pointer.
+** FREE: releases the INSTBLK and its source pool allocated by LOAD.
+**
+** DD search order (per ticket WP-CPS-07):
+**   1. EXECBLK_DDNAME if non-blank
+**   2. SYSEXEC
+**   3. SYSPROC
+**   SYSUEXEC is out of scope (TSO-specific; future separate ticket).
+**
+** Source accumulation uses a single-pass approach:
+**   - Temp buffers (line_info table + source pool) are allocated via
+**     irxstor, filled in one pass, then compacted into final blocks.
+**   - Limits: IRXLOAD_MAX_LINES lines, IRXLOAD_MAX_SRCBYTES source bytes.
+**     Execs exceeding either limit return RC=8.
+**
+** LOAD/FREE bookkeeping:
+**   The source-pool pointer is stashed in instblk._filler4[0..] using
+**   memcpy so FREE can recover it without any external table.
+**   _filler4 is IBM-reserved and private to this LOAD/FREE pair; no
+**   other module may read or write these bytes in an IRXLOAD-owned block.
+**
+** Ref: SC28-1883-0 §14 (IRXLOAD Programming Service)
+** Ref: CON-1 §3.4 (INSTBLK byte-exact layout)
+** Ref: WP-CPS-07 / TSK-219 / GitHub mvslovers/rexx370#116
+**
+** (c) 2026 mvslovers - REXX/370 Project
+*/
+
+#include <stddef.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxfunc.h"
+#include "irxinstb.h"
+#include "irxload.h"
+
+#ifdef __MVS__
+#include <clibos.h>
+#include <osdcb.h>
+#include <osio.h>
+#else
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#endif
+
+/* On MVS, sizeof(struct instblk) must equal INSTBLK_HDRLEN (128).
+ * On 64-bit hosts the layout differs (8-byte pointers); assertion is
+ * MVS-only for the same reason as envblock_size_is_320_ in irx#init.c. */
+#ifdef __MVS__
+typedef char instblk_hdrlen_ok_[(sizeof(struct instblk) == INSTBLK_HDRLEN) ? 1 : -1];
+#endif
+
+/* Source-pool pointer stored in _filler4[0..1] by LOAD; recovered by FREE.
+ * Assert pointer fits in the 8-byte _filler4 field (int[2] on MVS = 8 B,
+ * same on 64-bit host). */
+typedef char instblk_filler4_fits_[(sizeof(void *) <= sizeof(((struct instblk *)0)->_filler4)) ? 1 : -1];
+
+/* Per-line accumulation entry during single-pass source read. */
+struct line_info
+{
+    int offset; /* byte offset of this line's start in temp source pool */
+    int length; /* line byte count (trailing spaces stripped) */
+};
+
+/* Upper bounds for single-pass accumulation.
+ * Execs exceeding either limit return IRXLOAD_NOTFOUND. */
+#define IRXLOAD_MAX_LINES    2048
+#define IRXLOAD_MAX_SRCBYTES 65536
+
+/* EBCDIC space character (used to strip trailing blanks on MVS). */
+#define EBCDIC_SPACE ((unsigned char)0x40)
+
+/* Byte count of a BDW or RDW field in a VB block. */
+#define VB_HDR_SIZE 4
+
+/* Length of any CL8 (8-character blank-padded) IBM field. */
+#define CL8_LEN 8
+
+/* Byte length of a CL8 function code (same as CL8_LEN, named for clarity). */
+#define IRXLOAD_FC_LEN CL8_LEN
+
+/* Length of the TTR (Track-Track-Record) field in a BLDL entry (3 bytes). */
+#define TTR_LEN 3
+
+/* Bit shift to extract the high byte of a 16-bit big-endian integer. */
+#define BYTE_SHIFT 8
+
+/* Size of a NUL-terminated copy of a CL8 field (8 data bytes + NUL). */
+#define CL8_BUFLEN (CL8_LEN + 1)
+
+/* Allocate via irxstor; on failure jump to cleanup: in the enclosing
+ * function.  Mirrors the ALLOC macro in irx#init.c. */
+#define ALLOC(ptr, size, env)                               \
+    do                                                      \
+    {                                                       \
+        void *_t = NULL;                                    \
+        if (irxstor(RXSMGET, (int)(size), &_t, (env)) != 0) \
+            goto cleanup;                                   \
+        (ptr) = _t;                                         \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  trim8 — strip trailing spaces from an 8-char padded field         */
+/*  Writes a NUL-terminated copy to out (caller supplies >= 9 bytes). */
+/* ------------------------------------------------------------------ */
+static void trim8(const unsigned char *src, char *out)
+{
+    int len = CL8_LEN;
+    /* EBCDIC space = 0x40; ASCII space = 0x20; both handled. */
+    while (len > 0 && (src[len - 1] == ' ' || src[len - 1] == EBCDIC_SPACE))
+    {
+        --len;
+    }
+    memcpy(out, src, (size_t)len);
+    out[len] = '\0';
+}
+
+/* ================================================================== */
+/*  build_instblk — assemble the final INSTBLK from accumulated data  */
+/*                                                                    */
+/*  Allocates two blocks via irxstor:                                 */
+/*    1. header + entry table (INSTBLK_HDRLEN + n * 8 bytes)         */
+/*    2. final source pool (total source bytes, min 1)               */
+/*                                                                    */
+/*  Fills the header, copies source text, and builds entry pointers.  */
+/*  Stashes the source-pool pointer in instblk._filler4 for FREE.    */
+/*  Returns IRXLOAD_OK on success; frees both blocks and returns      */
+/*  IRXLOAD_NOMEM on allocation failure.                              */
+/* ================================================================== */
+static int build_instblk(struct envblock *envblk,
+                         struct instblk **out,
+                         const unsigned char *member8,
+                         const unsigned char *ddname8,
+                         const struct line_info *lt, int n,
+                         const char *tsrc, int total)
+{
+    struct instblk *hdr = NULL;
+    char *fsrc = NULL;
+    struct instblk_entry *ents;
+    int block_size;
+    void *sp_copy;
+    int i;
+
+    block_size = INSTBLK_HDRLEN + n * (int)sizeof(struct instblk_entry);
+    ALLOC(hdr, block_size, envblk);
+    ALLOC(fsrc, (total > 0 ? total : 1), envblk);
+
+    if (total > 0)
+    {
+        memcpy(fsrc, tsrc, (size_t)total);
+    }
+
+    /* Initialise header to zero, then fill known fields. */
+    memset(hdr, 0, (size_t)INSTBLK_HDRLEN);
+    memcpy(hdr->instblk_acronym, INSTBLK_ID, sizeof(hdr->instblk_acronym));
+    hdr->instblk_hdrlen = INSTBLK_HDRLEN;
+    ents = (struct instblk_entry *)((char *)hdr + INSTBLK_HDRLEN);
+    hdr->instblk_address = ents;
+    hdr->instblk_usedlen = n * (int)sizeof(struct instblk_entry);
+    memcpy(hdr->instblk_member, member8, sizeof(hdr->instblk_member));
+    if (ddname8)
+    {
+        memcpy(hdr->instblk_ddname, ddname8, sizeof(hdr->instblk_ddname));
+    }
+    /* instblk_subcom left blank (initial subcommand = default) */
+
+    /* Build entry pointers: each entry points into the final source pool. */
+    for (i = 0; i < n; i++)
+    {
+        ents[i].instblk_stmt_ = fsrc + lt[i].offset;
+        ents[i].instblk_stmtlen = lt[i].length;
+    }
+
+    /* Stash source-pool pointer in _filler4 for FREE to recover. */
+    sp_copy = fsrc;
+    memcpy(hdr->_filler4, (const void *)&sp_copy, sizeof(void *));
+
+    *out = hdr;
+    return IRXLOAD_OK;
+
+cleanup:
+    if (fsrc)
+    {
+        void *p = fsrc;
+        irxstor(RXSMFRE, 0, &p, envblk);
+    }
+    if (hdr)
+    {
+        void *p = hdr;
+        irxstor(RXSMFRE, 0, &p, envblk);
+    }
+    return IRXLOAD_NOMEM;
+}
+
+/* ================================================================== */
+/*  MVS BSAM path                                                     */
+/* ================================================================== */
+#ifdef __MVS__
+
+/* scan_member — read all source lines of a PDS member via BSAM.
+ *
+ * Appends line offsets and text to the caller-supplied lt/tsrc arrays.
+ * Returns 0 on success, IRXLOAD_NOTFOUND if the DD or member is absent,
+ * IRXLOAD_NOMEM if the read buffer cannot be allocated, or IRXLOAD_NOTFOUND
+ * if the accumulated data would exceed max_lines / max_srcbytes.
+ */
+static int scan_member(const char *ddname,
+                       const unsigned char *member8,
+                       struct envblock *envblk,
+                       struct line_info *lt, int max_lines,
+                       char *tsrc, int max_srcbytes,
+                       int *n_out, int *total_out)
+{
+    BLDL bldl_buf;
+    DECB decb;
+    DCB *dcb;
+    void *rbuf_v = NULL;
+    char *rbuf;
+    int blksize;
+    int lrecl;
+    int recfm;
+    int n = 0;
+    int total = 0;
+    int rc = IRXLOAD_NOTFOUND;
+
+    memset(&bldl_buf, 0, sizeof(bldl_buf));
+    bldl_buf.ff = 1;
+    bldl_buf.ll = (short)sizeof(DE14);
+    memcpy(bldl_buf.de14[0].name, member8, sizeof(bldl_buf.de14[0].name));
+
+    dcb = osbdcb(ddname, NULL);
+    if (!dcb)
+    {
+        return IRXLOAD_NOTFOUND;
+    }
+
+    if (osbopen(dcb, 0, "r") != 0)
+    {
+        osbclose(dcb, NULL, 1, 0);
+        return IRXLOAD_NOTFOUND;
+    }
+
+    if (__bldl(&bldl_buf, dcb) != 0)
+    {
+        osbclose(dcb, NULL, 1, 0);
+        return IRXLOAD_NOTFOUND;
+    }
+
+    /* Position DCB at member start: TTR from BLDL, R=0. */
+    memcpy(dcb->ttrn, bldl_buf.de14[0].ttr, TTR_LEN);
+    dcb->ttrn[TTR_LEN] = 0; /* R byte = 0 → start from beginning */
+
+    blksize = (int)dcb->dcbblksi;
+    lrecl = (int)dcb->dcblrecl;
+    recfm = (int)(dcb->dcbrecfm & (DCBRECF | DCBRECV));
+
+    if (irxstor(RXSMGET, blksize, &rbuf_v, envblk) != 0)
+    {
+        osbclose(dcb, NULL, 1, 0);
+        return IRXLOAD_NOMEM;
+    }
+    rbuf = (char *)rbuf_v;
+    rc = 0;
+
+    for (;;)
+    {
+        int chk;
+        osbread(&decb, dcb, rbuf, blksize);
+        chk = oscheck(&decb);
+        if (chk != 0)
+        {
+            break; /* end of member */
+        }
+
+        if (recfm == DCBRECF)
+        {
+            /* FB: fixed-length records of LRECL bytes each. */
+            int nr = (lrecl > 0) ? blksize / lrecl : 0;
+            int i;
+            for (i = 0; i < nr; i++)
+            {
+                char *rec = rbuf + (ptrdiff_t)i * lrecl;
+                int len = lrecl;
+                /* Trim trailing EBCDIC spaces. */
+                while (len > 0 && (unsigned char)rec[len - 1] == EBCDIC_SPACE)
+                {
+                    --len;
+                }
+                if (n >= max_lines || total + len > max_srcbytes)
+                {
+                    rc = IRXLOAD_NOTFOUND;
+                    goto done;
+                }
+                lt[n].offset = total;
+                lt[n].length = len;
+                if (len > 0)
+                {
+                    memcpy(tsrc + total, rec, (size_t)len);
+                }
+                total += len;
+                n++;
+            }
+        }
+        else if (recfm == DCBRECV)
+        {
+            /* VB: BDW (4-byte block descriptor) + records with RDW prefix. */
+            int blk_len = ((unsigned char)rbuf[0] << BYTE_SHIFT) |
+                          (unsigned char)rbuf[1];
+            int pos = VB_HDR_SIZE; /* skip BDW */
+            while (pos + VB_HDR_SIZE <= blk_len)
+            {
+                int rdw = ((unsigned char)rbuf[pos] << BYTE_SHIFT) |
+                          (unsigned char)rbuf[pos + 1];
+                int dlen = rdw - VB_HDR_SIZE;
+                if (dlen < 0)
+                {
+                    break; /* corrupt RDW */
+                }
+                if (dlen > 0)
+                {
+                    if (n >= max_lines || total + dlen > max_srcbytes)
+                    {
+                        rc = IRXLOAD_NOTFOUND;
+                        goto done;
+                    }
+                    lt[n].offset = total;
+                    lt[n].length = dlen;
+                    memcpy(tsrc + total, rbuf + pos + VB_HDR_SIZE, (size_t)dlen);
+                    total += dlen;
+                    n++;
+                }
+                pos += rdw;
+            }
+        }
+        /* DCBRECU (undefined RECFM) is not supported for PDS source. */
+    }
+
+done:
+    irxstor(RXSMFRE, 0, &rbuf_v, envblk);
+    osbclose(dcb, NULL, 1, 0);
+    if (rc == 0)
+    {
+        *n_out = n;
+        *total_out = total;
+    }
+    return rc;
+}
+
+#endif /* __MVS__ */
+
+/* ================================================================== */
+/*  irx_load_load — LOAD function code implementation                 */
+/* ================================================================== */
+static int irx_load_load(struct execblk *execblk,
+                         struct instblk **instblk_p,
+                         struct envblock *envblk)
+{
+    struct line_info *lt = NULL;
+    char *tsrc = NULL;
+    int n = 0;
+    int total = 0;
+    int found = 0;
+    int rc = IRXLOAD_NOTFOUND;
+
+    /* Validate EXECBLK. */
+    if (!execblk ||
+        memcmp(execblk->exec_blk_acryn, EXECBLK_ID, sizeof(execblk->exec_blk_acryn)) != 0 ||
+        execblk->exec_blk_length < EXECBLK_V1_LEN)
+    {
+        return IRXLOAD_ERROR;
+    }
+
+    /* Allocate temp accumulation buffers. */
+    ALLOC(lt, (int)(IRXLOAD_MAX_LINES * sizeof(struct line_info)), envblk);
+    ALLOC(tsrc, IRXLOAD_MAX_SRCBYTES, envblk);
+
+#ifdef __MVS__
+    {
+        char dd_hint[CL8_BUFLEN];
+        trim8(execblk->exec_ddname, dd_hint);
+
+        if (dd_hint[0] != '\0')
+        {
+            /* Caller supplied a specific DD — use only that. */
+            if (scan_member(dd_hint, execblk->exec_member, envblk,
+                            lt, IRXLOAD_MAX_LINES, tsrc, IRXLOAD_MAX_SRCBYTES,
+                            &n, &total) == 0)
+            {
+                found = 1;
+            }
+        }
+        else
+        {
+            /* Standard search order: SYSEXEC first, then SYSPROC. */
+            static const char *dds[] = {"SYSEXEC", "SYSPROC"};
+            int di;
+            for (di = 0; di < 2 && !found; di++)
+            {
+                if (scan_member(dds[di], execblk->exec_member, envblk,
+                                lt, IRXLOAD_MAX_LINES, tsrc, IRXLOAD_MAX_SRCBYTES,
+                                &n, &total) == 0)
+                {
+                    found = 1;
+                }
+            }
+        }
+    }
+#else
+    {
+        char dd_hint[CL8_BUFLEN];
+        char mname[CL8_BUFLEN];
+        char fpath[512];
+
+        trim8(execblk->exec_ddname, dd_hint);
+        trim8(execblk->exec_member, mname);
+
+        /* Uppercase member name for filesystem lookup. */
+        {
+            int i;
+            for (i = 0; mname[i]; i++)
+            {
+                mname[i] = (char)toupper((unsigned char)mname[i]);
+            }
+        }
+
+        /* Build DD search list.
+         * On host, getenv("SYSEXEC") etc. return directory paths set by the
+         * test harness.  If a DD-name env var is not set, skip that DD. */
+        {
+            const char *try_dds[3];
+            int nd = 0;
+
+            if (dd_hint[0] != '\0')
+            {
+                try_dds[nd++] = dd_hint;
+            }
+            else
+            {
+                try_dds[nd++] = "SYSEXEC";
+                try_dds[nd++] = "SYSPROC";
+            }
+
+            {
+                int di;
+                for (di = 0; di < nd && !found; di++)
+                {
+                    const char *dir = getenv(try_dds[di]);
+                    FILE *f;
+                    if (!dir)
+                    {
+                        continue;
+                    }
+                    snprintf(fpath, sizeof(fpath), "%s/%s.rex", dir, mname);
+                    f = fopen(fpath, "r");
+                    if (!f)
+                    {
+                        continue;
+                    }
+
+                    /* Single-pass: fgets each line into temp buffers. */
+                    {
+                        char linebuf[256];
+                        while (fgets(linebuf, (int)sizeof(linebuf), f))
+                        {
+                            int len = (int)strlen(linebuf);
+                            /* Strip newline and trailing spaces. */
+                            while (len > 0 &&
+                                   (linebuf[len - 1] == '\n' ||
+                                    linebuf[len - 1] == '\r' ||
+                                    linebuf[len - 1] == ' '))
+                            {
+                                --len;
+                            }
+                            if (n >= IRXLOAD_MAX_LINES ||
+                                total + len > IRXLOAD_MAX_SRCBYTES)
+                            {
+                                break; /* exec too large */
+                            }
+                            lt[n].offset = total;
+                            lt[n].length = len;
+                            if (len > 0)
+                            {
+                                memcpy(tsrc + total, linebuf, (size_t)len);
+                            }
+                            total += len;
+                            n++;
+                        }
+                    }
+                    fclose(f);
+                    found = 1;
+                }
+            }
+        }
+    }
+#endif /* __MVS__ */
+
+    if (!found)
+    {
+        rc = IRXLOAD_NOTFOUND;
+        goto cleanup;
+    }
+
+    rc = build_instblk(envblk, instblk_p,
+                       execblk->exec_member,
+                       execblk->exec_ddname,
+                       lt, n, tsrc, total);
+
+cleanup:
+    if (tsrc)
+    {
+        void *p = tsrc;
+        irxstor(RXSMFRE, 0, &p, envblk);
+    }
+    if (lt)
+    {
+        void *p = lt;
+        irxstor(RXSMFRE, 0, &p, envblk);
+    }
+    return rc;
+}
+
+/* ================================================================== */
+/*  irx_load_free — FREE function code implementation                 */
+/* ================================================================== */
+static int irx_load_free(struct instblk **instblk_pp,
+                         struct envblock *envblk)
+{
+    struct instblk *hdr;
+    void *sp = NULL;
+
+    if (!instblk_pp || !*instblk_pp)
+    {
+        return IRXLOAD_ERROR;
+    }
+
+    hdr = *instblk_pp;
+    if (memcmp(hdr->instblk_acronym, INSTBLK_ID, sizeof(hdr->instblk_acronym)) != 0)
+    {
+        return IRXLOAD_ERROR;
+    }
+
+    /* Recover and free source pool stashed by LOAD. */
+    memcpy((void *)&sp, hdr->_filler4, sizeof(void *));
+    if (sp)
+    {
+        irxstor(RXSMFRE, 0, &sp, envblk);
+    }
+
+    /* Clear caller's pointer before freeing so any use-after-free is
+     * immediately visible as a NULL dereference. */
+    *instblk_pp = NULL;
+    {
+        void *p = hdr;
+        irxstor(RXSMFRE, 0, &p, envblk);
+    }
+
+    return IRXLOAD_OK;
+}
+
+/* ================================================================== */
+/*  irx_load_dispatch — central dispatcher (asm() alias: IRXLDISP)   */
+/* ================================================================== */
+int irx_load_dispatch(const char *funccode,
+                      struct execblk *execblk,
+                      struct instblk **instblk_p,
+                      struct envblock *envblk,
+                      int *retval)
+{
+    int rc;
+
+    if (!funccode || !instblk_p || !retval)
+    {
+        rc = IRXLOAD_ERROR;
+        if (retval)
+        {
+            *retval = rc;
+        }
+        return rc;
+    }
+
+    if (memcmp(funccode, IRXLOAD_FC_LOAD, IRXLOAD_FC_LEN) == 0)
+    {
+        rc = irx_load_load(execblk, instblk_p, envblk);
+    }
+    else if (memcmp(funccode, IRXLOAD_FC_FREE, IRXLOAD_FC_LEN) == 0)
+    {
+        rc = irx_load_free(instblk_p, envblk);
+    }
+    else
+    {
+        rc = IRXLOAD_ERROR;
+    }
+
+    *retval = rc;
+    return rc;
+}

--- a/test/mvs/tstload.c
+++ b/test/mvs/tstload.c
@@ -1,0 +1,357 @@
+/* ------------------------------------------------------------------ */
+/*  tstload.c - WP-CPS-07 IRXLOAD C-core unit tests                  */
+/*                                                                    */
+/*  Tests irx_load_dispatch() directly (bypasses the asm IRXLOAD      */
+/*  wrapper).  Host build uses the filesystem backend; MVS build       */
+/*  tests the BSAM path with real DD allocations (AC-11).             */
+/*                                                                    */
+/*  Test cases:                                                        */
+/*  T1: LOAD valid member (SYSEXEC) -> RC=0, valid INSTBLK            */
+/*  T2: LOAD+FREE cycle -> INSTBLK ptr cleared, no leak               */
+/*  T3: LOAD member-not-found -> RC=8                                 */
+/*  T4: LOAD DD not set (no SYSEXEC/SYSPROC env var) -> RC=8         */
+/*  T5: LOAD bad EXECBLK eye-catcher -> RC=20                         */
+/*  T6: FREE bad INSTBLK eye-catcher -> RC=20                         */
+/*  T7: FREE NULL instblk_p dereference -> RC=20                      */
+/*  T8: LOAD via explicit DDNAME in EXECBLK -> RC=0                  */
+/*  T9: LOAD empty member (zero source lines) -> RC=0, usedlen=0     */
+/*                                                                    */
+/*  Host cross-compile:                                               */
+/*    gcc -I include -Wall -Wextra -std=gnu99 \                       */
+/*        -o /tmp/tstload test/mvs/tstload.c \                        */
+/*        src/irx#load.c src/irx#stor.c                               */
+/*                                                                    */
+/*  MVS invocation:                                                   */
+/*    TSO   :  CALL 'hlq.LOAD(TSTLOAD)'                               */
+/*    Batch :  EXEC PGM=TSTLOAD                                       */
+/*  Expected: CC=0                                                    */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxfunc.h"
+#include "irxload.h"
+
+/* ------------------------------------------------------------------
+ * Test infrastructure
+ * ------------------------------------------------------------------ */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                                       \
+    do                                                         \
+    {                                                          \
+        tests_run++;                                           \
+        if (cond)                                              \
+        {                                                      \
+            tests_passed++;                                    \
+            printf("  PASS: %s\n", (msg));                     \
+        }                                                      \
+        else                                                   \
+        {                                                      \
+            tests_failed++;                                    \
+            printf("  FAIL: %s (line %d)\n", (msg), __LINE__); \
+        }                                                      \
+    } while (0)
+
+/* Build a minimal, valid EXECBLK.
+ * member8: exactly 8 chars, blank-padded (e.g. "HELLO   ")
+ * ddname8: exactly 8 chars, blank-padded, or all-blank for auto-search */
+static void make_execblk(struct execblk *e,
+                         const char *member8,
+                         const char *ddname8)
+{
+    memset(e, 0, sizeof(*e));
+    memcpy(e->exec_blk_acryn, EXECBLK_ID, sizeof(e->exec_blk_acryn));
+    e->exec_blk_length = EXECBLK_V1_LEN;
+    memcpy(e->exec_member, member8, sizeof(e->exec_member));
+    memcpy(e->exec_ddname, ddname8, sizeof(e->exec_ddname));
+}
+
+/* ------------------------------------------------------------------
+ * Host-only test helpers
+ * (on MVS these are replaced by real JCL DD setup)
+ * ------------------------------------------------------------------ */
+#ifndef __MVS__
+
+#include <sys/stat.h>
+
+static char s_sysexec_dir[256];
+static char s_altdd_dir[256];
+
+/* Create a directory and one or more .rex files inside it. */
+static void write_test_file(const char *dir, const char *member,
+                            const char *content)
+{
+    char path[512];
+    FILE *f;
+    snprintf(path, sizeof(path), "%s/%s.rex", dir, member);
+    f = fopen(path, "w");
+    if (f)
+    {
+        fputs(content, f);
+        fclose(f);
+    }
+}
+
+/* Set up temp directories and test .rex files.
+ * Returns 0 on success. */
+static int setup_test_dirs(void)
+{
+    snprintf(s_sysexec_dir, sizeof(s_sysexec_dir), "/tmp/tstload_sysexec");
+    snprintf(s_altdd_dir, sizeof(s_altdd_dir), "/tmp/tstload_altdd");
+
+    mkdir(s_sysexec_dir, 0755);
+    mkdir(s_altdd_dir, 0755);
+
+    /* T1 / T2 / T9: member HELLO in SYSEXEC */
+    write_test_file(s_sysexec_dir, "HELLO",
+                    "/* test REXX exec */\n"
+                    "say 'hello'\n"
+                    "exit 0\n");
+
+    /* T8: member ALTM in ALTDD (separate directory) */
+    write_test_file(s_altdd_dir, "ALTM",
+                    "/* alt dd exec */\n"
+                    "exit 0\n");
+
+    /* T9: empty member (zero lines) */
+    write_test_file(s_sysexec_dir, "EMPTY", "");
+
+    /* Set env vars so irx#load.c's getenv() path finds the dirs. */
+    setenv("SYSEXEC", s_sysexec_dir, 1);
+    setenv("ALTDD", s_altdd_dir, 1);
+
+    /* Unset SYSPROC so T4 can test "both DDs absent". */
+    unsetenv("SYSPROC");
+
+    return 0;
+}
+
+#endif /* !__MVS__ */
+
+/* ================================================================== */
+/*  Tests                                                             */
+/* ================================================================== */
+
+static void test_load_valid(void)
+{
+    struct execblk eb;
+    struct instblk *ib = NULL;
+    struct instblk_entry *ent;
+    int retval = -1;
+    int rc;
+
+    printf("T1: LOAD valid member\n");
+    make_execblk(&eb, "HELLO   ", "        ");
+
+    rc = irx_load_dispatch(IRXLOAD_FC_LOAD, &eb, &ib, NULL, &retval);
+
+    CHECK(rc == IRXLOAD_OK, "LOAD returns RC=0");
+    CHECK(retval == IRXLOAD_OK, "retval written to 0");
+    CHECK(ib != NULL, "INSTBLK pointer non-NULL");
+
+    if (!ib)
+    {
+        return;
+    }
+
+    CHECK(memcmp(ib->instblk_acronym, INSTBLK_ID,
+                 sizeof(ib->instblk_acronym)) == 0,
+          "INSTBLK_ACRONYM = 'IRXINSTB'");
+    CHECK(ib->instblk_hdrlen == INSTBLK_HDRLEN, "instblk_hdrlen = 128");
+    CHECK(ib->instblk_address != NULL, "instblk_address non-NULL");
+    CHECK(ib->instblk_usedlen >= 0, "instblk_usedlen non-negative");
+    CHECK((ib->instblk_usedlen % (int)sizeof(struct instblk_entry)) == 0,
+          "instblk_usedlen multiple of entry size");
+
+    /* Verify entries point into valid memory (access first entry). */
+    if (ib->instblk_usedlen >= (int)sizeof(struct instblk_entry))
+    {
+        ent = (struct instblk_entry *)ib->instblk_address;
+        CHECK(ent->instblk_stmtlen >= 0, "first entry length >= 0");
+    }
+
+    /* Leave ib for T2. */
+}
+
+static void test_load_free_cycle(void)
+{
+    struct execblk eb;
+    struct instblk *ib = NULL;
+    int retval = -1;
+    int rc;
+
+    printf("T2: LOAD + FREE cycle\n");
+    make_execblk(&eb, "HELLO   ", "        ");
+
+    rc = irx_load_dispatch(IRXLOAD_FC_LOAD, &eb, &ib, NULL, &retval);
+    CHECK(rc == IRXLOAD_OK && ib != NULL, "LOAD succeeds");
+
+    if (!ib)
+    {
+        return;
+    }
+
+    rc = irx_load_dispatch(IRXLOAD_FC_FREE, NULL, &ib, NULL, &retval);
+    CHECK(rc == IRXLOAD_OK, "FREE returns RC=0");
+    CHECK(ib == NULL, "FREE clears caller pointer");
+    CHECK(retval == IRXLOAD_OK, "retval written to 0 by FREE");
+}
+
+static void test_member_not_found(void)
+{
+    struct execblk eb;
+    struct instblk *ib = NULL;
+    int retval = -1;
+    int rc;
+
+    printf("T3: LOAD member not found\n");
+    make_execblk(&eb, "NOSUCHM ", "        ");
+
+    rc = irx_load_dispatch(IRXLOAD_FC_LOAD, &eb, &ib, NULL, &retval);
+    CHECK(rc == IRXLOAD_NOTFOUND, "LOAD returns RC=8");
+    CHECK(ib == NULL, "INSTBLK pointer stays NULL");
+}
+
+static void test_dd_not_set(void)
+{
+    struct execblk eb;
+    struct instblk *ib = NULL;
+    int retval = -1;
+    int rc;
+
+    printf("T4: LOAD DD not allocated\n");
+    /* Use a DDNAME that is not in the environment. */
+    make_execblk(&eb, "HELLO   ", "NOSUCHDD");
+
+    rc = irx_load_dispatch(IRXLOAD_FC_LOAD, &eb, &ib, NULL, &retval);
+    CHECK(rc == IRXLOAD_NOTFOUND, "LOAD returns RC=8 when DD absent");
+    CHECK(ib == NULL, "INSTBLK pointer stays NULL");
+}
+
+static void test_bad_execblk(void)
+{
+    struct execblk eb;
+    struct instblk *ib = NULL;
+    int retval = -1;
+    int rc;
+
+    printf("T5: LOAD bad EXECBLK eye-catcher\n");
+    make_execblk(&eb, "HELLO   ", "        ");
+    memcpy(eb.exec_blk_acryn, "BADBLOCK", sizeof(eb.exec_blk_acryn));
+
+    rc = irx_load_dispatch(IRXLOAD_FC_LOAD, &eb, &ib, NULL, &retval);
+    CHECK(rc == IRXLOAD_ERROR, "LOAD returns RC=20 for bad eye-catcher");
+    CHECK(ib == NULL, "INSTBLK pointer stays NULL");
+}
+
+static void test_free_bad_eyecatcher(void)
+{
+    struct instblk fake;
+    struct instblk *p = &fake;
+    int retval = -1;
+    int rc;
+
+    printf("T6: FREE bad INSTBLK eye-catcher\n");
+    memset(&fake, 0, sizeof(fake));
+    memcpy(fake.instblk_acronym, "BADBLOCK", sizeof(fake.instblk_acronym));
+
+    rc = irx_load_dispatch(IRXLOAD_FC_FREE, NULL, &p, NULL, &retval);
+    CHECK(rc == IRXLOAD_ERROR, "FREE returns RC=20 for bad eye-catcher");
+}
+
+static void test_free_null_ptr(void)
+{
+    struct instblk *p = NULL;
+    int retval = -1;
+    int rc;
+
+    printf("T7: FREE NULL instblk pointer\n");
+    rc = irx_load_dispatch(IRXLOAD_FC_FREE, NULL, &p, NULL, &retval);
+    CHECK(rc == IRXLOAD_ERROR, "FREE returns RC=20 for NULL pointer");
+}
+
+static void test_load_explicit_ddname(void)
+{
+    struct execblk eb;
+    struct instblk *ib = NULL;
+    int retval = -1;
+    int rc;
+
+    printf("T8: LOAD via explicit DDNAME in EXECBLK\n");
+    make_execblk(&eb, "ALTM    ", "ALTDD   ");
+
+    rc = irx_load_dispatch(IRXLOAD_FC_LOAD, &eb, &ib, NULL, &retval);
+    CHECK(rc == IRXLOAD_OK, "LOAD via explicit DDNAME returns RC=0");
+    CHECK(ib != NULL, "INSTBLK non-NULL");
+
+    if (ib)
+    {
+        int free_rc = irx_load_dispatch(IRXLOAD_FC_FREE, NULL, &ib, NULL, &retval);
+        CHECK(free_rc == IRXLOAD_OK, "FREE after explicit-DDNAME LOAD ok");
+    }
+}
+
+static void test_load_empty_member(void)
+{
+    struct execblk eb;
+    struct instblk *ib = NULL;
+    int retval = -1;
+    int rc;
+
+    printf("T9: LOAD empty member\n");
+    make_execblk(&eb, "EMPTY   ", "        ");
+
+    rc = irx_load_dispatch(IRXLOAD_FC_LOAD, &eb, &ib, NULL, &retval);
+    CHECK(rc == IRXLOAD_OK, "LOAD empty member returns RC=0");
+
+    if (ib)
+    {
+        CHECK(ib->instblk_usedlen == 0, "instblk_usedlen = 0 for empty exec");
+        {
+            int free_rc = irx_load_dispatch(IRXLOAD_FC_FREE, NULL, &ib, NULL, &retval);
+            CHECK(free_rc == IRXLOAD_OK, "FREE empty exec ok");
+        }
+    }
+}
+
+/* ================================================================== */
+/*  main                                                              */
+/* ================================================================== */
+int main(void)
+{
+    printf("TSTLOAD: IRXLOAD C-core tests\n");
+    printf("------------------------------\n");
+
+#ifndef __MVS__
+    if (setup_test_dirs() != 0)
+    {
+        printf("FATAL: could not set up test directories\n");
+        return 1;
+    }
+#endif
+
+    test_load_valid();
+    test_load_free_cycle();
+    test_member_not_found();
+    test_dd_not_set();
+    test_bad_execblk();
+    test_free_bad_eyecatcher();
+    test_free_null_ptr();
+    test_load_explicit_ddname();
+    test_load_empty_member();
+
+    printf("------------------------------\n");
+    printf("Results: %d run, %d passed, %d failed\n",
+           tests_run, tests_passed, tests_failed);
+
+    return (tests_failed == 0) ? 0 : 1;
+}


### PR DESCRIPTION
Closes #116

## Summary

- `asm/irxload.asm` — HLASM VLIST entry wrapper (5-slot, VL-terminator validated, BUILDC→IRXLDISP, PDP-DSA/WPOOL shape matching `irxinit.asm`)
- `src/irx#load.c` — C-core dispatcher + LOAD/FREE; single-pass accumulation into INSTBLK + separate source pool; DD search order: EXECBLK\_DDNAME → SYSEXEC → SYSPROC; MVS: BSAM (osbdcb/osbread) with FB/VB detection; host: getenv + fopen backend
- `include/irxload.h` — function codes, return codes, `irx_load_dispatch()` prototype with `asm("IRXLDISP")` alias
- `include/irxinstb.h` — MVS-only static assertion `sizeof(instblk) == 128`
- `test/mvs/tstload.c` — 9 test cases, 27 assertions
- `project.toml` — `[[link.module]]` entries for IRXLOAD and TSTLOAD

## Test plan

- [x] Host cross-compile: `tstload` — **27/27 pass**
- [x] No regressions in existing suite — **1236/1236 pass** (16 binaries)
- [ ] MVS build: `mbt build --target IRXLOAD` + `mbt build --target TSTLOAD`
- [ ] MVS test: `EXEC PGM=TSTLOAD` → CC=0
- [ ] MVS BSAM path: LOAD from real PDS member, FB and VB RECFM