### PR TITLE
polish(cps-06/07): T6 skip, IRXEXEC hardening, tstall.jcl fixtures

### DIFF
--- a/asm/irxexec.asm
+++ b/asm/irxexec.asm
@@ -43,6 +43,11 @@
 *        (size deterministic from sum(instblk_stmtlen) upfront).
 *    (c) Separator byte: C literal '\n'; c2asm370 translates to
 *        EBCDIC 0x15 at compile time; tokenizer accepts it.
+*    (d) Null slot-address guard: after VLIST parse, BUILDC checks
+*        each P1-P9 slot address (WPARMS+0..+32).  A zero slot
+*        address returns BADPLIST rather than faulting on page zero.
+*        Null parameter VALUES (e.g. P5=0 for non-TSO callers) are
+*        legal and are NOT rejected by this guard.
 *
 *  V1 vs z/OS-stage:
 *    SC28-1883-0 V1 had a shorter, different slot layout.
@@ -165,6 +170,23 @@ P10PRES  EQU   *
 *        fall through to BUILDC
 *
 BUILDC   EQU   *
+*  --- null slot-address guard (arch decision (d)) ------------------
+*  Walk WPARMS[0..8] (P1-P9 slot addresses). A zero address means
+*  the caller's VLIST entry itself is zero -- malformed; BADPLIST.
+*  Null VALUES pointed to by a valid slot address are legal.
+*
+         LA    R2,9                R2 = 9 slots (P1-P9)
+         LA    R3,WPARMS           R3 = &WPARMS[0]
+CHKSLP   L     R6,0(,R3)          R6 = bare slot address
+         LTR   R6,R6               zero slot address?
+         BZ    NULLSLOT            yes -> BADPLIST
+         LA    R3,4(,R3)           advance to next slot
+         BCT   R2,CHKSLP
+         B     DOSLOTS             all slot addresses valid
+NULLSLOT LA    R15,32              BADPLIST = 32
+         B     ERREARLY
+DOSLOTS  EQU   *
+*
 *  --- build C-call plist for IRXEDISP ----------------------------
 *
 *  irx_exec_dispatch(execblk, argtable, flags_val,

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -143,8 +143,9 @@ int irx_exec_dispatch(struct execblk *execblk,
         }
         /* NULL INSTBLK + valid EXECBLK = DD-based load path.
          * DD loading is IRXLOAD's job; IRXEXEC requires a caller-supplied
-         * INSTBLK. Deferred path documented; return BADPLIST for now. */
-        return IRXEXEC_BADPLIST;
+         * INSTBLK. The parameter list is well-formed, so this is
+         * IRXEXEC_ERROR (RC=20), not BADPLIST (RC=32). */
+        return IRXEXEC_ERROR;
     }
     else
     {

--- a/test/mvs/tstall.jcl
+++ b/test/mvs/tstall.jcl
@@ -88,17 +88,16 @@
 //* HELLO, EMPTY, ALTM must exist in IBMUSER.EXEC before any
 //* TSTLOAD step runs (both Batch and TSO invocations below).
 //*---------------------------------------------------------------
-//SETUP    EXEC PGM=IEBUPDTE,PARM=NEW,COND=EVEN
+//SETUP    EXEC PGM=IEBUPDTE,PARM=MOD,COND=EVEN
 //SYSPRINT DD SYSOUT=*
+//SYSUT1   DD DSN=IBMUSER.EXEC,DISP=SHR
 //SYSUT2   DD DSN=IBMUSER.EXEC,DISP=SHR
 //SYSIN    DD *
 ./ ADD NAME=HELLO
-/* test REXX exec */
 say 'hello'
 exit 0
 ./ ADD NAME=EMPTY
 ./ ADD NAME=ALTM
-/* alt-DD test REXX exec */
 say 'alt'
 exit 0
 ./ ENDUP

--- a/test/mvs/tstall.jcl
+++ b/test/mvs/tstall.jcl
@@ -83,6 +83,26 @@
 //BADDR   EXEC PGM=TSTADDR,COND=EVEN
 //STEPLIB  DD DSN=IBMUSER.REXX370.V0R1M0D.LOAD,DISP=SHR
 //SYSPRINT DD SYSOUT=*
+//*---------------------------------------------------------------
+//* Pre-populate SYSEXEC fixtures for TSTLOAD (T1/T2/T8/T9).
+//* HELLO, EMPTY, ALTM must exist in IBMUSER.EXEC before any
+//* TSTLOAD step runs (both Batch and TSO invocations below).
+//*---------------------------------------------------------------
+//SETUP    EXEC PGM=IEBUPDTE,PARM=NEW,COND=EVEN
+//SYSPRINT DD SYSOUT=*
+//SYSUT2   DD DSN=IBMUSER.EXEC,DISP=SHR
+//SYSIN    DD *
+./ ADD NAME=HELLO
+/* test REXX exec */
+say 'hello'
+exit 0
+./ ADD NAME=EMPTY
+./ ADD NAME=ALTM
+/* alt-DD test REXX exec */
+say 'alt'
+exit 0
+./ ENDUP
+/*
 //BLOAD   EXEC PGM=TSTLOAD,COND=EVEN
 //STEPLIB  DD DSN=IBMUSER.REXX370.V0R1M0D.LOAD,DISP=SHR
 //SYSPRINT DD SYSOUT=*

--- a/test/mvs/tstall.jcl
+++ b/test/mvs/tstall.jcl
@@ -85,22 +85,32 @@
 //SYSPRINT DD SYSOUT=*
 //*---------------------------------------------------------------
 //* Pre-populate SYSEXEC fixtures for TSTLOAD (T1/T2/T8/T9).
-//* HELLO, EMPTY, ALTM must exist in IBMUSER.EXEC before any
-//* TSTLOAD step runs (both Batch and TSO invocations below).
+//* HELLO, EMPTY, ALTM must exist in IBMUSER.EXEC before BLOAD
+//* and TLOAD run. Three IEBGENER steps (one per member) are
+//* used instead of IEBUPDTE; IEBUPDTE SYSUT1=SYSUT2 in-place
+//* PDS modification corrupts the directory on MVS 3.8j.
 //*---------------------------------------------------------------
-//SETUP    EXEC PGM=IEBUPDTE,PARM=MOD,COND=EVEN
+//SETHELO  EXEC PGM=IEBGENER,COND=EVEN
 //SYSPRINT DD SYSOUT=*
-//SYSUT1   DD DSN=IBMUSER.EXEC,DISP=SHR
-//SYSUT2   DD DSN=IBMUSER.EXEC,DISP=SHR
-//SYSIN    DD *
-./ ADD NAME=HELLO
+//SYSIN    DD DUMMY
+//SYSUT2   DD DSN=IBMUSER.EXEC(HELLO),DISP=SHR
+//SYSUT1   DD *
 say 'hello'
 exit 0
-./ ADD NAME=EMPTY
-./ ADD NAME=ALTM
+/*
+//SETEMPT  EXEC PGM=IEBGENER,COND=EVEN
+//SYSPRINT DD SYSOUT=*
+//SYSIN    DD DUMMY
+//SYSUT2   DD DSN=IBMUSER.EXEC(EMPTY),DISP=SHR
+//SYSUT1   DD *
+/*
+//SETALTM  EXEC PGM=IEBGENER,COND=EVEN
+//SYSPRINT DD SYSOUT=*
+//SYSIN    DD DUMMY
+//SYSUT2   DD DSN=IBMUSER.EXEC(ALTM),DISP=SHR
+//SYSUT1   DD *
 say 'alt'
 exit 0
-./ ENDUP
 /*
 //BLOAD   EXEC PGM=TSTLOAD,COND=EVEN
 //STEPLIB  DD DSN=IBMUSER.REXX370.V0R1M0D.LOAD,DISP=SHR

--- a/test/mvs/tstexec.c
+++ b/test/mvs/tstexec.c
@@ -46,6 +46,7 @@
 #include <string.h>
 
 #include "irx.h"
+#include "irx_init.h"
 #include "irxexec.h"
 #include "irxfunc.h"
 #include "irxwkblk.h"
@@ -405,6 +406,21 @@ static void test_noenv(void)
     int rc;
 
     printf("T6: No env registered -> NOENV (RC=28)\n");
+
+    /* Foreground TSO has a pre-initialised REXX env from the READY
+     * prompt's IRXINIT. We cannot tear that down without disturbing
+     * IKJEFT01's own state, so this case only runs meaningfully in
+     * Batch / Batch-TSO contexts where no pre-existing env exists. */
+    {
+        struct envblock *probe = NULL;
+        int probe_rsn = 0;
+        if (irx_init_findenvb(&probe, &probe_rsn) == 0 && probe != NULL)
+        {
+            printf("  SKIP: pre-existing env on TCB (Foreground TSO);"
+                   " no-env scenario not reproducible here\n");
+            return;
+        }
+    }
 
 #ifndef __MVS__
     /* Ensure IRXANCHR slot table has no registered env by resetting


### PR DESCRIPTION
Closes #122

## Summary

Five non-blocking polish items following the WP-CPS-06 (#121) and WP-CPS-07 (#119) merges. All verified on MVS (JOB02182): TSTEXEC 16/16, TSTLOAD 15/15 in both Batch and Batch-TSO.

- **TSTEXEC T6 skip under Foreground TSO** — `irx_init_findenvb` probe detects a pre-existing REXX env (set up by IKJEFT01 at the READY prompt) and skips the no-env test case with a documented reason. Batch and Batch-TSO still run T6 and pass.

- **IRXEXEC EXECBLK-only path returns `IRXEXEC_ERROR` (20) not `BADPLIST` (32)** — a valid EXECBLK with NULL INSTBLK is a well-formed parameter list; RC=32 implies a malformed list. RC=20 is semantically correct for the deferred DD-load path.

- **IRXEXEC asm wrapper: null VLIST slot-address guard** — BUILDC previously faulted on a page-zero load if any P1–P9 VLIST slot address was zero. A single post-parse loop (CHKSLP/NULLSLOT/DOSLOTS) returns BADPLIST (32) cleanly. Null parameter *values* (e.g. P9=0 for env-via-R0 callers) remain legal. Architecture decision (d) added to the module header. All lines ≤ 71 chars (IFOX00 column-72 invariant maintained).

- **tstall.jcl SYSEXEC fixtures** — three IEBGENER steps (SETHELO/SETEMPT/SETALTM) write HELLO, EMPTY, and ALTM into `IBMUSER.EXEC` before BLOAD/TLOAD run. IEBGENER per-member (direct `DSN=IBMUSER.EXEC(name)`) is used instead of IEBUPDTE; IEBUPDTE PARM=MOD with SYSUT1=SYSUT2 on the same PDS corrupts the directory on MVS 3.8j (IEC020I 001-1, diagnosed during testing).

## Test plan

- [x] TSTEXEC Batch: 16/16 (T6 passes — clean ECT in batch)
- [x] TSTEXEC Batch-TSO: 16/16
- [x] TSTEXEC Foreground TSO: T6 skips with "pre-existing env" message, rest pass
- [x] TSTLOAD Batch: 15/15 (CC=0, IEC020I on T3/T4/T8 are expected error-path messages)
- [x] TSTLOAD Batch-TSO: 15/15 (CC=0)
- [x] IRXEXEC asm: assembles RC=0 under IFOX00
- [x] Host cross-compile: 16/16 (tstexec)