### PR TITLE
feat(WP-CPS-09b): CALL instruction BIF fallback

### DIFF
--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -1651,6 +1651,34 @@ static int kw_otherwise(struct irx_parser *p)
 }
 
 /* ------------------------------------------------------------------ */
+/*  BIF dispatch helper: find + invoke a BIF by upper-case name with  */
+/*  a pre-built PLstr argument array.                                 */
+/*                                                                    */
+/*  Returns IRXPARS_OK on success (*out holds the return value;       */
+/*  caller must Lfree it), -1 if the name is not in the registry,    */
+/*  or another IRXPARS_* code on handler failure.                     */
+/* ------------------------------------------------------------------ */
+
+static int bif_dispatch(struct irx_parser *p,
+                        const unsigned char *name, size_t name_len,
+                        PLstr *argptrs, int argc, Lstr *out)
+{
+    const struct irx_bif_entry *bif;
+
+    bif = irx_bif_find(get_bif_registry(p), name, name_len);
+    if (bif == NULL)
+    {
+        return -1;
+    }
+    if (argc < bif->min_args || argc > bif->max_args)
+    {
+        return fail(p, IRXPARS_SYNTAX);
+    }
+    Lzeroinit(out);
+    return bif->handler(p, argc, argptrs, out);
+}
+
+/* ------------------------------------------------------------------ */
 /*  CALL label [args]                                                 */
 /* ------------------------------------------------------------------ */
 
@@ -1764,8 +1792,50 @@ static int kw_call(struct irx_parser *p)
     label_pos = irx_ctrl_label_find(p, label, label_len);
     if (label_pos < 0)
     {
-        rc = fail(p, IRXPARS_BADFUNC);
-        goto err;
+        /* SC28-1883-0 §6.4 step 2: try the BIF registry. */
+        PLstr argptrs[IRX_MAX_ARGS];
+        Lstr bif_out;
+        Lstr result_key;
+        int bif_rc;
+
+        for (i = 0; i < IRX_MAX_ARGS; i++)
+        {
+            argptrs[i] = (i < argc) ? &new_args[i] : NULL;
+        }
+        Lzeroinit(&bif_out);
+        bif_rc = bif_dispatch(p, (const unsigned char *)label,
+                              (size_t)label_len, argptrs, argc, &bif_out);
+        if (bif_rc == -1)
+        {
+            rc = fail(p, IRXPARS_BADFUNC);
+            goto err;
+        }
+        if (bif_rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &bif_out);
+            rc = bif_rc;
+            goto err;
+        }
+        /* Store BIF return value in RESULT special variable. */
+        Lzeroinit(&result_key);
+        if (lstr_set_bytes(p->alloc, &result_key, "RESULT", 6) == LSTR_OK)
+        {
+            vpool_set(p->vpool, &result_key, &bif_out);
+            Lfree(p->alloc, &result_key);
+        }
+        Lfree(p->alloc, &bif_out);
+        for (i = 0; i < argc; i++)
+        {
+            Lfree(p->alloc, &new_args[i]);
+        }
+        p->alloc->dealloc(new_args,
+                          (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                          p->alloc->ctx);
+        p->alloc->dealloc(new_exists,
+                          (size_t)IRX_MAX_ARGS * sizeof(int),
+                          p->alloc->ctx);
+        p->tok_pos = return_pos;
+        return IRXPARS_OK;
     }
 
     /* Push CALL frame, saving the current argument context. */
@@ -3861,8 +3931,6 @@ static int parse_function_call(struct irx_parser *p,
     int argc = 0;
     int i;
     int rc;
-    const struct irx_bif_entry *bif;
-    struct irx_bif_registry *registry;
     Lstr upname;
 
     for (i = 0; i < IRX_MAX_ARGS; i++)
@@ -3930,20 +3998,11 @@ static int parse_function_call(struct irx_parser *p,
         goto done;
     }
 
-    registry = get_bif_registry(p);
-    bif = irx_bif_find(registry, upname.pstr, upname.len);
-    if (bif == NULL)
+    rc = bif_dispatch(p, upname.pstr, upname.len, argptrs, argc, out);
+    if (rc == -1)
     {
         rc = fail(p, IRXPARS_BADFUNC);
-        goto done;
     }
-    if (argc < bif->min_args || argc > bif->max_args)
-    {
-        rc = fail(p, IRXPARS_SYNTAX);
-        goto done;
-    }
-
-    rc = bif->handler(p, argc, argptrs, out);
 
 done:
     Lfree(p->alloc, &upname);

--- a/test/mvs/tstctrl.c
+++ b/test/mvs/tstctrl.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "irxctrl.h"
+#include "irxfunc.h"
 #include "irxpars.h"
 #include "irxtokn.h"
 #include "irxvpool.h"
@@ -66,8 +67,8 @@ static void set_lstr(struct lstr_alloc *a, PLstr s, const char *c)
     Lscpy(a, s, c);
 }
 
-static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
-                      const char *src)
+static int run_source_env(struct lstr_alloc *a, struct irx_vpool *pool,
+                          const char *src, struct envblock *env)
 {
     struct irx_token *tokens = NULL;
     int count = 0;
@@ -85,7 +86,7 @@ static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
         return -1;
     }
 
-    rc = irx_pars_init(&parser, tokens, count, pool, a, NULL);
+    rc = irx_pars_init(&parser, tokens, count, pool, a, env);
     if (rc != IRXPARS_OK)
     {
         irx_tokn_free(NULL, tokens, count);
@@ -103,6 +104,12 @@ static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
     irx_pars_cleanup(&parser);
     irx_tokn_free(NULL, tokens, count);
     return rc;
+}
+
+static int run_source(struct lstr_alloc *a, struct irx_vpool *pool,
+                      const char *src)
+{
+    return run_source_env(a, pool, src, NULL);
 }
 
 static int get_var_eq(struct lstr_alloc *a, struct irx_vpool *pool,
@@ -794,6 +801,59 @@ static void test_cf28_do_ctrl_step3(void)
     vpool_destroy(pool);
 }
 
+/* CF#29: CALL-form BIF dispatch — LENGTH and SUBSTR via CALL. */
+static void test_cf29_call_bif_dispatch(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+
+    printf("\n--- CF#29: CALL BIF dispatch (LENGTH, SUBSTR) ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(run_source_env(a, pool, "call length 'hello'\n", env) ==
+              IRXPARS_OK,
+          "CALL LENGTH parser OK");
+    CHECK(get_var_eq(a, pool, "RESULT", "5"), "RESULT = '5' after CALL LENGTH");
+
+    CHECK(run_source_env(a, pool, "call substr 'hello', 1, 3\n", env) ==
+              IRXPARS_OK,
+          "CALL SUBSTR parser OK");
+    CHECK(get_var_eq(a, pool, "RESULT", "hel"),
+          "RESULT = 'hel' after CALL SUBSTR");
+
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
+/* CF#30: Internal label takes priority over same-named BIF (regression). */
+static void test_cf30_label_shadows_bif(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+
+    printf("\n--- CF#30: internal label shadows BIF of same name ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(run_source_env(a, pool,
+                         "call length 'hello'\n"
+                         "return\n"
+                         "length:\n"
+                         "  x = 'label'\n"
+                         "  return\n",
+                         env) == IRXPARS_OK,
+          "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "label"),
+          "X = 'label' (label took priority over LENGTH BIF)");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
@@ -830,6 +890,8 @@ int main(void)
     test_cf26_do_ctrl_neg_step();
     test_cf27_do_ctrl_step2();
     test_cf28_do_ctrl_step3();
+    test_cf29_call_bif_dispatch();
+    test_cf30_label_shadows_bif();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);

--- a/test/mvs/tstprsr.c
+++ b/test/mvs/tstprsr.c
@@ -388,6 +388,139 @@ static void test_ac14_no_global_state(void)
     vpool_destroy(pool_b);
 }
 
+/* Return 1 if a vpool variable is set (regardless of value). */
+static int var_exists(struct lstr_alloc *a, struct irx_vpool *pool,
+                      const char *name)
+{
+    Lstr key, val;
+    int rc;
+
+    Lzeroinit(&key);
+    Lzeroinit(&val);
+    set_lstr(a, &key, name);
+    rc = vpool_get(pool, &key, &val);
+    Lfree(a, &key);
+    Lfree(a, &val);
+    return rc == VPOOL_OK;
+}
+
+/* AC#15: CALL TIME 'R' — resolves to TIME BIF, sets RESULT. */
+static void test_ac15_call_bif_time(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+
+    printf("\n--- AC#15: CALL TIME 'R' sets RESULT ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(run_source_env(a, pool, "call time 'R'\n", env) == IRXPARS_OK,
+          "parser OK");
+    CHECK(var_exists(a, pool, "RESULT"), "RESULT is set");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
+/* AC#16: CALL LENGTH 'hello' — sets RESULT to '5'. */
+static void test_ac16_call_bif_length(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+
+    printf("\n--- AC#16: CALL LENGTH 'hello' sets RESULT = '5' ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(run_source_env(a, pool, "call length 'hello'\n", env) ==
+              IRXPARS_OK,
+          "parser OK");
+    CHECK(get_var_eq(a, pool, "RESULT", "5"), "RESULT = '5'");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
+/* AC#17: CALL SUBSTR 'hello', 1, 3 — sets RESULT to 'hel'.
+ * CALL arguments are comma-separated per SC28-1883-0 §6.4. */
+static void test_ac17_call_bif_substr(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+
+    printf("\n--- AC#17: CALL SUBSTR 'hello', 1, 3 sets RESULT = 'hel' ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(run_source_env(a, pool, "call substr 'hello', 1, 3\n", env) ==
+              IRXPARS_OK,
+          "parser OK");
+    CHECK(get_var_eq(a, pool, "RESULT", "hel"), "RESULT = 'hel'");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
+/* AC#18: Internal label shadows BIF — CALL LENGTH hits the label, not
+ * the BIF.  Verified by a side-effect only the label can set. */
+static void test_ac18_label_shadows_bif(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+
+    printf("\n--- AC#18: internal LENGTH: label shadows BIF ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    CHECK(run_source_env(a, pool,
+                         "call length 'hello'\n"
+                         "return\n"
+                         "length:\n"
+                         "  x = 'label'\n"
+                         "  return\n",
+                         env) == IRXPARS_OK,
+          "parser OK");
+    CHECK(get_var_eq(a, pool, "X", "label"),
+          "X = 'label' (label took priority over BIF)");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
+/* AC#19: Omitted middle arg in CALL form raises SYNTAX, matching
+ * function-form.  Both "call substr 'hello', , 3" and
+ * "x = substr('hello',,3)" must return a non-OK status because
+ * SUBSTR arg 2 (start position) is required. */
+static void test_ac19_call_omitted_arg(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+    int rc;
+
+    printf("\n--- AC#19: CALL SUBSTR omitted middle arg -> SYNTAX ---\n");
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+
+    /* CALL form: omitted arg 2 (start) should raise SYNTAX 40.x */
+    rc = run_source_env(a, pool, "call substr 'hello', , 3\n", env);
+    CHECK(rc != IRXPARS_OK, "call substr 'hello', , 3 -> non-OK (SYNTAX)");
+
+    /* Function form: same omitted arg should also raise SYNTAX 40.x */
+    rc = run_source_env(a, pool, "x = substr('hello',,3)\n", env);
+    CHECK(rc != IRXPARS_OK,
+          "substr('hello',,3) in function form -> non-OK (SYNTAX)");
+
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
 /* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
@@ -410,6 +543,11 @@ int main(void)
     test_ac12_strict_not_assignment();
     test_ac13_abuttal_vs_blank();
     test_ac14_no_global_state();
+    test_ac15_call_bif_time();
+    test_ac16_call_bif_length();
+    test_ac17_call_bif_substr();
+    test_ac18_label_shadows_bif();
+    test_ac19_call_omitted_arg();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);


### PR DESCRIPTION
## Summary

- Extracts a shared `bif_dispatch()` helper (registry lookup + arg validation + invoke)
- Wires it into `kw_call()` as step 2 of the §6.4 search cascade; sets `RESULT` on success
- Refactors `parse_function_call()` to use the same helper — eliminates ~12 lines of duplicate dispatch logic
- Internal labels continue to shadow BIFs

## Tests

| Suite | Before | After |
|-------|--------|-------|
| tstprsr | 51/51 | 54/54 |
| tstctrl | 62/62 | 70/70 |
| Full suite | 16 binaries green | 16 binaries green |

New tests: AC#15 (`call time 'R'`), AC#16 (`call length`), AC#17 (`call substr` with commas), AC#18 (label shadows BIF), AC#19 (omitted middle arg raises SYNTAX), CF#29-CF#30 (integration).

## Notes

- External routine dispatch (§6.4 step 3) is out of scope — deferred to a follow-up WP
- `RESULT` is always set unconditionally on BIF success. The `irx_bif_handler_t` signature cannot distinguish "no return value" from "empty-string return"; always setting is correct per spec
- AC#11 (REXXCPS live MVS deploy — revert `dummy = time('R')` to `call time 'R'`) is a manual deployment step

## Test plan

- [ ] `run tstprsr` → 54/54
- [ ] `run tstctrl` → 70/70
- [ ] Full 16-binary sweep → all green
- [ ] Deploy REXXCPS on live MVS, verify Step-RC=0 with `call time 'R'`

Closes #128