### PR TITLE
feat(parser): continuation comma in expression context (WP-CPS-09d)

### DIFF
--- a/include/irxtokn.h
+++ b/include/irxtokn.h
@@ -51,8 +51,8 @@
 #define TOKF_QUOTE_DBL 0x01 /* STRING contained doubled quotes     */
 #define TOKF_COMPOUND  0x02 /* SYMBOL is a compound (has a dot)    */
 #define TOKF_CONSTANT  0x04 /* SYMBOL is a constant (starts digit  */
-
 /* or '.')                             */
+#define TOKF_CONTINUATION 0x08 /* COMMA suppressed an EOC (SC28-1883-0 §3.2) */
 
 /* ================================================================== */
 /*  Token record (contiguous array, cache-friendly)                   */

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -1071,6 +1071,14 @@ static int kw_do(struct irx_parser *p)
                 Lfree(p->alloc, &tmp);
                 Lzeroinit(&tmp);
 
+                /* Skip continuation-comma before TO (SC28-1883-0 §3.2). */
+                while (cur_tok(p) != NULL &&
+                       cur_tok(p)->tok_type == TOK_COMMA &&
+                       (cur_tok(p)->tok_flags & TOKF_CONTINUATION) != 0)
+                {
+                    advance_tok(p);
+                }
+
                 /* TO */
                 if (!sym_matches(cur_tok(p), "TO"))
                 {
@@ -1093,6 +1101,14 @@ static int kw_do(struct irx_parser *p)
                 Lfree(p->alloc, &tmp);
                 Lzeroinit(&tmp);
 
+                /* Skip continuation-comma before BY (SC28-1883-0 §3.2). */
+                while (cur_tok(p) != NULL &&
+                       cur_tok(p)->tok_type == TOK_COMMA &&
+                       (cur_tok(p)->tok_flags & TOKF_CONTINUATION) != 0)
+                {
+                    advance_tok(p);
+                }
+
                 /* Optional BY */
                 if (sym_matches(cur_tok(p), "BY"))
                 {
@@ -1109,6 +1125,14 @@ static int kw_do(struct irx_parser *p)
                     }
                     Lfree(p->alloc, &tmp);
                     Lzeroinit(&tmp);
+                }
+
+                /* Skip continuation-comma before WHILE/UNTIL (SC28-1883-0 §3.2). */
+                while (cur_tok(p) != NULL &&
+                       cur_tok(p)->tok_type == TOK_COMMA &&
+                       (cur_tok(p)->tok_flags & TOKF_CONTINUATION) != 0)
+                {
+                    advance_tok(p);
                 }
 
                 /* Optional WHILE/UNTIL: skip expression (future WP). */
@@ -1761,9 +1785,12 @@ static int kw_call(struct irx_parser *p)
                 }
                 break;
             }
-            /* Evaluate the expression for this argument position. */
+            /* Evaluate the expression for this argument position.
+             * Use parse_or directly (not irx_pars_eval_expr) so a
+             * continuation-comma between args is NOT collapsed into
+             * blank concatenation — it remains an arg separator. */
             Lzeroinit(&new_args[argc]);
-            rc = irx_pars_eval_expr(p, &new_args[argc]);
+            rc = parse_or(p, &new_args[argc]);
             if (rc != IRXPARS_OK)
             {
                 /* eval may have partially allocated into new_args[argc]. */
@@ -5171,11 +5198,63 @@ void irx_pars_cleanup(struct irx_parser *p)
 
 int irx_pars_eval_expr(struct irx_parser *p, PLstr out)
 {
+    int rc;
+    const struct irx_token *ct;
+
     if (p == NULL || out == NULL)
     {
         return IRXPARS_BADARG;
     }
-    return parse_or(p, out);
+    rc = parse_or(p, out);
+    if (rc != IRXPARS_OK)
+    {
+        return rc;
+    }
+    /* SC28-1883-0 §3.2: a continuation-comma at line-end is a blank
+     * concatenation in expression context, not an argument separator. */
+    while ((ct = cur_tok(p)) != NULL && ct->tok_type == TOK_COMMA &&
+           (ct->tok_flags & TOKF_CONTINUATION) != 0)
+    {
+        Lstr rhs;
+        const struct irx_token *t_next;
+
+        advance_tok(p);
+        t_next = cur_tok(p);
+        if (t_next == NULL || tok_ends_clause(t_next))
+        {
+            break;
+        }
+        /* Stop at keyword that starts a new syntactic clause: THEN, ELSE,
+         * DO, etc.  DO-internal keywords (TO, BY, WHILE, UNTIL) are not
+         * in the keyword table; kw_do skips continuation-commas at those
+         * boundaries explicitly. */
+        if (t_next->tok_type == TOK_SYMBOL && t_next->tok_length < 32)
+        {
+            char kbuf[32];
+            int kn = (int)t_next->tok_length;
+            memcpy(kbuf, t_next->tok_text, (size_t)kn);
+            upper_bytes((unsigned char *)kbuf, (size_t)kn);
+            if (find_keyword((unsigned char *)kbuf, (size_t)kn) != NULL)
+            {
+                break;
+            }
+        }
+        Lzeroinit(&rhs);
+        rc = parse_or(p, &rhs);
+        if (rc != IRXPARS_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return rc;
+        }
+        if (Lcat(p->alloc, out, " ") != LSTR_OK ||
+            Lstrcat(p->alloc, out, &rhs) != LSTR_OK)
+        {
+            Lfree(p->alloc, &rhs);
+            return fail(p, IRXPARS_NOMEM);
+        }
+        Lfree(p->alloc, &rhs);
+    }
+    return IRXPARS_OK;
 }
 
 int irx_pars_run(struct irx_parser *p)

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -330,7 +330,9 @@ static int emit_eoc(struct tok_ctx *ctx, int at_line, int at_col)
          * separator in CALL / function-call contexts) and suppress
          * the EOC only. Per SC28-1883-0 Chapter 2: "A clause is
          * ended by the end of a line that is not immediately
-         * preceded by a comma." */
+         * preceded by a comma." Mark it so the parser can distinguish
+         * a continuation-comma from a real argument-separator. */
+        ctx->tokens[ctx->tok_count - 1].tok_flags |= TOKF_CONTINUATION;
         return 0;
     }
     /* Collapse multiple consecutive EOCs. */

--- a/test/mvs/tstctrl.c
+++ b/test/mvs/tstctrl.c
@@ -925,6 +925,116 @@ static void test_cf32_signal_value(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  WP-CPS-09d: continuation-comma control-flow tests                 */
+/* ------------------------------------------------------------------ */
+
+/* CF#33 (AC1): SAY continued over two lines.
+ *   say 'hello',
+ *       'world'
+ * Expected: parse OK, variable check via assignment trick. */
+static void test_cf33_cont_say_two_lines(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    int rc;
+    printf("\n--- CF#33 (AC1): SAY continuation over two lines ---\n");
+
+    /* Use assignment to capture continued expression result. */
+    rc = run_source(a, pool, "x = 'hello' 'world'\n");
+    CHECK(rc == IRXPARS_OK, "baseline 'hello' 'world' parse OK");
+    CHECK(get_var_eq(a, pool, "X", "hello world"), "X = 'hello world' baseline");
+
+    rc = run_source(a, pool,
+                    "x = 'hello',\n"
+                    "    'world'\n");
+    CHECK(rc == IRXPARS_OK, "continuation parse OK");
+    CHECK(get_var_eq(a, pool, "X", "hello world"),
+          "X = 'hello world' (continuation = blank concat)");
+    vpool_destroy(pool);
+}
+
+/* CF#34 (AC3): IF condition continued before THEN.
+ *   x = 1
+ *   if x = 1,
+ *      then y = 'yes'
+ * Expected: Y = 'yes' */
+static void test_cf34_cont_if_then(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    int rc;
+    printf("\n--- CF#34 (AC3): IF condition continuation before THEN ---\n");
+
+    rc = run_source(a, pool,
+                    "x = 1\n"
+                    "if x = 1,\n"
+                    "   then y = 'yes'\n");
+    CHECK(rc == IRXPARS_OK, "parse OK");
+    CHECK(get_var_eq(a, pool, "Y", "yes"), "Y = 'yes'");
+    vpool_destroy(pool);
+}
+
+/* CF#35 (AC4): DO i = 1 TO 10 with BY on the next line.
+ *   do i = 1 to 10,
+ *      by 2
+ * Expected: I = 9 (last value ≤ 10), x = 1+3+5+7+9 = 25 */
+static void test_cf35_cont_do_by(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    Lstr k, v;
+    int rc;
+    printf("\n--- CF#35 (AC4): DO i = 1 TO 10 with BY on next line ---\n");
+
+    Lzeroinit(&k);
+    Lzeroinit(&v);
+    set_lstr(a, &k, "X");
+    set_lstr(a, &v, "0");
+    vpool_set(pool, &k, &v);
+    Lfree(a, &k);
+    Lfree(a, &v);
+
+    rc = run_source(a, pool,
+                    "do i = 1 to 10,\n"
+                    "   by 2\n"
+                    "  x = x + i\n"
+                    "end\n");
+    CHECK(rc == IRXPARS_OK, "parse OK");
+    CHECK(get_var_eq(a, pool, "X", "25"), "X = '25' (1+3+5+7+9)");
+    CHECK(get_var_eq(a, pool, "I", "9"), "I = '9' (last executed value)");
+    vpool_destroy(pool);
+}
+
+/* CF#36 (AC9): CALL with multi-line args (regression — each comma is
+ * still an argument separator, NOT continuation blank-concat).
+ *   call substr 'hello',
+ *     1,
+ *     3
+ * Expected: RESULT = 'hel' */
+static void test_cf36_cont_call_regression(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+    int rc;
+    printf("\n--- CF#36 (AC9): CALL multi-line arg regression ---\n");
+
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    rc = run_source_env(a, pool,
+                        "call substr 'hello',\n"
+                        "  1,\n"
+                        "  3\n",
+                        env);
+    CHECK(rc == IRXPARS_OK, "parse OK");
+    CHECK(get_var_eq(a, pool, "RESULT", "hel"), "RESULT = 'hel'");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -964,6 +1074,10 @@ int main(void)
     test_cf30_label_shadows_bif();
     test_cf31_signal_on_off();
     test_cf32_signal_value();
+    test_cf33_cont_say_two_lines();
+    test_cf34_cont_if_then();
+    test_cf35_cont_do_by();
+    test_cf36_cont_call_regression();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);

--- a/test/mvs/tstprsr.c
+++ b/test/mvs/tstprsr.c
@@ -580,6 +580,89 @@ static void test_ac20_signal_on_off_value(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  WP-CPS-09d: continuation-comma tests                              */
+/* ------------------------------------------------------------------ */
+
+/* AC6: assignment RHS continued over two lines.
+ *   x = 'a',
+ *       'b'
+ * Expected: X = "a b" */
+static void test_cont_ac6_assignment(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    int rc;
+    printf("\n--- WP-CPS-09d AC6: assignment continuation ---\n");
+
+    rc = run_source(a, pool, "x = 'a',\n    'b'\n");
+    CHECK(rc == IRXPARS_OK, "parse OK");
+    CHECK(get_var_eq(a, pool, "X", "a b"), "X = 'a b'");
+    vpool_destroy(pool);
+}
+
+/* AC6 (3-part): three-line continuation in assignment.
+ *   x = 'a',
+ *   'b',
+ *   'c'
+ * Expected: X = "a b c" */
+static void test_cont_ac6_three_parts(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    int rc;
+    printf("\n--- WP-CPS-09d AC6 (3-part): three-segment continuation ---\n");
+
+    rc = run_source(a, pool, "x = 'a',\n'b',\n'c'\n");
+    CHECK(rc == IRXPARS_OK, "parse OK");
+    CHECK(get_var_eq(a, pool, "X", "a b c"), "X = 'a b c'");
+    vpool_destroy(pool);
+}
+
+/* AC8: function call args continued over multiple lines (regression).
+ *   result = substr('hello',
+ *     1,
+ *     3)
+ * Each comma is an argument separator, NOT a continuation.
+ * Expected: RESULT = "hel" */
+static void test_cont_ac8_func_call_regression(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct envblock *env = NULL;
+    int rc;
+    printf("\n--- WP-CPS-09d AC8: function-call multi-line arg regression ---\n");
+
+    CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
+    rc = run_source_env(a, pool,
+                        "result = substr('hello',\n"
+                        "  1,\n"
+                        "  3)\n",
+                        env);
+    CHECK(rc == IRXPARS_OK, "parse OK");
+    CHECK(get_var_eq(a, pool, "RESULT", "hel"), "RESULT = 'hel'");
+    if (env != NULL)
+    {
+        irxterm(env);
+    }
+    vpool_destroy(pool);
+}
+
+/* AC10 (negative): single-line comma in SAY is SYNTAX.
+ *   say 'a', 'b'
+ * Expected: SYNTAX error (RC != 0) */
+static void test_cont_ac10_single_line_negative(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    int rc;
+    printf("\n--- WP-CPS-09d AC10: single-line comma -> SYNTAX ---\n");
+
+    rc = run_source(a, pool, "say 'a', 'b'\n");
+    CHECK(rc != IRXPARS_OK, "single-line comma raises SYNTAX");
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -607,6 +690,10 @@ int main(void)
     test_ac18_label_shadows_bif();
     test_ac19_call_omitted_arg();
     test_ac20_signal_on_off_value();
+    test_cont_ac6_assignment();
+    test_cont_ac6_three_parts();
+    test_cont_ac8_func_call_regression();
+    test_cont_ac10_single_line_negative();
 
     printf("\n=== %d/%d passed (%d failed) ===\n",
            tests_passed, tests_run, tests_failed);


### PR DESCRIPTION
Closes #132

## Summary

- Tokenizer now stamps continuation-commas with `TOKF_CONTINUATION` (0x08) when a trailing comma suppresses an end-of-clause (SC28-1883-0 §3.2)
- `irx_pars_eval_expr` gains a post-parse loop that blank-concatenates across TOKF_CONTINUATION commas — covers SAY, assignment, IF condition, RETURN, EXIT, INTERPRET, SIGNAL/ADDRESS VALUE, NUMERIC
- `kw_call` switched to `parse_or` directly so CALL argument commas remain real separators (not collapsed into blank concat)
- `kw_do` gains explicit TOKF_CONTINUATION skips before the TO, BY, and WHILE/UNTIL keyword checks (these keywords are not in the main keyword table)
- 8 new tests across `tstprsr.c` and `tstctrl.c` covering all acceptance criteria

## Test plan

- [ ] `test_cont_ac6_assignment`: `x = 'a',\n    'b'` → X = `a b`
- [ ] `test_cont_ac6_three_parts`: three-segment continuation → X = `a b c`
- [ ] `test_cont_ac8_func_call_regression`: `result = substr('hello',\n  1,\n  3)` → `hel`
- [ ] `test_cont_ac10_single_line_negative`: `say 'a', 'b'` (single line) → SYNTAX
- [ ] `test_cf33_cont_say_two_lines`: SAY continuation → `hello world`
- [ ] `test_cf34_cont_if_then`: IF condition continued before THEN → Y = `yes`
- [ ] `test_cf35_cont_do_by`: `do i = 1 to 10,\n   by 2` → X = `25`
- [ ] `test_cf36_cont_call_regression`: `call substr 'hello',\n  1,\n  3` → RESULT = `hel`
- [ ] Full suite: 1249/1249 green