### PR TITLE
feat(profiling): WP-PERF-01 host profiling infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Host build output
+build/
+
 # Generated ASM sources
 *.s
 

--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -1,0 +1,159 @@
+# Host Profiling — WP-PERF-01
+
+This document describes how to profile the REXX/370 engine on a Linux
+host using gprof, as established by WP-PERF-01.
+
+---
+
+## Prerequisites
+
+| Tool | Package (Debian/Ubuntu) | Notes |
+|------|------------------------|-------|
+| `gcc` | `build-essential` | GNU C compiler. Apple clang on macOS is **not** supported — clang's `-pg` does not produce `gmon.out` on macOS. |
+| `gprof` | `binutils` | GNU profiler. Part of binutils on every Linux distro. |
+| `../lstring370` | — | Parallel clone of [mvslovers/lstring370](https://github.com/mvslovers/lstring370). Must be at `../lstring370` relative to the `rexx370` repo root. |
+
+Install on Debian/Ubuntu:
+
+```sh
+sudo apt-get install build-essential binutils
+```
+
+Clone lstring370 as a sibling:
+
+```sh
+# from the parent directory of your rexx370 clone:
+git clone https://github.com/mvslovers/lstring370
+# result: ../lstring370/
+```
+
+---
+
+## Quick start
+
+```sh
+./scripts/host-profile.sh
+```
+
+This runs the full pipeline:
+
+1. Preflight checks (gcc, gprof, ../lstring370)
+2. Build `test/host/tstcps_host` with `-pg -O0 -g -std=gnu99`
+3. Run the driver (embedded microbench); capture stdout → `build/host-profile/run.log`, stderr timing → `build/host-profile/timing.txt`
+4. Run `gprof` → `build/host-profile/profile.txt`
+5. Extract top-10 → `build/host-profile/top-hotspots.txt`
+6. Print summary to stdout (wall time, CPU time, top-3 hotspots)
+
+All output lands in `build/host-profile/` which is gitignored.
+
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| *(none)* | Full run with embedded microbench |
+| `--source=PATH` | Run `PATH` as the REXX source instead of the embedded bench |
+| `--summary` | Skip full `profile.txt`; still produce `top-hotspots.txt` and summary line |
+| `--clean` | Remove `build/host-profile/` and exit |
+
+### Compiler override
+
+```sh
+CC=gcc-14 GPROF=gprof ./scripts/host-profile.sh
+```
+
+---
+
+## Interpreting the output
+
+### `top-hotspots.txt`
+
+Tab-separated: `rank | self% | cumulative% | self-seconds | calls | function`
+
+- **`self%`** — percentage of total profiling time spent *inside* this function,
+  excluding time in callees. This is the most useful column for identifying
+  bottlenecks.
+- **`cumulative%`** — percentage of time in this function *and* all functions it
+  calls. High cumulative% on a top-level function (e.g. `irx_exec_run`) is
+  expected and not diagnostic.
+- **`calls`** — total call count over the run. High call count × non-trivial
+  self% is the classic signal for per-call optimisation.
+- **`function`** — C function name as seen by the linker. Inlined functions are
+  not visible because we compile with `-O0`.
+
+### Why `-O0` and not `-O2`?
+
+At `-O2`, the compiler inlines small functions, vectorises loops, and hoists
+subexpressions. gprof attributes time to the surviving (non-inlined) caller,
+making it impossible to tell which callee was hot. `-O0` gives exact per-function
+attribution at the cost of inflated absolute timings — use **relative percentages**,
+not absolute seconds, when comparing results across machines or builds.
+
+### Reading the call-graph section (`profile.txt`)
+
+After the flat profile, gprof emits a call-graph showing caller → callee
+relationships and the percentage of time each arc represents. This is useful for
+tracing *why* a function is called frequently, but the flat profile is sufficient
+for initial hotspot identification.
+
+---
+
+## Custom workloads
+
+To profile against a specific REXX program:
+
+```sh
+./scripts/host-profile.sh --source=/path/to/program.rexx
+```
+
+The driver passes `--source=PATH` through to `tstcps_host`, which reads the file
+and invokes the engine on its contents. SAY output is captured to `run.log` as
+usual.
+
+---
+
+## Baseline snapshots
+
+Committed snapshots live in `docs/profiling/`. Naming convention:
+
+```
+docs/profiling/host-baseline-YYYY-MM-DD-context.md
+```
+
+`context` is a short label that distinguishes the run (e.g. `initial`,
+`after-vpool-opt`, `after-bif-cache`). Each snapshot captures:
+
+- Engine commit hash
+- Build flags
+- Driver / workload description
+- Total timing
+- Top-10 hotspots table
+
+See `docs/profiling/host-baseline-2026-05-18-initial.md` for the first snapshot.
+
+To commit a new baseline after an optimisation:
+
+```sh
+./scripts/host-profile.sh
+# copy top-hotspots.txt into a new docs/profiling/host-baseline-YYYY-MM-DD-label.md
+# add brief observations
+```
+
+---
+
+## Known limitations
+
+- **Absolute times are not comparable across machines.** Always compare
+  `self%` percentages, not raw seconds.
+- **`-O0` inflates time for trivially inlinable helpers.** A function that
+  would be inlined at `-O2` shows up as its own entry at `-O0`. This is a
+  feature for profiling — you can see the call — but inflated call counts
+  for small wrappers are expected.
+- **macOS is not supported** for this profiling pipeline. Apple's toolchain
+  dropped working gprof support. Run on a Linux host.
+- **gprof uses statistical sampling** (typically 100 Hz). Functions with
+  very short runtimes may have zero or noisy samples. The embedded microbench
+  is sized to run 10–20 s to give enough samples across all hot paths.
+- **Host timings do not reflect MVS performance.** The profiling identifies
+  algorithmic bottlenecks (O(n²) operations, excessive allocation, redundant
+  parsing) that apply on both platforms. Absolute speeds differ significantly
+  due to architecture, cache sizes, and EBCDIC vs ASCII.

--- a/docs/profiling/host-baseline-2026-05-18-initial.md
+++ b/docs/profiling/host-baseline-2026-05-18-initial.md
@@ -1,0 +1,35 @@
+# Host Profile Baseline — initial (2026-05-18)
+
+**Engine commit:** 93884db  
+**Host:** Linux mvsdev 6.12.73+deb13-amd64 x86_64 (Debian 13)  
+**Build:** gcc (Debian 14.2.0-19) — `-pg -O0 -g -std=gnu99`  
+**Driver:** `test/host/tstcps_host` with embedded microbench (outer=1000, inner=500)  
+**Total wall-clock:** 27.841 s  
+**Total CPU (user+sys):** 27.709 s + 0.128 s = 27.837 s  
+
+## Top-10 hotspots
+
+| Rank | Self% | Cum% | Self s | Calls | Function |
+|------|-------|------|--------|-------|----------|
+| 1 | 37.42 | 37.42 | 3.45 | 13 002 011 | `find_in_bucket` |
+| 2 | 8.89 | 46.31 | 0.82 | 304 062 472 | `peek_tok` |
+| 3 | 3.80 | 50.11 | 0.35 | 500 000 | `num_div_impl` |
+| 4 | 3.04 | 53.15 | 0.28 | 175 523 266 | `tok_is_op_char` |
+| 5 | 2.60 | 55.75 | 0.24 | 115 000 000 | `ebcdic_eq` |
+| 6 | 2.39 | 58.14 | 0.22 | *(no count)* | `_init` ¹ |
+| 7 | 2.28 | 60.42 | 0.21 | 108 014 342 | `irxstor` |
+| 8 | 2.17 | 62.59 | 0.20 | 145 541 228 | `cur_tok` |
+| 9 | 1.74 | 64.33 | 0.16 | 42 008 067 | `Lfx` |
+| 10 | 1.74 | 66.07 | 0.16 | 2 000 000 | `parse_function_call` |
+
+¹ `_init` is the ELF constructor section (C runtime / lstring startup), not a REXX
+engine function. Its 2.39% is a one-time cost amortised across the run; it is not
+an optimisation target.
+
+## Initial observations
+
+`find_in_bucket` at **37.42%** (13M calls, one per variable read/write) dominates
+the profile and is the primary target for CON-12 variable-pool optimisation.
+`peek_tok` at **8.89%** (304M calls) indicates that the tokenizer re-scans the
+source on every pass through the DO loop body; an AST or token-stream cache would
+eliminate this cost class entirely.

--- a/scripts/host-profile.sh
+++ b/scripts/host-profile.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# scripts/host-profile.sh — WP-PERF-01 host profiling pipeline
+#
+# Builds the REXX/370 engine with -pg, runs the profiling driver, and
+# produces gprof output under build/host-profile/.
+#
+# Usage:
+#   ./scripts/host-profile.sh                  # full run, embedded microbench
+#   ./scripts/host-profile.sh --source=PATH    # custom REXX source file
+#   ./scripts/host-profile.sh --summary        # top-10 only, skip full profile.txt
+#   ./scripts/host-profile.sh --clean          # remove build/host-profile/, exit
+#
+# Prerequisites (Linux):
+#   gcc, gprof, and ../lstring370/ (parallel clone)
+#
+# Environment overrides:
+#   CC=gcc-14     override the C compiler (default: gcc)
+#   GPROF=gprof   override the gprof binary  (default: gprof)
+
+set -euo pipefail
+
+# ------------------------------------------------------------------ #
+#  Configuration                                                       #
+# ------------------------------------------------------------------ #
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${REPO_ROOT}/build/host-profile"
+BINARY="${BUILD_DIR}/tstcps_host"
+GMON="${BUILD_DIR}/gmon.out"
+
+CC="${CC:-gcc}"
+GPROF_CMD="${GPROF:-gprof}"
+
+SOURCE_FLAG=""
+SUMMARY_ONLY=0
+
+# ------------------------------------------------------------------ #
+#  Parse arguments                                                     #
+# ------------------------------------------------------------------ #
+
+for arg in "$@"; do
+    case "${arg}" in
+        --clean)
+            echo "Removing ${BUILD_DIR} ..."
+            rm -rf "${BUILD_DIR}"
+            echo "Done."
+            exit 0
+            ;;
+        --summary)
+            SUMMARY_ONLY=1
+            ;;
+        --source=*)
+            SOURCE_FLAG="${arg}"
+            ;;
+        *)
+            echo "host-profile.sh: unknown option '${arg}'" >&2
+            echo "usage: $0 [--source=PATH] [--summary] [--clean]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ------------------------------------------------------------------ #
+#  Step 1: Preflight checks                                            #
+# ------------------------------------------------------------------ #
+
+echo "==> Preflight checks"
+
+if ! command -v "${CC}" >/dev/null 2>&1; then
+    echo "ERROR: C compiler not found: ${CC}" >&2
+    echo "       Install gcc (e.g. 'sudo apt-get install gcc' on Debian/Ubuntu)." >&2
+    echo "       Set CC= to override the compiler name." >&2
+    exit 2
+fi
+
+if ! command -v "${GPROF_CMD}" >/dev/null 2>&1; then
+    echo "ERROR: gprof not found: ${GPROF_CMD}" >&2
+    echo "       Install binutils (e.g. 'sudo apt-get install binutils' on Debian/Ubuntu)." >&2
+    echo "       Set GPROF= to override the gprof binary name." >&2
+    exit 2
+fi
+
+LSTRING_DIR="${REPO_ROOT}/../lstring370"
+if [ ! -d "${LSTRING_DIR}" ]; then
+    echo "ERROR: lstring370 directory not found at ${LSTRING_DIR}" >&2
+    echo "       Clone the lstring370 repository as a sibling of rexx370:" >&2
+    echo "         git clone https://github.com/mvslovers/lstring370 ../lstring370" >&2
+    exit 2
+fi
+
+echo "  CC      = $("${CC}" --version 2>&1 | head -1)"
+echo "  gprof   = ${GPROF_CMD}"
+echo "  lstring = ${LSTRING_DIR}"
+
+# ------------------------------------------------------------------ #
+#  Step 2: Build                                                       #
+# ------------------------------------------------------------------ #
+
+echo "==> Building tstcps_host (profiling build)"
+
+mkdir -p "${BUILD_DIR}"
+
+LSTRING_INC="-I ${LSTRING_DIR}/include"
+LSTRING_SRC="${LSTRING_DIR}/src/lstr#cor.c \
+             ${LSTRING_DIR}/src/lstr#cvt.c \
+             ${LSTRING_DIR}/src/lstr#fmt.c \
+             ${LSTRING_DIR}/src/lstr#srch.c \
+             ${LSTRING_DIR}/src/lstr#sub.c \
+             ${LSTRING_DIR}/src/lstr#wrd.c \
+             ${LSTRING_DIR}/src/lstr#xlt.c"
+
+ENGINE_SRC="${REPO_ROOT}/src/irx#init.c \
+            ${REPO_ROOT}/src/irx#term.c \
+            ${REPO_ROOT}/src/irx#stor.c \
+            ${REPO_ROOT}/src/irx#anch.c \
+            ${REPO_ROOT}/src/irx#env.c  \
+            ${REPO_ROOT}/src/irx#uid.c  \
+            ${REPO_ROOT}/src/irx#msid.c \
+            ${REPO_ROOT}/src/irx#cond.c \
+            ${REPO_ROOT}/src/irx#bif.c  \
+            ${REPO_ROOT}/src/irx#bifs.c \
+            ${REPO_ROOT}/src/irx#io.c   \
+            ${REPO_ROOT}/src/irx#lstr.c \
+            ${REPO_ROOT}/src/irx#tokn.c \
+            ${REPO_ROOT}/src/irx#vpol.c \
+            ${REPO_ROOT}/src/irx#pars.c \
+            ${REPO_ROOT}/src/irx#ctrl.c \
+            ${REPO_ROOT}/src/irx#exec.c \
+            ${REPO_ROOT}/src/irx#arith.c"
+
+# shellcheck disable=SC2086
+"${CC}" \
+    -I "${REPO_ROOT}/include" \
+    -I "${REPO_ROOT}/contrib/lstring370-0.1.0-dev/include" \
+    ${LSTRING_INC} \
+    -Wall -Wextra -std=gnu99 -pg -O0 -g \
+    -o "${BINARY}" \
+    "${REPO_ROOT}/test/host/tstcps_host.c" \
+    ${ENGINE_SRC} \
+    ${LSTRING_SRC}
+
+echo "  Binary: ${BINARY}"
+
+# ------------------------------------------------------------------ #
+#  Step 3: Run                                                         #
+# ------------------------------------------------------------------ #
+
+echo "==> Running driver"
+
+cd "${BUILD_DIR}"
+
+if [ -n "${SOURCE_FLAG}" ]; then
+    # Translate --source=PATH to an absolute path before cd
+    SOURCE_ARG="${SOURCE_FLAG#--source=}"
+    if [[ "${SOURCE_ARG}" != /* ]]; then
+        SOURCE_ARG="${OLDPWD}/${SOURCE_ARG}"
+    fi
+    RUN_ARGS="--source=${SOURCE_ARG}"
+else
+    RUN_ARGS=""
+fi
+
+time_start=$(date +%s%N)
+
+# shellcheck disable=SC2086
+"${BINARY}" ${RUN_ARGS} \
+    > "${BUILD_DIR}/run.log" \
+    2> "${BUILD_DIR}/timing.txt"
+
+time_end=$(date +%s%N)
+wall_ms=$(( (time_end - time_start) / 1000000 ))
+
+echo "  Wall-clock: ${wall_ms} ms"
+echo "  Timing (from driver stderr):"
+sed 's/^/    /' "${BUILD_DIR}/timing.txt"
+echo "  SAY output -> ${BUILD_DIR}/run.log"
+
+if [ ! -f "${BUILD_DIR}/gmon.out" ]; then
+    echo "ERROR: gmon.out not produced under ${BUILD_DIR}" >&2
+    echo "       This is unexpected; check that the binary linked with -pg." >&2
+    exit 3
+fi
+
+cd - >/dev/null
+
+# ------------------------------------------------------------------ #
+#  Step 4: Profile (full gprof; skipped with --summary)               #
+# ------------------------------------------------------------------ #
+
+if [ "${SUMMARY_ONLY}" -eq 0 ]; then
+    echo "==> Running gprof (full profile)"
+    "${GPROF_CMD}" "${BINARY}" "${GMON}" > "${BUILD_DIR}/profile.txt"
+    echo "  Full profile -> ${BUILD_DIR}/profile.txt"
+fi
+
+# ------------------------------------------------------------------ #
+#  Step 5: Extract top-10 hotspots                                     #
+# ------------------------------------------------------------------ #
+
+echo "==> Extracting top-10 hotspots"
+
+# Parse the flat profile section from gprof output.
+# Format of the flat profile (after the header lines):
+#   %time  cumulative  self    calls  self  total  name
+#   XX.XX   XX.XX      XX.XX  NNNN  ...   ...    func_name
+#
+# We locate the section by finding the "Flat profile:" header, skip
+# the two separator lines and the column-header line, then take the
+# next N non-blank data lines.
+
+PROFILE_SRC="${BUILD_DIR}/profile.txt"
+if [ "${SUMMARY_ONLY}" -eq 1 ]; then
+    # For --summary we still need profile output to extract hotspots.
+    PROFILE_SRC="${BUILD_DIR}/.tmp_profile.txt"
+    "${GPROF_CMD}" "${BINARY}" "${GMON}" > "${PROFILE_SRC}"
+fi
+
+awk '
+/^Flat profile:/ { in_flat=1; header_count=0; next }
+in_flat && /^ *$/ { next }
+in_flat && header_count < 3 { header_count++; next }
+in_flat && header_count >= 3 {
+    if (/^Call graph/) { exit }
+    if (NF == 0) next
+    rank++
+    # fields: %time  cumulative  self  calls  self/call  total/call  name
+    self_pct=$1; cum=$2; self_s=$3; calls=$4; fname=$NF
+    printf "%d\t%s\t%s\t%s\t%s\t%s\n", rank, self_pct, cum, self_s, calls, fname
+    if (rank >= 10) exit
+}
+' "${PROFILE_SRC}" > "${BUILD_DIR}/top-hotspots.txt"
+
+# Clean up temp file if --summary
+if [ "${SUMMARY_ONLY}" -eq 1 ]; then
+    rm -f "${PROFILE_SRC}"
+fi
+
+echo "  Hotspots -> ${BUILD_DIR}/top-hotspots.txt"
+
+# ------------------------------------------------------------------ #
+#  Step 6: Summary line                                                #
+# ------------------------------------------------------------------ #
+
+TIMING_LINE=$(cat "${BUILD_DIR}/timing.txt" 2>/dev/null || echo "(no timing)")
+
+# Top-3 hotspot functions for inline summary
+TOP3=$(awk -F'\t' 'NR<=3 { printf "%s(%s%%) ", $6, $2 }' \
+       "${BUILD_DIR}/top-hotspots.txt" 2>/dev/null || echo "(no hotspots)")
+
+echo ""
+echo "======================================================================"
+echo "  Profile summary"
+echo "  Wall-clock : ${wall_ms} ms"
+echo "  Driver     : ${TIMING_LINE}"
+echo "  Top-3      : ${TOP3}"
+echo "  Output dir : ${BUILD_DIR}/"
+echo "======================================================================"

--- a/test/host/tstcps_host.c
+++ b/test/host/tstcps_host.c
@@ -1,0 +1,200 @@
+/* ------------------------------------------------------------------ */
+/*  test/host/tstcps_host.c — WP-PERF-01 profiling driver             */
+/*                                                                    */
+/*  Exercises the engine with a synthetic REXX microbench designed    */
+/*  to cover the hot paths profiled in REXXCPS-style workloads:       */
+/*  variable access, BIF dispatch, arithmetic, DO loops, CALL/RETURN, */
+/*  and compound variables.                                            */
+/*                                                                    */
+/*  Build (Linux):                                                     */
+/*    See scripts/host-profile.sh for the canonical build command.    */
+/*    Quick form (no -pg):                                             */
+/*      gcc -I include -I contrib/lstring370-0.1.0-dev/include \      */
+/*          -Wall -Wextra -std=gnu99 -O0 -g \                         */
+/*          -o /tmp/tstcps_host test/host/tstcps_host.c \             */
+/*          'src/irx#init.c' 'src/irx#term.c' 'src/irx#stor.c' \     */
+/*          'src/irx#anch.c' 'src/irx#env.c'  'src/irx#uid.c'  \     */
+/*          'src/irx#msid.c' 'src/irx#cond.c' 'src/irx#bif.c'  \     */
+/*          'src/irx#bifs.c' 'src/irx#io.c'   'src/irx#lstr.c' \     */
+/*          'src/irx#tokn.c' 'src/irx#vpol.c' 'src/irx#pars.c' \     */
+/*          'src/irx#ctrl.c' 'src/irx#exec.c' 'src/irx#arith.c' \    */
+/*          '../lstring370/src/lstr#cor.c'  \                         */
+/*          '../lstring370/src/lstr#cvt.c'  \                         */
+/*          '../lstring370/src/lstr#fmt.c'  \                         */
+/*          '../lstring370/src/lstr#srch.c' \                         */
+/*          '../lstring370/src/lstr#sub.c'  \                         */
+/*          '../lstring370/src/lstr#wrd.c'  \                         */
+/*          '../lstring370/src/lstr#xlt.c'                            */
+/*                                                                    */
+/*  Usage:                                                             */
+/*    ./tstcps_host               — run embedded microbench            */
+/*    ./tstcps_host --source=PATH — run REXX source file at PATH       */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <sys/resource.h>
+
+#include "irx.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+/* ------------------------------------------------------------------ */
+/*  Embedded microbench — mirrors REXXCPS hot paths.                  */
+/*  Tune outer*inner so the total run time hits ~10-20 s on a         */
+/*  modern Linux host. 1000*500 = 500 000 iterations is the           */
+/*  default; reduce outer if runtime exceeds 30 s, increase if        */
+/*  under 10 s. On macOS ARM this ran ~6 s; Linux x86_64 typically   */
+/*  runs 1.5-2x slower for this interpreter-heavy workload.           */
+/* ------------------------------------------------------------------ */
+static const char MICROBENCH[] =
+    "/* WP-PERF-01 embedded microbench */\n"
+    "outer = 1000\n"
+    "inner = 500\n"
+    "acc = 0\n"
+    "str = 'the quick brown fox jumps over the lazy dog'\n"
+    "stem. = 0\n"
+    "do o = 1 to outer\n"
+    "   do i = 1 to inner\n"
+    "      acc = acc + i\n"
+    "      stem.o.i = acc\n"
+    "      len = length(str)\n"
+    "      pos1 = pos('brown', str)\n"
+    "      sub = substr(str, pos1, 5)\n"
+    "      wc = words(str)\n"
+    "      x = (i * 3 + 7) / 2\n"
+    "      y = x ** 2\n"
+    "      call helper i\n"
+    "   end\n"
+    "end\n"
+    "say 'acc =' acc\n"
+    "say 'last sub =' sub\n"
+    "say 'last x =' x\n"
+    "say 'last y =' y\n"
+    "say 'wc =' wc\n"
+    "exit 0\n"
+    "\n"
+    "helper:\n"
+    "   parse arg n\n"
+    "   return n + 1\n";
+
+/* ------------------------------------------------------------------ */
+/*  Read a file into a malloc'd buffer. Returns NULL on error.        */
+/* ------------------------------------------------------------------ */
+static char *read_file(const char *path, int *len_out)
+{
+    FILE *f;
+    long size;
+    char *buf;
+
+    f = fopen(path, "r");
+    if (f == NULL)
+    {
+        fprintf(stderr, "tstcps_host: cannot open '%s'\n", path);
+        return NULL;
+    }
+    fseek(f, 0, SEEK_END);
+    size = ftell(f);
+    rewind(f);
+
+    buf = malloc((size_t)(size + 1));
+    if (buf == NULL)
+    {
+        fprintf(stderr, "tstcps_host: out of memory\n");
+        fclose(f);
+        return NULL;
+    }
+    *len_out = (int)fread(buf, 1, (size_t)size, f);
+    buf[*len_out] = '\0';
+    fclose(f);
+    return buf;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Elapsed wall-clock in seconds (CLOCK_MONOTONIC).                  */
+/* ------------------------------------------------------------------ */
+static double wall_seconds(struct timespec *start, struct timespec *end)
+{
+    return (double)(end->tv_sec - start->tv_sec) +
+           (double)(end->tv_nsec - start->tv_nsec) / 1.0e9;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main                                                               */
+/* ------------------------------------------------------------------ */
+int main(int argc, char *argv[])
+{
+    const char *source_path = NULL;
+    const char *src;
+    char *file_buf = NULL;
+    int src_len;
+    int exit_rc = -1;
+    int rc;
+    struct timespec t0, t1;
+    struct rusage ru0, ru1;
+    double wall;
+    double cpu_user, cpu_sys;
+    int i;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (strncmp(argv[i], "--source=", 9) == 0)
+        {
+            source_path = argv[i] + 9;
+        }
+        else
+        {
+            fprintf(stderr, "tstcps_host: unknown option '%s'\n", argv[i]);
+            fprintf(stderr, "usage: tstcps_host [--source=PATH]\n");
+            return 1;
+        }
+    }
+
+    if (source_path != NULL)
+    {
+        file_buf = read_file(source_path, &src_len);
+        if (file_buf == NULL)
+        {
+            return 1;
+        }
+        src = file_buf;
+    }
+    else
+    {
+        src = MICROBENCH;
+        src_len = (int)strlen(MICROBENCH);
+    }
+
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    getrusage(RUSAGE_SELF, &ru0);
+
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, NULL);
+
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    getrusage(RUSAGE_SELF, &ru1);
+
+    wall = wall_seconds(&t0, &t1);
+
+    cpu_user = (double)(ru1.ru_utime.tv_sec - ru0.ru_utime.tv_sec) +
+               (double)(ru1.ru_utime.tv_usec - ru0.ru_utime.tv_usec) / 1.0e6;
+    cpu_sys = (double)(ru1.ru_stime.tv_sec - ru0.ru_stime.tv_sec) +
+              (double)(ru1.ru_stime.tv_usec - ru0.ru_stime.tv_usec) / 1.0e6;
+
+    fprintf(stderr, "wall=%.3fs  cpu_user=%.3fs  cpu_sys=%.3fs  exit_rc=%d\n",
+            wall, cpu_user, cpu_sys, exit_rc);
+
+    if (file_buf != NULL)
+    {
+        free(file_buf);
+    }
+
+    return (rc == 0) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- `test/host/tstcps_host.c` — profiling driver with embedded REXX microbench (variable access, BIF dispatch, arithmetic, compound variables, CALL/RETURN)
- `scripts/host-profile.sh` — end-to-end gprof pipeline: preflight → build → run → profile → top-10 extraction → summary. Supports `--source=`, `--summary`, `--clean`; honours `CC=`/`GPROF=` env overrides
- `docs/profiling.md` — prerequisites, quick start, output interpretation, baseline convention, known limitations
- `docs/profiling/host-baseline-2026-05-18-initial.md` — first baseline from Linux x86_64 (Debian 13, gcc 14.2): 27.8 s, top hotspot `find_in_bucket` 37.42%

Closes #... (Notion: https://www.notion.so/3643d99387878190b615dc039e977a09)

## Test plan

- [x] Script runs end-to-end on Linux (mvsdev.lan, Debian 13)
- [x] Driver produces > 10 s of engine work (27.8 s)
- [x] `profile.txt` and `top-hotspots.txt` produced under `build/host-profile/`
- [x] `--source=`, `--clean`, `--summary` flags all functional (preflight verified on macOS; full run on Linux)
- [x] `docs/profiling.md` complete and accurate
- [x] Baseline snapshot committed with real data
- [x] `build/` in `.gitignore`
- [x] No `build/` artefacts committed
- [x] No Makefile changes
- [x] No REXXCPS source committed
- [x] Driver compiles without warnings under `-Wall -Wextra`
- [x] `set -euo pipefail` in script