### PR TITLE
perf(vpool): extend prime chain to 574021 + inline find_in_bucket (WP-PERF-02)

### DIFF
--- a/docs/profiling/host-baseline-2026-05-18-post-perf02.md
+++ b/docs/profiling/host-baseline-2026-05-18-post-perf02.md
@@ -1,0 +1,40 @@
+# Host Profile — post WP-PERF-02 (2026-05-18)
+
+**Engine commit:** da8fd0d  
+**Host:** Linux mvsdev 6.12.73+deb13-amd64 x86_64 (Debian 13)  
+**Build:** gcc (Debian 14.2.0-19) — `-pg -O0 -g -std=gnu99`  
+**Driver:** `test/host/tstcps_host` with embedded microbench (outer=1000, inner=500)  
+**Total wall-clock:** 25.138 s  
+**Total CPU (user+sys):** 25.023 s + 0.084 s = 25.107 s  
+
+## Top-10 hotspots
+
+| Rank | Self% | Cum% | Self s | Calls | Function |
+|------|-------|------|--------|-------|----------|
+| 1 | 11.89 | 11.89 | 0.71 | 304 062 472 | `peek_tok` |
+| 2 | 7.54 | 19.43 | 0.45 | 175 523 266 | `tok_is_op_char` |
+| 3 | 5.53 | 24.96 | 0.33 | *(no count)* | `_init` ¹ |
+| 4 | 4.52 | 29.48 | 0.27 | 115 000 000 | `ebcdic_eq` |
+| 5 | 4.36 | 33.84 | 0.26 | 500 000 | `num_div_impl` |
+| 6 | 4.02 | 37.86 | 0.24 | 108 014 350 | `irxstor` |
+| 7 | 3.02 | 40.88 | 0.18 | 15 003 023 | `upper_bytes` |
+| 8 | 2.68 | 43.56 | 0.16 | 2 000 000 | `parse_function_call` |
+| 9 | 2.51 | 46.07 | 0.15 | 2 000 000 | `IRXBIFFN` |
+| 10 | 2.35 | 48.42 | 0.14 | 13 002 011 | `find_in_bucket` |
+
+¹ `_init` is the ELF constructor section (C runtime / lstring startup), not a REXX
+engine function. Its cost is a one-time startup expense and is not an optimisation target.
+
+## Observations
+
+`find_in_bucket` dropped from **#1 at 37.42%** (3.45 s) to **#10 at 2.35%** (0.14 s)
+after the vp_primes[] extension to 574 021 buckets.  With 500 k unique compound
+variables the table now grows to a capacity where chains are near-length-1, so the
+previously dominant chain-walk is almost always a single pointer comparison.  The
+call count (13 M) is unchanged — every variable read/write still invokes
+`find_in_bucket` — but each call is now trivially fast.
+
+The new profile is well-distributed: the top function (`peek_tok` at 11.89%) is the
+next single target worth addressing.  It is called 304 M times because the tokenizer
+re-scans the source on every iteration of the DO loop body; a token-stream cache
+(WP future) would eliminate this cost class entirely.

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -26,8 +26,9 @@
 /* ------------------------------------------------------------------ */
 
 static const int vp_primes[] = {
-    67, 137, 277, 557, 1117, 2237, 4483, 8963};
-#define VP_PRIME_COUNT 8
+    67, 137, 277, 557, 1117, 2237, 4483, 8963,
+    17929, 35863, 71741, 143483, 287003, 574021};
+#define VP_PRIME_COUNT 14
 #define VP_INITIAL     67
 #define VP_MAX_LOAD    4 /* entries per bucket before resize */
 
@@ -221,8 +222,8 @@ static int bucket_index(const struct irx_vpool *pool, const PLstr name)
     return (int)(h % (unsigned long)pool->bucket_count);
 }
 
-static struct vpool_entry *find_in_bucket(struct vpool_entry *head,
-                                          const PLstr name)
+static inline struct vpool_entry *find_in_bucket(struct vpool_entry *head,
+                                                 const PLstr name)
 {
     struct vpool_entry *e;
     for (e = head; e != NULL; e = e->next)


### PR DESCRIPTION
## Summary

- Extends `vp_primes[]` in `src/irx#vpol.c` from 8 to 14 entries (max 574 021), keeping the existing 2× growth pattern
- Marks `find_in_bucket` `static inline` so the compiler may elide call overhead at `-O2`+
- All host tests pass (1236/1236, unchanged)

Closes #135

## Top-10 hotspot comparison

| Rank | **Before** (WP-PERF-01 baseline) | Self% | **After** (WP-PERF-02) | Self% |
|------|----------------------------------|-------|-------------------------|-------|
| 1 | `find_in_bucket` | 37.42 | `peek_tok` | 11.89 |
| 2 | `peek_tok` | 8.89 | `tok_is_op_char` | 7.54 |
| 3 | `num_div_impl` | 3.80 | `_init` | 5.53 |
| 4 | `tok_is_op_char` | 3.04 | `ebcdic_eq` | 4.52 |
| 5 | `ebcdic_eq` | 2.60 | `num_div_impl` | 4.36 |
| 6 | `_init` | 2.39 | `irxstor` | 4.02 |
| 7 | `irxstor` | 2.28 | `upper_bytes` | 3.02 |
| 8 | `cur_tok` | 2.17 | `parse_function_call` | 2.68 |
| 9 | `Lfx` | 1.74 | `IRXBIFFN` | 2.51 |
| 10 | `parse_function_call` | 1.74 | `find_in_bucket` | **2.35** |

**Wall-clock:** 27.841 s → 25.138 s  **(-2.703 s, -9.7%)**  
**CPU (user):** 27.709 s → 25.023 s  **(-2.686 s, -9.7%)**

## Interpretation

`find_in_bucket` fell from **#1 at 37.42%** (3.45 s, 13 M calls) to **#10 at 2.35%** (0.14 s, 13 M calls) — a 25× reduction in self-time with no change in call count. The call count is unchanged because every variable read/write still invokes `find_in_bucket`; what changed is chain length. With the extended prime table the hash table can now grow to 574 021 buckets, so under 500 k unique compound variables each bucket holds ≈1 entry and the chain-walk terminates on the first comparison. The `inline` annotation has no measurable effect at `-O0` (profiling build) but may further reduce overhead at `-O2` in production builds.

The new top hotspot is `peek_tok` (11.89%, 304 M calls), which is a tokenizer re-scan cost proportional to DO-loop iterations — a different cost class addressed by future token-stream caching work.

## Profile files

- Before: `docs/profiling/host-baseline-2026-05-18-initial.md`
- After: `docs/profiling/host-baseline-2026-05-18-post-perf02.md`