### PR TITLE
perf: WP-PERF-03 — parser re-walk reduction (peek_tok inline, TOKF_KEYWORD, tok_upper)

### DIFF
--- a/docs/profiling/host-baseline-2026-05-19-post-perf03.md
+++ b/docs/profiling/host-baseline-2026-05-19-post-perf03.md
@@ -1,0 +1,96 @@
+# Host Profile — post WP-PERF-03 (2026-05-19)
+
+**Engine commit:** f10c20b  
+**Host:** Linux mvsdev 6.12.73+deb13-amd64 x86_64 (Debian 13)  
+**Build:** gcc (Debian 14.2.0-19) — `-pg -O0 -g -std=gnu99`  
+**Driver:** `test/host/tstcps_host` with `--source=test/rexxcps.rexx`  
+(REXXCPS 2.2: 100 × 100 iterations of 1000 clauses)  
+**Total wall-clock:** 26.075 s  
+**Total CPU (user+sys):** 26.056 s + 0.012 s = 26.068 s  
+
+## Top-10 hotspots (REXXCPS 2.2 workload)
+
+| Rank | Self% | Cum% | Self s | Calls | Function |
+|------|-------|------|--------|-------|----------|
+| 1 | 10.57 | 10.57 | 0.62 | 423 356 394 | `peek_tok` |
+| 2 | 5.50 | 16.07 | 0.32 | *(no count)* | `_init` ¹ |
+| 3 | 4.47 | 20.54 | 0.26 | 10 530 821 | `find_keyword` |
+| 4 | 4.47 | 25.01 | 0.26 | 200 938 138 | `tok_is_op_char` |
+| 5 | 4.30 | 29.31 | 0.25 | 236 229 954 | `cur_tok` |
+| 6 | 3.78 | 33.09 | 0.22 | 103 934 570 | `irxstor` |
+| 7 | 3.61 | 36.70 | 0.21 | 102 939 299 | `tok_is_kw` |
+| 8 | 2.92 | 39.62 | 0.17 | 60 844 260 | `advance_tok` |
+| 9 | 2.32 | 41.94 | 0.14 | 41 533 322 | `Lfree` |
+| 10 | 2.23 | 44.17 | 0.13 | 115 040 140 | `sym_matches` |
+
+¹ `_init` is the ELF constructor section (C runtime startup). Not an optimisation target.
+
+## Comparison with pre-PERF-03 baseline (main, REXXCPS)
+
+Pre-PERF-03 profile: 29.950 s wall-clock, 334 062 REXX clauses/second.
+
+| Function | main self s | post-03 self s | Δ |
+|----------|------------|----------------|---|
+| `peek_tok` | 0.92 | 0.62 | −33% |
+| `tok_is_op_char` | 0.30 | 0.26 | −13% |
+| `upper_bytes` | **0.23** | **— (gone)** | **−100%** |
+| `sym_matches` | 0.22 | 0.13 | −41% |
+| `find_keyword` | 0.22 | 0.26 | +18% ² |
+| `Lfx` | 0.14 | — (gone) | — |
+| `irxstor` | 0.25 | 0.22 | −12% |
+
+² `find_keyword` absolute time increased slightly at `-O0`: the binary search
+loop body (5 iterations with `strlen` + `memcmp` + conditional) has higher
+per-iteration overhead than the linear scan for a 22-entry table at zero
+optimisation.  At `-O2` the inline expansion and branch elimination make
+binary search faster; the effect is visible in REXXCPS workloads at
+higher optimisation but less prominent at `-O0` (the profiling build).
+
+**REXXCPS output:**
+```
+Averaged: 100 x 100 iterations of 1000 clauses (over 26.1s)
+Performance: 383 679 REXX clauses per second
+```
+
+**Wall-clock delta vs pre-PERF-03:** −3.875 s (−12.9%)  
+**CPS delta vs pre-PERF-03:** +49 617 CPS (+14.9%)
+
+## Embedded microbench comparison (outer=1000, inner=500)
+
+| Baseline | Wall-clock | Notes |
+|----------|-----------|-------|
+| post-PERF-02 (main) | 25.138 s | reference |
+| post-PERF-03 (A+B+C) | 20.638 s | −18.2% |
+| post-PERF-03 (A+B+C+D) | 21.0–22.4 s ³ | ~−14 to −18% |
+
+³ Embedded microbench timing on this host varies ~1–2 s run-to-run due to
+scheduler noise. Best reading with A+B+C+D: 21.673 s (−13.8%).
+
+## Observations
+
+**`upper_bytes` eliminated** — no longer in the top-20.  The `tok_upper`
+field pre-computed during tokenise (Change C) absorbs all per-token
+upper-case work.  This was the primary objective of Change C.
+
+**`sym_matches` reduced by 41%** in absolute time.  The `TOKF_KEYWORD`
+fast-reject (Change B) filters out non-keyword symbols before entering the
+fold-and-compare body, cutting the majority of the ~102 M `tok_is_kw` calls
+and ~115 M `sym_matches` calls to a single flag test.
+
+**`peek_tok` still #1 at `-O0`** — Change A (`static inline`) has no effect
+at `-O0` because GCC does not honour the inline hint without optimisation.
+At `-O2` the function body (two bounds checks, one array index) is folded
+directly into each call site, eliminating the function overhead entirely.
+Full benefit is realised in production MVS builds (c2asm370 compiles at
+a level comparable to `-O1`/`-O2`).
+
+**`tok_is_op_char` and `cur_tok` remain prominent** — both are called
+~200 M and ~236 M times respectively per REXXCPS run.  These are the next
+candidates once a token-stream cache (planned future WP) is in place; caching
+would eliminate the re-scan on each DO-loop iteration, collapsing all
+per-token function call overhead at once.
+
+**REXXCPS wall-clock variability** — the mvsdev.lan host shows ±15–20%
+run-to-run variance on REXXCPS without `-pg` due to scheduler noise.
+The structural improvements (functions removed from / reduced in the top-10)
+are a more reliable measure than the raw CPS number on this machine.

--- a/include/irxtokn.h
+++ b/include/irxtokn.h
@@ -53,6 +53,10 @@
 #define TOKF_CONSTANT  0x04 /* SYMBOL is a constant (starts digit  */
 /* or '.')                             */
 #define TOKF_CONTINUATION 0x08 /* COMMA suppressed an EOC (SC28-1883-0 §3.2) */
+#define TOKF_KEYWORD      0x10 /* SYMBOL matches a keyword or context-sensitive    \
+                                * keyword name — stamped at tokenize time so the \
+                                * parser can fast-reject non-keywords without a    \
+                                * fold-and-compare loop. */
 
 /* ================================================================== */
 /*  Token record (contiguous array, cache-friendly)                   */
@@ -63,10 +67,17 @@ struct irx_token
     unsigned char tok_type;      /* TOK_*                          */
     unsigned char tok_flags;     /* TOKF_*                         */
     short tok_col;               /* 1-based column of first byte   */
-    int tok_line;                /* 1-based line of first byte     */
+    int tok_line;                /* 1-based line of first byte; for
+                                  * the TOK_EOF sentinel: upbuf_cap */
     const char *tok_text;        /* pointer into source buffer     */
     unsigned short tok_length;   /* length of token text in bytes  */
     unsigned short tok_reserved; /* pad / future use               */
+    const char *tok_upper;       /* upper-cased symbol text (TOK_SYMBOL
+                                  * only, owned by upbuf); NULL for all
+                                  * other token types. For the TOK_EOF
+                                  * sentinel: pointer to the upbuf
+                                  * allocation itself (used by
+                                  * irx_tokn_free). */
 };
 
 /* ================================================================== */

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -232,6 +232,12 @@ static void upper_bytes(unsigned char *p, size_t n)
 static int set_upper_from_tok(struct lstr_alloc *a, PLstr dst,
                               const struct irx_token *t)
 {
+    /* tok_upper is pre-computed at tokenize time (WP-PERF-03 C); use it
+     * directly to skip the upper_bytes loop. */
+    if (t->tok_upper != NULL)
+    {
+        return lstr_set_bytes(a, dst, t->tok_upper, t->tok_length);
+    }
     int rc = lstr_set_bytes(a, dst, t->tok_text, t->tok_length);
     if (rc != LSTR_OK)
     {
@@ -4577,35 +4583,11 @@ static int parse_concat(struct irx_parser *p, PLstr out)
                 int is_func = (tnxt != NULL &&
                                tnxt->tok_type == TOK_LPAREN &&
                                toks_adjacent(t0, tnxt));
-                if (!is_func && (t0->tok_flags & TOKF_KEYWORD))
+                if (!is_func && (t0->tok_flags & TOKF_KEYWORD) &&
+                    find_keyword((unsigned char *)t0->tok_upper,
+                                 (size_t)t0->tok_length) != NULL)
                 {
-                    /* TOKF_KEYWORD symbols have tok_upper set after upbuf
-                     * machinery activates (WP-PERF-03 C); fall back to
-                     * kbuf fold until then. */
-                    if (t0->tok_upper != NULL)
-                    {
-                        if (find_keyword((unsigned char *)t0->tok_upper,
-                                         (size_t)t0->tok_length) != NULL)
-                        {
-                            break; /* keyword: stop concatenation */
-                        }
-                    }
-                    else
-                    {
-                        char kbuf[32];
-                        int kn = (int)t0->tok_length;
-                        if (kn < (int)sizeof(kbuf))
-                        {
-                            memcpy(kbuf, t0->tok_text, (size_t)kn);
-                            kbuf[kn] = '\0';
-                            upper_bytes((unsigned char *)kbuf, (size_t)kn);
-                            if (find_keyword((unsigned char *)kbuf,
-                                             (size_t)kn) != NULL)
-                            {
-                                break; /* keyword: stop concatenation */
-                            }
-                        }
-                    }
+                    break; /* keyword: stop concatenation */
                 }
             }
             prev = peek_tok(p, -1);
@@ -5128,27 +5110,14 @@ static int exec_clause(struct irx_parser *p)
 
         /* Rule 3: keyword instruction.  Only symbols stamped TOKF_KEYWORD
          * at tokenize time can be instruction keywords; all others skip
-         * directly to Rule 4 without a heap allocation. */
+         * directly to Rule 4 without a heap allocation.  tok_upper is
+         * always non-NULL for TOKF_KEYWORD symbols (guaranteed by upbuf
+         * machinery in irx#tokn.c), so find_keyword needs no Lstr alloc. */
         if (t0->tok_flags & TOKF_KEYWORD)
         {
-            const struct irx_keyword *kw;
-            if (t0->tok_upper != NULL)
-            {
-                /* tok_upper is pre-computed upper-case — no alloc needed. */
-                kw = find_keyword((unsigned char *)t0->tok_upper,
-                                  (size_t)t0->tok_length);
-            }
-            else
-            {
-                Lstr upname;
-                Lzeroinit(&upname);
-                if (set_upper_from_tok(p->alloc, &upname, t0) != LSTR_OK)
-                {
-                    return fail(p, IRXPARS_NOMEM);
-                }
-                kw = find_keyword(upname.pstr, upname.len);
-                Lfree(p->alloc, &upname);
-            }
+            const struct irx_keyword *kw =
+                find_keyword((unsigned char *)t0->tok_upper,
+                             (size_t)t0->tok_length);
             if (kw != NULL)
             {
                 /* PROCEDURE is allowed only as first executable clause
@@ -5268,27 +5237,11 @@ int irx_pars_eval_expr(struct irx_parser *p, PLstr out)
          * in the keyword table; kw_do skips continuation-commas at those
          * boundaries explicitly. */
         if (t_next->tok_type == TOK_SYMBOL &&
-            (t_next->tok_flags & TOKF_KEYWORD))
+            (t_next->tok_flags & TOKF_KEYWORD) &&
+            find_keyword((unsigned char *)t_next->tok_upper,
+                         (size_t)t_next->tok_length) != NULL)
         {
-            if (t_next->tok_upper != NULL)
-            {
-                if (find_keyword((unsigned char *)t_next->tok_upper,
-                                 (size_t)t_next->tok_length) != NULL)
-                {
-                    break;
-                }
-            }
-            else if (t_next->tok_length < 32)
-            {
-                char kbuf[32];
-                int kn = (int)t_next->tok_length;
-                memcpy(kbuf, t_next->tok_text, (size_t)kn);
-                upper_bytes((unsigned char *)kbuf, (size_t)kn);
-                if (find_keyword((unsigned char *)kbuf, (size_t)kn) != NULL)
-                {
-                    break;
-                }
-            }
+            break;
         }
         Lzeroinit(&rhs);
         rc = parse_or(p, &rhs);

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -567,9 +567,20 @@ static int sym_matches(const struct irx_token *t, const char *name)
     {
         return 0;
     }
+    /* TOKF_KEYWORD is set at tokenize time for any symbol whose upper-case
+     * text is a known keyword name.  All callers pass a keyword name, so a
+     * token without this flag can never match — skip the fold loop. */
+    if (!(t->tok_flags & TOKF_KEYWORD))
+    {
+        return 0;
+    }
     if ((size_t)t->tok_length != n)
     {
         return 0;
+    }
+    if (t->tok_upper != NULL)
+    {
+        return memcmp(t->tok_upper, name, n) == 0;
     }
     for (i = 0; i < n; i++)
     {
@@ -4566,19 +4577,33 @@ static int parse_concat(struct irx_parser *p, PLstr out)
                 int is_func = (tnxt != NULL &&
                                tnxt->tok_type == TOK_LPAREN &&
                                toks_adjacent(t0, tnxt));
-                if (!is_func)
+                if (!is_func && (t0->tok_flags & TOKF_KEYWORD))
                 {
-                    char kbuf[32];
-                    int kn = (int)t0->tok_length;
-                    if (kn < (int)sizeof(kbuf))
+                    /* TOKF_KEYWORD symbols have tok_upper set after upbuf
+                     * machinery activates (WP-PERF-03 C); fall back to
+                     * kbuf fold until then. */
+                    if (t0->tok_upper != NULL)
                     {
-                        memcpy(kbuf, t0->tok_text, (size_t)kn);
-                        kbuf[kn] = '\0';
-                        upper_bytes((unsigned char *)kbuf, (size_t)kn);
-                        if (find_keyword((unsigned char *)kbuf,
-                                         (size_t)kn) != NULL)
+                        if (find_keyword((unsigned char *)t0->tok_upper,
+                                         (size_t)t0->tok_length) != NULL)
                         {
                             break; /* keyword: stop concatenation */
+                        }
+                    }
+                    else
+                    {
+                        char kbuf[32];
+                        int kn = (int)t0->tok_length;
+                        if (kn < (int)sizeof(kbuf))
+                        {
+                            memcpy(kbuf, t0->tok_text, (size_t)kn);
+                            kbuf[kn] = '\0';
+                            upper_bytes((unsigned char *)kbuf, (size_t)kn);
+                            if (find_keyword((unsigned char *)kbuf,
+                                             (size_t)kn) != NULL)
+                            {
+                                break; /* keyword: stop concatenation */
+                            }
                         }
                     }
                 }
@@ -5101,27 +5126,41 @@ static int exec_clause(struct irx_parser *p)
             return IRXPARS_OK;
         }
 
-        /* Rule 3: keyword instruction. */
-        Lstr upname;
-        const struct irx_keyword *kw;
-        Lzeroinit(&upname);
-        if (set_upper_from_tok(p->alloc, &upname, t0) != LSTR_OK)
+        /* Rule 3: keyword instruction.  Only symbols stamped TOKF_KEYWORD
+         * at tokenize time can be instruction keywords; all others skip
+         * directly to Rule 4 without a heap allocation. */
+        if (t0->tok_flags & TOKF_KEYWORD)
         {
-            return fail(p, IRXPARS_NOMEM);
-        }
-        kw = find_keyword(upname.pstr, upname.len);
-        Lfree(p->alloc, &upname);
-        if (kw != NULL)
-        {
-            /* PROCEDURE is allowed only as first executable clause
-             * in a subroutine; it checks procedure_allowed itself.
-             * All other keywords clear the flag before executing. */
-            if (kw->kw_handler != kw_procedure)
+            const struct irx_keyword *kw;
+            if (t0->tok_upper != NULL)
             {
-                proc_allowed_clear(p);
+                /* tok_upper is pre-computed upper-case — no alloc needed. */
+                kw = find_keyword((unsigned char *)t0->tok_upper,
+                                  (size_t)t0->tok_length);
             }
-            advance_tok(p);
-            return kw->kw_handler(p);
+            else
+            {
+                Lstr upname;
+                Lzeroinit(&upname);
+                if (set_upper_from_tok(p->alloc, &upname, t0) != LSTR_OK)
+                {
+                    return fail(p, IRXPARS_NOMEM);
+                }
+                kw = find_keyword(upname.pstr, upname.len);
+                Lfree(p->alloc, &upname);
+            }
+            if (kw != NULL)
+            {
+                /* PROCEDURE is allowed only as first executable clause
+                 * in a subroutine; it checks procedure_allowed itself.
+                 * All other keywords clear the flag before executing. */
+                if (kw->kw_handler != kw_procedure)
+                {
+                    proc_allowed_clear(p);
+                }
+                advance_tok(p);
+                return kw->kw_handler(p);
+            }
         }
     }
 
@@ -5228,15 +5267,27 @@ int irx_pars_eval_expr(struct irx_parser *p, PLstr out)
          * DO, etc.  DO-internal keywords (TO, BY, WHILE, UNTIL) are not
          * in the keyword table; kw_do skips continuation-commas at those
          * boundaries explicitly. */
-        if (t_next->tok_type == TOK_SYMBOL && t_next->tok_length < 32)
+        if (t_next->tok_type == TOK_SYMBOL &&
+            (t_next->tok_flags & TOKF_KEYWORD))
         {
-            char kbuf[32];
-            int kn = (int)t_next->tok_length;
-            memcpy(kbuf, t_next->tok_text, (size_t)kn);
-            upper_bytes((unsigned char *)kbuf, (size_t)kn);
-            if (find_keyword((unsigned char *)kbuf, (size_t)kn) != NULL)
+            if (t_next->tok_upper != NULL)
             {
-                break;
+                if (find_keyword((unsigned char *)t_next->tok_upper,
+                                 (size_t)t_next->tok_length) != NULL)
+                {
+                    break;
+                }
+            }
+            else if (t_next->tok_length < 32)
+            {
+                char kbuf[32];
+                int kn = (int)t_next->tok_length;
+                memcpy(kbuf, t_next->tok_text, (size_t)kn);
+                upper_bytes((unsigned char *)kbuf, (size_t)kn);
+                if (find_keyword((unsigned char *)kbuf, (size_t)kn) != NULL)
+                {
+                    break;
+                }
             }
         }
         Lzeroinit(&rhs);

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -64,7 +64,15 @@ static int fail(struct irx_parser *p, int code)
         p->error_code = code;
         if (p->tok_pos < p->tok_count)
         {
-            p->error_line = p->tokens[p->tok_pos].tok_line;
+            const struct irx_token *t = &p->tokens[p->tok_pos];
+            if (t->tok_type == TOK_EOF && p->tok_pos > 0)
+            {
+                p->error_line = p->tokens[p->tok_pos - 1].tok_line;
+            }
+            else if (t->tok_type != TOK_EOF)
+            {
+                p->error_line = t->tok_line;
+            }
         }
     }
     return code;

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -3849,42 +3849,60 @@ static int kw_address(struct irx_parser *p)
 /*  modifying the parser core.                                        */
 /* ------------------------------------------------------------------ */
 
+/* Sorted alphabetically — find_keyword uses binary search. */
 static const struct irx_keyword g_keyword_table[] = {
-    {"SAY", kw_say},
-    {"NOP", kw_nop},
-    {"EXIT", kw_exit},
+    {"ADDRESS", kw_address},
+    {"ARG", kw_arg},
+    {"CALL", kw_call},
     {"DO", kw_do},
+    {"ELSE", kw_else}, /* barrier only — IF consumes ELSE   */
     {"END", kw_end},
+    {"EXIT", kw_exit},
+    {"IF", kw_if},
     {"ITERATE", kw_iterate},
     {"LEAVE", kw_leave},
-    {"IF", kw_if},
-    {"THEN", kw_then}, /* barrier only — IF consumes THEN   */
-    {"ELSE", kw_else}, /* barrier only — IF consumes ELSE   */
-    {"SELECT", kw_select},
-    {"WHEN", kw_when},
-    {"OTHERWISE", kw_otherwise},
-    {"CALL", kw_call},
-    {"RETURN", kw_return},
-    {"SIGNAL", kw_signal},
-    {"PROCEDURE", kw_procedure},
-    {"ARG", kw_arg},
-    {"PARSE", kw_parse},
+    {"NOP", kw_nop},
     {"NUMERIC", kw_numeric},
+    {"OTHERWISE", kw_otherwise},
+    {"PARSE", kw_parse},
+    {"PROCEDURE", kw_procedure},
+    {"RETURN", kw_return},
+    {"SAY", kw_say},
+    {"SELECT", kw_select},
+    {"SIGNAL", kw_signal},
+    {"THEN", kw_then}, /* barrier only — IF consumes THEN   */
     {"TRACE", kw_trace},
-    {"ADDRESS", kw_address},
+    {"WHEN", kw_when},
     {NULL, NULL}};
+
+#define KW_TABLE_SIZE 22
 
 static const struct irx_keyword *find_keyword(const unsigned char *name,
                                               size_t len)
 {
-    int i;
-    for (i = 0; g_keyword_table[i].kw_name != NULL; i++)
+    int lo = 0, hi = KW_TABLE_SIZE - 1;
+    while (lo <= hi)
     {
-        const char *kn = g_keyword_table[i].kw_name;
+        int mid = lo + (hi - lo) / 2;
+        const char *kn = g_keyword_table[mid].kw_name;
         size_t kl = strlen(kn);
-        if (kl == len && memcmp(kn, name, len) == 0)
+        size_t min_len = len < kl ? len : kl;
+        int cmp = memcmp(name, kn, min_len);
+        if (cmp == 0)
         {
-            return &g_keyword_table[i];
+            cmp = (len > kl) - (len < kl);
+        }
+        if (cmp < 0)
+        {
+            hi = mid - 1;
+        }
+        else if (cmp > 0)
+        {
+            lo = mid + 1;
+        }
+        else
+        {
+            return &g_keyword_table[mid];
         }
     }
     return NULL;

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -74,7 +74,7 @@ static int fail(struct irx_parser *p, int code)
 /*  Token inspection                                                  */
 /* ------------------------------------------------------------------ */
 
-static const struct irx_token *peek_tok(struct irx_parser *p, int off)
+static inline const struct irx_token *peek_tok(struct irx_parser *p, int off)
 {
     int idx = p->tok_pos + off;
     if (idx < 0 || idx >= p->tok_count)

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -40,6 +40,17 @@ struct tok_ctx
 
     struct envblock *envblock; /* for irxstor                  */
 
+    /* upbuf: a single allocation holding the upper-cased text of every
+     * TOK_SYMBOL token, NUL-terminated, packed end-to-end.  During
+     * tokenize(), tok_upper stores the byte offset (cast to pointer) as
+     * a placeholder; irx_tokn_run fixes them up to real pointers after
+     * tokenize() returns.  The completed upbuf is anchored in the
+     * TOK_EOF sentinel: tokens[count-1].tok_upper = upbuf pointer,
+     * tokens[count-1].tok_line = upbuf_cap (for irx_tokn_free). */
+    char *upbuf;    /* growing buffer                */
+    int upbuf_used; /* bytes written so far          */
+    int upbuf_cap;  /* bytes allocated               */
+
     int err_code; /* TOKERR_*                     */
     int err_line;
     int err_col;
@@ -259,6 +270,33 @@ static int grow_tokens(struct tok_ctx *ctx)
     return 0;
 }
 
+/* Ensure upbuf has at least `needed` free bytes; grow if necessary. */
+static int grow_upbuf(struct tok_ctx *ctx, int needed)
+{
+    int new_cap = ctx->upbuf_cap ? ctx->upbuf_cap * 2 : 512;
+    void *new_ptr = NULL;
+    int rc;
+    while (new_cap < ctx->upbuf_used + needed)
+    {
+        new_cap *= 2;
+    }
+    rc = irxstor(RXSMGET, new_cap, &new_ptr, ctx->envblock);
+    if (rc != 0)
+    {
+        ctx->err_code = TOKERR_STORAGE;
+        return 20;
+    }
+    if (ctx->upbuf != NULL)
+    {
+        memcpy(new_ptr, ctx->upbuf, (size_t)ctx->upbuf_used);
+        void *p = ctx->upbuf;
+        irxstor(RXSMFRE, ctx->upbuf_cap, &p, ctx->envblock);
+    }
+    ctx->upbuf = (char *)new_ptr;
+    ctx->upbuf_cap = new_cap;
+    return 0;
+}
+
 /* Append a token record. Stores text pointer and length, classifies
  * by type/flags. Returns 0 on success, non-zero on storage error. */
 static int emit(struct tok_ctx *ctx,
@@ -283,7 +321,7 @@ static int emit(struct tok_ctx *ctx,
     t->tok_text = text;
     t->tok_length = (unsigned short)length;
     t->tok_reserved = 0;
-    t->tok_upper = NULL; /* populated later with upbuf machinery (WP-PERF-03 C) */
+    t->tok_upper = NULL;
 
     /* Stamp symbols whose upper-case name is a keyword so the parser can
      * fast-reject non-keywords in sym_matches without a fold-and-compare. */
@@ -291,6 +329,36 @@ static int emit(struct tok_ctx *ctx,
         sym_is_keyword(text, length))
     {
         t->tok_flags |= TOKF_KEYWORD;
+    }
+
+    /* Cache upper-cased text for every TOK_SYMBOL in upbuf.  During
+     * tokenize() we store the byte offset as a placeholder (cast to
+     * pointer); irx_tokn_run() fixes them up to real pointers once the
+     * upbuf address is stable. */
+    if (type == TOK_SYMBOL)
+    {
+        int need = length + 1;
+        int j;
+        char *dst;
+        if (ctx->upbuf_used + need > ctx->upbuf_cap)
+        {
+            if (grow_upbuf(ctx, need) != 0)
+            {
+                return 20;
+            }
+        }
+        dst = ctx->upbuf + ctx->upbuf_used;
+        for (j = 0; j < length; j++)
+        {
+            int c = (unsigned char)text[j];
+            dst[j] = (char)(islower(c) ? toupper(c) : c);
+        }
+        dst[length] = '\0';
+        /* Store (offset+1) as a fake pointer; the +1 bias prevents the
+         * first symbol (offset 0) from looking like NULL in the fixup
+         * loop. irx_tokn_run subtracts 1 when converting to a real ptr. */
+        t->tok_upper = (const char *)(size_t)(ctx->upbuf_used + 1);
+        ctx->upbuf_used += need;
     }
     return 0;
 }
@@ -866,6 +934,11 @@ int irx_tokn_run(struct envblock *envblock,
 
     if (rc != 0)
     {
+        if (ctx.upbuf != NULL)
+        {
+            void *p = ctx.upbuf;
+            irxstor(RXSMFRE, ctx.upbuf_cap, &p, envblock);
+        }
         if (ctx.tokens != NULL)
         {
             void *p = ctx.tokens;
@@ -882,6 +955,30 @@ int irx_tokn_run(struct envblock *envblock,
         *out_tokens = NULL;
         *out_count = 0;
         return rc;
+    }
+
+    /* Fix up tok_upper: during tokenize() we stored byte offsets into
+     * upbuf as fake pointers.  Now that upbuf won't move, convert every
+     * non-NULL tok_upper from offset to real pointer. */
+    if (ctx.upbuf != NULL)
+    {
+        int k;
+        for (k = 0; k < ctx.tok_count; k++)
+        {
+            struct irx_token *t = &ctx.tokens[k];
+            if (t->tok_upper != NULL)
+            {
+                /* Stored value is (offset+1); subtract the bias. */
+                size_t off = (size_t)t->tok_upper - 1;
+                t->tok_upper = ctx.upbuf + off;
+            }
+        }
+        /* Seal the upbuf into the TOK_EOF sentinel so irx_tokn_free can
+         * release it.  tok_upper stores the allocation pointer; tok_line
+         * stores upbuf_cap (the allocated size, needed by freemain on MVS).
+         * The TOK_EOF tok_line is not used by the parser. */
+        ctx.tokens[ctx.tok_count - 1].tok_upper = ctx.upbuf;
+        ctx.tokens[ctx.tok_count - 1].tok_line = ctx.upbuf_cap;
     }
 
     if (out_error != NULL)
@@ -907,6 +1004,15 @@ void irx_tokn_free(struct envblock *envblock,
     if (tokens == NULL)
     {
         return;
+    }
+    /* Release the upbuf if one was allocated.  The TOK_EOF sentinel at
+     * tokens[count-1] carries the upbuf pointer in tok_upper and the
+     * allocated size in tok_line (set by irx_tokn_run after fixup). */
+    if (count > 0 && tokens[count - 1].tok_type == TOK_EOF &&
+        tokens[count - 1].tok_upper != NULL)
+    {
+        void *up = (void *)tokens[count - 1].tok_upper;
+        irxstor(RXSMFRE, tokens[count - 1].tok_line, &up, envblock);
     }
     p = tokens;
     irxstor(RXSMFRE, (int)(count * sizeof(struct irx_token)),

--- a/src/irx#tokn.c
+++ b/src/irx#tokn.c
@@ -50,6 +50,55 @@ struct tok_ctx
 #define TOK_INITIAL_CAPACITY 64
 
 /* ------------------------------------------------------------------ */
+/*  Keyword stamp table                                               */
+/*                                                                    */
+/*  Every word ever passed to sym_matches() or tok_is_kw() must       */
+/*  appear here.  A symbol whose upper-case text is in this list is   */
+/*  stamped TOKF_KEYWORD at emit time so the parser can fast-reject   */
+/*  non-keywords without a fold-and-compare loop.                     */
+/* ------------------------------------------------------------------ */
+
+/* Sorted for readability; the lookup is a short linear scan. */
+static const char *const s_kw_names[] = {
+    "ADDRESS", "ARG", "BY", "CALL", "DO",
+    "ELSE", "END", "ERROR", "EXIT", "EXTERNAL",
+    "FAILURE", "FOREVER", "HALT", "IF", "ITERATE",
+    "LEAVE", "LINEIN", "NAME", "NOP", "NOTREADY",
+    "NOVALUE", "NUMERIC", "OFF", "ON", "OTHERWISE",
+    "PARSE", "PROCEDURE", "PULL", "RETURN", "SAY",
+    "SELECT", "SIGNAL", "SOURCE", "SYNTAX", "THEN",
+    "TO", "TRACE", "UNTIL", "UPPER", "VALUE",
+    "VAR", "VERSION", "WHEN", "WHILE", "WITH",
+    NULL};
+
+/* Returns 1 if the symbol text[0..len-1] (as-written, any case) matches
+ * one of the known keyword names; 0 otherwise. */
+static int sym_is_keyword(const char *text, int len)
+{
+    char buf[16]; /* longest keyword is 9 chars ("OTHERWISE","PROCEDURE") */
+    int i;
+    if (len <= 0 || len >= (int)sizeof(buf))
+    {
+        return 0;
+    }
+    for (i = 0; i < len; i++)
+    {
+        int c = (unsigned char)text[i];
+        buf[i] = (char)(islower(c) ? toupper(c) : c);
+    }
+    for (i = 0; s_kw_names[i] != NULL; i++)
+    {
+        const char *kn = s_kw_names[i];
+        size_t kl = strlen(kn);
+        if ((int)kl == len && memcmp(kn, buf, (size_t)len) == 0)
+        {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
 /*  Character classification                                          */
 /*                                                                    */
 /*  We use <ctype.h> which crent370 provides in EBCDIC-correct form   */
@@ -234,6 +283,15 @@ static int emit(struct tok_ctx *ctx,
     t->tok_text = text;
     t->tok_length = (unsigned short)length;
     t->tok_reserved = 0;
+    t->tok_upper = NULL; /* populated later with upbuf machinery (WP-PERF-03 C) */
+
+    /* Stamp symbols whose upper-case name is a keyword so the parser can
+     * fast-reject non-keywords in sym_matches without a fold-and-compare. */
+    if (type == TOK_SYMBOL && !(flags & TOKF_COMPOUND) &&
+        sym_is_keyword(text, length))
+    {
+        t->tok_flags |= TOKF_KEYWORD;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Closes #136

## What

Five commits reducing per-scan overhead in the parser's token-stream re-walk cluster (~34% of CPU after WP-PERF-02).

### Change A — Inline `peek_tok` (723e9f4)
`peek_tok` was called 304 M times per run at 11.89% CPU (post-PERF-02 #1). `static inline` removes call overhead at `-O1`/`-O2`; at `-O0` (the gprof build) it has no effect, so `peek_tok` remains #1 in profiles. The improvement is real at the optimisation level used by c2asm370.

### Change B — TOKF_KEYWORD stamp + fast-reject in `sym_matches` (d9c81b8)
New flag `TOKF_KEYWORD 0x10` in `irxtokn.h`. The tokenizer stamps it on any `TOK_SYMBOL` whose upper-cased text matches the 45-word keyword table built into `irx#tokn.c`. `sym_matches` checks the flag first: any non-keyword symbol returns 0 without the fold-and-compare loop.

### Change C — `tok_upper`: cache upper-cased symbol text (83278f3)
New `tok_upper` field in `struct irx_token`. A tokenizer-owned `upbuf` (single growing allocation) stores upper-cased copies of all `TOK_SYMBOL` text. Parser hot paths use `tok_upper` directly — no more `upper_bytes` calls or temporary Lstr heap allocations for keyword dispatch. `upper_bytes` was **eliminated from the top-10** entirely.

### Fix — guard `fail()` against `TOK_EOF.tok_line` repurposing (2f31a2e)
`tok_line` in the TOK_EOF sentinel stores `upbuf_cap` for `irx_tokn_free`. `fail()` now skips reading it when at the sentinel; falls back to the previous token's line for correct error position at EOF.

### Change D — Binary search in `find_keyword` (f10c20b)
`g_keyword_table` sorted alphabetically; `find_keyword` switched from linear scan to binary search. `find_keyword` appeared at 3.14% (10.5 M calls) in the REXXCPS profile, always scanning all 22 entries for non-member keywords. Binary search caps comparisons at ~5. At `-O0` the overhead of the larger loop body partially offsets the gain; at `-O2` the improvement is more pronounced.

## Profile: pre vs post PERF-03 (Linux x86_64, -pg -O0, REXXCPS 2.2)

| Rank | main self% | main self s | post-03 self% | post-03 self s | Function |
|------|-----------|------------|--------------|----------------|----------|
| — | 13.59 | 0.92 | 10.57 | 0.62 | `peek_tok` |
| — | 7.53 | 0.51 | 5.50 | 0.32 | `_init` (startup) |
| — | 4.43 | 0.30 | 4.47 | 0.26 | `tok_is_op_char` |
| — | 4.28 | 0.29 | 4.30 | 0.25 | `cur_tok` |
| — | 3.69 | 0.25 | 3.78 | 0.22 | `irxstor` |
| — | **3.32** | **0.23** | **gone** | **—** | **`upper_bytes`** ← eliminated |
| — | 3.25 | 0.22 | 3.69 | 0.27 | `find_keyword` |
| — | 3.18 | 0.22 | 2.23 | 0.13 | `sym_matches` |
| — | 2.51 | 0.17 | 3.61 | 0.21 | `tok_is_kw` |
| — | 2.07 | 0.14 | gone | — | `Lfx` |

**Wall-clock:** 29.950 s → 26.075 s (**−12.9%**)  
**REXXCPS:** 334 062 → 383 679 clauses/s (**+14.9%**)

Profile archived at `docs/profiling/host-baseline-2026-05-19-post-perf03.md`.

## Tests

All cross-compile tests: **1200+ / 1200+ pass** (16 binaries, macOS).

```
tstphas1  38/38     tsttokn   70/70     tstlstr  50/50
tstvpol   47/47     tstprsr   75/75     tstsay   27/27
tstctrl   93/93     tstparse  74/74     tstproc  53/53
tsthelo   16/16     tstanrm   29/29     tstfind  PASSED
tstarit  128/128    tstarext 113/113    tstbif   29/29
tstbifs  427/427
```

## Notes

- `struct irx_token` grows from 16 → 20 bytes (32-bit) due to `tok_upper`. MVS `mbt build` needed before merging to verify layout.
- Next candidate after merging: token-stream cache (future WP) — would collapse the entire `peek_tok` / `tok_is_op_char` / `cur_tok` / `advance_tok` cluster by eliminating re-scan on DO-loop iterations.