### PR TITLE
perf(WP-PERF-04): per-env free-list pool for small Lstrings

### DIFF
--- a/docs/profiling/host-baseline-2026-05-19-post-perf04.md
+++ b/docs/profiling/host-baseline-2026-05-19-post-perf04.md
@@ -1,0 +1,105 @@
+# Host Profile — post WP-PERF-04 (2026-05-19)
+
+**Engine commit:** (wp-perf-04-allocator-pool)  
+**Host:** Linux 6.6.114.1-microsoft-standard-WSL2 (Ubuntu 24.04)  
+**Build:** gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) — `-pg -O0 -g -std=gnu99`  
+**Driver:** `test/host/tstcps_host` with embedded microbench (outer=1000, inner=500)  
+**Total wall-clock:** 19.739 s  
+**Total CPU (user+sys):** 19.632 s + 0.096 s = 19.728 s  
+
+## Top-10 hotspots (embedded microbench)
+
+| Rank | Self% | Cum% | Self s | Calls | Function |
+|------|-------|------|--------|-------|----------|
+| 1 | 14.21 | 14.21 | 0.79 | 304 062 472 | `peek_tok` |
+| 2 | 6.29 | 20.50 | 0.35 | 13 002 011 | `find_in_bucket` |
+| 3 | 6.29 | 26.79 | 0.35 | 500 000 | `num_div_impl` |
+| 4 | 3.96 | 30.75 | 0.22 | 2 000 000 | `parse_function_call` |
+| 5 | 3.60 | 34.35 | 0.20 | 175 523 266 | `tok_is_op_char` |
+| 6 | 3.60 | 37.95 | 0.20 | 145 541 228 | `cur_tok` |
+| 7 | 3.24 | 41.19 | 0.22 | 115 000 000 | `ebcdic_eq` |
+| 8 | 3.06 | 44.25 | 0.17 | 33 005 095 | `rexx_lstr_alloc` |
+| 9 | 2.70 | 46.95 | 0.15 | 33 005 095 | `rexx_lstr_dealloc` |
+| 10 | 2.52 | 49.47 | 0.14 | 6 000 000 | `num_from_str` |
+
+## A/B comparison — same machine, same driver invocation
+
+The pre-PERF-04 baseline was run immediately before this profile on the same
+host (WSL2, gcc 13.3.0) from the `main` branch tip (commit 5d2f321).
+
+| Function | main self s | post-04 self s | Δ s | Δ% |
+|----------|------------|----------------|-----|-----|
+| `irxstor` | 0.23 (4.54%) | 0.11 (1.98%) | −0.12 | −52% |
+| `Lfx` | 0.16 (3.23%) | 0.08 (1.44%) | −0.08 | −50% |
+| `Lfree` | 0.10 (2.12%) | 0.04 (0.72%) | −0.06 | −60% |
+| `rexx_lstr_alloc` | 0.06 (1.21%) | 0.17 (3.06%) | +0.11 | pool wrapper |
+| `rexx_lstr_dealloc` | 0.05 (1.01%) | 0.15 (2.70%) | +0.10 | pool wrapper |
+| `rexx_lstr_alloc_raw` | — | 0.01 (0.09%) | — | pool-miss only |
+| `rexx_lstr_dealloc_raw` | — | 0.01 (0.18%) | — | pool-miss only |
+| `pool_bucket_for` | — | — (inlined) | — | `always_inline` |
+
+**Baseline wall-clock:** 21.036 s  
+**Post-PERF-04 wall-clock:** 19.739 s  
+**Delta:** −1.297 s (−6.2%)
+
+### Pool effectiveness
+
+| Metric | Value |
+|--------|-------|
+| `rexx_lstr_alloc` calls | 33 005 095 |
+| `rexx_lstr_alloc_raw` calls (pool miss) | 2 500 074 |
+| Pool hit rate (alloc) | **92.4%** |
+| `irxstor` calls pre-PERF-04 | 104 010 338 |
+| `irxstor` calls post-PERF-04 | 43 000 296 |
+| `irxstor` call reduction | **−59%** |
+
+### `pool_bucket_for` inlining
+
+The initial implementation used a 4-iteration linear scan (`for` loop).
+At `-O0` this was a non-inlined function call at each of the 66 M hot
+sites, consuming ~1.2% self-time and eating the irxstor savings.
+Replacing the loop with a `switch` and adding
+`__attribute__((always_inline))` forces the compiler to expand the
+4-case dispatch inline, reducing the total storage-path overhead and
+restoring the expected wall-clock delta.
+
+## Observations
+
+**`irxstor` drops from 4.54% to 1.98%** — the primary goal of WP-PERF-04.
+The pool intercepts 92.4% of allocations, reducing irxstor calls from
+104 M to 43 M. The 43 M remaining calls are non-lstring storage operations
+(vpool buckets, arithmetic temporaries, BIF env allocations).
+
+**`Lfx` and `Lfree` also drop substantially** (−50% and −60% in self-time)
+because both functions spend most of their time in the allocator callback;
+pool hits return without calling irxstor.
+
+**New wrapper cost is visible but bounded** — `rexx_lstr_alloc` (pool check
++ possible pool-hit return) and `rexx_lstr_dealloc` (pool check + possible
+pool deposit) now appear in the top-10 at 3.06% and 2.70% respectively. The
+pool_bucket_for switch adds ~4 comparisons per call, inlined via
+`__attribute__((always_inline))` to avoid function-call overhead.
+
+**Wall-clock −6.2% on WSL2 at `-O0`** — this is the lower bound of the
+expected improvement range. At `-O0` on a host with fast libc malloc, the
+pool wrapper overhead is proportionally larger than on the MVS target where
+each irxstor call translates to a GETMAIN/FREEMAIN SVC (expensive supervisor
+call) while the pool lookup is just a few memory reads. MVS measurement is
+AC9 (requires hardware access).
+
+**Host profiling limitation** — the WSL2 scheduler introduces ±10–15% run-to-run
+variance in absolute wall-clock times. The same-machine A/B comparison
+controls for hardware speed but not for OS scheduler noise. Structural
+metrics (irxstor call count −59%, pool hit rate 92.4%) are the reliable
+measures; wall-clock delta is indicative.
+
+## Next performance candidates
+
+`find_in_bucket` (variable pool hash collision walk) rose to rank 2 at 6.29%,
+up from a lower rank before. With irxstor cleared from the top-5,
+vpool lookup is now the dominant allocation-related cost. The 13 M calls
+indicate significant hash collision depth in the 1000×500 workload.
+
+`num_div_impl` at rank 3 (6.29%, 500 k calls) is the arithmetic engine
+division path. The high per-call cost (0.70 µs) suggests a future
+WP-PERF-06 candidate once vpool is addressed.

--- a/docs/profiling/host-baseline-2026-05-19-post-perf04.md
+++ b/docs/profiling/host-baseline-2026-05-19-post-perf04.md
@@ -1,4 +1,4 @@
-# Host Profile — post WP-PERF-04 (2026-05-19)
+# Profile — post WP-PERF-04 (2026-05-19)
 
 **Engine commit:** (wp-perf-04-allocator-pool)  
 **Host:** Linux 6.6.114.1-microsoft-standard-WSL2 (Ubuntu 24.04)  
@@ -124,11 +124,31 @@ expensive `irxstor` call. The net storage-path time is lower than before.
 **Wall-clock −5.4% REXXCPS, −6.2% microbench** on WSL2 at `-O0`. At `-O0`
 on a host with fast libc malloc, the pool wrapper overhead is proportionally
 larger than on the MVS target where each irxstor call is a GETMAIN/FREEMAIN
-SVC (supervisor call overhead). MVS measurement is AC9 (requires hardware).
+SVC (supervisor call overhead). See the MVS A/B section for the on-target
+result (+32.7% CPS).
 
 **WSL2 scheduler variance** — the WSL2 host shows ±10–15% run-to-run
 variance. The same-machine A/B controls for hardware speed; the structural
 metrics (irxstor call count, pool hit rate) are the reliable measures.
+
+---
+
+## MVS A/B — REXXCPS 2.2
+
+**Target:** MVS 3.8j on Hercules (TK5)  
+**Build:** c2asm370 (GCC 3.2.3) — `-O0`  
+**Driver:** REXXCPS 2.2 — 5 × 5 iterations of 1000 clauses
+
+| Branch | CPS | Elapsed | Delta |
+|--------|-----|---------|-------|
+| main (WP-PERF-03) | 5 710 | 4.4 s | — |
+| wp-perf-04 | 7 580 | 3.3 s | **+32.7%** |
+
+The larger gain on MVS vs. WSL2 (32.7% vs. 5.4%) is expected: on MVS
+each `irxstor` call is a GETMAIN/FREEMAIN SVC. Supervisor call overhead
+is orders of magnitude higher than a `libc malloc`, so the 80% reduction
+in `irxstor` calls from the pool carries far greater weight on the target
+platform.
 
 ---
 

--- a/docs/profiling/host-baseline-2026-05-19-post-perf04.md
+++ b/docs/profiling/host-baseline-2026-05-19-post-perf04.md
@@ -3,11 +3,18 @@
 **Engine commit:** (wp-perf-04-allocator-pool)  
 **Host:** Linux 6.6.114.1-microsoft-standard-WSL2 (Ubuntu 24.04)  
 **Build:** gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) — `-pg -O0 -g -std=gnu99`  
-**Driver:** `test/host/tstcps_host` with embedded microbench (outer=1000, inner=500)  
-**Total wall-clock:** 19.739 s  
-**Total CPU (user+sys):** 19.632 s + 0.096 s = 19.728 s  
+**Drivers:** embedded microbench (outer=1000, inner=500) + `--source=test/rexxcps.rexx`  
 
-## Top-10 hotspots (embedded microbench)
+All measurements are same-machine A/B: `main` tip (5d2f321) vs branch tip,
+same binary build flags, same host.
+
+---
+
+## Embedded microbench — top-10 hotspots
+
+**Post-PERF-04 wall-clock:** 19.739 s  
+**Baseline (main) wall-clock:** 21.036 s  
+**Delta:** −1.297 s (−6.2%)
 
 | Rank | Self% | Cum% | Self s | Calls | Function |
 |------|-------|------|--------|-------|----------|
@@ -22,84 +29,117 @@
 | 9 | 2.70 | 46.95 | 0.15 | 33 005 095 | `rexx_lstr_dealloc` |
 | 10 | 2.52 | 49.47 | 0.14 | 6 000 000 | `num_from_str` |
 
-## A/B comparison — same machine, same driver invocation
+## REXXCPS 2.2 — top-10 hotspots
 
-The pre-PERF-04 baseline was run immediately before this profile on the same
-host (WSL2, gcc 13.3.0) from the `main` branch tip (commit 5d2f321).
+**Post-PERF-04 wall-clock:** 25.913 s  
+**Baseline (main) wall-clock:** 27.381 s  
+**Delta:** −1.468 s (−5.4%)
+
+| Rank | Self% | Cum% | Self s | Calls | Function |
+|------|-------|------|--------|-------|----------|
+| 1 | 15.46 | 15.46 | 0.98 | 423 356 394 | `peek_tok` |
+| 2 | 3.61 | 19.07 | 0.23 | 42 826 156 | `rexx_lstr_alloc` |
+| 3 | 3.30 | 22.37 | 0.21 | 236 229 954 | `cur_tok` |
+| 4 | 3.14 | 25.51 | 0.20 | 42 826 156 | `rexx_lstr_dealloc` |
+| 5 | 2.83 | 28.34 | 0.18 | 10 530 821 | `find_keyword` |
+| 6 | 2.75 | 31.09 | 0.17 | 115 040 140 | `sym_matches` |
+| 7 | 2.67 | 33.76 | 0.17 | 31 882 468 | `tok_ends_clause` |
+| 8 | 2.67 | 36.43 | 0.17 | 13 881 194 | `hash_bytes` |
+| 9 | 2.67 | 39.10 | 0.17 | 1 390 203 | `parse_function_call` |
+| 10 | 2.51 | 41.61 | 0.16 | 60 844 260 | `advance_tok` |
+
+`irxstor` dropped from rank 6 (3.91%) to rank ~20 (0.78%); not visible in the top-10.
+
+Note: REXXCPS 2.2 uses `TIME('R')` internally to report CPS. The host-side
+`TIME()` BIF does not return a valid elapsed time on this non-MVS platform
+(returns an overflow value), so the in-script CPS figure is invalid. The
+wall-clock delta above is the reliable measure.
+
+---
+
+## Storage-path A/B — REXXCPS workload
 
 | Function | main self s | post-04 self s | Δ s | Δ% |
 |----------|------------|----------------|-----|-----|
-| `irxstor` | 0.23 (4.54%) | 0.11 (1.98%) | −0.12 | −52% |
-| `Lfx` | 0.16 (3.23%) | 0.08 (1.44%) | −0.08 | −50% |
-| `Lfree` | 0.10 (2.12%) | 0.04 (0.72%) | −0.06 | −60% |
-| `rexx_lstr_alloc` | 0.06 (1.21%) | 0.17 (3.06%) | +0.11 | pool wrapper |
-| `rexx_lstr_dealloc` | 0.05 (1.01%) | 0.15 (2.70%) | +0.10 | pool wrapper |
-| `rexx_lstr_alloc_raw` | — | 0.01 (0.09%) | — | pool-miss only |
-| `rexx_lstr_dealloc_raw` | — | 0.01 (0.18%) | — | pool-miss only |
-| `pool_bucket_for` | — | — (inlined) | — | `always_inline` |
+| `irxstor` | 0.25 (3.91%) | 0.05 (0.78%) | −0.20 | −80% |
+| `Lfree` | 0.20 (3.05%) | 0.12 (1.88%) | −0.08 | −40% |
+| `Lfx` | 0.15 (2.35%) | 0.11 (1.73%) | −0.04 | −27% |
+| `rexx_lstr_alloc` | 0.07 (1.17%) | 0.23 (3.61%) | +0.16 | pool wrapper |
+| `rexx_lstr_dealloc` | 0.08 (1.25%) | 0.20 (3.14%) | +0.12 | pool wrapper |
+| `rexx_lstr_alloc_raw` | — | 0.00 (0.00%) | — | pool-miss only |
+| `rexx_lstr_dealloc_raw` | — | 0.01 (0.16%) | — | pool-miss only |
+| `POOL_BUCKET_FOR` macro | — | — (inlined) | — | macro expansion |
 
-**Baseline wall-clock:** 21.036 s  
-**Post-PERF-04 wall-clock:** 19.739 s  
-**Delta:** −1.297 s (−6.2%)
+### Pool effectiveness — REXXCPS
 
-### Pool effectiveness
+| Metric | Value |
+|--------|-------|
+| `rexx_lstr_alloc` calls | 42 826 156 |
+| `rexx_lstr_alloc_raw` calls (pool miss) | 1 400 390 |
+| Pool hit rate (alloc) | **96.7%** |
+| `irxstor` calls — main | 103 934 570 |
+| `irxstor` calls — post-04 | 21 083 038 |
+| `irxstor` call reduction | **−80%** |
+
+### Pool effectiveness — embedded microbench
 
 | Metric | Value |
 |--------|-------|
 | `rexx_lstr_alloc` calls | 33 005 095 |
 | `rexx_lstr_alloc_raw` calls (pool miss) | 2 500 074 |
 | Pool hit rate (alloc) | **92.4%** |
-| `irxstor` calls pre-PERF-04 | 104 010 338 |
-| `irxstor` calls post-PERF-04 | 43 000 296 |
+| `irxstor` calls — main | 104 010 338 |
+| `irxstor` calls — post-04 | 43 000 296 |
 | `irxstor` call reduction | **−59%** |
 
-### `pool_bucket_for` inlining
+---
 
-The initial implementation used a 4-iteration linear scan (`for` loop).
-At `-O0` this was a non-inlined function call at each of the 66 M hot
-sites, consuming ~1.2% self-time and eating the irxstor savings.
-Replacing the loop with a `switch` and adding
-`__attribute__((always_inline))` forces the compiler to expand the
-4-case dispatch inline, reducing the total storage-path overhead and
-restoring the expected wall-clock delta.
+## POOL_BUCKET_FOR macro
+
+The original implementation used a `static int pool_bucket_for(int size)`
+function with a 4-iteration linear scan.  At `-O0` this was a non-inlined
+call at every alloc and dealloc site (66 M calls per microbench run),
+consuming all savings.
+
+Replacing it with a `#define POOL_BUCKET_FOR(size_, bkt_)` macro that
+expands the 4-case switch directly into each call site eliminates the
+function-call overhead on both the host (`-O0`) and MVS (c2asm370), without
+relying on `__attribute__((always_inline))` which is not portable across all
+c2asm370 builds.
+
+---
 
 ## Observations
 
-**`irxstor` drops from 4.54% to 1.98%** — the primary goal of WP-PERF-04.
-The pool intercepts 92.4% of allocations, reducing irxstor calls from
-104 M to 43 M. The 43 M remaining calls are non-lstring storage operations
-(vpool buckets, arithmetic temporaries, BIF env allocations).
+**`irxstor` drops from 3.91% to 0.78% under REXXCPS** — removed from the
+top-10. The 80% reduction in call count (103 M → 21 M) reflects the REXXCPS
+workload's tighter string reuse patterns (higher pool hit rate 96.7% vs
+92.4% in the microbench).
 
-**`Lfx` and `Lfree` also drop substantially** (−50% and −60% in self-time)
-because both functions spend most of their time in the allocator callback;
-pool hits return without calling irxstor.
+**`rexx_lstr_alloc` and `rexx_lstr_dealloc` enter the top-10** at 3.61%
+and 3.14%. This is expected: the pool check (wkbi deref + switch + count
+check) now has non-trivial cost that was previously absorbed by the more
+expensive `irxstor` call. The net storage-path time is lower than before.
 
-**New wrapper cost is visible but bounded** — `rexx_lstr_alloc` (pool check
-+ possible pool-hit return) and `rexx_lstr_dealloc` (pool check + possible
-pool deposit) now appear in the top-10 at 3.06% and 2.70% respectively. The
-pool_bucket_for switch adds ~4 comparisons per call, inlined via
-`__attribute__((always_inline))` to avoid function-call overhead.
+**Wall-clock −5.4% REXXCPS, −6.2% microbench** on WSL2 at `-O0`. At `-O0`
+on a host with fast libc malloc, the pool wrapper overhead is proportionally
+larger than on the MVS target where each irxstor call is a GETMAIN/FREEMAIN
+SVC (supervisor call overhead). MVS measurement is AC9 (requires hardware).
 
-**Wall-clock −6.2% on WSL2 at `-O0`** — this is the lower bound of the
-expected improvement range. At `-O0` on a host with fast libc malloc, the
-pool wrapper overhead is proportionally larger than on the MVS target where
-each irxstor call translates to a GETMAIN/FREEMAIN SVC (expensive supervisor
-call) while the pool lookup is just a few memory reads. MVS measurement is
-AC9 (requires hardware access).
+**WSL2 scheduler variance** — the WSL2 host shows ±10–15% run-to-run
+variance. The same-machine A/B controls for hardware speed; the structural
+metrics (irxstor call count, pool hit rate) are the reliable measures.
 
-**Host profiling limitation** — the WSL2 scheduler introduces ±10–15% run-to-run
-variance in absolute wall-clock times. The same-machine A/B comparison
-controls for hardware speed but not for OS scheduler noise. Structural
-metrics (irxstor call count −59%, pool hit rate 92.4%) are the reliable
-measures; wall-clock delta is indicative.
+---
 
 ## Next performance candidates
 
-`find_in_bucket` (variable pool hash collision walk) rose to rank 2 at 6.29%,
-up from a lower rank before. With irxstor cleared from the top-5,
-vpool lookup is now the dominant allocation-related cost. The 13 M calls
-indicate significant hash collision depth in the 1000×500 workload.
+`find_in_bucket` (variable pool collision walk) moved to rank 2 at 6.29%
+in the microbench. With `irxstor` cleared from the top-5, vpool lookup is
+now the dominant allocation-related cost.
 
-`num_div_impl` at rank 3 (6.29%, 500 k calls) is the arithmetic engine
-division path. The high per-call cost (0.70 µs) suggests a future
-WP-PERF-06 candidate once vpool is addressed.
+`num_div_impl` at rank 3 (6.29%, 500 k calls) has high per-call cost
+(0.70 µs). Division is the slowest path in the arithmetic engine.
+
+`peek_tok` remains rank 1 at 14–15% — awaiting a token-stream cache WP
+that would collapse per-token re-scan overhead entirely.

--- a/include/irxlstr.h
+++ b/include/irxlstr.h
@@ -68,7 +68,11 @@
  * Ownership: the allocator struct is owned by the envblock's work
  * block and is freed by irxterm().
  */
-struct lstr_alloc *irx_lstr_init(struct envblock *envblock);
+/* asm() aliases: irx_lstr_init and irx_lstr_pool_teardown share the same
+ * first 8 characters (irx_lstr → IRX@LSTR), which collides on MVS where
+ * entry point names are truncated to 8 characters.  Explicit aliases give
+ * each function a unique name in the object deck.                          */
+struct lstr_alloc *irx_lstr_init(struct envblock *envblock) asm("IRXLSINI");
 
 /* Release all pooled Lstring buffers back to the raw allocator.
  *
@@ -79,7 +83,7 @@ struct lstr_alloc *irx_lstr_init(struct envblock *envblock);
  * Safe to call when no pool items are present (count == 0 in all
  * buckets — the initial state).
  */
-void irx_lstr_pool_teardown(struct envblock *envblock);
+void irx_lstr_pool_teardown(struct envblock *envblock) asm("IRXLSPTD");
 
 /* Check if s contains a valid REXX number literal.
  *

--- a/include/irxlstr.h
+++ b/include/irxlstr.h
@@ -70,6 +70,17 @@
  */
 struct lstr_alloc *irx_lstr_init(struct envblock *envblock);
 
+/* Release all pooled Lstring buffers back to the raw allocator.
+ *
+ * Must be called during env teardown, before the wkbi is freed.
+ * Calls rexx_lstr_dealloc_raw() on every item held in the per-env
+ * free-list pool, preventing leaks under repeated env init/term cycles.
+ *
+ * Safe to call when no pool items are present (count == 0 in all
+ * buckets — the initial state).
+ */
+void irx_lstr_pool_teardown(struct envblock *envblock);
+
 /* Check if s contains a valid REXX number literal.
  *
  * Accepts:

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -78,6 +78,32 @@
 #define COND_FAILURE  0x20
 
 /* ================================================================== */
+/*  Lstring allocator pool (WP-PERF-04)                              */
+/*                                                                    */
+/*  Per-env free-list pool for small Lstring buffers.  Embedded in    */
+/*  irx_wkblk_int; zero-init from irxstor(RXSMGET) on wkbi alloc is  */
+/*  sufficient.                                                       */
+/*                                                                    */
+/*  Bucket capacities (16, 32, 64, 128) match lstring370's            */
+/*  round_capacity() growth sequence — the only sizes the Lfx         */
+/*  callback ever passes.  A size outside this set bypasses the pool. */
+/* ================================================================== */
+
+#define LSTR_POOL_BUCKET_COUNT   4
+#define LSTR_POOL_MAX_PER_BUCKET 64
+
+struct lstr_pool_bucket
+{
+    void *items[LSTR_POOL_MAX_PER_BUCKET];
+    int count;
+};
+
+struct lstr_pool
+{
+    struct lstr_pool_bucket buckets[LSTR_POOL_BUCKET_COUNT];
+};
+
+/* ================================================================== */
 /*  Internal Work Block Extension (irx_wkblk_int)                     */
 /*  Per-environment interpreter runtime state                         */
 /* ================================================================== */
@@ -171,6 +197,14 @@ struct irx_wkblk_int
      * creation from pb->tsofl ("TSO     " or "MVS     "); write path
      * follows in WP-CPS-05 (ADDRESS keyword).                        */
     char wkbi_address[8];
+
+    /* --- Lstring allocator pool (WP-PERF-04) ----------------------- */
+    /* Per-env free-list pool for small Lstring buffers. Organized into
+     * four size buckets matching lstring370's round_capacity() sequence
+     * (16, 32, 64, 128 bytes). Zero-initialized by irxstor(RXSMGET)
+     * on wkbi allocation — no explicit init call needed.
+     * Released by irx_lstr_pool_teardown() during irxterm().          */
+    struct lstr_pool wkbi_lstr_pool;
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -86,24 +86,31 @@ enum lstr_bucket_cap
 static const int lstr_pool_caps[LSTR_POOL_BUCKET_COUNT] = {
     LSTR_CAP_16, LSTR_CAP_32, LSTR_CAP_64, LSTR_CAP_128};
 
-/* Return the bucket index for an exact-match size, or -1 if not pooled.
- * always_inline eliminates per-call overhead on the 66 M hot call sites.  */
-static __inline__ __attribute__((always_inline)) int pool_bucket_for(int size)
-{
-    switch (size)
-    {
-        case LSTR_CAP_16:
-            return 0;
-        case LSTR_CAP_32:
-            return 1;
-        case LSTR_CAP_64:
-            return 2;
-        case LSTR_CAP_128:
-            return LSTR_POOL_BUCKET_COUNT - 1;
-        default:
-            return -1;
-    }
-}
+/* pool_bucket_for() is intentionally not a separate function: the switch
+ * is pasted directly into the two hot callers so the compiler never emits
+ * a call — important both at -O0 on the host and with c2asm370 on MVS.    */
+#define POOL_BUCKET_FOR(size_, bkt_)                 \
+    do                                               \
+    {                                                \
+        switch (size_)                               \
+        {                                            \
+            case LSTR_CAP_16:                        \
+                (bkt_) = 0;                          \
+                break;                               \
+            case LSTR_CAP_32:                        \
+                (bkt_) = 1;                          \
+                break;                               \
+            case LSTR_CAP_64:                        \
+                (bkt_) = 2;                          \
+                break;                               \
+            case LSTR_CAP_128:                       \
+                (bkt_) = LSTR_POOL_BUCKET_COUNT - 1; \
+                break;                               \
+            default:                                 \
+                (bkt_) = -1;                         \
+                break;                               \
+        }                                            \
+    } while (0)
 
 static void *rexx_lstr_alloc(size_t size, void *ctx)
 {
@@ -114,7 +121,7 @@ static void *rexx_lstr_alloc(size_t size, void *ctx)
     wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
     if (wkbi != NULL)
     {
-        bkt = pool_bucket_for((int)size);
+        POOL_BUCKET_FOR((int)size, bkt);
         if (bkt >= 0 && wkbi->wkbi_lstr_pool.buckets[bkt].count > 0)
         {
             return wkbi->wkbi_lstr_pool.buckets[bkt]
@@ -133,7 +140,7 @@ static void rexx_lstr_dealloc(void *ptr, size_t size, void *ctx)
     wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
     if (wkbi != NULL)
     {
-        bkt = pool_bucket_for((int)size);
+        POOL_BUCKET_FOR((int)size, bkt);
         if (bkt >= 0 &&
             wkbi->wkbi_lstr_pool.buckets[bkt].count < LSTR_POOL_MAX_PER_BUCKET)
         {

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -75,20 +75,34 @@ static void rexx_lstr_dealloc_raw(void *ptr, size_t size, void *ctx)
 /* ------------------------------------------------------------------ */
 
 /* Bucket capacities — must match lstring370's round_capacity() sequence. */
-static const int lstr_pool_caps[LSTR_POOL_BUCKET_COUNT] = {16, 32, 64, 128};
-
-/* Return the bucket index for an exact-match size, or -1 if not pooled. */
-static int pool_bucket_for(int size)
+enum lstr_bucket_cap
 {
-    int i;
-    for (i = 0; i < LSTR_POOL_BUCKET_COUNT; i++)
+    LSTR_CAP_16 = 16,
+    LSTR_CAP_32 = 32,
+    LSTR_CAP_64 = 64,
+    LSTR_CAP_128 = 128
+};
+
+static const int lstr_pool_caps[LSTR_POOL_BUCKET_COUNT] = {
+    LSTR_CAP_16, LSTR_CAP_32, LSTR_CAP_64, LSTR_CAP_128};
+
+/* Return the bucket index for an exact-match size, or -1 if not pooled.
+ * always_inline eliminates per-call overhead on the 66 M hot call sites.  */
+static __inline__ __attribute__((always_inline)) int pool_bucket_for(int size)
+{
+    switch (size)
     {
-        if (size == lstr_pool_caps[i])
-        {
-            return i;
-        }
+        case LSTR_CAP_16:
+            return 0;
+        case LSTR_CAP_32:
+            return 1;
+        case LSTR_CAP_64:
+            return 2;
+        case LSTR_CAP_128:
+            return LSTR_POOL_BUCKET_COUNT - 1;
+        default:
+            return -1;
     }
-    return -1;
 }
 
 static void *rexx_lstr_alloc(size_t size, void *ctx)

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -26,9 +26,13 @@
 /*  so each alloc/dealloc routes through the correct environment's    */
 /*  storage management replaceable routine. No statics - everything   */
 /*  travels with the struct.                                          */
+/*                                                                    */
+/*  rexx_lstr_alloc_raw / rexx_lstr_dealloc_raw are the direct        */
+/*  irxstor wrappers. rexx_lstr_alloc / rexx_lstr_dealloc are the     */
+/*  pool-aware entry points installed in the lstr_alloc callbacks.   */
 /* ------------------------------------------------------------------ */
 
-static void *rexx_lstr_alloc(size_t size, void *ctx)
+static void *rexx_lstr_alloc_raw(size_t size, void *ctx)
 {
     struct envblock *env = (struct envblock *)ctx;
     void *ptr = NULL;
@@ -42,13 +46,22 @@ static void *rexx_lstr_alloc(size_t size, void *ctx)
     return ptr;
 }
 
-static void rexx_lstr_dealloc(void *ptr, size_t size, void *ctx)
+static void rexx_lstr_dealloc_raw(void *ptr, size_t size, void *ctx)
 {
     struct envblock *env = (struct envblock *)ctx;
     void *p = ptr;
 
-    (void)size; /* irxstor's free path doesn't use the length */
     irxstor(RXSMFRE, (int)size, &p, env);
+}
+
+static void *rexx_lstr_alloc(size_t size, void *ctx)
+{
+    return rexx_lstr_alloc_raw(size, ctx);
+}
+
+static void rexx_lstr_dealloc(void *ptr, size_t size, void *ctx)
+{
+    rexx_lstr_dealloc_raw(ptr, size, ctx);
 }
 
 struct lstr_alloc *irx_lstr_init(struct envblock *envblock)

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -54,14 +54,110 @@ static void rexx_lstr_dealloc_raw(void *ptr, size_t size, void *ctx)
     irxstor(RXSMFRE, (int)size, &p, env);
 }
 
+/* ------------------------------------------------------------------ */
+/*  Allocator pool                                                    */
+/*                                                                    */
+/*  Bucket capacities match lstring370's round_capacity() sequence:  */
+/*    bucket 0 →  16 bytes                                            */
+/*    bucket 1 →  32 bytes                                            */
+/*    bucket 2 →  64 bytes                                            */
+/*    bucket 3 → 128 bytes                                            */
+/*                                                                    */
+/*  Lfx always calls the allocator with a size that is already        */
+/*  rounded to one of these values, so pool_bucket_for is exact.      */
+/*  Sizes outside these four values bypass the pool entirely.         */
+/*                                                                    */
+/*  Subpool safety: all buffers in a per-env pool were GETMAIN'd with  */
+/*  the same subpool (the env's parmblock_subpool). On MVS, freemain()*/
+/*  reads subpool from the 8-byte prefix embedded by crent370's       */
+/*  getmain(), not from parmblock — so teardown is safe even after    */
+/*  PARMBLOCK has been released.                                       */
+/* ------------------------------------------------------------------ */
+
+/* Bucket capacities — must match lstring370's round_capacity() sequence. */
+static const int lstr_pool_caps[LSTR_POOL_BUCKET_COUNT] = {16, 32, 64, 128};
+
+/* Return the bucket index for an exact-match size, or -1 if not pooled. */
+static int pool_bucket_for(int size)
+{
+    int i;
+    for (i = 0; i < LSTR_POOL_BUCKET_COUNT; i++)
+    {
+        if (size == lstr_pool_caps[i])
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
 static void *rexx_lstr_alloc(size_t size, void *ctx)
 {
+    struct envblock *env = (struct envblock *)ctx;
+    struct irx_wkblk_int *wkbi;
+    int bkt;
+
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wkbi != NULL)
+    {
+        bkt = pool_bucket_for((int)size);
+        if (bkt >= 0 && wkbi->wkbi_lstr_pool.buckets[bkt].count > 0)
+        {
+            return wkbi->wkbi_lstr_pool.buckets[bkt]
+                .items[--wkbi->wkbi_lstr_pool.buckets[bkt].count];
+        }
+    }
     return rexx_lstr_alloc_raw(size, ctx);
 }
 
 static void rexx_lstr_dealloc(void *ptr, size_t size, void *ctx)
 {
+    struct envblock *env = (struct envblock *)ctx;
+    struct irx_wkblk_int *wkbi;
+    int bkt;
+
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wkbi != NULL)
+    {
+        bkt = pool_bucket_for((int)size);
+        if (bkt >= 0 &&
+            wkbi->wkbi_lstr_pool.buckets[bkt].count < LSTR_POOL_MAX_PER_BUCKET)
+        {
+            wkbi->wkbi_lstr_pool.buckets[bkt]
+                .items[wkbi->wkbi_lstr_pool.buckets[bkt].count++] = ptr;
+            return;
+        }
+    }
     rexx_lstr_dealloc_raw(ptr, size, ctx);
+}
+
+void irx_lstr_pool_teardown(struct envblock *envblock)
+{
+    struct irx_wkblk_int *wkbi;
+    struct lstr_pool *pool;
+    int bkt;
+    int i;
+
+    if (envblock == NULL)
+    {
+        return;
+    }
+    wkbi = (struct irx_wkblk_int *)envblock->envblock_userfield;
+    if (wkbi == NULL)
+    {
+        return;
+    }
+
+    pool = &wkbi->wkbi_lstr_pool;
+    for (bkt = 0; bkt < LSTR_POOL_BUCKET_COUNT; bkt++)
+    {
+        for (i = 0; i < pool->buckets[bkt].count; i++)
+        {
+            rexx_lstr_dealloc_raw(pool->buckets[bkt].items[i],
+                                  (size_t)lstr_pool_caps[bkt], envblock);
+        }
+        pool->buckets[bkt].count = 0;
+    }
 }
 
 struct lstr_alloc *irx_lstr_init(struct envblock *envblock)

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -27,6 +27,7 @@
 #include "irxanchr.h"
 #include "irxbif.h"
 #include "irxfunc.h"
+#include "irxlstr.h"
 #include "irxwkblk.h"
 
 /* Forward-declare the ECTENVBK slot accessor from irx#anch.c. */
@@ -155,6 +156,9 @@ int irxterm(struct envblock *envblk)
         /* TODO Phase 2+: Free variable pool, data stack,
          * exec stack, token stream, label table, cache
          * that hang off wkbi before freeing wkbi itself. */
+
+        /* Release all pooled lstring buffers before freeing wkbi. */
+        irx_lstr_pool_teardown(envblk);
 
         /* Free the lstring370 allocator bridge if it was installed. */
         if (wkbi->wkbi_lstr_alloc != NULL)

--- a/test/host/tstpool.c
+++ b/test/host/tstpool.c
@@ -1,0 +1,364 @@
+/* ------------------------------------------------------------------ */
+/*  test/host/tstpool.c — WP-PERF-04 allocator pool stress test       */
+/*                                                                    */
+/*  Verifies the per-env Lstring free-list pool:                      */
+/*  - Pool starts empty, fills on Lfree, drains on Lfx pool-hit       */
+/*  - Grow path (16→32) exercises bucket ping-pong correctly          */
+/*  - 100 000 tight alloc/free cycles via Lfx/Lfree on stack Lstr     */
+/*  - Pool count stays bounded (never exceeds LSTR_POOL_MAX_PER_BUCKET)*/
+/*  - 100 env init/term cycles leave no pool leaks                    */
+/*                                                                    */
+/*  Build (Linux):                                                     */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -O0 -g \                           */
+/*        -o /tmp/tstpool test/host/tstpool.c \                       */
+/*        src/irx#init.c  src/irx#term.c  src/irx#stor.c \           */
+/*        src/irx#anch.c  src/irx#env.c   src/irx#uid.c  \           */
+/*        src/irx#msid.c  src/irx#cond.c  src/irx#bif.c  \           */
+/*        src/irx#bifs.c  src/irx#io.c    src/irx#lstr.c \           */
+/*        src/irx#tokn.c  src/irx#vpol.c  src/irx#pars.c \           */
+/*        src/irx#ctrl.c  src/irx#exec.c  src/irx#arith.c \          */
+/*        ../lstring370/src/lstr#cor.c  \                             */
+/*        ../lstring370/src/lstr#cvt.c  \                             */
+/*        ../lstring370/src/lstr#fmt.c  \                             */
+/*        ../lstring370/src/lstr#srch.c \                             */
+/*        ../lstring370/src/lstr#sub.c  \                             */
+/*        ../lstring370/src/lstr#wrd.c  \                             */
+/*        ../lstring370/src/lstr#xlt.c                                */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxfunc.h"
+#include "irxlstr.h"
+#include "irxwkblk.h"
+#include "lstring.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Helper: create a minimal env                                      */
+/* ------------------------------------------------------------------ */
+
+static struct envblock *make_env(void)
+{
+    struct envblock *env = NULL;
+    irxinit(NULL, &env);
+    return env;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test 1 — pool starts empty, fills, drains                         */
+/* ------------------------------------------------------------------ */
+
+static void test_pool_basic(void)
+{
+    struct envblock *env = make_env();
+    struct lstr_alloc *a;
+    struct irx_wkblk_int *wkbi;
+    Lstr s;
+
+    printf("\n[test_pool_basic]\n");
+
+    CHECK(env != NULL, "env created");
+
+    a = irx_lstr_init(env);
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+
+    CHECK(a != NULL, "lstr allocator initialized");
+    CHECK(wkbi != NULL, "wkbi reachable");
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == 0,
+          "bucket-0 starts empty");
+
+    /* Alloc 8 bytes → Lfx rounds to 16 → bucket 0 */
+    Lzeroinit(&s);
+    CHECK(Lfx(a, &s, 8) == LSTR_OK, "Lfx(8) ok");
+    CHECK((int)s.maxlen == 16, "maxlen rounded to 16");
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == 0,
+          "bucket-0 still 0 after alloc (pool was empty)");
+
+    /* Free → item goes to bucket 0 */
+    Lfree(a, &s);
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == 1,
+          "bucket-0 count=1 after Lfree");
+
+    /* Re-alloc → pool hit */
+    CHECK(Lfx(a, &s, 8) == LSTR_OK, "Lfx(8) pool hit ok");
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == 0,
+          "bucket-0 drained after pool hit");
+
+    Lfree(a, &s);
+    irxterm(env);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test 2 — grow path (16→32) exercises bucket ping-pong            */
+/* ------------------------------------------------------------------ */
+
+static void test_pool_grow_path(void)
+{
+    struct envblock *env = make_env();
+    struct lstr_alloc *a;
+    struct irx_wkblk_int *wkbi;
+    Lstr s;
+    int b0_before;
+    int b1_before;
+
+    printf("\n[test_pool_grow_path]\n");
+
+    a = irx_lstr_init(env);
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+
+    /* Alloc a 16-byte buffer and deposit it in the pool. */
+    Lzeroinit(&s);
+    CHECK(Lfx(a, &s, 8) == LSTR_OK, "initial Lfx(8)");
+    CHECK((int)s.maxlen == 16, "initial maxlen == 16");
+    Lfree(a, &s);
+    b0_before = wkbi->wkbi_lstr_pool.buckets[0].count;
+    b1_before = wkbi->wkbi_lstr_pool.buckets[1].count;
+    CHECK(b0_before == 1, "bucket-0 has 1 item before grow");
+
+    /* Grow to 32 bytes: Lfx frees the old 16-byte buffer (→ bucket 0)
+     * and allocates a new 32-byte buffer.  If bucket 1 is empty the
+     * new alloc goes to raw; if not empty it hits the pool. */
+    CHECK(Lfx(a, &s, 8) == LSTR_OK, "pool-hit alloc for grow base");
+    CHECK((int)s.maxlen == 16, "maxlen still 16 after pool hit");
+    /* bucket-0 is now empty (drained by the pool hit above) */
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == 0,
+          "bucket-0 empty after pool hit");
+    /* Grow: request 20 bytes → round_capacity → 32.
+     * Lfx frees the old 16-byte buf (→ bucket-0) and allocs a 32-byte
+     * buf from raw (bucket-1 is empty). */
+    CHECK(Lfx(a, &s, 20) == LSTR_OK, "Lfx(20) grows to 32");
+    CHECK((int)s.maxlen == 32, "maxlen == 32 after grow");
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == 1,
+          "bucket-0 has 1 item (old 16B buf returned to pool by grow)");
+    (void)b0_before;
+    (void)b1_before;
+
+    Lfree(a, &s);
+    irxterm(env);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test 3 — 100k tight alloc/free cycles, bounded pool count         */
+/* ------------------------------------------------------------------ */
+
+static void test_pool_100k_cycles(void)
+{
+    struct envblock *env = make_env();
+    struct lstr_alloc *a;
+    struct irx_wkblk_int *wkbi;
+    int i;
+    int ok = 1;
+    int max_seen = 0;
+
+    printf("\n[test_pool_100k_cycles]\n");
+
+    a = irx_lstr_init(env);
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+
+    for (i = 0; i < 100000; i++)
+    {
+        Lstr s;
+        Lzeroinit(&s);
+        if (Lfx(a, &s, 8) != LSTR_OK)
+        {
+            ok = 0;
+            break;
+        }
+        if ((int)s.maxlen != 16)
+        {
+            ok = 0;
+        }
+        Lfree(a, &s);
+        if (wkbi->wkbi_lstr_pool.buckets[0].count > max_seen)
+        {
+            max_seen = wkbi->wkbi_lstr_pool.buckets[0].count;
+        }
+        if (wkbi->wkbi_lstr_pool.buckets[0].count > LSTR_POOL_MAX_PER_BUCKET)
+        {
+            ok = 0;
+            break;
+        }
+    }
+
+    CHECK(ok == 1, "100k alloc/free cycles: no error, no overflow");
+    CHECK(max_seen == 1, "pool count never exceeds 1 in tight 1-alloc loop");
+
+    irxterm(env);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test 4 — pool count bounded at LSTR_POOL_MAX_PER_BUCKET           */
+/* ------------------------------------------------------------------ */
+
+static void test_pool_max_items(void)
+{
+    struct envblock *env = make_env();
+    struct lstr_alloc *a;
+    struct irx_wkblk_int *wkbi;
+    Lstr items[LSTR_POOL_MAX_PER_BUCKET + 10];
+    int n = LSTR_POOL_MAX_PER_BUCKET + 10;
+    int i;
+
+    printf("\n[test_pool_max_items]\n");
+
+    a = irx_lstr_init(env);
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+
+    /* Allocate n items, then free them all — the pool takes the first
+     * LSTR_POOL_MAX_PER_BUCKET and the remaining 10 fall through to
+     * rexx_lstr_dealloc_raw. */
+    for (i = 0; i < n; i++)
+    {
+        Lzeroinit(&items[i]);
+        Lfx(a, &items[i], 8);
+    }
+    for (i = 0; i < n; i++)
+    {
+        Lfree(a, &items[i]);
+    }
+
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == LSTR_POOL_MAX_PER_BUCKET,
+          "bucket-0 capped at LSTR_POOL_MAX_PER_BUCKET");
+
+    irxterm(env);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test 5 — pool teardown: irxterm with live pool items must not     */
+/*           crash or leak; bucket counts are zeroed after teardown   */
+/* ------------------------------------------------------------------ */
+
+static void test_pool_teardown(void)
+{
+    struct envblock *env = make_env();
+    struct lstr_alloc *a;
+    struct irx_wkblk_int *wkbi;
+    Lstr s;
+
+    printf("\n[test_pool_teardown]\n");
+
+    a = irx_lstr_init(env);
+    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+
+    /* Deposit one item into each of buckets 0, 1, 2. */
+    Lzeroinit(&s);
+    Lfx(a, &s, 8); /* -> bucket-0 (cap 16)  */
+    Lfree(a, &s);
+    Lzeroinit(&s);
+    Lfx(a, &s, 20); /* -> bucket-1 (cap 32)  */
+    Lfree(a, &s);
+    Lzeroinit(&s);
+    Lfx(a, &s, 40); /* -> bucket-2 (cap 64)  */
+    Lfree(a, &s);
+
+    CHECK(wkbi->wkbi_lstr_pool.buckets[0].count == 1,
+          "bucket-0 has 1 item before teardown");
+    CHECK(wkbi->wkbi_lstr_pool.buckets[1].count == 1,
+          "bucket-1 has 1 item before teardown");
+    CHECK(wkbi->wkbi_lstr_pool.buckets[2].count == 1,
+          "bucket-2 has 1 item before teardown");
+
+    /* irxterm calls irx_lstr_pool_teardown; absence of crash = success. */
+    CHECK(irxterm(env) == 0, "irxterm with 3 pooled items: rc=0");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Test 6 — repeated init/term cycles with pool items                */
+/*                                                                    */
+/*  Capped at 50 iterations: IRXANCHR has 64 slots and the host       */
+/*  32-bit envblock_ptr field truncates 64-bit pointers, so address   */
+/*  aliasing can confuse the slot lookup after ~62 reuses.            */
+/* ------------------------------------------------------------------ */
+
+static void test_pool_init_term_cycles(void)
+{
+    int i;
+    int ok = 1;
+
+    printf("\n[test_pool_init_term_cycles]\n");
+
+    for (i = 0; i < 50; i++)
+    {
+        struct envblock *env = make_env();
+        struct lstr_alloc *a;
+        Lstr s;
+
+        if (env == NULL)
+        {
+            ok = 0;
+            break;
+        }
+
+        a = irx_lstr_init(env);
+        if (a == NULL)
+        {
+            ok = 0;
+            irxterm(env);
+            break;
+        }
+
+        /* Leave items in the pool so teardown has real work to do. */
+        Lzeroinit(&s);
+        Lfx(a, &s, 8); /* alloc 16-byte buf */
+        Lfree(a, &s);  /* deposit to pool (bucket-0) */
+        Lzeroinit(&s);
+        Lfx(a, &s, 20); /* alloc 32-byte buf */
+        Lfree(a, &s);   /* deposit to pool (bucket-1) */
+
+        if (irxterm(env) != 0)
+        {
+            ok = 0;
+            break;
+        }
+    }
+
+    CHECK(ok == 1, "50 env init/term cycles with pool items: all clean");
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    printf("tstpool: allocator pool stress tests\n");
+
+    test_pool_basic();
+    test_pool_grow_path();
+    test_pool_100k_cycles();
+    test_pool_max_items();
+    test_pool_teardown();
+    test_pool_init_term_cycles();
+
+    printf("\n=== Results: %d/%d passed ===\n", tests_passed, tests_run);
+    return (tests_failed > 0) ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Adds a per-environment free-list pool for `Lstring` buffers ≤ 128 bytes (4 buckets: 16 / 32 / 64 / 128 B), embedded in `irx_wkblk_int` — zero global state
- Replaces every `irxstor` GETMAIN/FREEMAIN call on pool-sized strings with a list pop/push; falls back to `irxstor` only on miss or size > 128 B
- `POOL_BUCKET_FOR` macro pastes the 4-case switch inline at both call sites — no function call overhead at `-O0` or under c2asm370
- Adds `irx_lstr_pool_teardown()` called by `irxterm()` to drain the pool back to the raw allocator; no leaks under repeated init/term cycles
- Fixes `IRX@LSTR` duplicate MVS entry point collision (`irx_lstr_init` + `irx_lstr_pool_teardown` both truncate to 8 chars); resolved with `asm("IRXLSINI")` / `asm("IRXLSPTD")` aliases

## Performance results

### MVS (target platform) — REXXCPS 2.2, c2asm370 `-O0`

| Branch | CPS | Delta |
|--------|-----|-------|
| main (WP-PERF-03) | 5 710 | — |
| this PR | 7 580 | **+32.7%** |

### WSL2 host — same-machine A/B, gcc `-O0`

| Workload | main | this PR | Delta |
|----------|------|---------|-------|
| REXXCPS wall-clock | 27.381 s | 25.913 s | −5.4% |
| Microbench wall-clock | 21.036 s | 19.739 s | −6.2% |
| `irxstor` calls (REXXCPS) | 103 934 570 | 21 083 038 | −80% |
| Pool hit rate (REXXCPS) | — | 96.7% | — |

The larger gain on MVS reflects SVC overhead: GETMAIN/FREEMAIN is orders of magnitude more expensive than `libc malloc`, so eliminating 80% of `irxstor` calls carries far greater weight on the target platform.

Full profiling data: `docs/profiling/host-baseline-2026-05-19-post-perf04.md`

## Test plan

- [x] `tstlstr` — 50/50 lstring adapter tests pass
- [x] `test/host/tstpool.c` — 27/27 pool stress-test assertions pass
- [x] Full test matrix — 1200/1200 tests green (all 16 standard binaries)
- [x] MVS build — `IRX#LSTR` assembles RC=0, links RC=0
- [x] MVS REXXCPS 2.2 — 7580 CPS (vs. 5710 baseline, +32.7%)