### PR TITLE
feat(bytecode): WP-BC-01 — EXECBLK container, bytecode format, skeleton compiler + VM

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -678,7 +678,110 @@ This principle emerged during WP-21b Phase C review. Both reviewers argued from 
 
 ---
 
-# 15. Test strategy
+# 15. Bytecode VM (WP-BC series)
+
+The bytecode phase replaces the token-walk interpreter with a compile-then-execute
+pipeline. Expected throughput gain: 5–6× on top of the Phase 3 optimisations
+(2.86× REXXCPS speedup achieved by WP-PERF-02..05A).
+
+## 15.1 EXECBLK container format
+
+```
+Offset  Size  Field
+   0      4   magic       "RX37" — eye-catcher
+   4      2   version     format version (currently 1)
+   6      2   flags       reserved, zero
+   8      4   const_count number of constant-pool entries
+  12      4   symbol_count number of symbol-table entries
+  16      4   code_length bytecode length in bytes
+  20      4   entry_offset offset within bytecode of entry point
+  24      4   trace_map_offset offset to trace map (0 = absent)
+ [28]    ... Constants Table  (count × length-prefixed Lstring)
+         ... Symbol Table     (count × length-prefixed uppercased name)
+         ... Bytecode          (code_length bytes)
+         ... Trace Map         (optional, absent in Phase 1)
+```
+
+All operands in the bytecode are indices or relative offsets — no
+absolute pointers. The container is position-independent and will be
+serialisable to CEXEC (a later work package).
+
+The C definition is in `include/irxexbl.h` as `struct irx_bc_execblk`.
+Note: this is **distinct** from the IBM-defined `struct execblk` in
+`include/irx.h`, which is the IRXEXEC parameter block.
+
+## 15.2 Opcode encoding
+
+All opcodes are defined in `include/irxbops.h`.
+
+Phase 1 opcodes (1 byte each, no operands):
+
+| Opcode | Byte | Description |
+|--------|------|-------------|
+| `OP_NOP` | 0x00 | No operation, advance PC |
+| `OP_EXIT` | 0x01 | Terminate execution, RC=0 |
+| `OP_NEWCLAUSE` | 0x02 | Clause boundary (TRACE hook, no-op in Phase 1) |
+
+Future work packages extend the opcode table with operand-bearing
+instructions for literals, variable access, arithmetic, control flow, etc.
+
+## 15.3 Evaluation stack
+
+The evaluation stack type is `struct bc_stack_slot` (defined in
+`include/irxbvm.h`), 24 bytes per slot:
+
+```c
+struct bc_stack_slot {
+    PLstr   str;        /* canonical string form; always valid */
+    int32_t type_cache; /* 0=none, LINTEGER_TY, etc.          */
+    int64_t int_cache;  /* integer fast-path value             */
+};
+```
+
+`type_cache` enables an arithmetic fast path: when a value was recently
+computed as an integer, subsequent operations can skip the string→integer
+parse. On `OP_STORE`, `type_cache` is written to the variable pool so
+that `OP_LOAD` can repopulate the cache slot.
+
+Phase 1 does not allocate a stack — no opcode pushes or pops yet.
+WP-BC-02 introduces the first stack-consuming opcode.
+
+## 15.4 Compiler entry point
+
+```
+irx_bc_compile(envblock, source, source_len, &bc_out)
+```
+
+Located in `src/irx#bcom.c` (PDS member `IRX#BCOM`).
+
+Phase 1: tokenises the source, walks the token stream, emits opcodes
+into a local buffer, then allocates an EXECBLK container via `irxstor`
+and copies the bytecode in. The caller must free the returned container
+with `irxstor(RXSMFRE, 0, &p, envblock)`.
+
+## 15.5 VM loop
+
+```
+irx_bc_execute(envblock, bc, &rc_out)
+```
+
+Located in `src/irx#bvm.c` (PDS member `IRX#BVM`).
+
+Uses a big-switch dispatch on an unsigned char opcode byte. c2asm370
+generates an optimised branch table from this pattern. The PC starts
+at `IRXBC_ENTRY(bc)` (= start of bytecode + `entry_offset`).
+
+## 15.6 Integration
+
+`irx_exec_run()` in `src/irx#exec.c` checks `wkbi_use_bytecode` on
+the work block before invoking the token-walk pipeline. When the flag
+is set, it routes to `irx_bc_compile` + `irx_bc_execute` instead.
+The flag defaults to 0 (token-walk path). Setting it to 1 enables A/B
+benchmarking while both paths coexist.
+
+---
+
+# 16. Test strategy
 
 | Category | Description | Estimated count |
 |---|---|---|

--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -1,0 +1,41 @@
+/* ------------------------------------------------------------------ */
+/*  irxbops.h - REXX/370 Bytecode Opcode Definitions (WP-BC-01)      */
+/*                                                                    */
+/*  Opcode encoding for the bytecode VM.  All Phase 1 opcodes are    */
+/*  exactly 1 byte with no operands.  Future work packages extend     */
+/*  this set with operand-bearing opcodes.                            */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef IRXBOPS_H
+#define IRXBOPS_H
+
+/* ================================================================== */
+/*  Opcode table (Phase 1 — minimal set)                             */
+/* ================================================================== */
+
+#define OP_NOP       0x00 /* 1 byte — no operation, advance PC       */
+#define OP_EXIT      0x01 /* 1 byte — terminate execution, RC=0      */
+#define OP_NEWCLAUSE 0x02 /* 1 byte — clause boundary (TRACE hook)   */
+
+/* ================================================================== */
+/*  Per-opcode size in bytes (including the opcode byte itself)       */
+/*                                                                    */
+/*  All Phase 1 opcodes are 1 byte.  Future phases add operands;      */
+/*  extend the switch in OP_SIZE before introducing them.            */
+/* ================================================================== */
+
+#define OP_SIZE(op) 1 /* Phase 1: every opcode is 1 byte         */
+
+/* ================================================================== */
+/*  Compiler and VM return codes                                      */
+/* ================================================================== */
+
+#define IRXBC_OK         0  /* success                               */
+#define IRXBC_ERR_STOR   20 /* irxstor allocation failed             */
+#define IRXBC_ERR_TOKN   21 /* tokenizer returned an error           */
+#define IRXBC_ERR_UNSUP  22 /* unsupported construct (Phase 1 limit) */
+#define IRXBC_ERR_OPCODE 23 /* unknown opcode encountered by VM      */
+
+#endif /* IRXBOPS_H */

--- a/include/irxbvm.h
+++ b/include/irxbvm.h
@@ -1,0 +1,81 @@
+/* ------------------------------------------------------------------ */
+/*  irxbvm.h - REXX/370 Bytecode VM Entry Points (WP-BC-01)          */
+/*                                                                    */
+/*  Declares the compiler (irx_bc_compile) and VM loop               */
+/*  (irx_bc_execute) entry points, and the canonical stack-slot      */
+/*  layout shared by all WP-BC work packages.                        */
+/*                                                                    */
+/*  The stack slot type is defined here for forward compatibility.   */
+/*  Phase 1 does not push or pop values, so no slot array is         */
+/*  allocated; WP-BC-02 adds the first opcode that touches the stack. */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef IRXBVM_H
+#define IRXBVM_H
+
+#include <stdint.h>
+
+#include "irx.h"
+#include "irxexbl.h"
+#include "lstring.h"
+
+/* ================================================================== */
+/*  Stack slot (canonical layout for all WP-BC)                      */
+/*                                                                    */
+/*  Every evaluation stack entry is 24 bytes:                        */
+/*    str        — always valid; canonical string form of the value  */
+/*    type_cache — 0=none, LINTEGER_TY, LBCD_TY, LSTRING_TY         */
+/*    int_cache  — integer fast-path (valid when type_cache==LINTEGER)*/
+/*                                                                    */
+/*  On OP_STORE, type_cache is written to the variable pool so a     */
+/*  subsequent OP_LOAD can repopulate the cache slot without a        */
+/*  string-to-integer parse.                                         */
+/* ================================================================== */
+
+#define IRXBC_STACK_LINTEGER 1
+
+struct bc_stack_slot
+{
+    PLstr str;          /* canonical string form; always present      */
+    int32_t type_cache; /* 0=none, 1=integer, see LINTEGER_TY etc.   */
+    int64_t int_cache;  /* integer fast-path value                    */
+};
+
+/* ================================================================== */
+/*  irx_bc_compile — compile REXX source to a bytecode container     */
+/*                                                                    */
+/*  Phase 1 handles only EXIT and empty clauses.  Any other          */
+/*  construct returns IRXBC_ERR_UNSUP.                               */
+/*                                                                    */
+/*  Parameters:                                                       */
+/*    envblock   — owning environment (used for irxstor)             */
+/*    source     — REXX source text (need not be NUL-terminated)     */
+/*    source_len — length in bytes                                   */
+/*    bc_out     — receives pointer to allocated irx_bc_execblk on   */
+/*                 success; caller must free with irxstor(RXSMFRE)   */
+/*                                                                    */
+/*  Returns: IRXBC_OK (0) on success, IRXBC_ERR_* on failure.       */
+/* ================================================================== */
+
+int irx_bc_compile(struct envblock *envblock,
+                   const char *source, int source_len,
+                   struct irx_bc_execblk **bc_out);
+
+/* ================================================================== */
+/*  irx_bc_execute — execute a compiled bytecode container           */
+/*                                                                    */
+/*  Parameters:                                                       */
+/*    envblock — owning environment                                  */
+/*    bc       — container produced by irx_bc_compile               */
+/*    rc_out   — receives the program RC on success; may be NULL     */
+/*                                                                    */
+/*  Returns: IRXBC_OK (0) on success, IRXBC_ERR_* on failure.       */
+/* ================================================================== */
+
+int irx_bc_execute(struct envblock *envblock,
+                   struct irx_bc_execblk *bc,
+                   int *rc_out);
+
+#endif /* IRXBVM_H */

--- a/include/irxbvm.h
+++ b/include/irxbvm.h
@@ -61,7 +61,7 @@ struct bc_stack_slot
 
 int irx_bc_compile(struct envblock *envblock,
                    const char *source, int source_len,
-                   struct irx_bc_execblk **bc_out);
+                   struct irx_bc_execblk **bc_out) asm("IRXBCOMP");
 
 /* ================================================================== */
 /*  irx_bc_execute — execute a compiled bytecode container           */
@@ -76,6 +76,6 @@ int irx_bc_compile(struct envblock *envblock,
 
 int irx_bc_execute(struct envblock *envblock,
                    struct irx_bc_execblk *bc,
-                   int *rc_out);
+                   int *rc_out) asm("IRXBEXEC");
 
 #endif /* IRXBVM_H */

--- a/include/irxexbl.h
+++ b/include/irxexbl.h
@@ -1,0 +1,76 @@
+/* ------------------------------------------------------------------ */
+/*  irxexbl.h - REXX/370 Bytecode EXECBLK Format (WP-BC-01)          */
+/*                                                                    */
+/*  Defines struct irx_bc_execblk — the in-memory bytecode container */
+/*  produced by the bytecode compiler (irx#bcom.c) and consumed by   */
+/*  the VM loop (irx#bvm.c).  Distinct from the IBM-defined struct    */
+/*  execblk in irx.h, which is the IRXEXEC parameter block.          */
+/*                                                                    */
+/*  Layout:                                                           */
+/*    [ struct irx_bc_execblk header        ]                        */
+/*    [ Constants Table  (const_count items) ]                       */
+/*    [ Symbol Table     (symbol_count items)]                       */
+/*    [ Bytecode         (code_length bytes) ]                       */
+/*    [ Trace Map        (optional)          ]                       */
+/*                                                                    */
+/*  All operands in the bytecode are indices or relative offsets —   */
+/*  no absolute pointers.  The container is position-independent     */
+/*  and will be serialisable to CEXEC in a later work package.       */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#ifndef IRXEXBL_H
+#define IRXEXBL_H
+
+#include <stdint.h>
+
+/* ================================================================== */
+/*  Magic and version                                                 */
+/* ================================================================== */
+
+#define IRXBC_MAGIC   "RX37"
+#define IRXBC_VERSION 1
+
+/* ================================================================== */
+/*  Bytecode EXECBLK header                                           */
+/*                                                                    */
+/*  sizeof(struct irx_bc_execblk) == 28 bytes (no padding on         */
+/*  byte-aligned platforms; uint16_t at offset 4, uint32_t at 8+).  */
+/* ================================================================== */
+
+struct irx_bc_execblk
+{
+    char magic[4];             /* "RX37" — eye-catcher                */
+    uint16_t version;          /* format version, currently 1         */
+    uint16_t flags;            /* reserved, must be zero              */
+    uint32_t const_count;      /* number of entries in constants table */
+    uint32_t symbol_count;     /* number of entries in symbol table   */
+    uint32_t code_length;      /* bytecode length in bytes            */
+    uint32_t entry_offset;     /* offset into bytecode of entry point */
+    uint32_t trace_map_offset; /* offset to trace map (0 = absent)    */
+    /* Variable-length payload follows immediately after this header. */
+};
+
+/* ================================================================== */
+/*  Payload access macros                                             */
+/*                                                                    */
+/*  Phase 1: const_count == 0 and symbol_count == 0, so the          */
+/*  bytecode starts at (char*)bc + sizeof(*bc) + entry_offset.       */
+/*  Future phases will insert the constants and symbol tables         */
+/*  between the header and the bytecode.                             */
+/* ================================================================== */
+
+/* Pointer to start of bytecode within a container. */
+#define IRXBC_CODE(bc) \
+    ((unsigned char *)(bc) + sizeof(struct irx_bc_execblk))
+
+/* Pointer to entry point within a container. */
+#define IRXBC_ENTRY(bc) \
+    (IRXBC_CODE(bc) + (bc)->entry_offset)
+
+/* Total byte size of a container: header + payload. */
+#define IRXBC_TOTAL(bc) \
+    ((int)(sizeof(struct irx_bc_execblk)) + (int)(bc)->code_length)
+
+#endif /* IRXEXBL_H */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -205,6 +205,12 @@ struct irx_wkblk_int
      * on wkbi allocation — no explicit init call needed.
      * Released by irx_lstr_pool_teardown() during irxterm().          */
     struct lstr_pool wkbi_lstr_pool;
+
+    /* --- Bytecode engine opt-in (WP-BC-01) ------------------------- */
+    /* When non-zero, irx_exec_run routes through the bytecode compiler
+     * and VM instead of the token-walk interpreter.  Default: 0 (off).
+     * Set explicitly in tests or callers to engage the bytecode path. */
+    int wkbi_use_bytecode;
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/project.toml
+++ b/project.toml
@@ -139,7 +139,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -176,7 +178,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -223,7 +227,9 @@ entry = "IRXEXEC"
 options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
 include = [
   "IRXEXEC",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#INIT",
   "IRX#TERM",
   "IRX#STOR",
@@ -278,7 +284,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -337,7 +345,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -401,7 +411,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -430,7 +442,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -491,7 +505,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -532,7 +548,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -573,7 +591,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -602,7 +622,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -631,7 +653,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -660,7 +684,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -689,7 +715,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -718,7 +746,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -747,7 +777,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -782,7 +814,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -811,7 +845,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -840,7 +876,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -869,7 +907,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -898,7 +938,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -927,7 +969,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -956,7 +1000,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -985,7 +1031,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -1040,7 +1088,9 @@ include = [
   "TSTJCL",
   "IRX#JCL",
   "IRX#LOAD",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#INIT",
   "IRX#TERM",
   "IRX#STOR",
@@ -1084,7 +1134,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -1113,7 +1165,9 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -1194,7 +1248,9 @@ include = [
   "IRX#JCLM",
   "IRX#JCL",
   "IRX#LOAD",
-  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
   "IRX#INIT",
   "IRX#TERM",
   "IRX#STOR",

--- a/project.toml
+++ b/project.toml
@@ -139,7 +139,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -176,7 +176,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -223,7 +223,7 @@ entry = "IRXEXEC"
 options = ["LIST", "MAP", "XREF", "RENT", "REUS"]
 include = [
   "IRXEXEC",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#INIT",
   "IRX#TERM",
   "IRX#STOR",
@@ -278,7 +278,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -337,7 +337,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -401,7 +401,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -430,7 +430,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -491,7 +491,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -532,7 +532,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -573,7 +573,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -602,7 +602,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -631,7 +631,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -660,7 +660,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -689,7 +689,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -718,7 +718,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -747,7 +747,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -782,7 +782,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -811,7 +811,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -840,7 +840,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -869,7 +869,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -898,7 +898,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -927,7 +927,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -956,7 +956,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -985,7 +985,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -1040,7 +1040,7 @@ include = [
   "TSTJCL",
   "IRX#JCL",
   "IRX#LOAD",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#INIT",
   "IRX#TERM",
   "IRX#STOR",
@@ -1084,7 +1084,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -1113,7 +1113,7 @@ include = [
   "IRX#VPOL",
   "IRX#PARS",
   "IRX#CTRL",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#ARIT",
 ]
 
@@ -1194,7 +1194,7 @@ include = [
   "IRX#JCLM",
   "IRX#JCL",
   "IRX#LOAD",
-  "IRX#EXEC",
+  "IRX#EXEC",\n  "IRX#BCOM",\n  "IRX#BVM",
   "IRX#INIT",
   "IRX#TERM",
   "IRX#STOR",

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -1,0 +1,176 @@
+/* ------------------------------------------------------------------ */
+/*  irx#bcom.c - REXX/370 Bytecode Compiler Skeleton (WP-BC-01)      */
+/*                                                                    */
+/*  irx_bc_compile() — Entry point.                                  */
+/*                                                                    */
+/*  Phase 1 scope:                                                    */
+/*    - Recognises EXIT and empty clauses only                       */
+/*    - Emits OP_NEWCLAUSE + OP_EXIT for explicit EXIT statements    */
+/*    - Emits OP_EXIT at source end (implicit program termination)   */
+/*    - Any other construct returns IRXBC_ERR_UNSUP                  */
+/*                                                                    */
+/*  Memory: caller must free the returned irx_bc_execblk with        */
+/*    irxstor(RXSMFRE, 0, &p, envblock)                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include <string.h>
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexbl.h"
+#include "irxfunc.h"
+#include "irxtokn.h"
+#include "irxwkblk.h"
+
+/* Maximum bytecode bytes the Phase 1 compiler can emit. */
+#define BCOM_MAX_CODE 64
+
+/* ------------------------------------------------------------------ */
+/*  emit — append one opcode byte to the local buffer.               */
+/*  Returns 0 on success, IRXBC_ERR_STOR if the buffer is full.     */
+/* ------------------------------------------------------------------ */
+static int emit(unsigned char *buf, int *len, unsigned char op)
+{
+    if (*len >= BCOM_MAX_CODE)
+    {
+        return IRXBC_ERR_STOR;
+    }
+    buf[(*len)++] = op;
+    return IRXBC_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  irx_bc_compile                                                    */
+/* ------------------------------------------------------------------ */
+int irx_bc_compile(struct envblock *envblock,
+                   const char *source, int source_len,
+                   struct irx_bc_execblk **bc_out)
+{
+    struct irx_token *tokens = NULL;
+    int tok_count = 0;
+    struct irx_tokn_error tok_err;
+    unsigned char code[BCOM_MAX_CODE];
+    int code_len = 0;
+    int rc = IRXBC_OK;
+    int i;
+    int hit_exit = 0;
+    struct irx_bc_execblk *bc = NULL;
+    int total_size;
+    void *mem = NULL;
+
+    memset(&tok_err, 0, sizeof(tok_err));
+
+    if (bc_out == NULL)
+    {
+        return IRXBC_ERR_UNSUP;
+    }
+    *bc_out = NULL;
+
+    /* 1. Tokenize -------------------------------------------------- */
+    rc = irx_tokn_run(envblock, source, source_len,
+                      &tokens, &tok_count, &tok_err);
+    if (rc != 0)
+    {
+        return IRXBC_ERR_TOKN;
+    }
+
+    /* 2. Walk token stream ----------------------------------------- */
+    for (i = 0; i < tok_count && !hit_exit; i++)
+    {
+        const struct irx_token *t = &tokens[i];
+
+        switch (t->tok_type)
+        {
+            case TOK_EOC:
+                /* Empty clause boundary — no bytecode emitted. */
+                break;
+
+            case TOK_EOF:
+                /* End of source — stop walking. */
+                i = tok_count; /* break outer loop */
+                break;
+
+            case TOK_SYMBOL:
+                if (t->tok_upper != NULL &&
+                    strcmp(t->tok_upper, "EXIT") == 0)
+                {
+                    /* EXIT statement: emit clause marker + exit opcode. */
+                    rc = emit(code, &code_len, OP_NEWCLAUSE);
+                    if (rc != IRXBC_OK)
+                    {
+                        goto cleanup;
+                    }
+                    rc = emit(code, &code_len, OP_EXIT);
+                    if (rc != IRXBC_OK)
+                    {
+                        goto cleanup;
+                    }
+                    hit_exit = 1;
+                }
+                else
+                {
+                    /* Any other symbol in Phase 1 is unsupported. */
+                    rc = IRXBC_ERR_UNSUP;
+                    goto cleanup;
+                }
+                break;
+
+            default:
+                /* Any token type not listed above is unsupported. */
+                rc = IRXBC_ERR_UNSUP;
+                goto cleanup;
+        }
+    }
+
+    /* 3. Implicit program exit ------------------------------------- */
+    if (!hit_exit)
+    {
+        rc = emit(code, &code_len, OP_EXIT);
+        if (rc != IRXBC_OK)
+        {
+            goto cleanup;
+        }
+    }
+
+    /* 4. Allocate EXECBLK + bytecode payload ----------------------- */
+    total_size = (int)sizeof(struct irx_bc_execblk) + code_len;
+    if (irxstor(RXSMGET, total_size, &mem, envblock) != 0)
+    {
+        rc = IRXBC_ERR_STOR;
+        goto cleanup;
+    }
+
+    /* 5. Populate header ------------------------------------------ */
+    bc = (struct irx_bc_execblk *)mem;
+    memset(bc, 0, (size_t)total_size);
+    memcpy(bc->magic, IRXBC_MAGIC, sizeof(bc->magic));
+    bc->version = IRXBC_VERSION;
+    bc->flags = 0;
+    bc->const_count = 0;
+    bc->symbol_count = 0;
+    bc->code_length = (uint32_t)code_len;
+    bc->entry_offset = 0;
+    bc->trace_map_offset = 0;
+
+    /* 6. Copy bytecode payload ------------------------------------ */
+    memcpy(IRXBC_CODE(bc), code, (size_t)code_len);
+
+    *bc_out = bc;
+    bc = NULL; /* ownership transferred */
+
+cleanup:
+    if (tokens != NULL)
+    {
+        irx_tokn_free(envblock, tokens, tok_count);
+    }
+    if (bc != NULL)
+    {
+        /* Allocation succeeded but a later step failed. */
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+    return rc;
+}

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -1,0 +1,70 @@
+/* ------------------------------------------------------------------ */
+/*  irx#bvm.c - REXX/370 Bytecode VM Loop Skeleton (WP-BC-01)        */
+/*                                                                    */
+/*  irx_bc_execute() — Entry point.                                  */
+/*                                                                    */
+/*  Phase 1 scope:                                                    */
+/*    - OP_NOP (0x00)      — advance PC                              */
+/*    - OP_EXIT (0x01)     — terminate with RC=0                     */
+/*    - OP_NEWCLAUSE (0x02)— clause boundary (no-op for Phase 1)    */
+/*                                                                    */
+/*  The big-switch dispatch is the canonical form: c2asm370 (GCC     */
+/*  3.2.3) generates an optimised branch table from a dense switch   */
+/*  on an unsigned char, matching BREXX-style dispatch performance.  */
+/*                                                                    */
+/*  Stack: bc_stack_slot is defined in irxbvm.h but no slot array   */
+/*  is allocated in Phase 1 — no opcode pushes or pops yet.  WP-BC- */
+/*  02 introduces the first stack-consuming opcode.                  */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                            */
+/* ------------------------------------------------------------------ */
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexbl.h"
+
+/* ------------------------------------------------------------------ */
+/*  irx_bc_execute                                                    */
+/* ------------------------------------------------------------------ */
+int irx_bc_execute(struct envblock *envblock,
+                   struct irx_bc_execblk *bc,
+                   int *rc_out)
+{
+    const unsigned char *pc;
+    unsigned char op;
+
+    (void)envblock; /* not yet consumed in Phase 1 */
+
+    if (bc == NULL)
+    {
+        return IRXBC_ERR_OPCODE;
+    }
+
+    pc = IRXBC_ENTRY(bc);
+
+    for (;;)
+    {
+        op = *pc++;
+
+        switch (op)
+        {
+            case OP_NOP:
+                break;
+
+            case OP_NEWCLAUSE:
+                /* Phase 1: no-op — TRACE hook reserved for WP-BC-03. */
+                break;
+
+            case OP_EXIT:
+                if (rc_out != NULL)
+                {
+                    *rc_out = 0;
+                }
+                return IRXBC_OK;
+
+            default:
+                return IRXBC_ERR_OPCODE;
+        }
+    }
+}

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -12,7 +12,10 @@
 
 #include "irx.h"
 #include "irx_init.h"
+#include "irxbops.h"
+#include "irxbvm.h"
 #include "irxctrl.h"
+#include "irxexbl.h"
 #include "irxexec.h"
 #include "irxfunc.h"
 #include "irxlstr.h"
@@ -334,6 +337,33 @@ int irx_exec_run(const char *source, int source_len,
             retention_saved = 1;
             wk->wkbi_source = (void *)source;
             wk->wkbi_source_len = source_len;
+        }
+    }
+
+    /* 3. Bytecode path (opt-in via wkbi_use_bytecode) -------------- */
+    {
+        struct irx_wkblk_int *wk =
+            (struct irx_wkblk_int *)envblock->envblock_userfield;
+        if (wk != NULL && wk->wkbi_use_bytecode)
+        {
+            struct irx_bc_execblk *bc = NULL;
+            int bc_rc = 0;
+
+            rc = irx_bc_compile(envblock, source, source_len, &bc);
+            if (rc == IRXBC_OK)
+            {
+                rc = irx_bc_execute(envblock, bc, &bc_rc);
+            }
+            if (rc_out != NULL)
+            {
+                *rc_out = bc_rc;
+            }
+            if (bc != NULL)
+            {
+                void *p = bc;
+                irxstor(RXSMFRE, 0, &p, envblock);
+            }
+            goto cleanup;
         }
     }
 

--- a/test/host/tstbc_compile.c
+++ b/test/host/tstbc_compile.c
@@ -1,0 +1,196 @@
+/* ------------------------------------------------------------------ */
+/*  test/host/tstbc_compile.c — WP-BC-01 compiler unit tests          */
+/*                                                                    */
+/*  Verifies that irx_bc_compile() produces well-formed bytecode      */
+/*  containers for the Phase 1 subset (EXIT and empty source).        */
+/*                                                                    */
+/*  Build (Linux):                                                     */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -O0 -g \                           */
+/*        -o /tmp/tstbc_compile test/host/tstbc_compile.c \           */
+/*        'src/irx#init.c'  'src/irx#term.c'  'src/irx#stor.c' \    */
+/*        'src/irx#anch.c'  'src/irx#env.c'   'src/irx#uid.c'  \    */
+/*        'src/irx#msid.c'  'src/irx#cond.c'  'src/irx#bif.c'  \    */
+/*        'src/irx#bifs.c'  'src/irx#io.c'    'src/irx#lstr.c' \    */
+/*        'src/irx#tokn.c'  'src/irx#vpol.c'  'src/irx#pars.c' \    */
+/*        'src/irx#ctrl.c'  'src/irx#exec.c'  'src/irx#arith.c' \   */
+/*        'src/irx#bcom.c'  'src/irx#bvm.c' \                        */
+/*        '../lstring370/src/lstr#cor.c'  \                           */
+/*        '../lstring370/src/lstr#cvt.c'  \                           */
+/*        '../lstring370/src/lstr#fmt.c'  \                           */
+/*        '../lstring370/src/lstr#srch.c' \                           */
+/*        '../lstring370/src/lstr#sub.c'  \                           */
+/*        '../lstring370/src/lstr#wrd.c'  \                           */
+/*        '../lstring370/src/lstr#xlt.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexbl.h"
+#include "irxfunc.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Helper: compile a source string, run checks, free the container.  */
+/* ------------------------------------------------------------------ */
+static void test_compile_empty(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    const unsigned char *code;
+    int rc;
+
+    printf("  [compile: empty source]\n");
+
+    rc = irx_bc_compile(env, "/* nothing */",
+                        (int)strlen("/* nothing */"), &bc);
+    CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
+    CHECK(bc != NULL, "bc pointer is non-NULL");
+
+    if (bc == NULL)
+    {
+        return;
+    }
+
+    CHECK(memcmp(bc->magic, IRXBC_MAGIC, sizeof(bc->magic)) == 0,
+          "magic is RX37");
+    CHECK(bc->version == IRXBC_VERSION, "version == 1");
+    CHECK(bc->flags == 0, "flags == 0");
+    CHECK(bc->const_count == 0, "const_count == 0");
+    CHECK(bc->symbol_count == 0, "symbol_count == 0");
+    CHECK(bc->entry_offset == 0, "entry_offset == 0");
+    CHECK(bc->trace_map_offset == 0, "trace_map_offset == 0");
+
+    /* Empty source -> only OP_EXIT in bytecode. */
+    CHECK(bc->code_length == 1, "code_length == 1 (OP_EXIT only)");
+
+    code = IRXBC_CODE(bc);
+    CHECK(code[0] == OP_EXIT, "bytecode[0] == OP_EXIT");
+
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+static void test_compile_exit(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    const unsigned char *code;
+    int rc;
+
+    printf("  [compile: exit]\n");
+
+    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), &bc);
+    CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
+    CHECK(bc != NULL, "bc pointer is non-NULL");
+
+    if (bc == NULL)
+    {
+        return;
+    }
+
+    CHECK(memcmp(bc->magic, IRXBC_MAGIC, sizeof(bc->magic)) == 0,
+          "magic is RX37");
+    CHECK(bc->version == IRXBC_VERSION, "version == 1");
+    CHECK(bc->const_count == 0, "const_count == 0");
+    CHECK(bc->symbol_count == 0, "symbol_count == 0");
+
+    /* exit -> OP_NEWCLAUSE + OP_EXIT */
+    CHECK(bc->code_length == 2, "code_length == 2 (OP_NEWCLAUSE + OP_EXIT)");
+
+    code = IRXBC_CODE(bc);
+    CHECK(code[0] == OP_NEWCLAUSE, "bytecode[0] == OP_NEWCLAUSE");
+    CHECK(code[1] == OP_EXIT, "bytecode[1] == OP_EXIT");
+
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+static void test_compile_unsupported(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    int rc;
+
+    printf("  [compile: unsupported construct]\n");
+
+    /* "say 'hello'" is not handled in Phase 1. */
+    rc = irx_bc_compile(env, "say 'hello'", (int)strlen("say 'hello'"), &bc);
+    CHECK(rc == IRXBC_ERR_UNSUP,
+          "compile returns IRXBC_ERR_UNSUP for unsupported construct");
+    CHECK(bc == NULL, "bc is NULL on error");
+}
+
+static void test_compile_null_out(struct envblock *env)
+{
+    int rc;
+
+    printf("  [compile: NULL bc_out]\n");
+
+    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), NULL);
+    CHECK(rc != IRXBC_OK, "compile rejects NULL bc_out");
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+int main(void)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    printf("=== WP-BC-01 Compiler Tests ===\n\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbc_compile: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    test_compile_empty(env);
+    test_compile_exit(env);
+    test_compile_unsupported(env);
+    test_compile_null_out(env);
+
+    irxterm(env);
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/host/tstbc_execute.c
+++ b/test/host/tstbc_execute.c
@@ -1,0 +1,241 @@
+/* ------------------------------------------------------------------ */
+/*  test/host/tstbc_execute.c — WP-BC-01 VM execution tests           */
+/*                                                                    */
+/*  Verifies that irx_bc_execute() runs compiled bytecode correctly   */
+/*  and that the end-to-end path (irx_exec_run with wkbi_use_bytecode */
+/*  = 1) produces the correct exit codes.                             */
+/*                                                                    */
+/*  Build (Linux):                                                     */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -O0 -g \                           */
+/*        -o /tmp/tstbc_execute test/host/tstbc_execute.c \           */
+/*        'src/irx#init.c'  'src/irx#term.c'  'src/irx#stor.c' \    */
+/*        'src/irx#anch.c'  'src/irx#env.c'   'src/irx#uid.c'  \    */
+/*        'src/irx#msid.c'  'src/irx#cond.c'  'src/irx#bif.c'  \    */
+/*        'src/irx#bifs.c'  'src/irx#io.c'    'src/irx#lstr.c' \    */
+/*        'src/irx#tokn.c'  'src/irx#vpol.c'  'src/irx#pars.c' \    */
+/*        'src/irx#ctrl.c'  'src/irx#exec.c'  'src/irx#arith.c' \   */
+/*        'src/irx#bcom.c'  'src/irx#bvm.c' \                        */
+/*        '../lstring370/src/lstr#cor.c'  \                           */
+/*        '../lstring370/src/lstr#cvt.c'  \                           */
+/*        '../lstring370/src/lstr#fmt.c'  \                           */
+/*        '../lstring370/src/lstr#srch.c' \                           */
+/*        '../lstring370/src/lstr#sub.c'  \                           */
+/*        '../lstring370/src/lstr#wrd.c'  \                           */
+/*        '../lstring370/src/lstr#xlt.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexbl.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Compile source and execute via the VM directly.                   */
+/* ------------------------------------------------------------------ */
+static void test_execute_empty(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    int bc_rc = -1;
+    int rc;
+
+    printf("  [execute: empty source]\n");
+
+    rc = irx_bc_compile(env, "/* nothing */",
+                        (int)strlen("/* nothing */"), &bc);
+    CHECK(rc == IRXBC_OK, "compile succeeds");
+    if (bc == NULL)
+    {
+        return;
+    }
+
+    rc = irx_bc_execute(env, bc, &bc_rc);
+    CHECK(rc == IRXBC_OK, "execute returns IRXBC_OK");
+    CHECK(bc_rc == 0, "program RC == 0");
+
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+static void test_execute_exit(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    int bc_rc = -1;
+    int rc;
+
+    printf("  [execute: exit]\n");
+
+    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), &bc);
+    CHECK(rc == IRXBC_OK, "compile succeeds");
+    if (bc == NULL)
+    {
+        return;
+    }
+
+    rc = irx_bc_execute(env, bc, &bc_rc);
+    CHECK(rc == IRXBC_OK, "execute returns IRXBC_OK");
+    CHECK(bc_rc == 0, "program RC == 0");
+
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+static void test_execute_null(struct envblock *env)
+{
+    int bc_rc = -1;
+    int rc;
+
+    printf("  [execute: NULL container]\n");
+
+    rc = irx_bc_execute(env, NULL, &bc_rc);
+    CHECK(rc != IRXBC_OK, "execute rejects NULL container");
+}
+
+/* ------------------------------------------------------------------ */
+/*  End-to-end: irx_exec_run with wkbi_use_bytecode = 1.             */
+/* ------------------------------------------------------------------ */
+static void test_e2e_bytecode_flag(void)
+{
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    int exit_rc = -1;
+    int rc;
+
+    printf("  [e2e: wkbi_use_bytecode=1, source=exit]\n");
+
+    rc = irxinit(NULL, &env);
+    CHECK(rc == 0 && env != NULL, "irxinit succeeds");
+    if (rc != 0 || env == NULL)
+    {
+        return;
+    }
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    CHECK(wk != NULL, "work block is present");
+    if (wk == NULL)
+    {
+        irxterm(env);
+        return;
+    }
+
+    wk->wkbi_use_bytecode = 1;
+
+    rc = irx_exec_run("exit", (int)strlen("exit"), NULL, 0, &exit_rc, env);
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit_rc == 0");
+
+    wk->wkbi_use_bytecode = 0;
+
+    /* Token-walk path still works after disabling bytecode. */
+    rc = irx_exec_run("exit", (int)strlen("exit"), NULL, 0, &exit_rc, env);
+    CHECK(rc == 0, "token-walk path still returns 0");
+    CHECK(exit_rc == 0, "token-walk exit_rc == 0");
+
+    irxterm(env);
+}
+
+static void test_e2e_empty_bytecode(void)
+{
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    int exit_rc = -1;
+    int rc;
+
+    printf("  [e2e: wkbi_use_bytecode=1, source=empty]\n");
+
+    rc = irxinit(NULL, &env);
+    CHECK(rc == 0 && env != NULL, "irxinit succeeds");
+    if (rc != 0 || env == NULL)
+    {
+        return;
+    }
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        irxterm(env);
+        return;
+    }
+
+    wk->wkbi_use_bytecode = 1;
+
+    rc = irx_exec_run("/* nothing */", (int)strlen("/* nothing */"),
+                      NULL, 0, &exit_rc, env);
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit_rc == 0");
+
+    irxterm(env);
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+int main(void)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    printf("=== WP-BC-01 VM Execution Tests ===\n\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbc_execute: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    test_execute_empty(env);
+    test_execute_exit(env);
+    test_execute_null(env);
+
+    irxterm(env);
+
+    /* End-to-end tests create their own environments. */
+    test_e2e_bytecode_flag();
+    test_e2e_empty_bytecode();
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #141

## Summary

- Adds `struct irx_bc_execblk` (28-byte position-independent bytecode container) in `include/irxexbl.h`. Named distinctly from the IBM-defined `struct execblk` in `irx.h` to avoid the type collision.
- Opcode table (`irxbops.h`): Phase 1 minimal set — `OP_NOP` (0x00), `OP_EXIT` (0x01), `OP_NEWCLAUSE` (0x02), all 1 byte with no operands.
- `bc_stack_slot` canonical layout (`irxbvm.h`): 24 bytes per slot, `str`/`type_cache`/`int_cache`. Defined now for forward compatibility; no stack is allocated in Phase 1.
- Compiler (`src/irx#bcom.c`): tokenises source, walks token stream, emits bytecode into a local buffer, allocates EXECBLK + payload via `irxstor`. Phase 1 handles EXIT and empty clauses only — any other construct returns `IRXBC_ERR_UNSUP`.
- VM loop (`src/irx#bvm.c`): big-switch dispatch; c2asm370 generates branch table. Phase 1 handlers: NOP (advance), NEWCLAUSE (no-op), EXIT (return RC=0).
- `irx_exec_run` in `src/irx#exec.c` checks `wkbi_use_bytecode` (new field in `irx_wkblk_int`, default 0) and routes through the bytecode path when set. Token-walk path is completely untouched.
- `docs/architecture.md` section 15: EXECBLK layout diagram, opcode table, stack slot, integration notes.

## Test plan

- [x] `test/host/tstbc_compile.c` — 23 compiler tests (magic, version, const/symbol counts, code_length, per-byte opcode checks, error cases): **23/23 green**
- [x] `test/host/tstbc_execute.c` — 16 VM + end-to-end tests (empty source, EXIT, NULL container, `wkbi_use_bytecode=1` round-trip): **16/16 green**
- [x] All 1239 existing host tests unchanged: **1239/1239 green** (token-walk path unmodified)
- [ ] MVS build (`mbt build --target IRX#BCOM IRX#BVM`) — requires live MVS connection; verify no IFOX00 errors