### PR TITLE
feat(bytecode): WP-BC-02 — expressions, variables, assignment

### DIFF
--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -1,9 +1,12 @@
 /* ------------------------------------------------------------------ */
-/*  irxbops.h - REXX/370 Bytecode Opcode Definitions (WP-BC-01)      */
+/*  irxbops.h - REXX/370 Bytecode Opcode Definitions (WP-BC-02)      */
 /*                                                                    */
-/*  Opcode encoding for the bytecode VM.  All Phase 1 opcodes are    */
-/*  exactly 1 byte with no operands.  Future work packages extend     */
-/*  this set with operand-bearing opcodes.                            */
+/*  Opcode encoding for the bytecode VM.                             */
+/*                                                                    */
+/*  Operand-bearing opcodes carry inline operands:                   */
+/*    3-byte: op + u16-le index (PUSH_LIT, LOAD, STORE, DROP)        */
+/*    2-byte: op + u8 count     (POP)                                */
+/*    1-byte: all others                                              */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
@@ -12,21 +15,94 @@
 #define IRXBOPS_H
 
 /* ================================================================== */
-/*  Opcode table (Phase 1 — minimal set)                             */
+/*  Control opcodes (Phase 1 + Phase 2)                              */
 /* ================================================================== */
 
-#define OP_NOP       0x00 /* 1 byte — no operation, advance PC       */
+#define OP_NOP       0x00 /* 1 byte — no operation                   */
 #define OP_EXIT      0x01 /* 1 byte — terminate execution, RC=0      */
 #define OP_NEWCLAUSE 0x02 /* 1 byte — clause boundary (TRACE hook)   */
+#define OP_EXIT_RC   0x03 /* 1 byte — pop TOS, convert to int, exit  */
+
+/* ================================================================== */
+/*  Stack ops (WP-BC-02)                                             */
+/* ================================================================== */
+
+#define OP_PUSH_LIT 0x10 /* 3 bytes: op + idx:u16 — push const[idx] */
+#define OP_PUSH_TMP 0x11 /* 1 byte  — reserved for future use       */
+#define OP_POP      0x12 /* 2 bytes: op + n:u8 — discard n items    */
+#define OP_DUP      0x13 /* 1 byte  — duplicate top of stack        */
+
+/* ================================================================== */
+/*  Variable ops (WP-BC-02)                                          */
+/* ================================================================== */
+
+#define OP_LOAD  0x20 /* 3 bytes: op + idx:u16 — push vpool[sym[idx]] */
+#define OP_STORE 0x21 /* 3 bytes: op + idx:u16 — pop, store vpool[sym[idx]] */
+#define OP_DROP  0x22 /* 3 bytes: op + idx:u16 — drop vpool[sym[idx]] */
+
+/* ================================================================== */
+/*  Arithmetic ops (WP-BC-02) — all 1 byte                          */
+/*  Binary (pop b, pop a, push result): ADD SUB MUL DIV IDIV MOD POW */
+/*  Unary (pop a, push result):         NEG                          */
+/* ================================================================== */
+
+#define OP_ADD  0x30 /* a + b                                   */
+#define OP_SUB  0x31 /* a - b                                   */
+#define OP_MUL  0x32 /* a * b                                   */
+#define OP_DIV  0x33 /* a / b  (normal division)                */
+#define OP_IDIV 0x34 /* a % b  (integer division, truncate-to-0)*/
+#define OP_MOD  0x35 /* a // b (remainder)                      */
+#define OP_POW  0x36 /* a ** b                                   */
+#define OP_NEG  0x37 /* -a     (unary minus)                    */
+
+/* ================================================================== */
+/*  Comparison ops (WP-BC-02) — all 1 byte                          */
+/*  Pop b, pop a, push "1" or "0".                                   */
+/* ================================================================== */
+
+#define OP_EQ  0x40 /* =   fuzzy equal                         */
+#define OP_NE  0x41 /* \=  fuzzy not-equal                     */
+#define OP_LT  0x42 /* <   less than                           */
+#define OP_LE  0x43 /* <=  less or equal                       */
+#define OP_GT  0x44 /* >   greater than                        */
+#define OP_GE  0x45 /* >=  greater or equal                    */
+#define OP_DEQ 0x46 /* ==  strict equal                        */
+#define OP_DNE 0x47 /* \== strict not-equal                    */
+#define OP_DLT 0x48 /* <<  strict less                         */
+#define OP_DLE 0x49 /* <<= strict less-or-equal                */
+#define OP_DGT 0x4A /* >>  strict greater                      */
+#define OP_DGE 0x4B /* >>= strict greater-or-equal             */
+
+/* ================================================================== */
+/*  Logical/boolean ops (WP-BC-02) — all 1 byte                     */
+/*  Boolean values are "0" (false) or "1" (true).                    */
+/* ================================================================== */
+
+#define OP_AND 0x50 /* &  — logical and                        */
+#define OP_OR  0x51 /* |  — logical or                         */
+#define OP_XOR 0x52 /* && — logical exclusive or               */
+#define OP_NOT 0x53 /* \  — logical not (unary)                */
+
+/* ================================================================== */
+/*  String ops (WP-BC-02) — all 1 byte                              */
+/* ================================================================== */
+
+#define OP_CONCAT  0x60 /* ||  — explicit concatenation            */
+#define OP_BCONCAT 0x61 /* abuttal with one blank                  */
 
 /* ================================================================== */
 /*  Per-opcode size in bytes (including the opcode byte itself)       */
-/*                                                                    */
-/*  All Phase 1 opcodes are 1 byte.  Future phases add operands;      */
-/*  extend the switch in OP_SIZE before introducing them.            */
 /* ================================================================== */
 
-#define OP_SIZE(op) 1 /* Phase 1: every opcode is 1 byte         */
+/* clang-format off */
+#define OP_SIZE(op)                   \
+    (((op) == OP_PUSH_LIT) ? 3 :     \
+     ((op) == OP_POP)      ? 2 :     \
+     ((op) == OP_LOAD)     ? 3 :     \
+     ((op) == OP_STORE)    ? 3 :     \
+     ((op) == OP_DROP)     ? 3 :     \
+     1)
+/* clang-format on */
 
 /* ================================================================== */
 /*  Compiler and VM return codes                                      */
@@ -35,7 +111,9 @@
 #define IRXBC_OK         0  /* success                               */
 #define IRXBC_ERR_STOR   20 /* irxstor allocation failed             */
 #define IRXBC_ERR_TOKN   21 /* tokenizer returned an error           */
-#define IRXBC_ERR_UNSUP  22 /* unsupported construct (Phase 1 limit) */
+#define IRXBC_ERR_UNSUP  22 /* unsupported construct                 */
 #define IRXBC_ERR_OPCODE 23 /* unknown opcode encountered by VM      */
+#define IRXBC_ERR_ARITH  24 /* arithmetic error (type, divzero etc.) */
+#define IRXBC_ERR_STACK  25 /* stack underflow or overflow           */
 
 #endif /* IRXBOPS_H */

--- a/include/irxexbl.h
+++ b/include/irxexbl.h
@@ -94,7 +94,12 @@ struct irx_bc_execblk
     (IRXBC_CODE(bc) + (bc)->entry_offset)
 
 /* Total byte size of a container: header + tables + bytecode. */
-#define IRXBC_TOTAL(bc) \
-    ((int)sizeof(struct irx_bc_execblk) + (int)(bc)->const_count * IRXBC_ENTRY_SIZE + (int)(bc)->symbol_count * IRXBC_ENTRY_SIZE + (int)(bc)->code_length)
+/* clang-format off */
+#define IRXBC_TOTAL(bc)                                               \
+    ((int)sizeof(struct irx_bc_execblk)                               \
+     + (int)(bc)->const_count  * IRXBC_ENTRY_SIZE                     \
+     + (int)(bc)->symbol_count * IRXBC_ENTRY_SIZE                     \
+     + (int)(bc)->code_length)
+/* clang-format on */
 
 #endif /* IRXEXBL_H */

--- a/include/irxexbl.h
+++ b/include/irxexbl.h
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------------ */
-/*  irxexbl.h - REXX/370 Bytecode EXECBLK Format (WP-BC-01)          */
+/*  irxexbl.h - REXX/370 Bytecode EXECBLK Format (WP-BC-02)          */
 /*                                                                    */
 /*  Defines struct irx_bc_execblk — the in-memory bytecode container */
 /*  produced by the bytecode compiler (irx#bcom.c) and consumed by   */
@@ -13,9 +13,16 @@
 /*    [ Bytecode         (code_length bytes) ]                       */
 /*    [ Trace Map        (optional)          ]                       */
 /*                                                                    */
-/*  All operands in the bytecode are indices or relative offsets —   */
-/*  no absolute pointers.  The container is position-independent     */
-/*  and will be serialisable to CEXEC in a later work package.       */
+/*  Table entry format (IRXBC_ENTRY_SIZE == 64 bytes):              */
+/*    byte[0]     = string length (0..IRXBC_STR_MAX)                */
+/*    byte[1..63] = string data (not NUL-terminated)                */
+/*                                                                    */
+/*  When const_count == 0 and symbol_count == 0 the bytecode starts  */
+/*  immediately after the header — backward-compatible with WP-BC-01. */
+/*                                                                    */
+/*  All operands in the bytecode are table indices or relative        */
+/*  offsets — no absolute pointers.  The container is position-      */
+/*  independent and will be serialisable to CEXEC in a later WP.    */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
@@ -53,24 +60,41 @@ struct irx_bc_execblk
 };
 
 /* ================================================================== */
-/*  Payload access macros                                             */
-/*                                                                    */
-/*  Phase 1: const_count == 0 and symbol_count == 0, so the          */
-/*  bytecode starts at (char*)bc + sizeof(*bc) + entry_offset.       */
-/*  Future phases will insert the constants and symbol tables         */
-/*  between the header and the bytecode.                             */
+/*  Table entry geometry                                              */
 /* ================================================================== */
 
+/* Bytes per entry in the constants and symbol tables. */
+#define IRXBC_ENTRY_SIZE 64
+
+/* Maximum string length that fits in one table entry. */
+#define IRXBC_STR_MAX 63
+
+/* ================================================================== */
+/*  Payload access macros                                             */
+/*                                                                    */
+/*  When const_count == 0 and symbol_count == 0, IRXBC_CODE returns  */
+/*  the same address as the old Phase 1 macro — backward-compatible.  */
+/* ================================================================== */
+
+/* Pointer to the start of the constants table. */
+#define IRXBC_CONST_TBL(bc) \
+    ((char *)(bc) + (int)sizeof(struct irx_bc_execblk))
+
+/* Pointer to the start of the symbol table. */
+#define IRXBC_SYM_TBL(bc) \
+    (IRXBC_CONST_TBL(bc) + (int)(bc)->const_count * IRXBC_ENTRY_SIZE)
+
 /* Pointer to start of bytecode within a container. */
-#define IRXBC_CODE(bc) \
-    ((unsigned char *)(bc) + sizeof(struct irx_bc_execblk))
+#define IRXBC_CODE(bc)                     \
+    ((unsigned char *)(IRXBC_SYM_TBL(bc) + \
+                       (int)(bc)->symbol_count * IRXBC_ENTRY_SIZE))
 
 /* Pointer to entry point within a container. */
 #define IRXBC_ENTRY(bc) \
     (IRXBC_CODE(bc) + (bc)->entry_offset)
 
-/* Total byte size of a container: header + payload. */
+/* Total byte size of a container: header + tables + bytecode. */
 #define IRXBC_TOTAL(bc) \
-    ((int)(sizeof(struct irx_bc_execblk)) + (int)(bc)->code_length)
+    ((int)sizeof(struct irx_bc_execblk) + (int)(bc)->const_count * IRXBC_ENTRY_SIZE + (int)(bc)->symbol_count * IRXBC_ENTRY_SIZE + (int)(bc)->code_length)
 
 #endif /* IRXEXBL_H */

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -7,7 +7,7 @@
 /*    - Assignment statements:  symbol = expr                        */
 /*    - Expressions: literals, variables, arithmetic, comparison,    */
 /*      logical, string concatenation, parenthesised groups          */
-/*    - EXIT statement (no expression)                               */
+/*    - EXIT [expr] statement                                         */
 /*    - Any other construct returns IRXBC_ERR_UNSUP                  */
 /*                                                                    */
 /*  Memory: caller must free the returned irx_bc_execblk with        */
@@ -123,7 +123,7 @@ static char tok_ch(const struct bcom_ctx *ctx, int offset)
 }
 
 /* Add a constant string (text, len) to the const table; return index.
- * Returns -1 on overflow. Duplicates are not merged (acceptable for now). */
+ * Deduplicates by value. Returns -1 on overflow. */
 static int add_const(struct bcom_ctx *ctx, const char *text, int len)
 {
     int i;
@@ -553,6 +553,8 @@ static void bc_exp3(struct bcom_ctx *ctx)
 /* Level 2 — comparison operators */
 static void bc_exp2(struct bcom_ctx *ctx)
 {
+    unsigned char op = 0;
+
     if (ctx->rc != IRXBC_OK)
     {
         return;
@@ -564,143 +566,140 @@ static void bc_exp2(struct bcom_ctx *ctx)
         return;
     }
 
-    /* Comparison is non-associative: parse at most one operator. */
+    /* Comparison is non-associative: parse at most one operator.
+     * 2- and 3-character composites are checked before single chars
+     * so the longer match wins. */
+
+    /* 2-character composites checked first (longer match wins) */
+    if (tok_type_at(ctx, 0, TOK_COMPARISON) && tok_ch(ctx, 0) == '=' &&
+        tok_type_at(ctx, 1, TOK_COMPARISON) && tok_ch(ctx, 1) == '=')
     {
-        unsigned char op = 0;
+        /* ==  but not \== (handled via \) */
+        op = OP_DEQ;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '>' &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '>' &&
+             tok_type_at(ctx, 2, TOK_COMPARISON) &&
+             tok_ch(ctx, 2) == '=')
+    {
+        /* >>= */
+        op = OP_DGE;
+        ctx->pos += 3;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '<' &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '<' &&
+             tok_type_at(ctx, 2, TOK_COMPARISON) &&
+             tok_ch(ctx, 2) == '=')
+    {
+        /* <<= */
+        op = OP_DLE;
+        ctx->pos += 3;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '>' &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '>')
+    {
+        /* >> */
+        op = OP_DGT;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '<' &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '<')
+    {
+        /* << */
+        op = OP_DLT;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '>' &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '=')
+    {
+        /* >= */
+        op = OP_GE;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '<' &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '=')
+    {
+        /* <= */
+        op = OP_LE;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_NOT) &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '=' &&
+             tok_type_at(ctx, 2, TOK_COMPARISON) &&
+             tok_ch(ctx, 2) == '=')
+    {
+        /* \== */
+        op = OP_DNE;
+        ctx->pos += 3;
+    }
+    else if (tok_type_at(ctx, 0, TOK_NOT) &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '=')
+    {
+        /* \= */
+        op = OP_NE;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_NOT) &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '>')
+    {
+        /* \> same as <= */
+        op = OP_LE;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_NOT) &&
+             tok_type_at(ctx, 1, TOK_COMPARISON) &&
+             tok_ch(ctx, 1) == '<')
+    {
+        /* \< same as >= */
+        op = OP_GE;
+        ctx->pos += 2;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '=')
+    {
+        /* = */
+        op = OP_EQ;
+        ctx->pos++;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '>')
+    {
+        /* > */
+        op = OP_GT;
+        ctx->pos++;
+    }
+    else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+             tok_ch(ctx, 0) == '<')
+    {
+        /* < */
+        op = OP_LT;
+        ctx->pos++;
+    }
 
-        /* 3-character strict: >>= <<= \== (handled as two below via nesting) */
-
-        /* 2-character composites checked first (longer match wins) */
-        if (tok_type_at(ctx, 0, TOK_COMPARISON) && tok_ch(ctx, 0) == '=' &&
-            tok_type_at(ctx, 1, TOK_COMPARISON) && tok_ch(ctx, 1) == '=')
+    if (op != 0)
+    {
+        bc_exp3(ctx);
+        if (ctx->rc != IRXBC_OK)
         {
-            /* ==  but not \== (handled via \) */
-            op = OP_DEQ;
-            ctx->pos += 2;
+            return;
         }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '>' &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '>' &&
-                 tok_type_at(ctx, 2, TOK_COMPARISON) &&
-                 tok_ch(ctx, 2) == '=')
-        {
-            /* >>= */
-            op = OP_DGE;
-            ctx->pos += 3;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '<' &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '<' &&
-                 tok_type_at(ctx, 2, TOK_COMPARISON) &&
-                 tok_ch(ctx, 2) == '=')
-        {
-            /* <<= */
-            op = OP_DLE;
-            ctx->pos += 3;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '>' &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '>')
-        {
-            /* >> */
-            op = OP_DGT;
-            ctx->pos += 2;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '<' &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '<')
-        {
-            /* << */
-            op = OP_DLT;
-            ctx->pos += 2;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '>' &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '=')
-        {
-            /* >= */
-            op = OP_GE;
-            ctx->pos += 2;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '<' &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '=')
-        {
-            /* <= */
-            op = OP_LE;
-            ctx->pos += 2;
-        }
-        else if (tok_type_at(ctx, 0, TOK_NOT) &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '=' &&
-                 tok_type_at(ctx, 2, TOK_COMPARISON) &&
-                 tok_ch(ctx, 2) == '=')
-        {
-            /* \== */
-            op = OP_DNE;
-            ctx->pos += 3;
-        }
-        else if (tok_type_at(ctx, 0, TOK_NOT) &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '=')
-        {
-            /* \= */
-            op = OP_NE;
-            ctx->pos += 2;
-        }
-        else if (tok_type_at(ctx, 0, TOK_NOT) &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '>')
-        {
-            /* \> same as <= */
-            op = OP_LE;
-            ctx->pos += 2;
-        }
-        else if (tok_type_at(ctx, 0, TOK_NOT) &&
-                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
-                 tok_ch(ctx, 1) == '<')
-        {
-            /* \< same as >= */
-            op = OP_GE;
-            ctx->pos += 2;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '=')
-        {
-            /* = */
-            op = OP_EQ;
-            ctx->pos++;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '>')
-        {
-            /* > */
-            op = OP_GT;
-            ctx->pos++;
-        }
-        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
-                 tok_ch(ctx, 0) == '<')
-        {
-            /* < */
-            op = OP_LT;
-            ctx->pos++;
-        }
-
-        if (op != 0)
-        {
-            bc_exp3(ctx);
-            if (ctx->rc != IRXBC_OK)
-            {
-                return;
-            }
-            emit_byte(ctx, op);
-        }
+        emit_byte(ctx, op);
     }
 }
 

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -1,12 +1,13 @@
 /* ------------------------------------------------------------------ */
-/*  irx#bcom.c - REXX/370 Bytecode Compiler Skeleton (WP-BC-01)      */
+/*  irx#bcom.c - REXX/370 Bytecode Compiler (WP-BC-02)               */
 /*                                                                    */
 /*  irx_bc_compile() — Entry point.                                  */
 /*                                                                    */
-/*  Phase 1 scope:                                                    */
-/*    - Recognises EXIT and empty clauses only                       */
-/*    - Emits OP_NEWCLAUSE + OP_EXIT for explicit EXIT statements    */
-/*    - Emits OP_EXIT at source end (implicit program termination)   */
+/*  Phase 2 scope:                                                    */
+/*    - Assignment statements:  symbol = expr                        */
+/*    - Expressions: literals, variables, arithmetic, comparison,    */
+/*      logical, string concatenation, parenthesised groups          */
+/*    - EXIT statement (no expression)                               */
 /*    - Any other construct returns IRXBC_ERR_UNSUP                  */
 /*                                                                    */
 /*  Memory: caller must free the returned irx_bc_execblk with        */
@@ -25,26 +26,878 @@
 #include "irxtokn.h"
 #include "irxwkblk.h"
 
-/* Maximum bytecode bytes the Phase 1 compiler can emit. */
-#define BCOM_MAX_CODE 64
+/* ================================================================== */
+/*  Compiler limits                                                   */
+/* ================================================================== */
 
-/* ------------------------------------------------------------------ */
-/*  emit — append one opcode byte to the local buffer.               */
-/*  Returns 0 on success, IRXBC_ERR_STOR if the buffer is full.     */
-/* ------------------------------------------------------------------ */
-static int emit(unsigned char *buf, int *len, unsigned char op)
+#define BCOM_MAX_CODE   1024
+#define BCOM_MAX_CONSTS 64
+#define BCOM_MAX_SYMS   64
+
+/* ================================================================== */
+/*  Compiler context (heap-allocated to avoid large stack frames)     */
+/* ================================================================== */
+
+struct bcom_ctx
 {
-    if (*len >= BCOM_MAX_CODE)
+    struct envblock *env;
+    const struct irx_token *tokens;
+    int tok_count;
+    int pos;
+
+    unsigned char code[BCOM_MAX_CODE];
+    int code_len;
+
+    /* Each table entry: byte[0]=length, byte[1..63]=data */
+    char consts[BCOM_MAX_CONSTS][IRXBC_ENTRY_SIZE];
+    int const_count;
+
+    char syms[BCOM_MAX_SYMS][IRXBC_ENTRY_SIZE];
+    int sym_count;
+
+    int rc;
+    int hit_exit;
+};
+
+/* ================================================================== */
+/*  Forward declarations                                              */
+/* ================================================================== */
+
+static void bc_exp0(struct bcom_ctx *ctx);
+
+/* ================================================================== */
+/*  Helpers                                                           */
+/* ================================================================== */
+
+static int emit_byte(struct bcom_ctx *ctx, unsigned char op)
+{
+    if (ctx->code_len >= BCOM_MAX_CODE)
     {
+        ctx->rc = IRXBC_ERR_STOR;
         return IRXBC_ERR_STOR;
     }
-    buf[(*len)++] = op;
+    ctx->code[ctx->code_len++] = op;
     return IRXBC_OK;
 }
 
-/* ------------------------------------------------------------------ */
+static int emit_u16(struct bcom_ctx *ctx, int idx)
+{
+    if (ctx->code_len + 2 > BCOM_MAX_CODE)
+    {
+        ctx->rc = IRXBC_ERR_STOR;
+        return IRXBC_ERR_STOR;
+    }
+    ctx->code[ctx->code_len++] = (unsigned char)(idx & 0xFF);
+    ctx->code[ctx->code_len++] = (unsigned char)((idx >> 8) & 0xFF);
+    return IRXBC_OK;
+}
+
+/* Return token at pos+offset, or NULL if out of range. */
+static const struct irx_token *tok_at(const struct bcom_ctx *ctx, int offset)
+{
+    int i = ctx->pos + offset;
+    if (i < 0 || i >= ctx->tok_count)
+    {
+        return NULL;
+    }
+    return &ctx->tokens[i];
+}
+
+/* Return 1 if token at pos+offset has the given type. */
+static int tok_type_at(const struct bcom_ctx *ctx, int offset,
+                       unsigned char type)
+{
+    const struct irx_token *t = tok_at(ctx, offset);
+    return t != NULL && t->tok_type == type;
+}
+
+/* Return first character of tok_text for the token at pos+offset, or 0. */
+static char tok_ch(const struct bcom_ctx *ctx, int offset)
+{
+    const struct irx_token *t = tok_at(ctx, offset);
+    if (t == NULL || t->tok_length == 0 || t->tok_text == NULL)
+    {
+        return 0;
+    }
+    return t->tok_text[0];
+}
+
+/* Add a constant string (text, len) to the const table; return index.
+ * Returns -1 on overflow. Duplicates are not merged (acceptable for now). */
+static int add_const(struct bcom_ctx *ctx, const char *text, int len)
+{
+    int i;
+    if (len > IRXBC_STR_MAX)
+    {
+        len = IRXBC_STR_MAX;
+    }
+    /* check for duplicate */
+    for (i = 0; i < ctx->const_count; i++)
+    {
+        if ((unsigned char)ctx->consts[i][0] == (unsigned char)len &&
+            memcmp(ctx->consts[i] + 1, text, (size_t)len) == 0)
+        {
+            return i;
+        }
+    }
+    if (ctx->const_count >= BCOM_MAX_CONSTS)
+    {
+        return -1;
+    }
+    i = ctx->const_count++;
+    ctx->consts[i][0] = (char)(unsigned char)len;
+    if (len > 0)
+    {
+        memcpy(ctx->consts[i] + 1, text, (size_t)len);
+    }
+    return i;
+}
+
+/* Add a symbol name (upper-case, NUL-terminated) to the sym table.
+ * Returns index.  Deduplicates by name. Returns -1 on overflow. */
+static int add_sym(struct bcom_ctx *ctx, const char *name)
+{
+    int i;
+    int len = (int)strlen(name);
+    if (len > IRXBC_STR_MAX)
+    {
+        len = IRXBC_STR_MAX;
+    }
+    for (i = 0; i < ctx->sym_count; i++)
+    {
+        if ((unsigned char)ctx->syms[i][0] == (unsigned char)len &&
+            memcmp(ctx->syms[i] + 1, name, (size_t)len) == 0)
+        {
+            return i;
+        }
+    }
+    if (ctx->sym_count >= BCOM_MAX_SYMS)
+    {
+        return -1;
+    }
+    i = ctx->sym_count++;
+    ctx->syms[i][0] = (char)(unsigned char)len;
+    memcpy(ctx->syms[i] + 1, name, (size_t)len);
+    return i;
+}
+
+/* ================================================================== */
+/*  Expression cascade — bc_exp0 is the entry point (lowest prec.)   */
+/*                                                                    */
+/*  Precedence (lowest first):                                        */
+/*   0 — | (OR), && (XOR)                                            */
+/*   1 — & (AND)                                                      */
+/*   2 — comparison operators                                         */
+/*   3 — || (concat), abuttal-blank                                   */
+/*   4 — + - (add/subtract)                                          */
+/*   5 — * / % // (multiply/divide)                                  */
+/*   6 — ** (power)                                                   */
+/*   7 — unary + - \                                                  */
+/*   8 — atoms: literals, variables, ( expr )                        */
+/* ================================================================== */
+
+/* Level 8 — atoms */
+static void bc_exp8(struct bcom_ctx *ctx)
+{
+    const struct irx_token *t = tok_at(ctx, 0);
+
+    if (t == NULL || ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    /* Parenthesised expression */
+    if (t->tok_type == TOK_LPAREN)
+    {
+        ctx->pos++;
+        bc_exp0(ctx);
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        t = tok_at(ctx, 0);
+        if (t == NULL || t->tok_type != TOK_RPAREN)
+        {
+            ctx->rc = IRXBC_ERR_UNSUP;
+            return;
+        }
+        ctx->pos++;
+        return;
+    }
+
+    /* String literal */
+    if (t->tok_type == TOK_STRING)
+    {
+        int ci = add_const(ctx, t->tok_text, (int)t->tok_length);
+        if (ci < 0)
+        {
+            ctx->rc = IRXBC_ERR_STOR;
+            return;
+        }
+        ctx->pos++;
+        emit_byte(ctx, OP_PUSH_LIT);
+        emit_u16(ctx, ci);
+        return;
+    }
+
+    /* Number token */
+    if (t->tok_type == TOK_NUMBER)
+    {
+        int ci = add_const(ctx, t->tok_text, (int)t->tok_length);
+        if (ci < 0)
+        {
+            ctx->rc = IRXBC_ERR_STOR;
+            return;
+        }
+        ctx->pos++;
+        emit_byte(ctx, OP_PUSH_LIT);
+        emit_u16(ctx, ci);
+        return;
+    }
+
+    /* Symbol — constant symbol (starts with digit or '.') or variable */
+    if (t->tok_type == TOK_SYMBOL)
+    {
+        if (t->tok_flags & TOKF_CONSTANT)
+        {
+            /* constant symbol: treat as literal */
+            int ci = add_const(ctx, t->tok_text, (int)t->tok_length);
+            if (ci < 0)
+            {
+                ctx->rc = IRXBC_ERR_STOR;
+                return;
+            }
+            ctx->pos++;
+            emit_byte(ctx, OP_PUSH_LIT);
+            emit_u16(ctx, ci);
+        }
+        else
+        {
+            /* variable: load from vpool (NOVALUE = uppercase name) */
+            const char *name = (t->tok_upper != NULL) ? t->tok_upper
+                                                      : t->tok_text;
+            int si = add_sym(ctx, name);
+            if (si < 0)
+            {
+                ctx->rc = IRXBC_ERR_STOR;
+                return;
+            }
+            ctx->pos++;
+            emit_byte(ctx, OP_LOAD);
+            emit_u16(ctx, si);
+        }
+        return;
+    }
+
+    ctx->rc = IRXBC_ERR_UNSUP;
+}
+
+/* Level 7 — unary prefix: + - \ */
+static void bc_exp7(struct bcom_ctx *ctx)
+{
+    const struct irx_token *t;
+
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    t = tok_at(ctx, 0);
+    if (t == NULL)
+    {
+        return;
+    }
+
+    if (t->tok_type == TOK_OPERATOR && tok_ch(ctx, 0) == '-')
+    {
+        ctx->pos++;
+        bc_exp7(ctx); /* right-associative unary */
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        emit_byte(ctx, OP_NEG);
+        return;
+    }
+
+    if (t->tok_type == TOK_OPERATOR && tok_ch(ctx, 0) == '+')
+    {
+        /* Unary + is a no-op in REXX (forces numeric context). */
+        ctx->pos++;
+        bc_exp7(ctx);
+        return;
+    }
+
+    if (t->tok_type == TOK_NOT)
+    {
+        ctx->pos++;
+        bc_exp7(ctx);
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        emit_byte(ctx, OP_NOT);
+        return;
+    }
+
+    bc_exp8(ctx);
+}
+
+/* Level 6 — power: ** (right-associative) */
+static void bc_exp6(struct bcom_ctx *ctx)
+{
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    bc_exp7(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    if (tok_type_at(ctx, 0, TOK_OPERATOR) && tok_ch(ctx, 0) == '*' &&
+        tok_type_at(ctx, 1, TOK_OPERATOR) && tok_ch(ctx, 1) == '*')
+    {
+        ctx->pos += 2;
+        bc_exp6(ctx); /* right-associative */
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        emit_byte(ctx, OP_POW);
+    }
+}
+
+/* Level 5 — multiplicative: * / // % */
+static void bc_exp5(struct bcom_ctx *ctx)
+{
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    bc_exp6(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    for (;;)
+    {
+        if (tok_type_at(ctx, 0, TOK_OPERATOR) && tok_ch(ctx, 0) == '/' &&
+            tok_type_at(ctx, 1, TOK_OPERATOR) && tok_ch(ctx, 1) == '/')
+        {
+            /* // remainder */
+            ctx->pos += 2;
+            bc_exp6(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_MOD);
+        }
+        else if (tok_type_at(ctx, 0, TOK_OPERATOR) && tok_ch(ctx, 0) == '*' &&
+                 !(tok_type_at(ctx, 1, TOK_OPERATOR) && tok_ch(ctx, 1) == '*'))
+        {
+            ctx->pos++;
+            bc_exp6(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_MUL);
+        }
+        else if (tok_type_at(ctx, 0, TOK_OPERATOR) && tok_ch(ctx, 0) == '/' &&
+                 !(tok_type_at(ctx, 1, TOK_OPERATOR) && tok_ch(ctx, 1) == '/'))
+        {
+            ctx->pos++;
+            bc_exp6(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_DIV);
+        }
+        else if (tok_type_at(ctx, 0, TOK_OPERATOR) && tok_ch(ctx, 0) == '%')
+        {
+            ctx->pos++;
+            bc_exp6(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_IDIV);
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+/* Level 4 — additive: + - */
+static void bc_exp4(struct bcom_ctx *ctx)
+{
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    bc_exp5(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    for (;;)
+    {
+        if (tok_type_at(ctx, 0, TOK_OPERATOR) && tok_ch(ctx, 0) == '+')
+        {
+            ctx->pos++;
+            bc_exp5(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_ADD);
+        }
+        else if (tok_type_at(ctx, 0, TOK_OPERATOR) && tok_ch(ctx, 0) == '-')
+        {
+            ctx->pos++;
+            bc_exp5(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_SUB);
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+/* Level 3 — concatenation: || and abuttal-blank.
+ *
+ * Abuttal: two adjacent value-producing tokens (symbol, string,
+ * number, or closing paren) without an operator between them are
+ * concatenated with one blank (SC28-1883-0 §2.3.6).
+ *
+ * Detection: after parsing the left operand, if the next token is a
+ * value-starter (symbol, string, number, '(') or a prefix unary
+ * operator that can start an expression, we have abuttal.
+ */
+static int is_value_starter(const struct bcom_ctx *ctx, int offset)
+{
+    const struct irx_token *t = tok_at(ctx, offset);
+    if (t == NULL)
+    {
+        return 0;
+    }
+    /* Only pure value-producing tokens can start an abuttal: symbols,
+     * string literals, numbers, and parenthesised expressions.
+     * Operator tokens (including unary - and \) are NOT included:
+     * they would be mis-parsed as abuttal when the intent is a binary
+     * operator (e.g. '3 \= 4' would be parsed as concat, not NE). */
+    return t->tok_type == TOK_SYMBOL || t->tok_type == TOK_STRING ||
+           t->tok_type == TOK_NUMBER || t->tok_type == TOK_LPAREN;
+}
+
+static void bc_exp3(struct bcom_ctx *ctx)
+{
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    bc_exp4(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    for (;;)
+    {
+        /* || explicit concatenation */
+        if (tok_type_at(ctx, 0, TOK_LOGICAL) && tok_ch(ctx, 0) == '|' &&
+            tok_type_at(ctx, 1, TOK_LOGICAL) && tok_ch(ctx, 1) == '|')
+        {
+            ctx->pos += 2;
+            bc_exp4(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_CONCAT);
+        }
+        /* abuttal-blank */
+        else if (is_value_starter(ctx, 0))
+        {
+            bc_exp4(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_BCONCAT);
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+/* Level 2 — comparison operators */
+static void bc_exp2(struct bcom_ctx *ctx)
+{
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    bc_exp3(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    /* Comparison is non-associative: parse at most one operator. */
+    {
+        unsigned char op = 0;
+
+        /* 3-character strict: >>= <<= \== (handled as two below via nesting) */
+
+        /* 2-character composites checked first (longer match wins) */
+        if (tok_type_at(ctx, 0, TOK_COMPARISON) && tok_ch(ctx, 0) == '=' &&
+            tok_type_at(ctx, 1, TOK_COMPARISON) && tok_ch(ctx, 1) == '=')
+        {
+            /* ==  but not \== (handled via \) */
+            op = OP_DEQ;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '>' &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '>' &&
+                 tok_type_at(ctx, 2, TOK_COMPARISON) &&
+                 tok_ch(ctx, 2) == '=')
+        {
+            /* >>= */
+            op = OP_DGE;
+            ctx->pos += 3;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '<' &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '<' &&
+                 tok_type_at(ctx, 2, TOK_COMPARISON) &&
+                 tok_ch(ctx, 2) == '=')
+        {
+            /* <<= */
+            op = OP_DLE;
+            ctx->pos += 3;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '>' &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '>')
+        {
+            /* >> */
+            op = OP_DGT;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '<' &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '<')
+        {
+            /* << */
+            op = OP_DLT;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '>' &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '=')
+        {
+            /* >= */
+            op = OP_GE;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '<' &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '=')
+        {
+            /* <= */
+            op = OP_LE;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_NOT) &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '=' &&
+                 tok_type_at(ctx, 2, TOK_COMPARISON) &&
+                 tok_ch(ctx, 2) == '=')
+        {
+            /* \== */
+            op = OP_DNE;
+            ctx->pos += 3;
+        }
+        else if (tok_type_at(ctx, 0, TOK_NOT) &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '=')
+        {
+            /* \= */
+            op = OP_NE;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_NOT) &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '>')
+        {
+            /* \> same as <= */
+            op = OP_LE;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_NOT) &&
+                 tok_type_at(ctx, 1, TOK_COMPARISON) &&
+                 tok_ch(ctx, 1) == '<')
+        {
+            /* \< same as >= */
+            op = OP_GE;
+            ctx->pos += 2;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '=')
+        {
+            /* = */
+            op = OP_EQ;
+            ctx->pos++;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '>')
+        {
+            /* > */
+            op = OP_GT;
+            ctx->pos++;
+        }
+        else if (tok_type_at(ctx, 0, TOK_COMPARISON) &&
+                 tok_ch(ctx, 0) == '<')
+        {
+            /* < */
+            op = OP_LT;
+            ctx->pos++;
+        }
+
+        if (op != 0)
+        {
+            bc_exp3(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, op);
+        }
+    }
+}
+
+/* Level 1 — AND: & */
+static void bc_exp1(struct bcom_ctx *ctx)
+{
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    bc_exp2(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    while (tok_type_at(ctx, 0, TOK_LOGICAL) && tok_ch(ctx, 0) == '&' &&
+           !(tok_type_at(ctx, 1, TOK_LOGICAL) && tok_ch(ctx, 1) == '&'))
+    {
+        ctx->pos++;
+        bc_exp2(ctx);
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        emit_byte(ctx, OP_AND);
+    }
+}
+
+/* Level 0 — OR / XOR: | && */
+static void bc_exp0(struct bcom_ctx *ctx)
+{
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    bc_exp1(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    for (;;)
+    {
+        if (tok_type_at(ctx, 0, TOK_LOGICAL) && tok_ch(ctx, 0) == '&' &&
+            tok_type_at(ctx, 1, TOK_LOGICAL) && tok_ch(ctx, 1) == '&')
+        {
+            ctx->pos += 2;
+            bc_exp1(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_XOR);
+        }
+        else if (tok_type_at(ctx, 0, TOK_LOGICAL) &&
+                 tok_ch(ctx, 0) == '|' &&
+                 !(tok_type_at(ctx, 1, TOK_LOGICAL) && tok_ch(ctx, 1) == '|'))
+        {
+            ctx->pos++;
+            bc_exp1(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_OR);
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+/* ================================================================== */
+/*  Statement compiler                                                */
+/* ================================================================== */
+
+static void bc_stmt(struct bcom_ctx *ctx)
+{
+    const struct irx_token *t0 = tok_at(ctx, 0);
+    const struct irx_token *t1 = tok_at(ctx, 1);
+
+    if (t0 == NULL || t0->tok_type == TOK_EOC || t0->tok_type == TOK_EOF)
+    {
+        return;
+    }
+
+    emit_byte(ctx, OP_NEWCLAUSE);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    /* EXIT [expr] statement */
+    if (t0->tok_type == TOK_SYMBOL && t0->tok_upper != NULL &&
+        strcmp(t0->tok_upper, "EXIT") == 0)
+    {
+        const struct irx_token *t_next;
+        ctx->pos++;
+        t_next = tok_at(ctx, 0);
+        if (t_next == NULL || t_next->tok_type == TOK_EOC ||
+            t_next->tok_type == TOK_EOF)
+        {
+            /* EXIT without expression */
+            emit_byte(ctx, OP_EXIT);
+        }
+        else
+        {
+            /* EXIT with expression: evaluate, pop as int, exit */
+            bc_exp0(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_EXIT_RC);
+        }
+        ctx->hit_exit = 1;
+        return;
+    }
+
+    /* Assignment: simple-symbol = expr  (= must be single, not ==) */
+    if (t0->tok_type == TOK_SYMBOL && !(t0->tok_flags & TOKF_CONSTANT) &&
+        t1 != NULL && t1->tok_type == TOK_COMPARISON &&
+        t1->tok_length > 0 && t1->tok_text[0] == '=' &&
+        !(tok_type_at(ctx, 2, TOK_COMPARISON) && tok_ch(ctx, 2) == '='))
+    {
+        const char *name =
+            (t0->tok_upper != NULL) ? t0->tok_upper : t0->tok_text;
+        int si = add_sym(ctx, name);
+        if (si < 0)
+        {
+            ctx->rc = IRXBC_ERR_STOR;
+            return;
+        }
+        ctx->pos += 2; /* consume symbol and = */
+        bc_exp0(ctx);
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        emit_byte(ctx, OP_STORE);
+        emit_u16(ctx, si);
+        return;
+    }
+
+    ctx->rc = IRXBC_ERR_UNSUP;
+}
+
+/* ================================================================== */
+/*  Program compiler                                                  */
+/* ================================================================== */
+
+static void bc_program(struct bcom_ctx *ctx)
+{
+    for (;;)
+    {
+        const struct irx_token *t = tok_at(ctx, 0);
+
+        if (t == NULL || t->tok_type == TOK_EOF)
+        {
+            break;
+        }
+        if (t->tok_type == TOK_EOC)
+        {
+            ctx->pos++;
+            continue;
+        }
+
+        bc_stmt(ctx);
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        if (ctx->hit_exit)
+        {
+            return;
+        }
+
+        /* Consume trailing EOC */
+        t = tok_at(ctx, 0);
+        if (t != NULL && t->tok_type == TOK_EOC)
+        {
+            ctx->pos++;
+        }
+    }
+
+    /* Implicit program exit */
+    emit_byte(ctx, OP_EXIT);
+}
+
+/* ================================================================== */
 /*  irx_bc_compile                                                    */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
+
 int irx_bc_compile(struct envblock *envblock,
                    const char *source, int source_len,
                    struct irx_bc_execblk **bc_out)
@@ -52,14 +905,14 @@ int irx_bc_compile(struct envblock *envblock,
     struct irx_token *tokens = NULL;
     int tok_count = 0;
     struct irx_tokn_error tok_err;
-    unsigned char code[BCOM_MAX_CODE];
-    int code_len = 0;
-    int rc = IRXBC_OK;
-    int i;
-    int hit_exit = 0;
+    struct bcom_ctx *ctx = NULL;
+    void *ctx_mem = NULL;
     struct irx_bc_execblk *bc = NULL;
-    int total_size;
-    void *mem = NULL;
+    void *bc_mem = NULL;
+    int total;
+    char *dst;
+    int i;
+    int rc = IRXBC_OK;
 
     memset(&tok_err, 0, sizeof(tok_err));
 
@@ -69,7 +922,7 @@ int irx_bc_compile(struct envblock *envblock,
     }
     *bc_out = NULL;
 
-    /* 1. Tokenize -------------------------------------------------- */
+    /* 1. Tokenize */
     rc = irx_tokn_run(envblock, source, source_len,
                       &tokens, &tok_count, &tok_err);
     if (rc != 0)
@@ -77,99 +930,80 @@ int irx_bc_compile(struct envblock *envblock,
         return IRXBC_ERR_TOKN;
     }
 
-    /* 2. Walk token stream ----------------------------------------- */
-    for (i = 0; i < tok_count && !hit_exit; i++)
+    /* 2. Allocate compiler context */
+    if (irxstor(RXSMGET, (int)sizeof(struct bcom_ctx),
+                &ctx_mem, envblock) != 0)
     {
-        const struct irx_token *t = &tokens[i];
+        rc = IRXBC_ERR_STOR;
+        goto cleanup;
+    }
+    ctx = (struct bcom_ctx *)ctx_mem;
+    memset(ctx, 0, sizeof(struct bcom_ctx));
+    ctx->env = envblock;
+    ctx->tokens = tokens;
+    ctx->tok_count = tok_count;
+    ctx->rc = IRXBC_OK;
 
-        switch (t->tok_type)
-        {
-            case TOK_EOC:
-                /* Empty clause boundary — no bytecode emitted. */
-                break;
-
-            case TOK_EOF:
-                /* End of source — stop walking. */
-                i = tok_count; /* break outer loop */
-                break;
-
-            case TOK_SYMBOL:
-                if (t->tok_upper != NULL &&
-                    strcmp(t->tok_upper, "EXIT") == 0)
-                {
-                    /* EXIT statement: emit clause marker + exit opcode. */
-                    rc = emit(code, &code_len, OP_NEWCLAUSE);
-                    if (rc != IRXBC_OK)
-                    {
-                        goto cleanup;
-                    }
-                    rc = emit(code, &code_len, OP_EXIT);
-                    if (rc != IRXBC_OK)
-                    {
-                        goto cleanup;
-                    }
-                    hit_exit = 1;
-                }
-                else
-                {
-                    /* Any other symbol in Phase 1 is unsupported. */
-                    rc = IRXBC_ERR_UNSUP;
-                    goto cleanup;
-                }
-                break;
-
-            default:
-                /* Any token type not listed above is unsupported. */
-                rc = IRXBC_ERR_UNSUP;
-                goto cleanup;
-        }
+    /* 3. Compile */
+    bc_program(ctx);
+    rc = ctx->rc;
+    if (rc != IRXBC_OK)
+    {
+        goto cleanup;
     }
 
-    /* 3. Implicit program exit ------------------------------------- */
-    if (!hit_exit)
-    {
-        rc = emit(code, &code_len, OP_EXIT);
-        if (rc != IRXBC_OK)
-        {
-            goto cleanup;
-        }
-    }
+    /* 4. Allocate EXECBLK */
+    total = (int)sizeof(struct irx_bc_execblk) + ctx->const_count * IRXBC_ENTRY_SIZE + ctx->sym_count * IRXBC_ENTRY_SIZE + ctx->code_len;
 
-    /* 4. Allocate EXECBLK + bytecode payload ----------------------- */
-    total_size = (int)sizeof(struct irx_bc_execblk) + code_len;
-    if (irxstor(RXSMGET, total_size, &mem, envblock) != 0)
+    if (irxstor(RXSMGET, total, &bc_mem, envblock) != 0)
     {
         rc = IRXBC_ERR_STOR;
         goto cleanup;
     }
 
-    /* 5. Populate header ------------------------------------------ */
-    bc = (struct irx_bc_execblk *)mem;
-    memset(bc, 0, (size_t)total_size);
+    /* 5. Populate header */
+    bc = (struct irx_bc_execblk *)bc_mem;
+    memset(bc, 0, (size_t)total);
     memcpy(bc->magic, IRXBC_MAGIC, sizeof(bc->magic));
     bc->version = IRXBC_VERSION;
     bc->flags = 0;
-    bc->const_count = 0;
-    bc->symbol_count = 0;
-    bc->code_length = (uint32_t)code_len;
+    bc->const_count = (uint32_t)ctx->const_count;
+    bc->symbol_count = (uint32_t)ctx->sym_count;
+    bc->code_length = (uint32_t)ctx->code_len;
     bc->entry_offset = 0;
     bc->trace_map_offset = 0;
 
-    /* 6. Copy bytecode payload ------------------------------------ */
-    memcpy(IRXBC_CODE(bc), code, (size_t)code_len);
+    /* 6. Copy tables and bytecode */
+    dst = IRXBC_CONST_TBL(bc);
+    for (i = 0; i < ctx->const_count; i++)
+    {
+        memcpy(dst, ctx->consts[i], IRXBC_ENTRY_SIZE);
+        dst += IRXBC_ENTRY_SIZE;
+    }
+    dst = IRXBC_SYM_TBL(bc);
+    for (i = 0; i < ctx->sym_count; i++)
+    {
+        memcpy(dst, ctx->syms[i], IRXBC_ENTRY_SIZE);
+        dst += IRXBC_ENTRY_SIZE;
+    }
+    memcpy(IRXBC_CODE(bc), ctx->code, (size_t)ctx->code_len);
 
     *bc_out = bc;
-    bc = NULL; /* ownership transferred */
+    bc_mem = NULL; /* ownership transferred */
 
 cleanup:
     if (tokens != NULL)
     {
         irx_tokn_free(envblock, tokens, tok_count);
     }
-    if (bc != NULL)
+    if (ctx_mem != NULL)
     {
-        /* Allocation succeeded but a later step failed. */
-        void *p = bc;
+        void *p = ctx_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+    if (bc_mem != NULL)
+    {
+        void *p = bc_mem;
         irxstor(RXSMFRE, 0, &p, envblock);
     }
     return rc;

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -1,70 +1,864 @@
 /* ------------------------------------------------------------------ */
-/*  irx#bvm.c - REXX/370 Bytecode VM Loop Skeleton (WP-BC-01)        */
+/*  irx#bvm.c - REXX/370 Bytecode VM Loop (WP-BC-02)                 */
 /*                                                                    */
 /*  irx_bc_execute() — Entry point.                                  */
 /*                                                                    */
-/*  Phase 1 scope:                                                    */
-/*    - OP_NOP (0x00)      — advance PC                              */
-/*    - OP_EXIT (0x01)     — terminate with RC=0                     */
-/*    - OP_NEWCLAUSE (0x02)— clause boundary (no-op for Phase 1)    */
+/*  Phase 2 adds: stack slots, variable pool, arithmetic/comparison/ */
+/*  logical/string opcodes, and PUSH_LIT / LOAD / STORE / POP.      */
 /*                                                                    */
-/*  The big-switch dispatch is the canonical form: c2asm370 (GCC     */
-/*  3.2.3) generates an optimised branch table from a dense switch   */
-/*  on an unsigned char, matching BREXX-style dispatch performance.  */
-/*                                                                    */
-/*  Stack: bc_stack_slot is defined in irxbvm.h but no slot array   */
-/*  is allocated in Phase 1 — no opcode pushes or pops yet.  WP-BC- */
-/*  02 introduces the first stack-consuming opcode.                  */
+/*  Stack discipline: SP always points to the next FREE slot.        */
+/*    push: stack[sp++]                                              */
+/*    pop:  stack[--sp]                                              */
 /*                                                                    */
 /*  (c) 2026 mvslovers - REXX/370 Project                            */
 /* ------------------------------------------------------------------ */
 
+#include <string.h>
+
 #include "irx.h"
+#include "irxarith.h"
 #include "irxbops.h"
 #include "irxbvm.h"
 #include "irxexbl.h"
+#include "irxfunc.h"
+#include "irxlstr.h"
+#include "irxpars.h"
+#include "irxvpool.h"
+#include "irxwkblk.h"
 
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
+/*  Stack configuration                                               */
+/* ================================================================== */
+
+#define IRXBC_STACK_DEPTH 64
+
+/* ================================================================== */
+/*  Read a little-endian u16 from the bytecode stream.               */
+/* ================================================================== */
+
+static int read_u16(const unsigned char *pc)
+{
+    return (int)pc[0] | ((int)pc[1] << 8);
+}
+
+/* ================================================================== */
+/*  Retrieve a table entry string by index; place result in dst.     */
+/*  Returns the string length, or -1 on bad index.                   */
+/* ================================================================== */
+
+static int get_entry(const char *table_base, int table_count, int idx,
+                     const char **data_out)
+{
+    const char *entry;
+    int len;
+
+    if (idx < 0 || idx >= table_count)
+    {
+        *data_out = NULL;
+        return -1;
+    }
+    entry = table_base + idx * IRXBC_ENTRY_SIZE;
+    len = (int)(unsigned char)entry[0];
+    *data_out = entry + 1;
+    return len;
+}
+
+/* ================================================================== */
+/*  Lstr helpers                                                      */
+/* ================================================================== */
+
+/* Copy a raw byte buffer into a stack slot's Lstr, using the given
+ * lstring allocator.  Resets type_cache. */
+static int slot_set_buf(struct bc_stack_slot *slot,
+                        struct lstr_alloc *alloc,
+                        const char *buf, int len)
+{
+    int rc = Lfx(alloc, slot->str, (size_t)len);
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
+    if (len > 0)
+    {
+        memcpy(Lpstr(slot->str), buf, (size_t)len);
+    }
+    slot->str->len = (size_t)len;
+    slot->type_cache = 0;
+    slot->int_cache = 0;
+    return LSTR_OK;
+}
+
+/* Copy one slot's Lstr into another. */
+static int slot_copy(struct bc_stack_slot *dst,
+                     struct lstr_alloc *alloc,
+                     const struct bc_stack_slot *src)
+{
+    int rc = Lstrcpy(alloc, dst->str, src->str);
+    if (rc != LSTR_OK)
+    {
+        return rc;
+    }
+    dst->type_cache = src->type_cache;
+    dst->int_cache = src->int_cache;
+    return LSTR_OK;
+}
+
+/* Write "0" or "1" into a slot. */
+static int slot_set_bool(struct bc_stack_slot *slot,
+                         struct lstr_alloc *alloc, int val)
+{
+    const char *s = val ? "1" : "0";
+    return slot_set_buf(slot, alloc, s, 1);
+}
+
+/* ================================================================== */
+/*  Boolean evaluation (REXX: any non-zero integer is truthy, but    */
+/*  the spec requires "0" or "1" on the stack for boolean ops).      */
+/*  Returns 0 or 1, or -1 on error (not a valid REXX number / bool). */
+/* ================================================================== */
+
+static int slot_to_bool(const struct bc_stack_slot *slot)
+{
+    PLstr s = slot->str;
+    /* Accept only "0" or "1" for boolean operands per SC28-1883-0 §7. */
+    if (Llen(s) == 1 && Lpstr(s) != NULL)
+    {
+        char c = (char)Lpstr(s)[0];
+        if (c == '0')
+        {
+            return 0;
+        }
+        if (c == '1')
+        {
+            return 1;
+        }
+    }
+    return -1; /* not a boolean */
+}
+
+/* ================================================================== */
 /*  irx_bc_execute                                                    */
-/* ------------------------------------------------------------------ */
+/* ================================================================== */
+
 int irx_bc_execute(struct envblock *envblock,
                    struct irx_bc_execblk *bc,
                    int *rc_out)
 {
     const unsigned char *pc;
     unsigned char op;
-
-    (void)envblock; /* not yet consumed in Phase 1 */
+    struct lstr_alloc *alloc = NULL;
+    struct irx_vpool *vpool = NULL;
+    struct bc_stack_slot *stack = NULL;
+    Lstr *lstrs = NULL;
+    void *stack_mem = NULL;
+    void *lstr_mem = NULL;
+    int sp = 0; /* next free slot */
+    int vm_rc = IRXBC_OK;
+    int i;
 
     if (bc == NULL)
     {
         return IRXBC_ERR_OPCODE;
     }
 
-    pc = IRXBC_ENTRY(bc);
-
-    for (;;)
+    /* --- Allocator -------------------------------------------------- */
+    alloc = irx_lstr_init(envblock);
+    if (alloc == NULL)
     {
-        op = *pc++;
+        return IRXBC_ERR_STOR;
+    }
 
-        switch (op)
+    /* --- Stack: bc_stack_slot array ---------------------------------- */
+    if (irxstor(RXSMGET,
+                IRXBC_STACK_DEPTH * (int)sizeof(struct bc_stack_slot),
+                &stack_mem, envblock) != 0)
+    {
+        return IRXBC_ERR_STOR;
+    }
+    memset(stack_mem, 0, IRXBC_STACK_DEPTH * sizeof(struct bc_stack_slot));
+    stack = (struct bc_stack_slot *)stack_mem;
+
+    /* --- Stack: backing Lstr array ----------------------------------- */
+    if (irxstor(RXSMGET,
+                IRXBC_STACK_DEPTH * (int)sizeof(Lstr),
+                &lstr_mem, envblock) != 0)
+    {
+        vm_rc = IRXBC_ERR_STOR;
+        goto done;
+    }
+    memset(lstr_mem, 0, IRXBC_STACK_DEPTH * sizeof(Lstr));
+    lstrs = (Lstr *)lstr_mem;
+
+    for (i = 0; i < IRXBC_STACK_DEPTH; i++)
+    {
+        stack[i].str = &lstrs[i];
+    }
+
+    /* --- Variable pool ----------------------------------------------- */
+    vpool = vpool_create(alloc, NULL);
+    if (vpool == NULL)
+    {
+        vm_rc = IRXBC_ERR_STOR;
+        goto done;
+    }
+
+    /* --- Fetch constants / symbol table pointers --------------------- */
+    {
+        const char *const_base = IRXBC_CONST_TBL(bc);
+        const char *sym_base = IRXBC_SYM_TBL(bc);
+        int n_consts = (int)bc->const_count;
+        int n_syms = (int)bc->symbol_count;
+
+        pc = IRXBC_ENTRY(bc);
+
+        /* ---- VM loop ------------------------------------------------ */
+        for (;;)
         {
-            case OP_NOP:
-                break;
+            op = *pc++;
 
-            case OP_NEWCLAUSE:
-                /* Phase 1: no-op — TRACE hook reserved for WP-BC-03. */
-                break;
+            switch (op)
+            {
+                /* ---- Phase 1 ---------------------------------------- */
+                case OP_NOP:
+                    break;
 
-            case OP_EXIT:
-                if (rc_out != NULL)
+                case OP_NEWCLAUSE:
+                    break;
+
+                case OP_EXIT:
+                    if (rc_out != NULL)
+                    {
+                        *rc_out = 0;
+                    }
+                    goto done;
+
+                case OP_EXIT_RC:
                 {
-                    *rc_out = 0;
-                }
-                return IRXBC_OK;
+                    int rcval = 0;
 
-            default:
-                return IRXBC_ERR_OPCODE;
+                    if (sp >= 1)
+                    {
+                        PLstr s = stack[sp - 1].str;
+                        const unsigned char *p = Lpstr(s);
+                        size_t len = Llen(s);
+                        size_t ki;
+                        int neg = 0;
+
+                        if (p != NULL && len > 0)
+                        {
+                            ki = 0;
+                            if (p[ki] == (unsigned char)'-')
+                            {
+                                neg = 1;
+                                ki++;
+                            }
+                            else if (p[ki] == (unsigned char)'+')
+                            {
+                                ki++;
+                            }
+                            while (ki < len &&
+                                   p[ki] >= (unsigned char)'0' &&
+                                   p[ki] <= (unsigned char)'9')
+                            {
+                                rcval = rcval * 10 +
+                                        (int)(p[ki] - (unsigned char)'0');
+                                ki++;
+                            }
+                            if (neg)
+                            {
+                                rcval = -rcval;
+                            }
+                        }
+                        sp--;
+                    }
+                    if (rc_out != NULL)
+                    {
+                        *rc_out = rcval;
+                    }
+                    goto done;
+                }
+
+                /* ---- Stack ops -------------------------------------- */
+                case OP_PUSH_LIT:
+                {
+                    int idx = read_u16(pc);
+                    const char *data;
+                    int len;
+
+                    pc += 2;
+                    if (sp >= IRXBC_STACK_DEPTH)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    len = get_entry(const_base, n_consts, idx, &data);
+                    if (len < 0)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+                    if (slot_set_buf(&stack[sp], alloc,
+                                     data, len) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    sp++;
+                    break;
+                }
+
+                case OP_POP:
+                {
+                    int n = (int)*pc++;
+                    if (sp < n)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    sp -= n;
+                    break;
+                }
+
+                case OP_DUP:
+                {
+                    if (sp < 1 || sp >= IRXBC_STACK_DEPTH)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    if (slot_copy(&stack[sp], alloc,
+                                  &stack[sp - 1]) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    sp++;
+                    break;
+                }
+
+                /* ---- Variable ops ---------------------------------- */
+                case OP_LOAD:
+                {
+                    int idx = read_u16(pc);
+                    const char *name_data;
+                    int name_len;
+                    Lstr name_lstr;
+                    int vrc;
+
+                    pc += 2;
+                    if (sp >= IRXBC_STACK_DEPTH)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    name_len =
+                        get_entry(sym_base, n_syms, idx, &name_data);
+                    if (name_len < 0)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+
+                    Lzeroinit(&name_lstr);
+                    if (Lfx(alloc, &name_lstr,
+                            (size_t)name_len) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    memcpy(Lpstr(&name_lstr), name_data,
+                           (size_t)name_len);
+                    name_lstr.len = (size_t)name_len;
+
+                    vrc = vpool_get(vpool, &name_lstr,
+                                    stack[sp].str);
+                    if (vrc == VPOOL_NOT_FOUND)
+                    {
+                        /* NOVALUE: variable value is its own name */
+                        if (Lstrcpy(alloc, stack[sp].str,
+                                    &name_lstr) != LSTR_OK)
+                        {
+                            Lfree(alloc, &name_lstr);
+                            vm_rc = IRXBC_ERR_STOR;
+                            goto done;
+                        }
+                    }
+                    else if (vrc != VPOOL_OK)
+                    {
+                        Lfree(alloc, &name_lstr);
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    stack[sp].type_cache = 0;
+                    stack[sp].int_cache = 0;
+                    sp++;
+                    Lfree(alloc, &name_lstr);
+                    break;
+                }
+
+                case OP_STORE:
+                {
+                    int idx = read_u16(pc);
+                    const char *name_data;
+                    int name_len;
+                    Lstr name_lstr;
+                    int vrc;
+
+                    pc += 2;
+                    if (sp < 1)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    name_len =
+                        get_entry(sym_base, n_syms, idx, &name_data);
+                    if (name_len < 0)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+
+                    Lzeroinit(&name_lstr);
+                    if (Lfx(alloc, &name_lstr,
+                            (size_t)name_len) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    memcpy(Lpstr(&name_lstr), name_data,
+                           (size_t)name_len);
+                    name_lstr.len = (size_t)name_len;
+
+                    sp--;
+                    vrc = vpool_set(vpool, &name_lstr,
+                                    stack[sp].str);
+                    Lfree(alloc, &name_lstr);
+                    if (vrc != VPOOL_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                case OP_DROP:
+                {
+                    int idx = read_u16(pc);
+                    const char *name_data;
+                    int name_len;
+                    Lstr name_lstr;
+
+                    pc += 2;
+                    name_len =
+                        get_entry(sym_base, n_syms, idx, &name_data);
+                    if (name_len < 0)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+
+                    Lzeroinit(&name_lstr);
+                    if (Lfx(alloc, &name_lstr,
+                            (size_t)name_len) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    memcpy(Lpstr(&name_lstr), name_data,
+                           (size_t)name_len);
+                    name_lstr.len = (size_t)name_len;
+                    vpool_drop(vpool, &name_lstr);
+                    Lfree(alloc, &name_lstr);
+                    break;
+                }
+
+                /* ---- Arithmetic ------------------------------------ */
+                case OP_ADD:
+                case OP_SUB:
+                case OP_MUL:
+                case OP_DIV:
+                case OP_IDIV:
+                case OP_MOD:
+                case OP_POW:
+                {
+                    static const enum irx_arith_opcode arith_map[] = {
+                        ARITH_ADD,    /* OP_ADD  0x30 */
+                        ARITH_SUB,    /* OP_SUB  0x31 */
+                        ARITH_MUL,    /* OP_MUL  0x32 */
+                        ARITH_DIV,    /* OP_DIV  0x33 */
+                        ARITH_INTDIV, /* OP_IDIV 0x34 */
+                        ARITH_MOD,    /* OP_MOD  0x35 */
+                        ARITH_POWER   /* OP_POW  0x36 */
+                    };
+                    enum irx_arith_opcode aop =
+                        arith_map[op - OP_ADD];
+                    int arc;
+
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    /* stack[sp-2] = a, stack[sp-1] = b */
+                    arc = irx_arith_op(envblock,
+                                       stack[sp - 2].str,
+                                       stack[sp - 1].str,
+                                       aop,
+                                       stack[sp - 2].str);
+                    sp--;
+                    if (arc != IRXPARS_OK)
+                    {
+                        vm_rc = IRXBC_ERR_ARITH;
+                        goto done;
+                    }
+                    stack[sp - 1].type_cache = 0;
+                    break;
+                }
+
+                case OP_NEG:
+                {
+                    int arc;
+
+                    if (sp < 1)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    arc = irx_arith_op(envblock,
+                                       stack[sp - 1].str, NULL,
+                                       ARITH_NEG,
+                                       stack[sp - 1].str);
+                    if (arc != IRXPARS_OK)
+                    {
+                        vm_rc = IRXBC_ERR_ARITH;
+                        goto done;
+                    }
+                    stack[sp - 1].type_cache = 0;
+                    break;
+                }
+
+                /* ---- Comparison ------------------------------------ */
+                case OP_EQ:
+                case OP_NE:
+                case OP_LT:
+                case OP_LE:
+                case OP_GT:
+                case OP_GE:
+                {
+                    int cmp;
+                    int result;
+                    int arc;
+
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    arc = irx_arith_compare(envblock,
+                                            stack[sp - 2].str,
+                                            stack[sp - 1].str,
+                                            &cmp);
+                    sp--;
+                    if (arc != IRXPARS_OK)
+                    {
+                        /* Fall back to string comparison */
+                        int slen_a = (int)Llen(stack[sp - 1].str);
+                        int slen_b = (int)Llen(stack[sp].str);
+                        int min_len =
+                            slen_a < slen_b ? slen_a : slen_b;
+                        int scmp = (Lpstr(stack[sp - 1].str) &&
+                                    Lpstr(stack[sp].str))
+                                       ? memcmp(Lpstr(stack[sp - 1].str),
+                                                Lpstr(stack[sp].str),
+                                                (size_t)min_len)
+                                       : 0;
+                        if (scmp == 0)
+                        {
+                            cmp = slen_a - slen_b;
+                        }
+                        else
+                        {
+                            cmp = scmp < 0 ? -1 : 1;
+                        }
+                    }
+                    switch (op)
+                    {
+                        case OP_EQ:
+                            result = (cmp == 0);
+                            break;
+                        case OP_NE:
+                            result = (cmp != 0);
+                            break;
+                        case OP_LT:
+                            result = (cmp < 0);
+                            break;
+                        case OP_LE:
+                            result = (cmp <= 0);
+                            break;
+                        case OP_GT:
+                            result = (cmp > 0);
+                            break;
+                        case OP_GE:
+                            result = (cmp >= 0);
+                            break;
+                        default:
+                            result = 0;
+                            break;
+                    }
+                    if (slot_set_bool(&stack[sp - 1], alloc,
+                                      result) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                case OP_DEQ:
+                case OP_DNE:
+                case OP_DLT:
+                case OP_DLE:
+                case OP_DGT:
+                case OP_DGE:
+                {
+                    /* Strict comparison: no numeric coercion, no FUZZ. */
+                    int la, lb, min_len, cmp;
+                    int result;
+
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    la = (int)Llen(stack[sp - 2].str);
+                    lb = (int)Llen(stack[sp - 1].str);
+                    min_len = la < lb ? la : lb;
+                    if (Lpstr(stack[sp - 2].str) &&
+                        Lpstr(stack[sp - 1].str))
+                    {
+                        cmp = memcmp(Lpstr(stack[sp - 2].str),
+                                     Lpstr(stack[sp - 1].str),
+                                     (size_t)min_len);
+                    }
+                    else
+                    {
+                        cmp = 0;
+                    }
+                    if (cmp == 0)
+                    {
+                        cmp = la - lb;
+                    }
+                    sp--;
+                    switch (op)
+                    {
+                        case OP_DEQ:
+                            result = (cmp == 0);
+                            break;
+                        case OP_DNE:
+                            result = (cmp != 0);
+                            break;
+                        case OP_DLT:
+                            result = (cmp < 0);
+                            break;
+                        case OP_DLE:
+                            result = (cmp <= 0);
+                            break;
+                        case OP_DGT:
+                            result = (cmp > 0);
+                            break;
+                        case OP_DGE:
+                            result = (cmp >= 0);
+                            break;
+                        default:
+                            result = 0;
+                            break;
+                    }
+                    if (slot_set_bool(&stack[sp - 1], alloc,
+                                      result) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                /* ---- Logical ops ----------------------------------- */
+                case OP_AND:
+                {
+                    int a, b;
+
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    a = slot_to_bool(&stack[sp - 2]);
+                    b = slot_to_bool(&stack[sp - 1]);
+                    if (a < 0 || b < 0)
+                    {
+                        vm_rc = IRXBC_ERR_ARITH;
+                        goto done;
+                    }
+                    sp--;
+                    if (slot_set_bool(&stack[sp - 1], alloc,
+                                      a & b) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                case OP_OR:
+                {
+                    int a, b;
+
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    a = slot_to_bool(&stack[sp - 2]);
+                    b = slot_to_bool(&stack[sp - 1]);
+                    if (a < 0 || b < 0)
+                    {
+                        vm_rc = IRXBC_ERR_ARITH;
+                        goto done;
+                    }
+                    sp--;
+                    if (slot_set_bool(&stack[sp - 1], alloc,
+                                      a | b) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                case OP_XOR:
+                {
+                    int a, b;
+
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    a = slot_to_bool(&stack[sp - 2]);
+                    b = slot_to_bool(&stack[sp - 1]);
+                    if (a < 0 || b < 0)
+                    {
+                        vm_rc = IRXBC_ERR_ARITH;
+                        goto done;
+                    }
+                    sp--;
+                    if (slot_set_bool(&stack[sp - 1], alloc,
+                                      a ^ b) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                case OP_NOT:
+                {
+                    int a;
+
+                    if (sp < 1)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    a = slot_to_bool(&stack[sp - 1]);
+                    if (a < 0)
+                    {
+                        vm_rc = IRXBC_ERR_ARITH;
+                        goto done;
+                    }
+                    if (slot_set_bool(&stack[sp - 1], alloc,
+                                      !a) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                /* ---- String ops ------------------------------------ */
+                case OP_CONCAT:
+                {
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    /* Append stack[sp-1] to stack[sp-2] in-place. */
+                    if (Lstrcat(alloc, stack[sp - 2].str,
+                                stack[sp - 1].str) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    sp--;
+                    stack[sp - 1].type_cache = 0;
+                    break;
+                }
+
+                case OP_BCONCAT:
+                {
+                    if (sp < 2)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    /* Insert one blank then append. */
+                    if (Lcat(alloc, stack[sp - 2].str, " ") != LSTR_OK ||
+                        Lstrcat(alloc, stack[sp - 2].str,
+                                stack[sp - 1].str) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    sp--;
+                    stack[sp - 1].type_cache = 0;
+                    break;
+                }
+
+                default:
+                    vm_rc = IRXBC_ERR_OPCODE;
+                    goto done;
+            }
         }
     }
+
+done:
+    /* Free Lstr buffers */
+    if (lstrs != NULL)
+    {
+        for (i = 0; i < IRXBC_STACK_DEPTH; i++)
+        {
+            Lfree(alloc, &lstrs[i]);
+        }
+    }
+
+    /* Destroy variable pool */
+    if (vpool != NULL)
+    {
+        vpool_destroy(vpool);
+    }
+
+    /* Free heap arrays */
+    if (lstr_mem != NULL)
+    {
+        void *p = lstr_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+    if (stack_mem != NULL)
+    {
+        void *p = stack_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+
+    return vm_rc;
 }

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -173,7 +173,8 @@ int irx_bc_execute(struct envblock *envblock,
                 IRXBC_STACK_DEPTH * (int)sizeof(struct bc_stack_slot),
                 &stack_mem, envblock) != 0)
     {
-        return IRXBC_ERR_STOR;
+        vm_rc = IRXBC_ERR_STOR;
+        goto done;
     }
     memset(stack_mem, 0, IRXBC_STACK_DEPTH * sizeof(struct bc_stack_slot));
     stack = (struct bc_stack_slot *)stack_mem;

--- a/test/host/tstbc_expr.c
+++ b/test/host/tstbc_expr.c
@@ -1,0 +1,457 @@
+/* ------------------------------------------------------------------ */
+/*  test/host/tstbc_expr.c — WP-BC-02 expression + assignment tests   */
+/*                                                                    */
+/*  Two test modes:                                                   */
+/*    1. Compile-only: check bytecode structure for known snippets.   */
+/*    2. Equivalence: run the same program via token-walk and via the  */
+/*       bytecode VM; compare exit codes.  A program ending with      */
+/*       EXIT <expr> is used as the observable output.               */
+/*                                                                    */
+/*  Build (Linux):                                                    */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -O0 -g \                           */
+/*        -o /tmp/tstbc_expr test/host/tstbc_expr.c \                 */
+/*        'src/irx#init.c'  'src/irx#term.c'  'src/irx#stor.c' \    */
+/*        'src/irx#anch.c'  'src/irx#env.c'   'src/irx#uid.c'  \    */
+/*        'src/irx#msid.c'  'src/irx#cond.c'  'src/irx#bif.c'  \    */
+/*        'src/irx#bifs.c'  'src/irx#io.c'    'src/irx#lstr.c' \    */
+/*        'src/irx#tokn.c'  'src/irx#vpol.c'  'src/irx#pars.c' \    */
+/*        'src/irx#ctrl.c'  'src/irx#exec.c'  'src/irx#arith.c' \   */
+/*        'src/irx#bcom.c'  'src/irx#bvm.c' \                        */
+/*        '../lstring370/src/lstr#cor.c' \                            */
+/*        '../lstring370/src/lstr#cvt.c' \                            */
+/*        '../lstring370/src/lstr#fmt.c' \                            */
+/*        '../lstring370/src/lstr#srch.c' \                           */
+/*        '../lstring370/src/lstr#sub.c' \                            */
+/*        '../lstring370/src/lstr#wrd.c' \                            */
+/*        '../lstring370/src/lstr#xlt.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexbl.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Run src through both interpreter paths; compare exit codes.       */
+/*  expected_tw and expected_bc are the expected exit codes.          */
+/* ------------------------------------------------------------------ */
+static void run_both(const char *desc, const char *src,
+                     int expected_tw, int expected_bc)
+{
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    int tw_rc = -999;
+    int bc_rc = -999;
+    int ok;
+    char msg[80];
+    int src_len = (int)strlen(src);
+
+    printf("  [%s]\n", desc);
+
+    /* token-walk */
+    ok = (irxinit(NULL, &env) == 0 && env != NULL);
+    if (ok)
+    {
+        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        if (wk != NULL)
+        {
+            wk->wkbi_use_bytecode = 0;
+        }
+        ok = (irx_exec_run(src, src_len, NULL, 0, &tw_rc, env) == 0);
+        irxterm(env);
+        env = NULL;
+    }
+    if (!ok)
+    {
+        tw_rc = -1;
+    }
+
+    /* bytecode */
+    ok = (irxinit(NULL, &env) == 0 && env != NULL);
+    if (ok)
+    {
+        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        if (wk != NULL)
+        {
+            wk->wkbi_use_bytecode = 1;
+        }
+        ok = (irx_exec_run(src, src_len, NULL, 0, &bc_rc, env) == 0);
+        irxterm(env);
+        env = NULL;
+    }
+    if (!ok)
+    {
+        bc_rc = -1;
+    }
+
+    snprintf(msg, sizeof(msg), "%s: token-walk rc==%d", desc, expected_tw);
+    CHECK(tw_rc == expected_tw, msg);
+    snprintf(msg, sizeof(msg), "%s: bytecode rc==%d", desc, expected_bc);
+    CHECK(bc_rc == expected_bc, msg);
+    snprintf(msg, sizeof(msg), "%s: bytecode==token-walk", desc);
+    CHECK(bc_rc == tw_rc, msg);
+}
+
+/* Both paths should agree; use when only one expected value is needed. */
+#define EQUIV(desc, src, expected) \
+    run_both(desc, src, expected, expected)
+
+/* ------------------------------------------------------------------ */
+/*  Compile-only structural checks                                    */
+/* ------------------------------------------------------------------ */
+static void test_compile_assignment(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    const unsigned char *code;
+    int rc;
+
+    printf("  [compile: x = 5]\n");
+
+    rc = irx_bc_compile(env, "x = 5", (int)strlen("x = 5"), &bc);
+    CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
+    CHECK(bc != NULL, "bc pointer is non-NULL");
+
+    if (bc == NULL)
+    {
+        return;
+    }
+
+    CHECK(bc->const_count == 1, "const_count == 1");
+    CHECK(bc->symbol_count == 1, "symbol_count == 1");
+
+    code = IRXBC_CODE(bc);
+    /* OP_NEWCLAUSE, OP_PUSH_LIT idx:u16, OP_STORE idx:u16, OP_EXIT */
+    CHECK(code[0] == OP_NEWCLAUSE, "code[0]==OP_NEWCLAUSE");
+    CHECK(code[1] == OP_PUSH_LIT, "code[1]==OP_PUSH_LIT");
+    CHECK(code[2] == 0, "code[2]==0 (const idx lo)");
+    CHECK(code[3] == 0, "code[3]==0 (const idx hi)");
+    CHECK(code[4] == OP_STORE, "code[4]==OP_STORE");
+    CHECK(code[5] == 0, "code[5]==0 (sym idx lo)");
+    CHECK(code[6] == 0, "code[6]==0 (sym idx hi)");
+    CHECK(code[7] == OP_EXIT, "code[7]==OP_EXIT");
+    CHECK(bc->code_length == 8, "code_length==8");
+
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+static void test_compile_expr(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    const unsigned char *code;
+    int rc;
+
+    printf("  [compile: x = 3 + 4]\n");
+
+    rc = irx_bc_compile(env, "x = 3 + 4", (int)strlen("x = 3 + 4"), &bc);
+    CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
+    CHECK(bc != NULL, "bc pointer is non-NULL");
+
+    if (bc == NULL)
+    {
+        return;
+    }
+
+    CHECK(bc->const_count == 2, "const_count==2 (literals '3','4')");
+    CHECK(bc->symbol_count == 1, "symbol_count==1 ('X')");
+
+    code = IRXBC_CODE(bc);
+    CHECK(code[0] == OP_NEWCLAUSE, "code[0]==OP_NEWCLAUSE");
+    CHECK(code[1] == OP_PUSH_LIT, "code[1]==OP_PUSH_LIT (3)");
+    CHECK(code[4] == OP_PUSH_LIT, "code[4]==OP_PUSH_LIT (4)");
+    CHECK(code[7] == OP_ADD, "code[7]==OP_ADD");
+    CHECK(code[8] == OP_STORE, "code[8]==OP_STORE");
+    CHECK(code[11] == OP_EXIT, "code[11]==OP_EXIT");
+
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+static void test_compile_exit_rc(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    const unsigned char *code;
+    int rc;
+
+    printf("  [compile: EXIT 7]\n");
+
+    rc = irx_bc_compile(env, "EXIT 7", (int)strlen("EXIT 7"), &bc);
+    CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
+    CHECK(bc != NULL, "bc pointer is non-NULL");
+
+    if (bc == NULL)
+    {
+        return;
+    }
+
+    CHECK(bc->const_count == 1, "const_count==1 (literal '7')");
+    CHECK(bc->symbol_count == 0, "symbol_count==0");
+
+    code = IRXBC_CODE(bc);
+    /* OP_NEWCLAUSE, PUSH_LIT 0 0, OP_EXIT_RC */
+    CHECK(code[0] == OP_NEWCLAUSE, "code[0]==OP_NEWCLAUSE");
+    CHECK(code[1] == OP_PUSH_LIT, "code[1]==OP_PUSH_LIT");
+    CHECK(code[4] == OP_EXIT_RC, "code[4]==OP_EXIT_RC");
+    CHECK(bc->code_length == 5, "code_length==5");
+
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Equivalence tests — use EXIT expr to expose the computed value    */
+/* ------------------------------------------------------------------ */
+
+static void test_equiv_literal(void)
+{
+    EQUIV("exit literal", "EXIT 42", 42);
+}
+
+static void test_equiv_add(void)
+{
+    EQUIV("add", "EXIT 3 + 4", 7);
+}
+
+static void test_equiv_sub(void)
+{
+    EQUIV("sub", "EXIT 10 - 3", 7);
+}
+
+static void test_equiv_mul(void)
+{
+    EQUIV("mul", "EXIT 3 * 4", 12);
+}
+
+static void test_equiv_idiv(void)
+{
+    EQUIV("idiv", "EXIT 10 % 3", 3);
+}
+
+static void test_equiv_mod(void)
+{
+    EQUIV("mod", "EXIT 10 // 3", 1);
+}
+
+static void test_equiv_pow(void)
+{
+    EQUIV("pow", "EXIT 2 ** 8", 256);
+}
+
+static void test_equiv_neg(void)
+{
+    EQUIV("neg", "EXIT -(10 - 3)", -7);
+}
+
+static void test_equiv_parens(void)
+{
+    EQUIV("parens", "EXIT (2 + 3) * 4", 20);
+}
+
+static void test_equiv_cmp_eq_true(void)
+{
+    EQUIV("cmp_eq_true", "EXIT (3 = 3)", 1);
+}
+
+static void test_equiv_cmp_eq_false(void)
+{
+    EQUIV("cmp_eq_false", "EXIT (3 = 4)", 0);
+}
+
+static void test_equiv_cmp_gt(void)
+{
+    EQUIV("cmp_gt", "EXIT (5 > 3)", 1);
+}
+
+static void test_equiv_cmp_lt(void)
+{
+    EQUIV("cmp_lt", "EXIT (3 < 5)", 1);
+}
+
+static void test_equiv_cmp_ne(void)
+{
+    EQUIV("cmp_ne", "EXIT (3 \\= 4)", 1);
+}
+
+static void test_equiv_cmp_ge(void)
+{
+    EQUIV("cmp_ge", "EXIT (3 >= 3)", 1);
+}
+
+static void test_equiv_cmp_le(void)
+{
+    EQUIV("cmp_le", "EXIT (3 <= 3)", 1);
+}
+
+static void test_equiv_strict_eq(void)
+{
+    EQUIV("strict_eq_true", "EXIT ('abc' == 'abc')", 1);
+    EQUIV("strict_eq_false", "EXIT ('abc' == 'ABC')", 0);
+}
+
+static void test_equiv_logical_and(void)
+{
+    EQUIV("and_tt", "EXIT (1 & 1)", 1);
+    EQUIV("and_tf", "EXIT (1 & 0)", 0);
+}
+
+static void test_equiv_logical_or(void)
+{
+    EQUIV("or_ff", "EXIT (0 | 0)", 0);
+    EQUIV("or_tf", "EXIT (1 | 0)", 1);
+}
+
+static void test_equiv_logical_xor(void)
+{
+    EQUIV("xor_tf", "EXIT (0 && 1)", 1);
+    EQUIV("xor_tt", "EXIT (1 && 1)", 0);
+}
+
+static void test_equiv_logical_not(void)
+{
+    EQUIV("not_true", "EXIT (\\1)", 0);
+    EQUIV("not_false", "EXIT (\\0)", 1);
+}
+
+static void test_equiv_var_assign(void)
+{
+    EQUIV("var_assign", "x = 5\nEXIT x", 5);
+}
+
+static void test_equiv_var_arith(void)
+{
+    EQUIV("var_arith",
+          "x = 10\n"
+          "y = x - 3\n"
+          "EXIT y",
+          7);
+}
+
+static void test_equiv_two_vars(void)
+{
+    EQUIV("two_vars",
+          "a = 3\n"
+          "b = 4\n"
+          "EXIT a + b",
+          7);
+}
+
+static void test_equiv_novalue(void)
+{
+    /* In REXX: unset variable Y has value "Y" (its name in uppercase).
+     * "Y" == "Y" is a strict comparison that returns 1. */
+    EQUIV("novalue", "EXIT (y == 'Y')", 1);
+}
+
+static void test_equiv_concat(void)
+{
+    EQUIV("concat_explicit", "EXIT ('hello' || 'world' == 'helloworld')", 1);
+    EQUIV("concat_abuttal", "EXIT ('foo' 'bar' == 'foo bar')", 1);
+}
+
+static void test_equiv_arith_to_logical(void)
+{
+    /* Arithmetic result used as boolean operand. */
+    EQUIV("arith_to_logical", "EXIT ((1 + 0) & 1)", 1);
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+int main(void)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    printf("=== WP-BC-02 Expression + Assignment Tests ===\n\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbc_expr: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    /* Compile-only structural checks */
+    test_compile_assignment(env);
+    test_compile_expr(env);
+    test_compile_exit_rc(env);
+
+    irxterm(env);
+
+    /* Equivalence harness — each creates its own envblocks */
+    test_equiv_literal();
+    test_equiv_add();
+    test_equiv_sub();
+    test_equiv_mul();
+    test_equiv_idiv();
+    test_equiv_mod();
+    test_equiv_pow();
+    test_equiv_neg();
+    test_equiv_parens();
+    test_equiv_cmp_eq_true();
+    test_equiv_cmp_eq_false();
+    test_equiv_cmp_gt();
+    test_equiv_cmp_lt();
+    test_equiv_cmp_ne();
+    test_equiv_cmp_ge();
+    test_equiv_cmp_le();
+    test_equiv_strict_eq();
+    test_equiv_logical_and();
+    test_equiv_logical_or();
+    test_equiv_logical_xor();
+    test_equiv_logical_not();
+    test_equiv_var_assign();
+    test_equiv_var_arith();
+    test_equiv_two_vars();
+    test_equiv_novalue();
+    test_equiv_concat();
+    test_equiv_arith_to_logical();
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Extends the bytecode compiler and VM from the Phase 1 skeleton to handle the full REXX expression grammar
- 30 new opcodes: arithmetic (ADD/SUB/MUL/DIV/IDIV/MOD/POW/NEG), comparison (EQ through strict DGE), logical (AND/OR/XOR/NOT), string (CONCAT/BCONCAT), stack (PUSH_LIT/POP/DUP), variable (LOAD/STORE/DROP), and EXIT_RC
- 9-level precedence cascade compiler with composite operator lookahead and NOVALUE semantics
- Stack-based VM with private vpool per execution; EBCDIC-safe integer parsing in OP_EXIT_RC
- 130/130 tests pass; WP-BC-01 tests (23+16) unaffected

## Test plan

- [ ] `gcc … -o /tmp/tstbc_expr test/host/tstbc_expr.c …` builds clean (no warnings with `-Wall -Wextra`)
- [ ] `/tmp/tstbc_expr` → `130/130 passed`
- [ ] `/tmp/tstbc_compile` → `23/23 passed` (WP-BC-01 regression)
- [ ] `/tmp/tstbc_execute` → `16/16 passed` (WP-BC-01 regression)

Fixes #143