### PR TITLE
feat(bytecode): WP-BC-CLEAN — bytecode hot-path performance cleanup

### DIFF
--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -4,8 +4,9 @@
 /*  Opcode encoding for the bytecode VM.                             */
 /*                                                                    */
 /*  Operand-bearing opcodes carry inline operands:                   */
+/*    4-byte: op + n:u8 + i16-le offset  (DECFOR)                    */
 /*    3-byte: op + i16-le signed offset  (JMP, JF, JT, ITERATE,     */
-/*            LEAVE, DECFOR)                                          */
+/*            LEAVE)                                                  */
 /*    3-byte: op + u16-le index          (PUSH_LIT, LOAD, STORE,    */
 /*            DROP)                                                   */
 /*    2-byte: op + u8                    (POP, FORINIT, BYINIT)      */
@@ -119,9 +120,9 @@
 /* ================================================================== */
 
 #define OP_TOINT   0x71 /* 1 byte — coerce TOS to integer string   */
-#define OP_FORINIT 0x72 /* 2 bytes: op + n:u8 — pop count → frame  */
+#define OP_FORINIT 0x72 /* 2 bytes: op + n:u8 — pop count → frame[n], push bool (count>0) */
 #define OP_BYINIT  0x73 /* 2 bytes: op + n:u8 — reserved           */
-#define OP_DECFOR  0x74 /* 3 bytes: op + i16 — dec frame, JT back  */
+#define OP_DECFOR  0x74 /* 4 bytes: op + n:u8 + i16 — dec frame[n], jump-if-done */
 #define OP_DOTEST  0x75 /* 1 byte — reserved (WHILE/UNTIL via JF)  */
 
 /* ================================================================== */
@@ -151,7 +152,7 @@
      ((op) == OP_JT)       ? 3 :      \
      ((op) == OP_FORINIT)  ? 2 :      \
      ((op) == OP_BYINIT)   ? 2 :      \
-     ((op) == OP_DECFOR)   ? 3 :      \
+     ((op) == OP_DECFOR)   ? 4 :      \
      ((op) == OP_ITERATE)  ? 3 :      \
      ((op) == OP_LEAVE)    ? 3 :      \
      1)
@@ -170,6 +171,7 @@
 #define IRXBC_ERR_STACK  25 /* stack underflow or overflow           */
 #define IRXBC_ERR_PATCH  26 /* too many forward-jump patches         */
 #define IRXBC_ERR_LOOP   27 /* DO nesting too deep                   */
-#define IRXBC_ERR_IO     28 /* I/O routine call failed               */
+#define IRXBC_ERR_IO         28 /* I/O routine call failed               */
+#define IRXBC_ERR_STRTOOLONG 29 /* literal/symbol exceeds IRXBC_STR_MAX  */
 
 #endif /* IRXBOPS_H */

--- a/include/irxbvm.h
+++ b/include/irxbvm.h
@@ -40,7 +40,7 @@ struct bc_stack_slot
 {
     PLstr str;          /* canonical string form; always present      */
     int32_t type_cache; /* 0=none, 1=integer, see LINTEGER_TY etc.   */
-    int64_t int_cache;  /* integer fast-path value                    */
+    int32_t int_cache;  /* integer fast-path value                    */
 };
 
 /* ================================================================== */

--- a/include/irxvpool.h
+++ b/include/irxvpool.h
@@ -26,6 +26,8 @@
 #ifndef IRXVPOOL_H
 #define IRXVPOOL_H
 
+#include <stdint.h>
+
 #include "lstralloc.h"
 #include "lstring.h"
 
@@ -58,6 +60,8 @@ struct vpool_entry
     Lstr value;                      /* variable value              */
     int flags;                       /* VPOOL_DROPPED / _EXPOSED_REF */
     struct vpool_entry *exposed_ref; /* -> parent entry if exposed  */
+    int32_t type_cache; /* 0=unknown, IRXBC_STACK_LINTEGER=1        */
+    int64_t int_cache;  /* integer value when type_cache==1         */
 };
 
 /* ================================================================== */
@@ -125,5 +129,25 @@ int vpool_expose_stem(struct irx_vpool *pool,
 int vpool_next(struct irx_vpool *pool,
                PLstr name, PLstr value) asm("VPOOLNXT");
 void vpool_next_reset(struct irx_vpool *pool) asm("VPOOLNRS");
+
+/* Buffer-pointer variants — bypass temporary Lstr allocation.
+ * The name is passed as (data, len) directly; no irxstor call is made
+ * for the lookup key.  type_cache/int_cache propagate the bytecode VM
+ * integer fast-path through variable load/store round-trips. */
+int vpool_get_buf(struct irx_vpool *pool,
+                  const char *name_data, int name_len,
+                  PLstr value,
+                  int32_t *type_cache_out,
+                  int64_t *int_cache_out) asm("VPOOLGTB");
+
+int vpool_set_buf(struct irx_vpool *pool,
+                  const char *name_data, int name_len,
+                  const PLstr value,
+                  int32_t type_cache,
+                  int64_t int_cache) asm("VPOOLSTB");
+
+int vpool_drop_buf(struct irx_vpool *pool,
+                   const char *name_data,
+                   int name_len) asm("VPOOLDRB");
 
 #endif /* IRXVPOOL_H */

--- a/include/irxvpool.h
+++ b/include/irxvpool.h
@@ -60,8 +60,8 @@ struct vpool_entry
     Lstr value;                      /* variable value              */
     int flags;                       /* VPOOL_DROPPED / _EXPOSED_REF */
     struct vpool_entry *exposed_ref; /* -> parent entry if exposed  */
-    int32_t type_cache; /* 0=unknown, IRXBC_STACK_LINTEGER=1        */
-    int64_t int_cache;  /* integer value when type_cache==1         */
+    int32_t type_cache;              /* 0=unknown, IRXBC_STACK_LINTEGER=1        */
+    int32_t int_cache;               /* integer value when type_cache==1         */
 };
 
 /* ================================================================== */
@@ -138,13 +138,13 @@ int vpool_get_buf(struct irx_vpool *pool,
                   const char *name_data, int name_len,
                   PLstr value,
                   int32_t *type_cache_out,
-                  int64_t *int_cache_out) asm("VPOOLGTB");
+                  int32_t *int_cache_out) asm("VPOOLGTB");
 
 int vpool_set_buf(struct irx_vpool *pool,
                   const char *name_data, int name_len,
                   const PLstr value,
                   int32_t type_cache,
-                  int64_t int_cache) asm("VPOOLSTB");
+                  int32_t int_cache) asm("VPOOLSTB");
 
 int vpool_drop_buf(struct irx_vpool *pool,
                    const char *name_data,

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -37,9 +37,9 @@
 /*  Compiler limits                                                   */
 /* ================================================================== */
 
-#define BCOM_MAX_CODE   4096
-#define BCOM_MAX_CONSTS 128
-#define BCOM_MAX_SYMS   128
+#define BCOM_MAX_CODE   16384
+#define BCOM_MAX_CONSTS 512
+#define BCOM_MAX_SYMS   512
 #define BCOM_MAX_LOOP   16
 #define BCOM_MAX_LPATCH 48
 #define BCOM_MAX_LABEL  33
@@ -280,7 +280,8 @@ static int add_const(struct bcom_ctx *ctx, const char *text, int len)
     int i;
     if (len > IRXBC_STR_MAX)
     {
-        len = IRXBC_STR_MAX;
+        ctx->rc = IRXBC_ERR_STRTOOLONG;
+        return -1;
     }
     for (i = 0; i < ctx->const_count; i++)
     {
@@ -292,6 +293,7 @@ static int add_const(struct bcom_ctx *ctx, const char *text, int len)
     }
     if (ctx->const_count >= BCOM_MAX_CONSTS)
     {
+        ctx->rc = IRXBC_ERR_STOR;
         return -1;
     }
     i = ctx->const_count++;
@@ -309,7 +311,8 @@ static int add_sym(struct bcom_ctx *ctx, const char *name)
     int len = (int)strlen(name);
     if (len > IRXBC_STR_MAX)
     {
-        len = IRXBC_STR_MAX;
+        ctx->rc = IRXBC_ERR_STRTOOLONG;
+        return -1;
     }
     for (i = 0; i < ctx->sym_count; i++)
     {
@@ -321,6 +324,7 @@ static int add_sym(struct bcom_ctx *ctx, const char *name)
     }
     if (ctx->sym_count >= BCOM_MAX_SYMS)
     {
+        ctx->rc = IRXBC_ERR_STOR;
         return -1;
     }
     i = ctx->sym_count++;
@@ -335,7 +339,6 @@ static void emit_push_int(struct bcom_ctx *ctx, const char *s)
     int ci = add_const(ctx, s, (int)strlen(s));
     if (ci < 0)
     {
-        ctx->rc = IRXBC_ERR_STOR;
         return;
     }
     emit_byte(ctx, OP_PUSH_LIT);
@@ -520,7 +523,6 @@ static void bc_exp8(struct bcom_ctx *ctx)
         int ci = add_const(ctx, t->tok_text, (int)t->tok_length);
         if (ci < 0)
         {
-            ctx->rc = IRXBC_ERR_STOR;
             return;
         }
         ctx->pos++;
@@ -534,7 +536,6 @@ static void bc_exp8(struct bcom_ctx *ctx)
         int ci = add_const(ctx, t->tok_text, (int)t->tok_length);
         if (ci < 0)
         {
-            ctx->rc = IRXBC_ERR_STOR;
             return;
         }
         ctx->pos++;
@@ -550,7 +551,6 @@ static void bc_exp8(struct bcom_ctx *ctx)
             int ci = add_const(ctx, t->tok_text, (int)t->tok_length);
             if (ci < 0)
             {
-                ctx->rc = IRXBC_ERR_STOR;
                 return;
             }
             ctx->pos++;
@@ -564,7 +564,6 @@ static void bc_exp8(struct bcom_ctx *ctx)
             int si = add_sym(ctx, name);
             if (si < 0)
             {
-                ctx->rc = IRXBC_ERR_STOR;
                 return;
             }
             ctx->pos++;
@@ -1281,13 +1280,11 @@ static void C_do_bc(struct bcom_ctx *ctx)
     int loop_type = BCTL_DO_FOREVER;
     int cond_jf = -1;
 
-    int si_ctr = -1;
     int si_var = -1;
     int si_lim = -1;
     int si_stp = -1;
     int si_for = -1;
 
-    char sym_ctr[24];
     char sym_lim[24];
     char sym_stp[24];
     char sym_for[24];
@@ -1297,7 +1294,6 @@ static void C_do_bc(struct bcom_ctx *ctx)
 
     int depth = ctx->loop_depth;
 
-    make_do_sym(sym_ctr, depth, "CTR");
     make_do_sym(sym_lim, depth, "LIM");
     make_do_sym(sym_stp, depth, "STP");
     make_do_sym(sym_for, depth, "FOR");
@@ -1350,7 +1346,6 @@ static void C_do_bc(struct bcom_ctx *ctx)
         si_stp = add_sym(ctx, sym_stp);
         if (si_var < 0 || si_lim < 0 || si_stp < 0)
         {
-            ctx->rc = IRXBC_ERR_STOR;
             return;
         }
 
@@ -1404,7 +1399,6 @@ static void C_do_bc(struct bcom_ctx *ctx)
             si_for = add_sym(ctx, sym_for);
             if (si_for < 0)
             {
-                ctx->rc = IRXBC_ERR_STOR;
                 return;
             }
             bc_exp0(ctx);
@@ -1417,20 +1411,13 @@ static void C_do_bc(struct bcom_ctx *ctx)
     }
     else
     {
-        /* DO count_expr */
+        /* DO count_expr — count stays on eval stack; FORINIT consumes it */
         loop_type = BCTL_DO_COUNT;
-        si_ctr = add_sym(ctx, sym_ctr);
-        if (si_ctr < 0)
-        {
-            ctx->rc = IRXBC_ERR_STOR;
-            return;
-        }
         bc_exp0(ctx);
         if (ctx->rc != IRXBC_OK)
         {
             return;
         }
-        emit_store(ctx, si_ctr);
     }
 
     consume_eoc(ctx);
@@ -1440,6 +1427,19 @@ static void C_do_bc(struct bcom_ctx *ctx)
     if (lf == NULL)
     {
         return;
+    }
+
+    /* ---- DO COUNT: FORINIT + entry guard (once, before loop_top) -- */
+    if (loop_type == BCTL_DO_COUNT)
+    {
+        emit_byte(ctx, OP_FORINIT);
+        emit_byte(ctx, (unsigned char)depth);
+        cond_jf = emit_jmp_op(ctx, OP_JF);
+        if (cond_jf < 0 || ctx->rc != IRXBC_OK)
+        {
+            loop_pop(ctx);
+            return;
+        }
     }
 
     /* ---- loop_top ------------------------------------------------- */
@@ -1468,19 +1468,6 @@ static void C_do_bc(struct bcom_ctx *ctx)
             return;
         }
         consume_eoc(ctx);
-        cond_jf = emit_jmp_op(ctx, OP_JF);
-        if (cond_jf < 0)
-        {
-            loop_pop(ctx);
-            return;
-        }
-    }
-    else if (loop_type == BCTL_DO_COUNT)
-    {
-        /* Exit if counter <= 0 */
-        emit_load(ctx, si_ctr);
-        emit_push_int(ctx, "0");
-        emit_byte(ctx, OP_GT);
         cond_jf = emit_jmp_op(ctx, OP_JF);
         if (cond_jf < 0)
         {
@@ -1532,11 +1519,22 @@ static void C_do_bc(struct bcom_ctx *ctx)
 
     if (loop_type == BCTL_DO_COUNT)
     {
+        int decfor_pos;
         loop_set_iterate(ctx, lf, ctx->code_len);
-        emit_load(ctx, si_ctr);
-        emit_push_int(ctx, "1");
-        emit_byte(ctx, OP_SUB);
-        emit_store(ctx, si_ctr);
+        /* DECFOR: dec frame[depth]; jump to loop_end when exhausted */
+        decfor_pos = ctx->code_len;
+        emit_byte(ctx, OP_DECFOR);
+        emit_byte(ctx, (unsigned char)depth);
+        emit_i16(ctx, 0); /* placeholder — patched after backward JMP */
+        emit_jmp_back(ctx, OP_JMP, loop_top);
+        /* ctx->code_len is now loop_end; patch DECFOR i16 */
+        if (ctx->rc == IRXBC_OK)
+        {
+            int off = ctx->code_len - (decfor_pos + 4);
+            unsigned int uv = (unsigned int)(short)(off);
+            ctx->code[decfor_pos + 2] = (unsigned char)(uv & 0xFF);
+            ctx->code[decfor_pos + 3] = (unsigned char)((uv >> 8) & 0xFF);
+        }
     }
     else if (loop_type == BCTL_DO_TO)
     {
@@ -1583,15 +1581,16 @@ static void C_do_bc(struct bcom_ctx *ctx)
         }
     }
 
-    /* ---- JMP back to loop_top (omitted for DO BLOCK) ------------- */
+    /* ---- JMP back to loop_top (omitted for DO BLOCK and DO COUNT) -- */
     if (loop_type == BCTL_DO_BLOCK)
     {
         /* Simple group: no backward jump.  ITERATE and LEAVE both
          * resolve to loop_end (the fall-through point). */
         loop_set_iterate(ctx, lf, ctx->code_len);
     }
-    else
+    else if (loop_type != BCTL_DO_COUNT)
     {
+        /* DO COUNT already emitted DECFOR + JMP back in the iterate section */
         emit_jmp_back(ctx, OP_JMP, loop_top);
     }
 
@@ -1847,7 +1846,6 @@ static void bc_stmt(struct bcom_ctx *ctx)
         int si = add_sym(ctx, name);
         if (si < 0)
         {
-            ctx->rc = IRXBC_ERR_STOR;
             return;
         }
         ctx->pos += 2;

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -42,7 +42,7 @@
 
 struct bc_do_frame
 {
-    int64_t counter;
+    int32_t counter;
 };
 
 /* ================================================================== */
@@ -170,7 +170,7 @@ static void try_parse_int_cache(struct bc_stack_slot *slot,
                                 const char *data, int len)
 {
     const unsigned char *p = (const unsigned char *)data;
-    int64_t v = 0;
+    int32_t v = 0;
     int neg = 0;
     int i = 0;
 
@@ -197,19 +197,19 @@ static void try_parse_int_cache(struct bc_stack_slot *slot,
         {
             return; /* non-digit — not a plain integer */
         }
-        v = v * 10 + (int64_t)(p[i] - (unsigned char)'0');
+        v = v * 10 + (int32_t)(p[i] - (unsigned char)'0');
     }
     slot->type_cache = IRXBC_STACK_LINTEGER;
     slot->int_cache = neg ? -v : v;
 }
 
-/* Convert a stack slot to int64.  Uses cached value when available;
+/* Convert a stack slot to int32.  Uses cached value when available;
  * otherwise parses the string.  Returns 0 for non-integer strings. */
-static int64_t slot_to_int64(const struct bc_stack_slot *slot)
+static int32_t slot_to_int32(const struct bc_stack_slot *slot)
 {
     const unsigned char *p;
     size_t len;
-    int64_t v = 0;
+    int32_t v = 0;
     int neg = 0;
     size_t i = 0;
 
@@ -238,16 +238,16 @@ static int64_t slot_to_int64(const struct bc_stack_slot *slot)
         {
             return 0; /* non-integer string — 0 iterations */
         }
-        v = v * 10 + (int64_t)(p[i] - (unsigned char)'0');
+        v = v * 10 + (int32_t)(p[i] - (unsigned char)'0');
     }
     return neg ? -v : v;
 }
 
-/* Format int64 into buf (no NUL terminator); return length. */
-static int i64toa(int64_t v, char *buf)
+/* Format int32 into buf (no NUL terminator); return length. */
+static int i64toa(int32_t v, char *buf)
 {
     char tmp[21];
-    uint64_t uv;
+    unsigned int uv;
     int i = 0;
     int neg = 0;
     int len;
@@ -256,11 +256,11 @@ static int i64toa(int64_t v, char *buf)
     if (v < 0)
     {
         neg = 1;
-        uv = (uint64_t)(-(v + 1)) + 1u;
+        uv = (unsigned int)(-(v + 1)) + 1u;
     }
     else
     {
-        uv = (uint64_t)v;
+        uv = (unsigned int)v;
     }
     if (uv == 0)
     {
@@ -294,9 +294,9 @@ static int try_arith_fast(struct bc_stack_slot *dst,
                           unsigned char op,
                           struct lstr_alloc *alloc)
 {
-    int64_t va;
-    int64_t vb;
-    int64_t result;
+    int32_t va;
+    int32_t vb;
+    int32_t result;
     char buf[24];
     int len;
 
@@ -601,9 +601,9 @@ int irx_bc_execute(struct envblock *envblock,
                     stack[sp].type_cache = 0;
                     stack[sp].int_cache = 0;
                     vrc = vpool_get_buf(vpool, name_data, name_len,
-                                       stack[sp].str,
-                                       &stack[sp].type_cache,
-                                       &stack[sp].int_cache);
+                                        stack[sp].str,
+                                        &stack[sp].type_cache,
+                                        &stack[sp].int_cache);
                     if (vrc == VPOOL_NOT_FOUND)
                     {
                         /* NOVALUE: value is the variable name itself */
@@ -1134,7 +1134,7 @@ int irx_bc_execute(struct envblock *envblock,
                 case OP_FORINIT:
                 {
                     unsigned char n = *pc++;
-                    int64_t count;
+                    int32_t count;
 
                     if (sp < 1)
                     {
@@ -1147,7 +1147,7 @@ int irx_bc_execute(struct envblock *envblock,
                         goto done;
                     }
                     sp--;
-                    count = slot_to_int64(&stack[sp]);
+                    count = slot_to_int32(&stack[sp]);
                     frames[n].counter = count;
                     if (slot_set_bool(&stack[sp], alloc,
                                       count > 0) != LSTR_OK)

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -32,7 +32,18 @@
 /*  Stack configuration                                               */
 /* ================================================================== */
 
-#define IRXBC_STACK_DEPTH 64
+#define IRXBC_STACK_DEPTH 256
+
+/* ================================================================== */
+/*  DO-loop frame (one per nesting level; up to IRXBC_DO_DEPTH deep)  */
+/* ================================================================== */
+
+#define IRXBC_DO_DEPTH 16
+
+struct bc_do_frame
+{
+    int64_t counter;
+};
 
 /* ================================================================== */
 /*  Read a little-endian u16 from the bytecode stream.               */
@@ -150,6 +161,208 @@ static int slot_to_bool(const struct bc_stack_slot *slot)
 }
 
 /* ================================================================== */
+/*  Integer fast-path helpers                                         */
+/* ================================================================== */
+
+/* If data[0..len-1] is a plain decimal integer (optional leading sign),
+ * populate slot->type_cache and slot->int_cache.  Otherwise no-op. */
+static void try_parse_int_cache(struct bc_stack_slot *slot,
+                                const char *data, int len)
+{
+    const unsigned char *p = (const unsigned char *)data;
+    int64_t v = 0;
+    int neg = 0;
+    int i = 0;
+
+    if (len <= 0)
+    {
+        return;
+    }
+    if (p[i] == (unsigned char)'-')
+    {
+        neg = 1;
+        i++;
+    }
+    else if (p[i] == (unsigned char)'+')
+    {
+        i++;
+    }
+    if (i >= len)
+    {
+        return; /* sign only */
+    }
+    for (; i < len; i++)
+    {
+        if (p[i] < (unsigned char)'0' || p[i] > (unsigned char)'9')
+        {
+            return; /* non-digit — not a plain integer */
+        }
+        v = v * 10 + (int64_t)(p[i] - (unsigned char)'0');
+    }
+    slot->type_cache = IRXBC_STACK_LINTEGER;
+    slot->int_cache = neg ? -v : v;
+}
+
+/* Convert a stack slot to int64.  Uses cached value when available;
+ * otherwise parses the string.  Returns 0 for non-integer strings. */
+static int64_t slot_to_int64(const struct bc_stack_slot *slot)
+{
+    const unsigned char *p;
+    size_t len;
+    int64_t v = 0;
+    int neg = 0;
+    size_t i = 0;
+
+    if (slot->type_cache == IRXBC_STACK_LINTEGER)
+    {
+        return slot->int_cache;
+    }
+    p = (const unsigned char *)Lpstr(slot->str);
+    len = Llen(slot->str);
+    if (p == NULL || len == 0)
+    {
+        return 0;
+    }
+    if (p[i] == (unsigned char)'-')
+    {
+        neg = 1;
+        i++;
+    }
+    else if (p[i] == (unsigned char)'+')
+    {
+        i++;
+    }
+    for (; i < len; i++)
+    {
+        if (p[i] < (unsigned char)'0' || p[i] > (unsigned char)'9')
+        {
+            return 0; /* non-integer string — 0 iterations */
+        }
+        v = v * 10 + (int64_t)(p[i] - (unsigned char)'0');
+    }
+    return neg ? -v : v;
+}
+
+/* Format int64 into buf (no NUL terminator); return length. */
+static int i64toa(int64_t v, char *buf)
+{
+    char tmp[21];
+    uint64_t uv;
+    int i = 0;
+    int neg = 0;
+    int len;
+    int j;
+
+    if (v < 0)
+    {
+        neg = 1;
+        uv = (uint64_t)(-(v + 1)) + 1u;
+    }
+    else
+    {
+        uv = (uint64_t)v;
+    }
+    if (uv == 0)
+    {
+        tmp[i++] = '0';
+    }
+    else
+    {
+        while (uv > 0)
+        {
+            tmp[i++] = (char)('0' + (int)(uv % 10u));
+            uv /= 10u;
+        }
+        if (neg)
+        {
+            tmp[i++] = '-';
+        }
+    }
+    len = i;
+    for (j = 0; i > 0; j++)
+    {
+        buf[j] = tmp[--i];
+    }
+    return len;
+}
+
+/* Attempt integer fast-path for binary arithmetic ops.
+ * Returns 1 and writes result into dst on success; 0 to fall back. */
+static int try_arith_fast(struct bc_stack_slot *dst,
+                          const struct bc_stack_slot *a,
+                          const struct bc_stack_slot *b,
+                          unsigned char op,
+                          struct lstr_alloc *alloc)
+{
+    int64_t va;
+    int64_t vb;
+    int64_t result;
+    char buf[24];
+    int len;
+
+    if (a->type_cache != IRXBC_STACK_LINTEGER ||
+        b->type_cache != IRXBC_STACK_LINTEGER)
+    {
+        return 0;
+    }
+    va = a->int_cache;
+    vb = b->int_cache;
+
+    switch (op)
+    {
+        case OP_ADD:
+            result = va + vb;
+            /* Overflow: same-sign operands with different-sign result */
+            if (((va ^ vb) >= 0) && ((result ^ va) < 0))
+            {
+                return 0;
+            }
+            break;
+        case OP_SUB:
+            result = va - vb;
+            if (((va ^ vb) < 0) && ((result ^ va) < 0))
+            {
+                return 0;
+            }
+            break;
+        case OP_MUL:
+            /* Avoid overflow: bail if either operand is large */
+            if (va > 1000000000LL || va < -1000000000LL ||
+                vb > 1000000000LL || vb < -1000000000LL)
+            {
+                return 0;
+            }
+            result = va * vb;
+            break;
+        case OP_IDIV:
+            if (vb == 0)
+            {
+                return 0; /* division by zero — let arith engine handle */
+            }
+            result = va / vb;
+            break;
+        case OP_MOD:
+            if (vb == 0)
+            {
+                return 0;
+            }
+            result = va % vb;
+            break;
+        default:
+            return 0;
+    }
+
+    len = i64toa(result, buf);
+    if (slot_set_buf(dst, alloc, buf, len) != LSTR_OK)
+    {
+        return 0;
+    }
+    dst->type_cache = IRXBC_STACK_LINTEGER;
+    dst->int_cache = result;
+    return 1;
+}
+
+/* ================================================================== */
 /*  irx_bc_execute                                                    */
 /* ================================================================== */
 
@@ -162,9 +375,11 @@ int irx_bc_execute(struct envblock *envblock,
     struct lstr_alloc *alloc = NULL;
     struct irx_vpool *vpool = NULL;
     struct bc_stack_slot *stack = NULL;
+    struct bc_do_frame *frames = NULL;
     Lstr *lstrs = NULL;
     void *stack_mem = NULL;
     void *lstr_mem = NULL;
+    void *frames_mem = NULL;
     int sp = 0; /* next free slot */
     int vm_rc = IRXBC_OK;
     int i;
@@ -207,6 +422,17 @@ int irx_bc_execute(struct envblock *envblock,
     {
         stack[i].str = &lstrs[i];
     }
+
+    /* --- DO-loop frame array ----------------------------------------- */
+    if (irxstor(RXSMGET,
+                IRXBC_DO_DEPTH * (int)sizeof(struct bc_do_frame),
+                &frames_mem, envblock) != 0)
+    {
+        vm_rc = IRXBC_ERR_STOR;
+        goto done;
+    }
+    memset(frames_mem, 0, IRXBC_DO_DEPTH * sizeof(struct bc_do_frame));
+    frames = (struct bc_do_frame *)frames_mem;
 
     /* --- Variable pool ----------------------------------------------- */
     vpool = vpool_create(alloc, NULL);
@@ -317,6 +543,7 @@ int irx_bc_execute(struct envblock *envblock,
                         vm_rc = IRXBC_ERR_STOR;
                         goto done;
                     }
+                    try_parse_int_cache(&stack[sp], data, len);
                     sp++;
                     break;
                 }
@@ -356,7 +583,6 @@ int irx_bc_execute(struct envblock *envblock,
                     int idx = read_u16(pc);
                     const char *name_data;
                     int name_len;
-                    Lstr name_lstr;
                     int vrc;
 
                     pc += 2;
@@ -372,41 +598,28 @@ int irx_bc_execute(struct envblock *envblock,
                         vm_rc = IRXBC_ERR_OPCODE;
                         goto done;
                     }
-
-                    Lzeroinit(&name_lstr);
-                    if (Lfx(alloc, &name_lstr,
-                            (size_t)name_len) != LSTR_OK)
-                    {
-                        vm_rc = IRXBC_ERR_STOR;
-                        goto done;
-                    }
-                    memcpy(Lpstr(&name_lstr), name_data,
-                           (size_t)name_len);
-                    name_lstr.len = (size_t)name_len;
-
-                    vrc = vpool_get(vpool, &name_lstr,
-                                    stack[sp].str);
+                    stack[sp].type_cache = 0;
+                    stack[sp].int_cache = 0;
+                    vrc = vpool_get_buf(vpool, name_data, name_len,
+                                       stack[sp].str,
+                                       &stack[sp].type_cache,
+                                       &stack[sp].int_cache);
                     if (vrc == VPOOL_NOT_FOUND)
                     {
-                        /* NOVALUE: variable value is its own name */
-                        if (Lstrcpy(alloc, stack[sp].str,
-                                    &name_lstr) != LSTR_OK)
+                        /* NOVALUE: value is the variable name itself */
+                        if (slot_set_buf(&stack[sp], alloc,
+                                         name_data, name_len) != LSTR_OK)
                         {
-                            Lfree(alloc, &name_lstr);
                             vm_rc = IRXBC_ERR_STOR;
                             goto done;
                         }
                     }
                     else if (vrc != VPOOL_OK)
                     {
-                        Lfree(alloc, &name_lstr);
                         vm_rc = IRXBC_ERR_STOR;
                         goto done;
                     }
-                    stack[sp].type_cache = 0;
-                    stack[sp].int_cache = 0;
                     sp++;
-                    Lfree(alloc, &name_lstr);
                     break;
                 }
 
@@ -415,7 +628,6 @@ int irx_bc_execute(struct envblock *envblock,
                     int idx = read_u16(pc);
                     const char *name_data;
                     int name_len;
-                    Lstr name_lstr;
                     int vrc;
 
                     pc += 2;
@@ -431,22 +643,11 @@ int irx_bc_execute(struct envblock *envblock,
                         vm_rc = IRXBC_ERR_OPCODE;
                         goto done;
                     }
-
-                    Lzeroinit(&name_lstr);
-                    if (Lfx(alloc, &name_lstr,
-                            (size_t)name_len) != LSTR_OK)
-                    {
-                        vm_rc = IRXBC_ERR_STOR;
-                        goto done;
-                    }
-                    memcpy(Lpstr(&name_lstr), name_data,
-                           (size_t)name_len);
-                    name_lstr.len = (size_t)name_len;
-
                     sp--;
-                    vrc = vpool_set(vpool, &name_lstr,
-                                    stack[sp].str);
-                    Lfree(alloc, &name_lstr);
+                    vrc = vpool_set_buf(vpool, name_data, name_len,
+                                        stack[sp].str,
+                                        stack[sp].type_cache,
+                                        stack[sp].int_cache);
                     if (vrc != VPOOL_OK)
                     {
                         vm_rc = IRXBC_ERR_STOR;
@@ -460,7 +661,6 @@ int irx_bc_execute(struct envblock *envblock,
                     int idx = read_u16(pc);
                     const char *name_data;
                     int name_len;
-                    Lstr name_lstr;
 
                     pc += 2;
                     name_len =
@@ -470,19 +670,7 @@ int irx_bc_execute(struct envblock *envblock,
                         vm_rc = IRXBC_ERR_OPCODE;
                         goto done;
                     }
-
-                    Lzeroinit(&name_lstr);
-                    if (Lfx(alloc, &name_lstr,
-                            (size_t)name_len) != LSTR_OK)
-                    {
-                        vm_rc = IRXBC_ERR_STOR;
-                        goto done;
-                    }
-                    memcpy(Lpstr(&name_lstr), name_data,
-                           (size_t)name_len);
-                    name_lstr.len = (size_t)name_len;
-                    vpool_drop(vpool, &name_lstr);
-                    Lfree(alloc, &name_lstr);
+                    vpool_drop_buf(vpool, name_data, name_len);
                     break;
                 }
 
@@ -512,6 +700,14 @@ int irx_bc_execute(struct envblock *envblock,
                     {
                         vm_rc = IRXBC_ERR_STACK;
                         goto done;
+                    }
+                    /* Integer fast-path: skip REXX arithmetic for simple ops */
+                    if (op != OP_DIV && op != OP_POW &&
+                        try_arith_fast(&stack[sp - 2], &stack[sp - 2],
+                                       &stack[sp - 1], op, alloc))
+                    {
+                        sp--;
+                        break;
                     }
                     /* stack[sp-2] = a, stack[sp-1] = b */
                     arc = irx_arith_op(envblock,
@@ -926,19 +1122,60 @@ int irx_bc_execute(struct envblock *envblock,
                     break;
                 }
 
-                /* ---- DO loop ops (WP-BC-03) — stubs ---------------- */
+                /* ---- DO loop ops (WP-BC-03) ----------------------- */
                 case OP_TOINT:
                 case OP_DOTEST:
                     break;
 
-                case OP_FORINIT:
                 case OP_BYINIT:
-                    pc++; /* skip u8 operand */
+                    pc++; /* skip u8 operand (reserved) */
                     break;
 
-                case OP_DECFOR:
-                    pc += 2; /* skip i16 operand */
+                case OP_FORINIT:
+                {
+                    unsigned char n = *pc++;
+                    int64_t count;
+
+                    if (sp < 1)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    if (n >= IRXBC_DO_DEPTH)
+                    {
+                        vm_rc = IRXBC_ERR_LOOP;
+                        goto done;
+                    }
+                    sp--;
+                    count = slot_to_int64(&stack[sp]);
+                    frames[n].counter = count;
+                    if (slot_set_bool(&stack[sp], alloc,
+                                      count > 0) != LSTR_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    sp++;
                     break;
+                }
+
+                case OP_DECFOR:
+                {
+                    unsigned char n = *pc++;
+                    int off = read_i16(pc);
+                    pc += 2;
+                    if (n >= IRXBC_DO_DEPTH)
+                    {
+                        vm_rc = IRXBC_ERR_LOOP;
+                        goto done;
+                    }
+                    frames[n].counter--;
+                    if (frames[n].counter <= 0)
+                    {
+                        pc += off;
+                    }
+                    break;
+                }
 
                 default:
                     vm_rc = IRXBC_ERR_OPCODE;
@@ -964,6 +1201,11 @@ done:
     }
 
     /* Free heap arrays */
+    if (frames_mem != NULL)
+    {
+        void *p = frames_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
     if (lstr_mem != NULL)
     {
         void *p = lstr_mem;

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -197,6 +197,10 @@ static void try_parse_int_cache(struct bc_stack_slot *slot,
         {
             return; /* non-digit — not a plain integer */
         }
+        if (v > 99999999)
+        {
+            return; /* would overflow int32 fast path */
+        }
         v = v * 10 + (int32_t)(p[i] - (unsigned char)'0');
     }
     slot->type_cache = IRXBC_STACK_LINTEGER;
@@ -244,7 +248,7 @@ static int32_t slot_to_int32(const struct bc_stack_slot *slot)
 }
 
 /* Format int32 into buf (no NUL terminator); return length. */
-static int i64toa(int32_t v, char *buf)
+static int i32toa(int32_t v, char *buf)
 {
     char tmp[21];
     unsigned int uv;
@@ -327,8 +331,8 @@ static int try_arith_fast(struct bc_stack_slot *dst,
             break;
         case OP_MUL:
             /* Avoid overflow: bail if either operand is large */
-            if (va > 1000000000LL || va < -1000000000LL ||
-                vb > 1000000000LL || vb < -1000000000LL)
+            if (va > 1000000000 || va < -1000000000 ||
+                vb > 1000000000 || vb < -1000000000)
             {
                 return 0;
             }
@@ -352,7 +356,7 @@ static int try_arith_fast(struct bc_stack_slot *dst,
             return 0;
     }
 
-    len = i64toa(result, buf);
+    len = i32toa(result, buf);
     if (slot_set_buf(dst, alloc, buf, len) != LSTR_OK)
     {
         return 0;

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -1393,6 +1393,16 @@ static int kw_iterate(struct irx_parser *p)
             return IRXPARS_OK;
         }
     }
+    else if (f->do_type == DO_COUNT)
+    {
+        if (f->ctrl_count <= 0)
+        {
+            p->tok_pos = f->loop_end;
+            irx_ctrl_frame_pop(p);
+            return IRXPARS_OK;
+        }
+        f->ctrl_count--;
+    }
 
     p->tok_pos = f->loop_start;
     return IRXPARS_OK;

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -861,41 +861,39 @@ int vpool_get_buf(struct irx_vpool *pool, const char *name_data, int name_len,
     }
 
     /* Stem default fallback. */
+    int dot = first_dot(&name);
+    if (dot >= 0 && name.len > (size_t)(dot + 1))
     {
-        int dot = first_dot(&name);
-        if (dot >= 0 && name.len > (size_t)(dot + 1))
+        Lstr stem_key;
+        int stem_idx;
+        struct vpool_entry *stem_e;
+
+        stem_key.pstr = name.pstr;
+        stem_key.len = (size_t)(dot + 1);
+        stem_key.maxlen = stem_key.len;
+        stem_key.type = LSTRING_TY;
+
+        stem_idx = bucket_index(pool, &stem_key);
+        stem_e = find_in_bucket(pool->buckets[stem_idx], &stem_key);
+        if (stem_e != NULL)
         {
-            Lstr stem_key;
-            int stem_idx;
-            struct vpool_entry *stem_e;
-
-            stem_key.pstr = name.pstr;
-            stem_key.len = (size_t)(dot + 1);
-            stem_key.maxlen = stem_key.len;
-            stem_key.type = LSTRING_TY;
-
-            stem_idx = bucket_index(pool, &stem_key);
-            stem_e = find_in_bucket(pool->buckets[stem_idx], &stem_key);
-            if (stem_e != NULL)
+            tgt = resolve_ref(stem_e);
+            if (tgt != NULL && !(tgt->flags & VPOOL_UNSET))
             {
-                tgt = resolve_ref(stem_e);
-                if (tgt != NULL && !(tgt->flags & VPOOL_UNSET))
+                rc = Lstrcpy(pool->alloc, value, &tgt->value);
+                if (rc != LSTR_OK)
                 {
-                    rc = Lstrcpy(pool->alloc, value, &tgt->value);
-                    if (rc != LSTR_OK)
-                    {
-                        return VPOOL_NOMEM;
-                    }
-                    if (tc_out != NULL)
-                    {
-                        *tc_out = tgt->type_cache;
-                    }
-                    if (ic_out != NULL)
-                    {
-                        *ic_out = tgt->int_cache;
-                    }
-                    return VPOOL_OK;
+                    return VPOOL_NOMEM;
                 }
+                if (tc_out != NULL)
+                {
+                    *tc_out = tgt->type_cache;
+                }
+                if (ic_out != NULL)
+                {
+                    *ic_out = tgt->int_cache;
+                }
+                return VPOOL_OK;
             }
         }
     }

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -86,6 +86,8 @@ static void vp_entry_init(struct vpool_entry *e)
     Lzeroinit(&e->value);
     e->flags = 0;
     e->exposed_ref = NULL;
+    e->type_cache = 0;
+    e->int_cache = 0;
 }
 
 static struct vpool_entry *vp_entry_new(struct lstr_alloc *a)
@@ -434,6 +436,8 @@ int vpool_set(struct irx_vpool *pool, const PLstr name, const PLstr value)
             return VPOOL_NOMEM;
         }
         tgt->flags &= ~VPOOL_UNSET;
+        tgt->type_cache = 0;
+        tgt->int_cache = 0;
         return VPOOL_OK;
     }
 
@@ -800,4 +804,192 @@ int vpool_next(struct irx_vpool *pool, PLstr name, PLstr value)
     /* Pre-advance so the caller can detect the final entry: if the
      * advance lands us at the end, next call returns VPOOL_LAST. */
     return VPOOL_OK;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Buffer-pointer variants (no irxstor call for the lookup key)      */
+/* ------------------------------------------------------------------ */
+
+int vpool_get_buf(struct irx_vpool *pool, const char *name_data, int name_len,
+                  PLstr value, int32_t *tc_out, int64_t *ic_out)
+{
+    Lstr name;
+    int idx;
+    int rc;
+    struct vpool_entry *e;
+    struct vpool_entry *tgt;
+
+    if (pool == NULL || name_data == NULL || value == NULL)
+    {
+        return VPOOL_BADARG;
+    }
+
+    name.pstr = (unsigned char *)name_data;
+    name.len = (size_t)name_len;
+    name.maxlen = (size_t)name_len;
+    name.type = LSTRING_TY;
+
+    if (matches_exposed_stem(pool, &name) && pool->parent != NULL)
+    {
+        return vpool_get_buf(pool->parent, name_data, name_len, value,
+                             tc_out, ic_out);
+    }
+
+    idx = bucket_index(pool, &name);
+    e = find_in_bucket(pool->buckets[idx], &name);
+
+    if (e != NULL)
+    {
+        tgt = resolve_ref(e);
+        if (tgt != NULL && !(tgt->flags & VPOOL_UNSET))
+        {
+            rc = Lstrcpy(pool->alloc, value, &tgt->value);
+            if (rc != LSTR_OK)
+            {
+                return VPOOL_NOMEM;
+            }
+            if (tc_out != NULL)
+            {
+                *tc_out = tgt->type_cache;
+            }
+            if (ic_out != NULL)
+            {
+                *ic_out = tgt->int_cache;
+            }
+            return VPOOL_OK;
+        }
+    }
+
+    /* Stem default fallback. */
+    {
+        int dot = first_dot(&name);
+        if (dot >= 0 && name.len > (size_t)(dot + 1))
+        {
+            Lstr stem_key;
+            int stem_idx;
+            struct vpool_entry *stem_e;
+
+            stem_key.pstr = name.pstr;
+            stem_key.len = (size_t)(dot + 1);
+            stem_key.maxlen = stem_key.len;
+            stem_key.type = LSTRING_TY;
+
+            stem_idx = bucket_index(pool, &stem_key);
+            stem_e = find_in_bucket(pool->buckets[stem_idx], &stem_key);
+            if (stem_e != NULL)
+            {
+                tgt = resolve_ref(stem_e);
+                if (tgt != NULL && !(tgt->flags & VPOOL_UNSET))
+                {
+                    rc = Lstrcpy(pool->alloc, value, &tgt->value);
+                    if (rc != LSTR_OK)
+                    {
+                        return VPOOL_NOMEM;
+                    }
+                    if (tc_out != NULL)
+                    {
+                        *tc_out = tgt->type_cache;
+                    }
+                    if (ic_out != NULL)
+                    {
+                        *ic_out = tgt->int_cache;
+                    }
+                    return VPOOL_OK;
+                }
+            }
+        }
+    }
+
+    return VPOOL_NOT_FOUND;
+}
+
+int vpool_set_buf(struct irx_vpool *pool, const char *name_data, int name_len,
+                  const PLstr value, int32_t tc, int64_t ic)
+{
+    Lstr name;
+    int idx;
+    int rc;
+    struct vpool_entry *e;
+    struct vpool_entry *tgt;
+
+    if (pool == NULL || name_data == NULL || value == NULL)
+    {
+        return VPOOL_BADARG;
+    }
+    if (memcmp(pool->vp_id, VPOOL_ID, VPOOL_ID_LEN) != 0)
+    {
+        return VPOOL_BADARG;
+    }
+
+    name.pstr = (unsigned char *)name_data;
+    name.len = (size_t)name_len;
+    name.maxlen = (size_t)name_len;
+    name.type = LSTRING_TY;
+
+    if (matches_exposed_stem(pool, &name) && pool->parent != NULL)
+    {
+        return vpool_set_buf(pool->parent, name_data, name_len, value, tc, ic);
+    }
+
+    idx = bucket_index(pool, &name);
+    e = find_in_bucket(pool->buckets[idx], &name);
+
+    if (e != NULL)
+    {
+        tgt = resolve_ref(e);
+        if (tgt == NULL)
+        {
+            return VPOOL_BADARG;
+        }
+        rc = Lstrcpy(pool->alloc, &tgt->value, value);
+        if (rc != LSTR_OK)
+        {
+            return VPOOL_NOMEM;
+        }
+        tgt->flags &= ~VPOOL_UNSET;
+        tgt->type_cache = tc;
+        tgt->int_cache = ic;
+        return VPOOL_OK;
+    }
+
+    /* Create a new local entry. */
+    e = vp_entry_new(pool->alloc);
+    if (e == NULL)
+    {
+        return VPOOL_NOMEM;
+    }
+
+    rc = Lstrcpy(pool->alloc, &e->name, &name);
+    if (rc != LSTR_OK)
+    {
+        vp_entry_free(pool->alloc, e);
+        return VPOOL_NOMEM;
+    }
+    rc = Lstrcpy(pool->alloc, &e->value, value);
+    if (rc != LSTR_OK)
+    {
+        vp_entry_free(pool->alloc, e);
+        return VPOOL_NOMEM;
+    }
+    e->type_cache = tc;
+    e->int_cache = ic;
+
+    return link_entry(pool, e);
+}
+
+int vpool_drop_buf(struct irx_vpool *pool, const char *name_data, int name_len)
+{
+    Lstr name;
+
+    if (pool == NULL || name_data == NULL)
+    {
+        return VPOOL_BADARG;
+    }
+
+    name.pstr = (unsigned char *)name_data;
+    name.len = (size_t)name_len;
+    name.maxlen = (size_t)name_len;
+    name.type = LSTRING_TY;
+
+    return vpool_drop(pool, &name);
 }

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -811,7 +811,7 @@ int vpool_next(struct irx_vpool *pool, PLstr name, PLstr value)
 /* ------------------------------------------------------------------ */
 
 int vpool_get_buf(struct irx_vpool *pool, const char *name_data, int name_len,
-                  PLstr value, int32_t *tc_out, int64_t *ic_out)
+                  PLstr value, int32_t *tc_out, int32_t *ic_out)
 {
     Lstr name;
     int idx;
@@ -904,7 +904,7 @@ int vpool_get_buf(struct irx_vpool *pool, const char *name_data, int name_len,
 }
 
 int vpool_set_buf(struct irx_vpool *pool, const char *name_data, int name_len,
-                  const PLstr value, int32_t tc, int64_t ic)
+                  const PLstr value, int32_t tc, int32_t ic)
 {
     Lstr name;
     int idx;

--- a/test/host/tstbc_clean.c
+++ b/test/host/tstbc_clean.c
@@ -1,0 +1,364 @@
+/* ------------------------------------------------------------------ */
+/*  test/host/tstbc_clean.c — WP-BC-CLEAN tests                       */
+/*                                                                    */
+/*  Covers:                                                           */
+/*    - Long-literal rejection (IRXBC_ERR_STRTOOLONG)                */
+/*    - DO COUNT: zero iterations, negative count, exactly 1,        */
+/*      small count (5), variable count, nested loops                */
+/*    - Integer fast-path: literals, variable round-trips             */
+/*    - vpool_get_buf / vpool_set_buf type_cache propagation          */
+/*                                                                    */
+/*  Build (Linux):                                                    */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -O0 -g \                           */
+/*        -o /tmp/tstbc_clean test/host/tstbc_clean.c \               */
+/*        'src/irx#init.c'  'src/irx#term.c'  'src/irx#stor.c' \    */
+/*        'src/irx#anch.c'  'src/irx#env.c'   'src/irx#uid.c'  \    */
+/*        'src/irx#msid.c'  'src/irx#cond.c'  'src/irx#bif.c'  \    */
+/*        'src/irx#bifs.c'  'src/irx#io.c'    'src/irx#lstr.c' \    */
+/*        'src/irx#tokn.c'  'src/irx#vpol.c'  'src/irx#pars.c' \    */
+/*        'src/irx#ctrl.c'  'src/irx#exec.c'  'src/irx#arith.c' \   */
+/*        'src/irx#bcom.c'  'src/irx#bvm.c' \                        */
+/*        '../lstring370/src/lstr#cor.c' \                            */
+/*        '../lstring370/src/lstr#cvt.c' \                            */
+/*        '../lstring370/src/lstr#fmt.c' \                            */
+/*        '../lstring370/src/lstr#srch.c' \                           */
+/*        '../lstring370/src/lstr#sub.c' \                            */
+/*        '../lstring370/src/lstr#wrd.c' \                            */
+/*        '../lstring370/src/lstr#xlt.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexbl.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* Run src through both interpreter paths and compare exit codes. */
+static void run_both(const char *desc, const char *src,
+                     int expected_tw, int expected_bc)
+{
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    int tw_rc = -999;
+    int bc_rc = -999;
+    int ok;
+    char msg[80];
+    int src_len = (int)strlen(src);
+
+    printf("  [%s]\n", desc);
+
+    /* token-walk */
+    ok = (irxinit(NULL, &env) == 0 && env != NULL);
+    if (ok)
+    {
+        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        if (wk != NULL)
+        {
+            wk->wkbi_use_bytecode = 0;
+        }
+        ok = (irx_exec_run(src, src_len, NULL, 0, &tw_rc, env) == 0);
+        irxterm(env);
+        env = NULL;
+    }
+    if (!ok)
+    {
+        tw_rc = -1;
+    }
+
+    /* bytecode */
+    ok = (irxinit(NULL, &env) == 0 && env != NULL);
+    if (ok)
+    {
+        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        if (wk != NULL)
+        {
+            wk->wkbi_use_bytecode = 1;
+        }
+        ok = (irx_exec_run(src, src_len, NULL, 0, &bc_rc, env) == 0);
+        irxterm(env);
+        env = NULL;
+    }
+    if (!ok)
+    {
+        bc_rc = -1;
+    }
+
+    snprintf(msg, sizeof(msg), "%s: token-walk rc==%d", desc, expected_tw);
+    CHECK(tw_rc == expected_tw, msg);
+    snprintf(msg, sizeof(msg), "%s: bytecode rc==%d", desc, expected_bc);
+    CHECK(bc_rc == expected_bc, msg);
+    snprintf(msg, sizeof(msg), "%s: bytecode==token-walk", desc);
+    CHECK(bc_rc == tw_rc, msg);
+}
+
+#define EQUIV(desc, src, expected) run_both(desc, src, expected, expected)
+
+/* ------------------------------------------------------------------ */
+/*  Long-literal rejection                                            */
+/* ------------------------------------------------------------------ */
+
+static void test_strtoolong(struct envblock *env)
+{
+    /* Construct a literal of exactly 64 bytes (one over IRXBC_STR_MAX=63) */
+    char src[128];
+    struct irx_bc_execblk *bc = NULL;
+    int rc;
+
+    memset(src, 0, sizeof(src));
+    /* SAY 'AAAA...A' where string is 64 'A's */
+    strcpy(src, "SAY '");
+    memset(src + 5, 'A', 64);
+    src[69] = '\'';
+    src[70] = '\0';
+
+    printf("  [long literal (64 bytes) rejected]\n");
+    rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+    CHECK(rc == IRXBC_ERR_STRTOOLONG, "compile returns IRXBC_ERR_STRTOOLONG");
+    CHECK(bc == NULL, "bc is NULL on strtoolong error");
+
+    if (bc != NULL)
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+
+    /* A literal of exactly 63 bytes should succeed */
+    printf("  [literal at max (63 bytes) accepted]\n");
+    memset(src, 0, sizeof(src));
+    strcpy(src, "SAY '");
+    memset(src + 5, 'B', 63);
+    src[68] = '\'';
+    src[69] = '\0';
+
+    bc = NULL;
+    rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+    CHECK(rc == IRXBC_OK, "63-byte literal compiles OK");
+    if (bc != NULL)
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  DO COUNT equivalence tests                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_do_zero(void)
+{
+    /* DO 0 should execute the body zero times */
+    EQUIV("do_zero",
+          "x = 0\n"
+          "DO 0\n"
+          "  x = x + 1\n"
+          "END\n"
+          "EXIT x",
+          0);
+}
+
+static void test_do_negative(void)
+{
+    /* DO -1 should execute the body zero times (negative count = 0 iters) */
+    EQUIV("do_neg",
+          "x = 0\n"
+          "DO -1\n"
+          "  x = x + 1\n"
+          "END\n"
+          "EXIT x",
+          0);
+}
+
+static void test_do_one(void)
+{
+    /* DO 1 executes body exactly once */
+    EQUIV("do_one",
+          "x = 0\n"
+          "DO 1\n"
+          "  x = x + 1\n"
+          "END\n"
+          "EXIT x",
+          1);
+}
+
+static void test_do_five(void)
+{
+    /* DO 5 executes body five times */
+    EQUIV("do_five",
+          "x = 0\n"
+          "DO 5\n"
+          "  x = x + 1\n"
+          "END\n"
+          "EXIT x",
+          5);
+}
+
+static void test_do_var(void)
+{
+    /* DO n where n is a variable */
+    EQUIV("do_var",
+          "n = 7\n"
+          "x = 0\n"
+          "DO n\n"
+          "  x = x + 1\n"
+          "END\n"
+          "EXIT x",
+          7);
+}
+
+static void test_do_expr(void)
+{
+    /* DO with an expression as count */
+    EQUIV("do_expr",
+          "x = 0\n"
+          "DO 2 + 3\n"
+          "  x = x + 1\n"
+          "END\n"
+          "EXIT x",
+          5);
+}
+
+static void test_do_nested(void)
+{
+    /* Nested DO COUNT: outer 3, inner 4 → 12 iterations total */
+    EQUIV("do_nested",
+          "x = 0\n"
+          "DO 3\n"
+          "  DO 4\n"
+          "    x = x + 1\n"
+          "  END\n"
+          "END\n"
+          "EXIT x",
+          12);
+}
+
+static void test_do_leave(void)
+{
+    /* LEAVE from inside DO COUNT */
+    EQUIV("do_leave",
+          "x = 0\n"
+          "DO 10\n"
+          "  x = x + 1\n"
+          "  IF x = 3 THEN LEAVE\n"
+          "END\n"
+          "EXIT x",
+          3);
+}
+
+static void test_do_iterate(void)
+{
+    /* ITERATE inside DO COUNT — skip body, continue loop */
+    EQUIV("do_iterate",
+          "x = 0\n"
+          "DO 5\n"
+          "  x = x + 1\n"
+          "  ITERATE\n"
+          "  x = x + 100\n"
+          "END\n"
+          "EXIT x",
+          5);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Integer fast-path observable tests                                */
+/* ------------------------------------------------------------------ */
+
+static void test_arith_chain(void)
+{
+    /* Chain of integer arithmetic via variables */
+    EQUIV("arith_chain",
+          "a = 10\n"
+          "b = a + 5\n"
+          "c = b * 2\n"
+          "EXIT c",
+          30);
+}
+
+static void test_large_count(void)
+{
+    /* DO 100 — tests that the counter doesn't overflow or mis-count */
+    EQUIV("do_100",
+          "x = 0\n"
+          "DO 100\n"
+          "  x = x + 1\n"
+          "END\n"
+          "EXIT x",
+          100);
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    struct envblock *env = NULL;
+    int rc;
+
+    printf("=== WP-BC-CLEAN Tests ===\n\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbc_clean: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    test_strtoolong(env);
+
+    irxterm(env);
+    env = NULL;
+
+    /* Equivalence tests — each creates its own envblocks */
+    test_do_zero();
+    test_do_negative();
+    test_do_one();
+    test_do_five();
+    test_do_var();
+    test_do_expr();
+    test_do_nested();
+    test_do_leave();
+    test_do_iterate();
+    test_arith_chain();
+    test_large_count();
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/host/tstbc_compile.c
+++ b/test/host/tstbc_compile.c
@@ -144,8 +144,8 @@ static void test_compile_unsupported(struct envblock *env)
 
     printf("  [compile: unsupported construct]\n");
 
-    /* "say 'hello'" is not handled in Phase 1. */
-    rc = irx_bc_compile(env, "say 'hello'", (int)strlen("say 'hello'"), &bc);
+    /* CALL is not yet handled by the bytecode compiler. */
+    rc = irx_bc_compile(env, "CALL foo", (int)strlen("CALL foo"), &bc);
     CHECK(rc == IRXBC_ERR_UNSUP,
           "compile returns IRXBC_ERR_UNSUP for unsupported construct");
     CHECK(bc == NULL, "bc is NULL on error");


### PR DESCRIPTION
## Summary

- Raise compiler limits: `BCOM_MAX_CODE` 4096→16384, `BCOM_MAX_CONSTS`/`SYMS` 128→512 (~80 KB heap)
- Fix `add_const`/`add_sym` to return `IRXBC_ERR_STRTOOLONG` instead of silently truncating literals ≥64 bytes; callers no longer mask the error code
- Eliminate per-opcode `Lfx`/`Lfree` for variable names in `OP_LOAD`/`STORE`/`DROP` via new `vpool_get_buf`/`vpool_set_buf`/`vpool_drop_buf` API; `type_cache`/`int_cache` propagate through vpool round-trips
- Implement real `FORINIT`/`DECFOR`: DO COUNT counter lives in a VM-side `bc_do_frame[16]` array instead of a vpool variable (4-byte encoding: `op + n:u8 + i16`)
- Integer fast-path: `try_parse_int_cache` on `PUSH_LIT`, `try_arith_fast` for ADD/SUB/MUL/IDIV/MOD when both stack slots carry a valid `int_cache`
- Fix token-walk ITERATE bug for DO COUNT: `kw_iterate` now decrements `ctrl_count` before jumping back, matching `do_should_iterate`; previously the loop ran forever when ITERATE was used inside DO COUNT

## Test plan

- [ ] `tstbc_clean` 36/36 passed (new test file)
- [ ] `tstbc_compile` 23/23 passed (no regression)
- [ ] Full regression suite: 16 binaries, all green

Fixes #147