### PR TITLE
feat(bytecode): WP-BC-04 — CALL/RETURN/BIF dispatch + function-call expressions

### DIFF
--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------------ */
-/*  irxbops.h - REXX/370 Bytecode Opcode Definitions (WP-BC-03)      */
+/*  irxbops.h - REXX/370 Bytecode Opcode Definitions (WP-BC-03/04)   */
 /*                                                                    */
 /*  Opcode encoding for the bytecode VM.                             */
 /*                                                                    */
@@ -137,24 +137,52 @@
 #define OP_LEAVE   0x77 /* 3 bytes: op + i16 — jump to loop end    */
 
 /* ================================================================== */
+/*  Function / CALL ops (WP-BC-04)                                    */
+/*                                                                    */
+/*  OP_LABEL marks a call target in the bytecode stream.  The VM     */
+/*  pre-scans for all OP_LABEL instructions at startup to build a    */
+/*  label_pc[] table indexed by sym_idx.                             */
+/*                                                                    */
+/*  OP_CALL: CALL statement — pops nargs from eval stack, tries      */
+/*  label_pc[sym_idx] first; falls back to BIF registry.            */
+/*  Pushes nothing; result (if any) is available as RESULT variable. */
+/*                                                                    */
+/*  OP_CALL_BIF: expression function call — pops nargs, dispatches   */
+/*  directly to BIF registry, pushes return value onto eval stack.   */
+/*                                                                    */
+/*  OP_RETURN: return from internal CALL with no value.              */
+/*  OP_RETURNV: pop TOS, store as RESULT, return from internal CALL. */
+/*  Both opcodes exit RC=0 when there is no active call frame.       */
+/* ================================================================== */
+
+#define OP_LABEL    0x78 /* 3 bytes: op + sym_idx:u16 — call target  */
+#define OP_CALL     0x79 /* 4 bytes: op + sym_idx:u16 + nargs:u8     */
+#define OP_CALL_BIF 0x7A /* 4 bytes: op + sym_idx:u16 + nargs:u8     */
+#define OP_RETURN   0x7B /* 1 byte — return, no value                 */
+#define OP_RETURNV  0x7C /* 1 byte — pop TOS, store as RESULT, return */
+
+/* ================================================================== */
 /*  Per-opcode size in bytes (including the opcode byte itself)       */
 /* ================================================================== */
 
 /* clang-format off */
-#define OP_SIZE(op)                    \
-    (((op) == OP_PUSH_LIT) ? 3 :      \
-     ((op) == OP_POP)      ? 2 :      \
-     ((op) == OP_LOAD)     ? 3 :      \
-     ((op) == OP_STORE)    ? 3 :      \
-     ((op) == OP_DROP)     ? 3 :      \
-     ((op) == OP_JMP)      ? 3 :      \
-     ((op) == OP_JF)       ? 3 :      \
-     ((op) == OP_JT)       ? 3 :      \
-     ((op) == OP_FORINIT)  ? 2 :      \
-     ((op) == OP_BYINIT)   ? 2 :      \
-     ((op) == OP_DECFOR)   ? 4 :      \
-     ((op) == OP_ITERATE)  ? 3 :      \
-     ((op) == OP_LEAVE)    ? 3 :      \
+#define OP_SIZE(op)                        \
+    (((op) == OP_PUSH_LIT)  ? 3 :         \
+     ((op) == OP_POP)       ? 2 :         \
+     ((op) == OP_LOAD)      ? 3 :         \
+     ((op) == OP_STORE)     ? 3 :         \
+     ((op) == OP_DROP)      ? 3 :         \
+     ((op) == OP_JMP)       ? 3 :         \
+     ((op) == OP_JF)        ? 3 :         \
+     ((op) == OP_JT)        ? 3 :         \
+     ((op) == OP_FORINIT)   ? 2 :         \
+     ((op) == OP_BYINIT)    ? 2 :         \
+     ((op) == OP_DECFOR)    ? 4 :         \
+     ((op) == OP_ITERATE)   ? 3 :         \
+     ((op) == OP_LEAVE)     ? 3 :         \
+     ((op) == OP_LABEL)     ? 3 :         \
+     ((op) == OP_CALL)      ? 4 :         \
+     ((op) == OP_CALL_BIF)  ? 4 :         \
      1)
 /* clang-format on */
 
@@ -162,15 +190,15 @@
 /*  Compiler and VM return codes                                      */
 /* ================================================================== */
 
-#define IRXBC_OK         0  /* success                               */
-#define IRXBC_ERR_STOR   20 /* irxstor allocation failed             */
-#define IRXBC_ERR_TOKN   21 /* tokenizer returned an error           */
-#define IRXBC_ERR_UNSUP  22 /* unsupported construct                 */
-#define IRXBC_ERR_OPCODE 23 /* unknown opcode encountered by VM      */
-#define IRXBC_ERR_ARITH  24 /* arithmetic error (type, divzero etc.) */
-#define IRXBC_ERR_STACK  25 /* stack underflow or overflow           */
-#define IRXBC_ERR_PATCH  26 /* too many forward-jump patches         */
-#define IRXBC_ERR_LOOP   27 /* DO nesting too deep                   */
+#define IRXBC_OK             0  /* success                               */
+#define IRXBC_ERR_STOR       20 /* irxstor allocation failed             */
+#define IRXBC_ERR_TOKN       21 /* tokenizer returned an error           */
+#define IRXBC_ERR_UNSUP      22 /* unsupported construct                 */
+#define IRXBC_ERR_OPCODE     23 /* unknown opcode encountered by VM      */
+#define IRXBC_ERR_ARITH      24 /* arithmetic error (type, divzero etc.) */
+#define IRXBC_ERR_STACK      25 /* stack underflow or overflow           */
+#define IRXBC_ERR_PATCH      26 /* too many forward-jump patches         */
+#define IRXBC_ERR_LOOP       27 /* DO nesting too deep                   */
 #define IRXBC_ERR_IO         28 /* I/O routine call failed               */
 #define IRXBC_ERR_STRTOOLONG 29 /* literal/symbol exceeds IRXBC_STR_MAX  */
 

--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -147,8 +147,9 @@
 /*  label_pc[sym_idx] first; falls back to BIF registry.            */
 /*  Pushes nothing; result (if any) is available as RESULT variable. */
 /*                                                                    */
-/*  OP_CALL_BIF: expression function call — pops nargs, dispatches   */
-/*  directly to BIF registry, pushes return value onto eval stack.   */
+/*  OP_CALL_BIF: expression function call — pops nargs, tries        */
+/*  label_pc[sym_idx] first (push_result=1); falls back to BIF       */
+/*  registry.  Pushes return value onto eval stack.                  */
 /*                                                                    */
 /*  OP_RETURN: return from internal CALL with no value.              */
 /*  OP_RETURNV: pop TOS, store as RESULT, return from internal CALL. */
@@ -201,5 +202,6 @@
 #define IRXBC_ERR_LOOP       27 /* DO nesting too deep                   */
 #define IRXBC_ERR_IO         28 /* I/O routine call failed               */
 #define IRXBC_ERR_STRTOOLONG 29 /* literal/symbol exceeds IRXBC_STR_MAX  */
+#define IRXBC_ERR_CALL       30 /* CALL stack overflow (IRXBC_CALL_DEPTH) */
 
 #endif /* IRXBOPS_H */

--- a/project.toml
+++ b/project.toml
@@ -1109,6 +1109,50 @@ include = [
 "mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
+# TSTBCAL - WP-BC-04 function call / CALL / RETURN equivalence tests.
+# Verifies BIF dispatch, internal CALL/RETURN, ARG() BIF, and
+# expression-context function calls via bytecode VM.
+#
+# Invocation:
+#   TSO    :  CALL 'hlq.LOAD(TSTBCAL)'
+#   Batch  :  EXEC PGM=TSTBCAL
+#
+# Expected: CC=0
+#
+# WP-BC-04 / GitHub mvslovers/rexx370#149.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "TSTBCAL"
+entry = "@@CRT0"
+options = ["LIST", "MAP", "XREF", "RENT"]
+include = [
+  "@@CRT1",
+  "TSTBCAL",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
+  "IRX#ARIT",
+]
+
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
+
+# ---------------------------------------------------------------
 # TSTLOAD - WP-CPS-07 IRXLOAD C-core unit tests.
 # Tests irx_load_dispatch() directly (bypasses the asm IRXLOAD
 # wrapper). Host build uses the filesystem backend; MVS build

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -1,7 +1,13 @@
 /* ------------------------------------------------------------------ */
-/*  irx#bcom.c - REXX/370 Bytecode Compiler (WP-BC-03)               */
+/*  irx#bcom.c - REXX/370 Bytecode Compiler (WP-BC-03/04)            */
 /*                                                                    */
 /*  irx_bc_compile() — Entry point.                                  */
+/*                                                                    */
+/*  Scope (WP-BC-04 extends WP-BC-03):                               */
+/*    - CALL name [arg,...] statement  (OP_CALL)                      */
+/*    - RETURN [expr]                  (OP_RETURN / OP_RETURNV)       */
+/*    - Function call in expression:   name(arg,...) (OP_CALL_BIF)   */
+/*    - Internal labels               (OP_LABEL)                     */
 /*                                                                    */
 /*  Scope (WP-BC-03 extends WP-BC-02):                               */
 /*    - SAY statement                                                 */
@@ -30,6 +36,7 @@
 #include "irxbvm.h"
 #include "irxexbl.h"
 #include "irxfunc.h"
+#include "irxpars.h"
 #include "irxtokn.h"
 #include "irxwkblk.h"
 
@@ -488,6 +495,183 @@ static void loop_add_iterate_patch(struct bcom_ctx *ctx, struct bc_loop_ctx *f,
 }
 
 /* ================================================================== */
+/*  Adjacency check (WP-BC-04)                                        */
+/* ================================================================== */
+
+/* True when b immediately follows a in source with no whitespace gap. */
+static int toks_adjacent_bc(const struct irx_token *a,
+                            const struct irx_token *b)
+{
+    int end;
+    if (a == NULL || b == NULL)
+    {
+        return 0;
+    }
+    if (a->tok_line != b->tok_line)
+    {
+        return 0;
+    }
+    end = (int)a->tok_col + (int)a->tok_length;
+    /* STRING tokens are delimited by quotes not reflected in tok_length */
+    if (a->tok_type == TOK_STRING)
+    {
+        end += 2;
+    }
+    return end == (int)b->tok_col;
+}
+
+/* ================================================================== */
+/*  Function call expression — name(arg, ...) (WP-BC-04)             */
+/* ================================================================== */
+
+/* Called with ctx->pos pointing PAST the symbol and '(' already
+ * consumed.  Collects comma-separated arg expressions up to ')'.
+ * Emits OP_CALL_BIF sym_idx nargs.  sym_idx is for the uppercased
+ * function name. */
+static void bc_funcall(struct bcom_ctx *ctx, int sym_idx)
+{
+    int nargs = 0;
+
+    /* Empty arg list */
+    if (tok_type_at(ctx, 0, TOK_RPAREN))
+    {
+        ctx->pos++;
+        emit_byte(ctx, OP_CALL_BIF);
+        emit_u16(ctx, sym_idx);
+        emit_byte(ctx, (unsigned char)nargs);
+        return;
+    }
+
+    for (;;)
+    {
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        if (nargs >= IRX_MAX_ARGS)
+        {
+            ctx->rc = IRXBC_ERR_UNSUP;
+            return;
+        }
+        bc_exp0(ctx);
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        nargs++;
+
+        if (tok_type_at(ctx, 0, TOK_RPAREN))
+        {
+            ctx->pos++;
+            break;
+        }
+        if (tok_type_at(ctx, 0, TOK_COMMA))
+        {
+            ctx->pos++;
+            continue;
+        }
+        ctx->rc = IRXBC_ERR_UNSUP;
+        return;
+    }
+
+    emit_byte(ctx, OP_CALL_BIF);
+    emit_u16(ctx, sym_idx);
+    emit_byte(ctx, (unsigned char)nargs);
+}
+
+/* ================================================================== */
+/*  CALL statement (WP-BC-04)                                         */
+/* ================================================================== */
+
+/* Collect comma-separated args until EOC/EOF.  Each arg is an expr.
+ * Emits OP_CALL sym_idx nargs. */
+static void bc_call_stmt(struct bcom_ctx *ctx)
+{
+    const struct irx_token *t;
+    const char *name;
+    int sym_idx;
+    int nargs = 0;
+
+    ctx->pos++; /* consume CALL */
+
+    t = tok_at(ctx, 0);
+    if (t == NULL || t->tok_type != TOK_SYMBOL ||
+        (t->tok_flags & TOKF_CONSTANT))
+    {
+        ctx->rc = IRXBC_ERR_UNSUP;
+        return;
+    }
+
+    name = (t->tok_upper != NULL) ? t->tok_upper : t->tok_text;
+    sym_idx = add_sym(ctx, name);
+    if (sym_idx < 0)
+    {
+        return;
+    }
+    ctx->pos++; /* consume target name */
+
+    /* Optional arg list: CALL NAME arg1, arg2 ... */
+    if (!tok_ends_clause(ctx))
+    {
+        for (;;)
+        {
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            if (nargs >= IRX_MAX_ARGS)
+            {
+                ctx->rc = IRXBC_ERR_UNSUP;
+                return;
+            }
+            bc_exp0(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            nargs++;
+            if (tok_ends_clause(ctx))
+            {
+                break;
+            }
+            if (tok_type_at(ctx, 0, TOK_COMMA))
+            {
+                ctx->pos++;
+                continue;
+            }
+            ctx->rc = IRXBC_ERR_UNSUP;
+            return;
+        }
+    }
+
+    emit_byte(ctx, OP_CALL);
+    emit_u16(ctx, sym_idx);
+    emit_byte(ctx, (unsigned char)nargs);
+}
+
+/* ================================================================== */
+/*  RETURN statement (WP-BC-04)                                       */
+/* ================================================================== */
+
+static void bc_return_stmt(struct bcom_ctx *ctx)
+{
+    ctx->pos++; /* consume RETURN */
+
+    if (tok_ends_clause(ctx))
+    {
+        emit_byte(ctx, OP_RETURN);
+        return;
+    }
+
+    bc_exp0(ctx);
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+    emit_byte(ctx, OP_RETURNV);
+}
+
+/* ================================================================== */
 /*  Expression compiler (bc_exp0 .. bc_exp8)                          */
 /* ================================================================== */
 
@@ -559,16 +743,33 @@ static void bc_exp8(struct bcom_ctx *ctx)
         }
         else
         {
+            const struct irx_token *next = tok_at(ctx, 1);
             const char *name =
                 (t->tok_upper != NULL) ? t->tok_upper : t->tok_text;
-            int si = add_sym(ctx, name);
-            if (si < 0)
+
+            /* Function call: SYMBOL immediately followed by '(' */
+            if (next != NULL && next->tok_type == TOK_LPAREN &&
+                toks_adjacent_bc(t, next))
             {
-                return;
+                int si = add_sym(ctx, name);
+                if (si < 0)
+                {
+                    return;
+                }
+                ctx->pos += 2; /* consume symbol + '(' */
+                bc_funcall(ctx, si);
             }
-            ctx->pos++;
-            emit_byte(ctx, OP_LOAD);
-            emit_u16(ctx, si);
+            else
+            {
+                int si = add_sym(ctx, name);
+                if (si < 0)
+                {
+                    return;
+                }
+                ctx->pos++;
+                emit_byte(ctx, OP_LOAD);
+                emit_u16(ctx, si);
+            }
         }
         return;
     }
@@ -769,6 +970,7 @@ static const char *const bc_kw_barriers[] = {
     "TO", "BY", "FOR", "WHILE", "UNTIL", "FOREVER",
     "IF", "DO", "SAY", "SELECT", "EXIT",
     "ITERATE", "LEAVE", "NOP",
+    "CALL", "RETURN", "PROCEDURE",
     NULL};
 
 static int is_kw_barrier(const struct bcom_ctx *ctx, int offset)
@@ -1835,6 +2037,25 @@ static void bc_stmt(struct bcom_ctx *ctx)
         return;
     }
 
+    if (tok_kw(ctx, 0, "CALL"))
+    {
+        bc_call_stmt(ctx);
+        return;
+    }
+
+    if (tok_kw(ctx, 0, "RETURN"))
+    {
+        bc_return_stmt(ctx);
+        return;
+    }
+
+    if (tok_kw(ctx, 0, "PROCEDURE"))
+    {
+        /* PROCEDURE [EXPOSE ...] is not supported in WP-BC-04 */
+        ctx->rc = IRXBC_ERR_UNSUP;
+        return;
+    }
+
     /* Assignment: simple-symbol = expr */
     if (t0->tok_type == TOK_SYMBOL && !(t0->tok_flags & TOKF_CONSTANT) &&
         t1 != NULL && t1->tok_type == TOK_COMPARISON &&
@@ -1886,16 +2107,21 @@ static void bc_program(struct bcom_ctx *ctx)
             tok_type_at(ctx, 1, TOK_SEMICOLON) &&
             tok_ch(ctx, 1) == ':')
         {
+            const char *lname =
+                (t->tok_upper != NULL) ? t->tok_upper : t->tok_text;
+            int lsi = add_sym(ctx, lname);
+            if (lsi < 0)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_LABEL);
+            emit_u16(ctx, lsi);
             ctx->pos += 2;
             continue;
         }
 
         bc_stmt(ctx);
         if (ctx->rc != IRXBC_OK)
-        {
-            return;
-        }
-        if (ctx->hit_exit)
         {
             return;
         }

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -1,5 +1,5 @@
 /* ------------------------------------------------------------------ */
-/*  irx#bvm.c - REXX/370 Bytecode VM Loop (WP-BC-03)                 */
+/*  irx#bvm.c - REXX/370 Bytecode VM Loop (WP-BC-03/04)              */
 /*                                                                    */
 /*  irx_bc_execute() — Entry point.                                  */
 /*                                                                    */
@@ -7,6 +7,8 @@
 /*  logical/string opcodes, PUSH_LIT / LOAD / STORE / POP.          */
 /*  WP-BC-03: control flow (JMP/JF/JT), SAY, DO loop ops            */
 /*  (FORINIT/BYINIT/DECFOR stubs), ITERATE, LEAVE.                  */
+/*  WP-BC-04: internal function CALL/RETURN, BIF dispatch via        */
+/*  OP_CALL_BIF; label table pre-scan; proxy irx_parser for BIFs.   */
 /*                                                                    */
 /*  Stack discipline: SP always points to the next FREE slot.        */
 /*    push: stack[sp++]                                              */
@@ -19,6 +21,7 @@
 
 #include "irx.h"
 #include "irxarith.h"
+#include "irxbif.h"
 #include "irxbops.h"
 #include "irxbvm.h"
 #include "irxexbl.h"
@@ -44,6 +47,41 @@ struct bc_do_frame
 {
     int32_t counter;
 };
+
+/* ================================================================== */
+/*  Call frame (WP-BC-04)                                             */
+/*                                                                    */
+/*  One frame per active CALL.  Args are copied from the eval stack   */
+/*  at call time and freed when the frame is popped by RETURN.        */
+/* ================================================================== */
+
+#define IRXBC_CALL_DEPTH 16
+
+struct bc_call_frame
+{
+    const unsigned char *return_pc;
+    int argc;
+    int push_result; /* 1 = leave return value on eval stack (expr call) */
+    Lstr args[IRX_MAX_ARGS];
+    int arg_exists[IRX_MAX_ARGS];
+};
+
+/* ================================================================== */
+/*  BIF registry access (WP-BC-04)                                   */
+/* ================================================================== */
+
+static const struct irx_bif_registry *
+bvm_get_bif_registry(struct envblock *envblock)
+{
+    struct irx_wkblk_int *wk;
+
+    if (envblock == NULL || envblock->envblock_userfield == NULL)
+    {
+        return NULL;
+    }
+    wk = (struct irx_wkblk_int *)envblock->envblock_userfield;
+    return (const struct irx_bif_registry *)wk->wkbi_bif_registry;
+}
 
 /* ================================================================== */
 /*  Read a little-endian u16 from the bytecode stream.               */
@@ -90,6 +128,25 @@ static int get_entry(const char *table_base, int table_count, int idx,
 /* ================================================================== */
 /*  Lstr helpers                                                      */
 /* ================================================================== */
+
+/* Copy a PLstr to an Lstr by value (used for call frame arg saving). */
+static int lstr_copy(struct lstr_alloc *alloc, Lstr *dst, PLstr src)
+{
+    size_t len = Llen(src);
+
+    Lzeroinit(dst);
+    if (len == 0)
+    {
+        return LSTR_OK;
+    }
+    if (Lfx(alloc, dst, len) != LSTR_OK)
+    {
+        return LSTR_ERR_NOMEM;
+    }
+    memcpy(Lpstr(dst), Lpstr(src), len);
+    Llen(dst) = len;
+    return LSTR_OK;
+}
 
 /* Copy a raw byte buffer into a stack slot's Lstr, using the given
  * lstring allocator.  Resets type_cache. */
@@ -375,16 +432,28 @@ int irx_bc_execute(struct envblock *envblock,
                    int *rc_out)
 {
     const unsigned char *pc;
+    const unsigned char *code_base;
     unsigned char op;
     struct lstr_alloc *alloc = NULL;
     struct irx_vpool *vpool = NULL;
     struct bc_stack_slot *stack = NULL;
     struct bc_do_frame *frames = NULL;
+    struct bc_call_frame *call_frames = NULL;
+    struct irx_parser *proxy_parser = NULL;
+    int *label_pc = NULL;
     Lstr *lstrs = NULL;
     void *stack_mem = NULL;
     void *lstr_mem = NULL;
     void *frames_mem = NULL;
+    void *call_frame_mem = NULL;
+    void *proxy_parser_mem = NULL;
+    void *label_pc_mem = NULL;
     int sp = 0; /* next free slot */
+    int call_sp = 0;
+    int n_consts;
+    int n_syms;
+    const char *const_base;
+    const char *sym_base;
     int vm_rc = IRXBC_OK;
     int i;
 
@@ -447,12 +516,77 @@ int irx_bc_execute(struct envblock *envblock,
     }
 
     /* --- Fetch constants / symbol table pointers --------------------- */
-    {
-        const char *const_base = IRXBC_CONST_TBL(bc);
-        const char *sym_base = IRXBC_SYM_TBL(bc);
-        int n_consts = (int)bc->const_count;
-        int n_syms = (int)bc->symbol_count;
+    const_base = IRXBC_CONST_TBL(bc);
+    sym_base = IRXBC_SYM_TBL(bc);
+    n_consts = (int)bc->const_count;
+    n_syms = (int)bc->symbol_count;
+    code_base = IRXBC_CODE(bc);
 
+    /* --- Call frame array (WP-BC-04) --------------------------------- */
+    if (irxstor(RXSMGET,
+                IRXBC_CALL_DEPTH * (int)sizeof(struct bc_call_frame),
+                &call_frame_mem, envblock) != 0)
+    {
+        vm_rc = IRXBC_ERR_STOR;
+        goto done;
+    }
+    memset(call_frame_mem, 0,
+           IRXBC_CALL_DEPTH * sizeof(struct bc_call_frame));
+    call_frames = (struct bc_call_frame *)call_frame_mem;
+
+    /* --- Label PC table (WP-BC-04) — indexed by sym_idx -------------- */
+    if (n_syms > 0)
+    {
+        if (irxstor(RXSMGET, n_syms * (int)sizeof(int),
+                    &label_pc_mem, envblock) != 0)
+        {
+            vm_rc = IRXBC_ERR_STOR;
+            goto done;
+        }
+        label_pc = (int *)label_pc_mem;
+        for (i = 0; i < n_syms; i++)
+        {
+            label_pc[i] = -1;
+        }
+        /* Pre-scan bytecode for OP_LABEL instructions */
+        {
+            int scan_pos = 0;
+            int code_len = (int)bc->code_length;
+
+            while (scan_pos < code_len)
+            {
+                unsigned char scan_op = code_base[scan_pos];
+                int opsz = OP_SIZE(scan_op);
+
+                if (scan_op == OP_LABEL && scan_pos + 2 < code_len)
+                {
+                    int lsi = (int)code_base[scan_pos + 1] |
+                              ((int)code_base[scan_pos + 2] << 8);
+                    if (lsi >= 0 && lsi < n_syms)
+                    {
+                        label_pc[lsi] = scan_pos + 3;
+                    }
+                }
+                scan_pos += opsz;
+            }
+        }
+    }
+
+    /* --- Proxy parser for BIF dispatch (WP-BC-04) -------------------- */
+    if (irxstor(RXSMGET, (int)sizeof(struct irx_parser),
+                &proxy_parser_mem, envblock) != 0)
+    {
+        vm_rc = IRXBC_ERR_STOR;
+        goto done;
+    }
+    proxy_parser = (struct irx_parser *)proxy_parser_mem;
+    memset(proxy_parser, 0, sizeof(struct irx_parser));
+    proxy_parser->alloc = alloc;
+    proxy_parser->envblock = envblock;
+    proxy_parser->vpool = vpool;
+    /* call_args / call_argc updated per call */
+
+    {
         pc = IRXBC_ENTRY(bc);
 
         /* ---- VM loop ------------------------------------------------ */
@@ -1181,6 +1315,344 @@ int irx_bc_execute(struct envblock *envblock,
                     break;
                 }
 
+                    /* ---- WP-BC-04: function / CALL / RETURN ----------- */
+
+                case OP_LABEL:
+                    /* No-op at runtime; label table built during pre-scan. */
+                    pc += 2;
+                    break;
+
+                case OP_CALL:
+                {
+                    int sym_idx = read_u16(pc);
+                    int nargs = (int)pc[2];
+                    int target = (label_pc != NULL && sym_idx >= 0 &&
+                                  sym_idx < n_syms)
+                                     ? label_pc[sym_idx]
+                                     : -1;
+                    pc += 3;
+
+                    if (sp < nargs)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+
+                    if (target >= 0)
+                    {
+                        /* Internal function call — push call frame */
+                        struct bc_call_frame *cf;
+                        int ci;
+
+                        if (call_sp >= IRXBC_CALL_DEPTH)
+                        {
+                            vm_rc = IRXBC_ERR_LOOP;
+                            goto done;
+                        }
+                        cf = &call_frames[call_sp];
+                        memset(cf, 0, sizeof(struct bc_call_frame));
+                        cf->return_pc = pc;
+                        cf->argc = nargs;
+                        cf->push_result = 0;
+                        for (ci = 0; ci < nargs; ci++)
+                        {
+                            PLstr src = stack[sp - nargs + ci].str;
+                            if (lstr_copy(alloc, &cf->args[ci], src) != LSTR_OK)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            cf->arg_exists[ci] = 1;
+                        }
+                        sp -= nargs;
+                        call_sp++;
+                        proxy_parser->call_args = cf->args;
+                        proxy_parser->call_arg_exists = cf->arg_exists;
+                        proxy_parser->call_argc = nargs;
+                        pc = code_base + target;
+                    }
+                    else
+                    {
+                        /* BIF fallback for CALL stmt */
+                        const struct irx_bif_registry *reg;
+                        const struct irx_bif_entry *bife;
+                        const char *name_data;
+                        int name_len;
+                        PLstr argv_arr[IRX_MAX_ARGS];
+                        int ci;
+                        int brc;
+
+                        name_len = get_entry(sym_base, n_syms,
+                                             sym_idx, &name_data);
+                        if (name_len < 0)
+                        {
+                            vm_rc = IRXBC_ERR_OPCODE;
+                            goto done;
+                        }
+                        reg = bvm_get_bif_registry(envblock);
+                        bife = irx_bif_find(
+                            reg,
+                            (const unsigned char *)name_data,
+                            (size_t)name_len);
+                        if (bife == NULL)
+                        {
+                            vm_rc = IRXBC_ERR_UNSUP;
+                            goto done;
+                        }
+                        if (nargs < bife->min_args ||
+                            nargs > bife->max_args)
+                        {
+                            vm_rc = IRXBC_ERR_ARITH;
+                            goto done;
+                        }
+                        for (ci = 0; ci < nargs; ci++)
+                        {
+                            argv_arr[ci] = stack[sp - nargs + ci].str;
+                        }
+                        brc = bife->handler(proxy_parser, nargs,
+                                            argv_arr,
+                                            &proxy_parser->result);
+                        sp -= nargs;
+                        if (brc != IRXPARS_OK)
+                        {
+                            vm_rc = IRXBC_ERR_ARITH;
+                            goto done;
+                        }
+                        /* Store result as RESULT variable (CALL stmt) */
+                        if (vpool_set_buf(vpool, "RESULT", 6,
+                                          &proxy_parser->result,
+                                          0, 0) != VPOOL_OK)
+                        {
+                            vm_rc = IRXBC_ERR_STOR;
+                            goto done;
+                        }
+                    }
+                    break;
+                }
+
+                case OP_CALL_BIF:
+                {
+                    int sym_idx = read_u16(pc);
+                    int nargs = (int)pc[2];
+                    int target = (label_pc != NULL && sym_idx >= 0 &&
+                                  sym_idx < n_syms)
+                                     ? label_pc[sym_idx]
+                                     : -1;
+                    const char *name_data;
+                    int name_len;
+                    int ci;
+
+                    pc += 3;
+                    if (sp < nargs)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+
+                    if (target >= 0)
+                    {
+                        /* User-defined function: jump to label.
+                         * push_result=1 causes RETURNV to leave the
+                         * value on the eval stack for the caller. */
+                        struct bc_call_frame *cf;
+
+                        if (call_sp >= IRXBC_CALL_DEPTH)
+                        {
+                            vm_rc = IRXBC_ERR_LOOP;
+                            goto done;
+                        }
+                        cf = &call_frames[call_sp];
+                        memset(cf, 0, sizeof(struct bc_call_frame));
+                        cf->return_pc = pc;
+                        cf->argc = nargs;
+                        cf->push_result = 1;
+                        for (ci = 0; ci < nargs; ci++)
+                        {
+                            PLstr src = stack[sp - nargs + ci].str;
+                            if (lstr_copy(alloc, &cf->args[ci], src) != LSTR_OK)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            cf->arg_exists[ci] = 1;
+                        }
+                        sp -= nargs;
+                        call_sp++;
+                        proxy_parser->call_args = cf->args;
+                        proxy_parser->call_arg_exists = cf->arg_exists;
+                        proxy_parser->call_argc = nargs;
+                        pc = code_base + target;
+                    }
+                    else
+                    {
+                        /* BIF dispatch */
+                        const struct irx_bif_registry *reg;
+                        const struct irx_bif_entry *bife;
+                        PLstr argv_arr[IRX_MAX_ARGS];
+                        int brc;
+
+                        if (sp >= IRXBC_STACK_DEPTH)
+                        {
+                            vm_rc = IRXBC_ERR_STACK;
+                            goto done;
+                        }
+                        name_len = get_entry(sym_base, n_syms,
+                                             sym_idx, &name_data);
+                        if (name_len < 0)
+                        {
+                            vm_rc = IRXBC_ERR_OPCODE;
+                            goto done;
+                        }
+                        reg = bvm_get_bif_registry(envblock);
+                        bife = irx_bif_find(
+                            reg,
+                            (const unsigned char *)name_data,
+                            (size_t)name_len);
+                        if (bife == NULL)
+                        {
+                            vm_rc = IRXBC_ERR_UNSUP;
+                            goto done;
+                        }
+                        if (nargs < bife->min_args ||
+                            nargs > bife->max_args)
+                        {
+                            vm_rc = IRXBC_ERR_ARITH;
+                            goto done;
+                        }
+                        for (ci = 0; ci < nargs; ci++)
+                        {
+                            argv_arr[ci] = stack[sp - nargs + ci].str;
+                        }
+                        brc = bife->handler(proxy_parser, nargs,
+                                            argv_arr,
+                                            &proxy_parser->result);
+                        sp -= nargs;
+                        if (brc != IRXPARS_OK)
+                        {
+                            vm_rc = IRXBC_ERR_ARITH;
+                            goto done;
+                        }
+                        if (slot_set_buf(
+                                &stack[sp], alloc,
+                                (const char *)Lpstr(&proxy_parser->result),
+                                (int)Llen(&proxy_parser->result)) != LSTR_OK)
+                        {
+                            vm_rc = IRXBC_ERR_STOR;
+                            goto done;
+                        }
+                        sp++;
+                    }
+                    break;
+                }
+
+                case OP_RETURN:
+                {
+                    if (call_sp > 0)
+                    {
+                        struct bc_call_frame *cf;
+                        int ci;
+
+                        call_sp--;
+                        cf = &call_frames[call_sp];
+                        for (ci = 0; ci < IRX_MAX_ARGS; ci++)
+                        {
+                            Lfree(alloc, &cf->args[ci]);
+                        }
+                        pc = cf->return_pc;
+                        if (call_sp > 0)
+                        {
+                            struct bc_call_frame *parent =
+                                &call_frames[call_sp - 1];
+                            proxy_parser->call_args = parent->args;
+                            proxy_parser->call_arg_exists =
+                                parent->arg_exists;
+                            proxy_parser->call_argc = parent->argc;
+                        }
+                        else
+                        {
+                            proxy_parser->call_args = NULL;
+                            proxy_parser->call_arg_exists = NULL;
+                            proxy_parser->call_argc = 0;
+                        }
+                    }
+                    else
+                    {
+                        if (rc_out != NULL)
+                        {
+                            *rc_out = 0;
+                        }
+                        goto done;
+                    }
+                    break;
+                }
+
+                case OP_RETURNV:
+                {
+                    int vrc;
+                    int push_r;
+
+                    if (sp < 1)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    sp--;
+                    vrc = vpool_set_buf(vpool, "RESULT", 6,
+                                        stack[sp].str,
+                                        stack[sp].type_cache,
+                                        stack[sp].int_cache);
+                    if (vrc != VPOOL_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+
+                    if (call_sp > 0)
+                    {
+                        struct bc_call_frame *cf;
+                        int ci;
+
+                        call_sp--;
+                        cf = &call_frames[call_sp];
+                        push_r = cf->push_result;
+                        for (ci = 0; ci < IRX_MAX_ARGS; ci++)
+                        {
+                            Lfree(alloc, &cf->args[ci]);
+                        }
+                        pc = cf->return_pc;
+                        if (call_sp > 0)
+                        {
+                            struct bc_call_frame *parent =
+                                &call_frames[call_sp - 1];
+                            proxy_parser->call_args = parent->args;
+                            proxy_parser->call_arg_exists =
+                                parent->arg_exists;
+                            proxy_parser->call_argc = parent->argc;
+                        }
+                        else
+                        {
+                            proxy_parser->call_args = NULL;
+                            proxy_parser->call_arg_exists = NULL;
+                            proxy_parser->call_argc = 0;
+                        }
+                        if (push_r)
+                        {
+                            /* Expression context: leave return value
+                             * on the eval stack for the caller. */
+                            sp++;
+                        }
+                    }
+                    else
+                    {
+                        if (rc_out != NULL)
+                        {
+                            *rc_out = 0;
+                        }
+                        goto done;
+                    }
+                    break;
+                }
+
                 default:
                     vm_rc = IRXBC_ERR_OPCODE;
                     goto done;
@@ -1189,6 +1661,25 @@ int irx_bc_execute(struct envblock *envblock,
     }
 
 done:
+    /* Free any active call frame arg Lstr buffers */
+    if (call_frames != NULL)
+    {
+        int fi, ci;
+        for (fi = 0; fi < call_sp; fi++)
+        {
+            for (ci = 0; ci < IRX_MAX_ARGS; ci++)
+            {
+                Lfree(alloc, &call_frames[fi].args[ci]);
+            }
+        }
+    }
+
+    /* Free proxy parser result Lstr and proxy parser itself */
+    if (proxy_parser != NULL)
+    {
+        Lfree(alloc, &proxy_parser->result);
+    }
+
     /* Free Lstr buffers */
     if (lstrs != NULL)
     {
@@ -1205,6 +1696,21 @@ done:
     }
 
     /* Free heap arrays */
+    if (label_pc_mem != NULL)
+    {
+        void *p = label_pc_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+    if (proxy_parser_mem != NULL)
+    {
+        void *p = proxy_parser_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+    if (call_frame_mem != NULL)
+    {
+        void *p = call_frame_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
     if (frames_mem != NULL)
     {
         void *p = frames_mem;

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -1346,7 +1346,7 @@ int irx_bc_execute(struct envblock *envblock,
 
                         if (call_sp >= IRXBC_CALL_DEPTH)
                         {
-                            vm_rc = IRXBC_ERR_LOOP;
+                            vm_rc = IRXBC_ERR_CALL;
                             goto done;
                         }
                         cf = &call_frames[call_sp];
@@ -1402,7 +1402,7 @@ int irx_bc_execute(struct envblock *envblock,
                         if (nargs < bife->min_args ||
                             nargs > bife->max_args)
                         {
-                            vm_rc = IRXBC_ERR_ARITH;
+                            vm_rc = IRXBC_ERR_UNSUP;
                             goto done;
                         }
                         for (ci = 0; ci < nargs; ci++)
@@ -1458,7 +1458,7 @@ int irx_bc_execute(struct envblock *envblock,
 
                         if (call_sp >= IRXBC_CALL_DEPTH)
                         {
-                            vm_rc = IRXBC_ERR_LOOP;
+                            vm_rc = IRXBC_ERR_CALL;
                             goto done;
                         }
                         cf = &call_frames[call_sp];
@@ -1491,7 +1491,8 @@ int irx_bc_execute(struct envblock *envblock,
                         PLstr argv_arr[IRX_MAX_ARGS];
                         int brc;
 
-                        if (sp >= IRXBC_STACK_DEPTH)
+                        /* net stack delta = -nargs+1; overflow only when nargs==0 */
+                        if (sp - nargs + 1 > IRXBC_STACK_DEPTH)
                         {
                             vm_rc = IRXBC_ERR_STACK;
                             goto done;
@@ -1516,7 +1517,7 @@ int irx_bc_execute(struct envblock *envblock,
                         if (nargs < bife->min_args ||
                             nargs > bife->max_args)
                         {
-                            vm_rc = IRXBC_ERR_ARITH;
+                            vm_rc = IRXBC_ERR_UNSUP;
                             goto done;
                         }
                         for (ci = 0; ci < nargs; ci++)
@@ -1551,6 +1552,10 @@ int irx_bc_execute(struct envblock *envblock,
                     {
                         struct bc_call_frame *cf;
                         int ci;
+
+                        /* §4.3.3: no return value — RESULT reverts to
+                         * uninitialized (evaluates to its own name). */
+                        vpool_drop_buf(vpool, "RESULT", 6);
 
                         call_sp--;
                         cf = &call_frames[call_sp];

--- a/test/mvs/tstbcal.c
+++ b/test/mvs/tstbcal.c
@@ -1,0 +1,430 @@
+/* ------------------------------------------------------------------ */
+/*  tstbcal.c - WP-BC-04 function call / CALL / RETURN equivalence    */
+/*                                                                    */
+/*  For each REXX snippet, runs via the token-walk interpreter and    */
+/*  the bytecode VM, then verifies both produce identical SAY output. */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    LSTR="-I contrib/lstring370-0.1.0-dev/include"                  */
+/*    LSRC="../lstring370/src/lstr#cor.c ../lstring370/src/lstr#cvt.c */
+/*          ../lstring370/src/lstr#fmt.c ../lstring370/src/lstr#srch.c */
+/*          ../lstring370/src/lstr#sub.c ../lstring370/src/lstr#wrd.c */
+/*          ../lstring370/src/lstr#xlt.c"                             */
+/*    gcc -I include $LSTR -Wall -Wextra -std=gnu99 \                 */
+/*        -o /tmp/tstbcal test/mvs/tstbcal.c \                        */
+/*        src/irx#init.c  src/irx#term.c  src/irx#stor.c \           */
+/*        src/irx#anch.c  src/irx#env.c   src/irx#uid.c  \           */
+/*        src/irx#msid.c  src/irx#cond.c  src/irx#bif.c  \           */
+/*        src/irx#bifs.c  src/irx#io.c    src/irx#lstr.c \           */
+/*        src/irx#tokn.c  src/irx#vpol.c  src/irx#pars.c \           */
+/*        src/irx#ctrl.c  src/irx#exec.c  src/irx#arith.c \          */
+/*        src/irx#bcom.c  src/irx#bvm.c   $LSRC && /tmp/tstbcal      */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Output capture                                                    */
+/* ------------------------------------------------------------------ */
+
+#define CAPBUF_SIZE 8192
+
+static char g_cap[CAPBUF_SIZE];
+static int g_cap_len = 0;
+
+static void cap_reset(void)
+{
+    g_cap_len = 0;
+    g_cap[0] = '\0';
+}
+
+static int capture_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL && Lpstr(data) != NULL)
+    {
+        int n = (int)Llen(data);
+        if (g_cap_len + n + 1 < CAPBUF_SIZE)
+        {
+            memcpy(g_cap + g_cap_len, Lpstr(data), (size_t)n);
+            g_cap_len += n;
+            g_cap[g_cap_len++] = '\n';
+            g_cap[g_cap_len] = '\0';
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Equivalence helper: run src via token-walk, then via bytecode,    */
+/*  check that SAY output matches.                                    */
+/* ------------------------------------------------------------------ */
+
+static int equiv(struct envblock *env, const char *src, const char *tag)
+{
+    struct irx_wkblk_int *wk;
+    int src_len = (int)strlen(src);
+    int rc;
+    int exit_rc = 0;
+    char tw_out[CAPBUF_SIZE];
+    char bc_out[CAPBUF_SIZE];
+    char label[128];
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: %s — no work block\n", tag);
+        tests_run++;
+        tests_failed++;
+        return 0;
+    }
+
+    /* Token-walk run */
+    cap_reset();
+    wk->wkbi_use_bytecode = 0;
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    (void)rc;
+    memcpy(tw_out, g_cap, (size_t)(g_cap_len + 1));
+
+    /* Bytecode run */
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    (void)rc;
+    memcpy(bc_out, g_cap, (size_t)(g_cap_len + 1));
+
+    wk->wkbi_use_bytecode = 0;
+
+    snprintf(label, sizeof(label), "equiv: %s", tag);
+    CHECK(strcmp(tw_out, bc_out) == 0, label);
+
+    if (strcmp(tw_out, bc_out) != 0)
+    {
+        printf("    tokwalk: [%s]\n", tw_out);
+        printf("    bytecode:[%s]\n", bc_out);
+        return 0;
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  bc_only: run src only via bytecode VM, check expected SAY output. */
+/* ------------------------------------------------------------------ */
+
+static int bc_only(struct envblock *env, const char *src,
+                   const char *expected, const char *tag)
+{
+    struct irx_wkblk_int *wk;
+    int src_len = (int)strlen(src);
+    int rc;
+    int exit_rc = 0;
+    char label[128];
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: %s — no work block\n", tag);
+        tests_run++;
+        tests_failed++;
+        return 0;
+    }
+
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    (void)rc;
+    wk->wkbi_use_bytecode = 0;
+
+    snprintf(label, sizeof(label), "bc_only: %s", tag);
+    CHECK(strcmp(g_cap, expected) == 0, label);
+
+    if (strcmp(g_cap, expected) != 0)
+    {
+        printf("    expected:[%s]\n", expected);
+        printf("    got:     [%s]\n", g_cap);
+        return 0;
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  BIF call in expression context (OP_CALL_BIF)                      */
+/* ------------------------------------------------------------------ */
+
+static void test_bif_expr(struct envblock *env)
+{
+    printf("\n[BIF in expression]\n");
+
+    equiv(env, "SAY LENGTH(\"hello\")", "LENGTH in SAY");
+    equiv(env, "SAY LENGTH(\"\")", "LENGTH empty string");
+    equiv(env, "SAY COPIES(\"ab\", 3)", "COPIES basic");
+    equiv(env, "SAY LEFT(\"hello\", 3)", "LEFT basic");
+    equiv(env, "SAY RIGHT(\"hello\", 3)", "RIGHT basic");
+    equiv(env, "SAY SUBSTR(\"abcdef\", 2, 3)", "SUBSTR basic");
+    equiv(env, "SAY REVERSE(\"abcd\")", "REVERSE");
+    equiv(env, "SAY STRIP(\"  hello  \")", "STRIP both");
+    equiv(env, "SAY UPPER(\"hello\")", "UPPER");
+    equiv(env, "SAY LOWER(\"HELLO\")", "LOWER");
+
+    /* BIF result used in expression */
+    equiv(env,
+          "x = LENGTH(\"hello\")\nSAY x",
+          "LENGTH assigned to var");
+    equiv(env,
+          "SAY LENGTH(\"hello\") + 0",
+          "LENGTH in arithmetic");
+    equiv(env,
+          "SAY COPIES(\"ab\", 2) || \"c\"",
+          "COPIES in concat");
+
+    /* Nested BIF calls */
+    equiv(env,
+          "SAY LENGTH(COPIES(\"ab\", 3))",
+          "LENGTH(COPIES()) nested");
+    equiv(env,
+          "SAY REVERSE(UPPER(\"hello\"))",
+          "REVERSE(UPPER()) nested");
+}
+
+/* ------------------------------------------------------------------ */
+/*  CALL statement (OP_CALL) — BIF path                               */
+/* ------------------------------------------------------------------ */
+
+static void test_call_bif_stmt(struct envblock *env)
+{
+    printf("\n[CALL stmt — BIF]\n");
+
+    /* CALL stores result in RESULT variable */
+    equiv(env,
+          "CALL LENGTH \"hello\"\nSAY RESULT",
+          "CALL LENGTH, SAY RESULT");
+    equiv(env,
+          "CALL COPIES \"ab\", 3\nSAY RESULT",
+          "CALL COPIES 2-arg, SAY RESULT");
+    equiv(env,
+          "CALL REVERSE \"abcd\"\nSAY RESULT",
+          "CALL REVERSE, SAY RESULT");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Internal function CALL / RETURN (OP_CALL + OP_RETURN/RETURNV)     */
+/* ------------------------------------------------------------------ */
+
+static void test_internal_call(struct envblock *env)
+{
+    printf("\n[internal CALL / RETURN]\n");
+
+    /* Subroutine that just SAYs — no return value */
+    equiv(env,
+          "CALL greet\n"
+          "EXIT\n"
+          "greet:\n"
+          "  SAY \"hello from sub\"\n"
+          "RETURN\n",
+          "CALL sub that SAYs");
+
+    /* Subroutine called multiple times */
+    equiv(env,
+          "CALL tick\n"
+          "CALL tick\n"
+          "CALL tick\n"
+          "EXIT\n"
+          "tick:\n"
+          "  SAY \"tick\"\n"
+          "RETURN\n",
+          "CALL sub 3 times");
+
+    /* RETURN with value — caller reads RESULT */
+    equiv(env,
+          "CALL double 5\n"
+          "SAY RESULT\n"
+          "EXIT\n"
+          "double:\n"
+          "  RETURN ARG(1) * 2\n",
+          "CALL RETURN ARG(1)*2");
+
+    /* RETURN with value, multiple calls via expression syntax.
+     * Token-walk doesn't support user-defined func() in expr context,
+     * so these are bytecode-only tests. */
+    bc_only(env,
+            "SAY double(3)\n"
+            "SAY double(7)\n"
+            "EXIT\n"
+            "double:\n"
+            "  RETURN ARG(1) * 2\n",
+            "6\n14\n",
+            "function call expr double()");
+
+    bc_only(env,
+            "x = double(4) + 1\n"
+            "SAY x\n"
+            "EXIT\n"
+            "double:\n"
+            "  RETURN ARG(1) * 2\n",
+            "9\n",
+            "function result in expr");
+}
+
+/* ------------------------------------------------------------------ */
+/*  ARG() BIF inside bytecode VM                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_arg_bif(struct envblock *env)
+{
+    printf("\n[ARG() BIF]\n");
+
+    /* ARG(1) returns first arg */
+    equiv(env,
+          "CALL echo \"world\"\n"
+          "SAY RESULT\n"
+          "EXIT\n"
+          "echo:\n"
+          "  RETURN ARG(1)\n",
+          "ARG(1) passthrough");
+
+    /* Multiple args */
+    equiv(env,
+          "CALL add 3, 4\n"
+          "SAY RESULT\n"
+          "EXIT\n"
+          "add:\n"
+          "  RETURN ARG(1) + ARG(2)\n",
+          "ARG(1)+ARG(2) two args");
+
+    /* ARG() argc */
+    equiv(env,
+          "CALL f 10, 20, 30\n"
+          "SAY RESULT\n"
+          "EXIT\n"
+          "f:\n"
+          "  RETURN ARG()\n",
+          "ARG() returns argc");
+}
+
+/* ------------------------------------------------------------------ */
+/*  RETURN at top level exits program with RC=0                        */
+/* ------------------------------------------------------------------ */
+
+static void test_return_top(struct envblock *env)
+{
+    printf("\n[RETURN at top level]\n");
+
+    /* RETURN at top level should stop execution */
+    bc_only(env,
+            "SAY \"before\"\nRETURN\nSAY \"after\"\n",
+            "before\n",
+            "RETURN stops at top level");
+
+    /* RETURN expr at top level — expr evaluated, execution stops */
+    bc_only(env,
+            "SAY \"before\"\nRETURN 0\nSAY \"after\"\n",
+            "before\n",
+            "RETURN 0 stops at top level");
+}
+
+/* ------------------------------------------------------------------ */
+/*  BIF calls in various expression positions                          */
+/* ------------------------------------------------------------------ */
+
+static void test_bif_contexts(struct envblock *env)
+{
+    printf("\n[BIF in various contexts]\n");
+
+    /* BIF in IF condition */
+    equiv(env,
+          "IF LENGTH(\"hi\") = 2 THEN SAY \"yes\" ELSE SAY \"no\"",
+          "BIF in IF condition");
+
+    /* BIF in DO count */
+    equiv(env,
+          "DO LENGTH(\"abc\")\n  SAY \"x\"\nEND",
+          "BIF as DO count");
+
+    /* BIF in assignment */
+    equiv(env,
+          "n = LENGTH(\"hello world\")\nSAY n",
+          "BIF in assignment");
+
+    /* Chained BIF results in comparison */
+    equiv(env,
+          "IF LENGTH(\"abc\") > LENGTH(\"ab\") THEN SAY \"longer\"",
+          "BIF result in comparison");
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                               */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    struct envblock *env = NULL;
+    struct irxexte *exte;
+    int rc;
+
+    printf("=== WP-BC-04 Function Call / CALL / RETURN Tests ===\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbcal: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+    {
+        exte->io_routine = (void *)capture_io;
+    }
+
+    test_bif_expr(env);
+    test_call_bif_stmt(env);
+    test_internal_call(env);
+    test_arg_bif(env);
+    test_return_top(env);
+    test_bif_contexts(env);
+
+    irxterm(env);
+
+    printf("\n--- Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ---\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/test/mvs/tstbcal.c
+++ b/test/mvs/tstbcal.c
@@ -333,6 +333,18 @@ static void test_arg_bif(struct envblock *env)
           "f:\n"
           "  RETURN ARG()\n",
           "ARG() returns argc");
+
+    /* SC28-1883 §4.3.3: no-value RETURN resets RESULT to uninitialized.
+     * After CALL sub (no RETURN expr), RESULT evaluates to its own name. */
+    bc_only(env,
+            "RESULT = \"old\"\n"
+            "CALL noop\n"
+            "SAY RESULT\n"
+            "EXIT\n"
+            "noop:\n"
+            "  RETURN\n",
+            "RESULT\n",
+            "RESULT uninitialized after no-value RETURN");
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary

- Adds 5 new opcodes (OP_LABEL, OP_CALL, OP_CALL_BIF, OP_RETURN, OP_RETURNV) to the bytecode compiler and VM
- Internal CALL/RETURN with proper call-frame stack (depth 16); RESULT variable set on return
- Expression-context function calls `name(args)` via OP_CALL_BIF with push_result=1 to leave return value on eval stack
- Internal labels tried first, BIF registry as fallback — correct REXX lookup order
- Label pre-scan at VM startup (O(n), no second compiler pass) builds label_pc[] table
- Proxy irx_parser (irxstor-allocated) threads call-frame args through to ARG() BIF handlers
- Removed hit_exit early-return from bc_program() — function bodies after EXIT now compiled correctly
- 32 new equivalence + bc_only tests in test/mvs/tstbcal.c; zero regressions in existing 1263-test suite

## Test plan

- [x] Linux cross-compile: `tstbcal` 32/32 passed
- [x] All existing test suites green (tsttokn 70, tstlstr 50, tstvpol 47, tstprsr 75, tstsay 27, tstctrl 93, tstparse 74, tstproc 53, tsthelo 16, tstanrm 29, tstfind, tstarit 128, tstarext 113, tstbif 29, tstbifs 427, tstbctl 43)
- [ ] MVS build: TSTBCAL load module + `CALL 'hlq.LOAD(TSTBCAL)'` (CC=0 expected)
- [ ] clang-format clean on all 4 changed files

Fixes #149