### PR TITLE
feat(bytecode): WP-BC-05 PR C — compound variables

### DIFF
--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -184,6 +184,29 @@
 #define OP_EXPOSE_INDIRECT 0x8D /* 3 bytes: op + sym_idx:u16          */
 
 /* ================================================================== */
+/*  Compound variable opcodes (WP-BC-05 PR C)                         */
+/*                                                                    */
+/*  OP_LOAD_STEM pops tail_count values (leftmost first), builds the  */
+/*  compound name STEM.tail0.tail1...tailN-1 (tails uppercased), then */
+/*  looks up the result in the vpool.  NOVALUE → compound name itself. */
+/*                                                                    */
+/*  OP_STORE_STEM pops the value (TOS), then pops tail_count tails,  */
+/*  builds the compound name, and stores the value in the vpool.      */
+/*                                                                    */
+/*  OP_DROP_STEM with tail_count=0 drops the entire stem (all entries */
+/*  whose name begins with the stem prefix including its trailing dot).*/
+/*  With tail_count>0 it pops tails, builds the compound name, and    */
+/*  drops only that one entry.                                         */
+/*                                                                    */
+/*  The stem symbol in the sym-table includes the trailing dot        */
+/*  (e.g. "A." for a compound variable A.something).                  */
+/* ================================================================== */
+
+#define OP_LOAD_STEM  0x8E /* 4 bytes: op + stem_sym:u16 + tail_count:u8 */
+#define OP_STORE_STEM 0x8F /* 4 bytes: op + stem_sym:u16 + tail_count:u8 */
+#define OP_DROP_STEM  0x90 /* 4 bytes: op + stem_sym:u16 + tail_count:u8 */
+
+/* ================================================================== */
 /*  PARSE sub-VM opcodes (WP-BC-05 PR A)                             */
 /*                                                                    */
 /*  PARSE [UPPER] source template [, template ...]                    */
@@ -251,6 +274,9 @@
      ((op) == OP_PROC)            ? 2 :         \
      ((op) == OP_EXPOSE)          ? 3 :         \
      ((op) == OP_EXPOSE_INDIRECT) ? 3 :         \
+     ((op) == OP_LOAD_STEM)       ? 4 :         \
+     ((op) == OP_STORE_STEM)      ? 4 :         \
+     ((op) == OP_DROP_STEM)       ? 4 :         \
      1)
 /* clang-format on */
 

--- a/include/irxvpool.h
+++ b/include/irxvpool.h
@@ -150,4 +150,11 @@ int vpool_drop_buf(struct irx_vpool *pool,
                    const char *name_data,
                    int name_len) asm("VPOOLDRB");
 
+/* Drop ALL pool entries whose name begins with stem_data (which must
+ * include the trailing dot, e.g. "STEM.").  Used by DROP STEM.
+ * Returns VPOOL_OK on success, VPOOL_BADARG on invalid arguments. */
+int vpool_drop_stem_all(struct irx_vpool *pool,
+                        const char *stem_data,
+                        int stem_len) asm("VPOOLDSA");
+
 #endif /* IRXVPOOL_H */

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -1377,6 +1377,108 @@ static void bc_procedure_stmt(struct bcom_ctx *ctx)
 }
 
 /* ================================================================== */
+/*  Compound variable helpers (WP-BC-05 PR C)                         */
+/* ================================================================== */
+
+/* Emit bytecode to push each tail segment of a compound variable onto
+ * the eval stack and register the stem in the symbol table.
+ *
+ * txt       — full uppercased compound name, e.g. "A.B.C"
+ * tlen      — length of txt
+ * dot_pos   — offset of the first '.' in txt
+ * stem_si_out — receives the sym-table index for the stem (e.g. "A.")
+ *
+ * Returns the tail count (>= 0), or -1 if an error was recorded in ctx.
+ * A bare stem like "A." (dot is the last char) returns 0 tails; the
+ * caller then emits OP_LOAD_STEM / OP_STORE_STEM / OP_DROP_STEM with
+ * tail_count = 0. */
+static int bc_compound_tails(struct bcom_ctx *ctx,
+                             const char *txt, int tlen, int dot_pos,
+                             int *stem_si_out)
+{
+    char stem_buf[IRXBC_STR_MAX + 2];
+    int stem_len = dot_pos + 1; /* includes trailing dot */
+    int si;
+    int i;
+    int tail_count = 0;
+
+    if (stem_len > IRXBC_STR_MAX)
+    {
+        ctx->rc = IRXBC_ERR_STRTOOLONG;
+        return -1;
+    }
+    memcpy(stem_buf, txt, (size_t)stem_len);
+    stem_buf[stem_len] = '\0';
+    si = add_sym(ctx, stem_buf);
+    if (si < 0)
+    {
+        return -1;
+    }
+    *stem_si_out = si;
+
+    /* Emit each tail segment after the first dot. */
+    i = stem_len;
+    while (i < tlen)
+    {
+        int seg_start = i;
+        int seg_len;
+        char seg_buf[IRXBC_STR_MAX + 1];
+
+        while (i < tlen && txt[i] != '.')
+        {
+            i++;
+        }
+        seg_len = i - seg_start;
+        if (i < tlen) /* skip the dot separator */
+        {
+            i++;
+        }
+
+        if (tail_count == 255)
+        {
+            ctx->rc = IRXBC_ERR_UNSUP;
+            return -1;
+        }
+
+        if (seg_len == 0 || isdigit((unsigned char)txt[seg_start]))
+        {
+            /* Constant tail: push as a literal string. */
+            int ci = add_const(ctx, txt + seg_start, seg_len);
+            if (ci < 0)
+            {
+                return -1;
+            }
+            emit_byte(ctx, OP_PUSH_LIT);
+            emit_u16(ctx, ci);
+        }
+        else
+        {
+            /* Variable tail: load the variable's value. */
+            if (seg_len > IRXBC_STR_MAX)
+            {
+                ctx->rc = IRXBC_ERR_STRTOOLONG;
+                return -1;
+            }
+            memcpy(seg_buf, txt + seg_start, (size_t)seg_len);
+            seg_buf[seg_len] = '\0';
+            si = add_sym(ctx, seg_buf);
+            if (si < 0)
+            {
+                return -1;
+            }
+            emit_byte(ctx, OP_LOAD);
+            emit_u16(ctx, si);
+        }
+        if (ctx->rc != IRXBC_OK)
+        {
+            return -1;
+        }
+        tail_count++;
+    }
+    return tail_count;
+}
+
+/* ================================================================== */
 /*  Expression compiler (bc_exp0 .. bc_exp8)                          */
 /* ================================================================== */
 
@@ -1445,6 +1547,33 @@ static void bc_exp8(struct bcom_ctx *ctx)
             ctx->pos++;
             emit_byte(ctx, OP_PUSH_LIT);
             emit_u16(ctx, ci);
+        }
+        else if (t->tok_flags & TOKF_COMPOUND)
+        {
+            /* Compound variable: A.B, A.B.C, A.1, A. etc. */
+            const char *txt =
+                (t->tok_upper != NULL) ? t->tok_upper : t->tok_text;
+            int tlen = (int)t->tok_length;
+            int dot_pos;
+            int stem_si;
+            int tail_count;
+
+            for (dot_pos = 0; dot_pos < tlen; dot_pos++)
+            {
+                if (txt[dot_pos] == '.')
+                {
+                    break;
+                }
+            }
+            ctx->pos++;
+            tail_count = bc_compound_tails(ctx, txt, tlen, dot_pos, &stem_si);
+            if (tail_count < 0 || ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_LOAD_STEM);
+            emit_u16(ctx, stem_si);
+            emit_byte(ctx, (unsigned char)tail_count);
         }
         else
         {
@@ -1675,7 +1804,7 @@ static const char *const bc_kw_barriers[] = {
     "TO", "BY", "FOR", "WHILE", "UNTIL", "FOREVER",
     "IF", "DO", "SAY", "SELECT", "EXIT",
     "ITERATE", "LEAVE", "NOP",
-    "CALL", "RETURN", "PROCEDURE", "PARSE",
+    "CALL", "RETURN", "PROCEDURE", "PARSE", "DROP",
     NULL};
 
 static int is_kw_barrier(const struct bcom_ctx *ctx, int offset)
@@ -2810,26 +2939,123 @@ static void bc_stmt(struct bcom_ctx *ctx)
         return;
     }
 
-    /* Assignment: simple-symbol = expr */
+    if (tok_kw(ctx, 0, "DROP"))
+    {
+        ctx->pos++; /* consume DROP */
+        for (;;)
+        {
+            const struct irx_token *td = tok_at(ctx, 0);
+            if (td == NULL || td->tok_type == TOK_EOC ||
+                td->tok_type == TOK_EOF)
+            {
+                break;
+            }
+            if (td->tok_type != TOK_SYMBOL ||
+                (td->tok_flags & TOKF_CONSTANT))
+            {
+                ctx->rc = IRXBC_ERR_UNSUP;
+                return;
+            }
+            if (td->tok_flags & TOKF_COMPOUND)
+            {
+                const char *txt =
+                    (td->tok_upper != NULL) ? td->tok_upper : td->tok_text;
+                int tlen = (int)td->tok_length;
+                int dot_pos;
+                int stem_si;
+                int tail_count;
+
+                for (dot_pos = 0; dot_pos < tlen; dot_pos++)
+                {
+                    if (txt[dot_pos] == '.')
+                    {
+                        break;
+                    }
+                }
+                tail_count =
+                    bc_compound_tails(ctx, txt, tlen, dot_pos, &stem_si);
+                if (tail_count < 0 || ctx->rc != IRXBC_OK)
+                {
+                    return;
+                }
+                ctx->pos++;
+                emit_byte(ctx, OP_DROP_STEM);
+                emit_u16(ctx, stem_si);
+                emit_byte(ctx, (unsigned char)tail_count);
+            }
+            else
+            {
+                const char *name =
+                    (td->tok_upper != NULL) ? td->tok_upper : td->tok_text;
+                int si = add_sym(ctx, name);
+                if (si < 0)
+                {
+                    return;
+                }
+                ctx->pos++;
+                emit_byte(ctx, OP_DROP);
+                emit_u16(ctx, si);
+            }
+        }
+        return;
+    }
+
+    /* Assignment: symbol = expr (simple or compound LHS) */
     if (t0->tok_type == TOK_SYMBOL && !(t0->tok_flags & TOKF_CONSTANT) &&
         t1 != NULL && t1->tok_type == TOK_COMPARISON &&
         t1->tok_length > 0 && t1->tok_text[0] == '=' &&
         !(tok_type_at(ctx, 2, TOK_COMPARISON) && tok_ch(ctx, 2) == '='))
     {
-        const char *name =
-            (t0->tok_upper != NULL) ? t0->tok_upper : t0->tok_text;
-        int si = add_sym(ctx, name);
-        if (si < 0)
+        if (t0->tok_flags & TOKF_COMPOUND)
         {
-            return;
+            const char *txt =
+                (t0->tok_upper != NULL) ? t0->tok_upper : t0->tok_text;
+            int tlen = (int)t0->tok_length;
+            int dot_pos;
+            int stem_si;
+            int tail_count;
+
+            for (dot_pos = 0; dot_pos < tlen; dot_pos++)
+            {
+                if (txt[dot_pos] == '.')
+                {
+                    break;
+                }
+            }
+            /* Push tails BEFORE consuming '=' so positions are correct. */
+            tail_count =
+                bc_compound_tails(ctx, txt, tlen, dot_pos, &stem_si);
+            if (tail_count < 0 || ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            ctx->pos += 2; /* consume compound-symbol + '=' */
+            bc_exp0(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_byte(ctx, OP_STORE_STEM);
+            emit_u16(ctx, stem_si);
+            emit_byte(ctx, (unsigned char)tail_count);
         }
-        ctx->pos += 2;
-        bc_exp0(ctx);
-        if (ctx->rc != IRXBC_OK)
+        else
         {
-            return;
+            const char *name =
+                (t0->tok_upper != NULL) ? t0->tok_upper : t0->tok_text;
+            int si = add_sym(ctx, name);
+            if (si < 0)
+            {
+                return;
+            }
+            ctx->pos += 2;
+            bc_exp0(ctx);
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+            emit_store(ctx, si);
         }
-        emit_store(ctx, si);
         return;
     }
 

--- a/src/irx#bctl.c
+++ b/src/irx#bctl.c
@@ -87,6 +87,9 @@ static const struct { unsigned char op; const char *name; } op_names[] = {
     { OP_PROC,             "PROC"             },
     { OP_EXPOSE,           "EXPOSE"           },
     { OP_EXPOSE_INDIRECT,  "EXPOSE_INDIRECT"  },
+    { OP_LOAD_STEM,        "LOAD_STEM"        },
+    { OP_STORE_STEM,       "STORE_STEM"       },
+    { OP_DROP_STEM,        "DROP_STEM"        },
 };
 
 /* clang-format on */
@@ -217,6 +220,25 @@ int irx_bc_disasm(const struct irx_bc_execblk *bc, char *buf, int bufsz)
             }
             app_cstr(buf, bufsz, &pos, " nargs=");
             app_int(buf, bufsz, &pos, nargs);
+        }
+        else if (sz == 4 && (op == OP_LOAD_STEM || op == OP_STORE_STEM ||
+                             op == OP_DROP_STEM))
+        {
+            /* stem_sym:u16 + tail_count:u8 */
+            int idx = (int)code[pc + 1] | ((int)code[pc + 2] << 8);
+            int tail_cnt = (int)code[pc + 3];
+            app_cstr(buf, bufsz, &pos, " [");
+            app_int(buf, bufsz, &pos, idx);
+            app_cstr(buf, bufsz, &pos, "]");
+            if (idx >= 0 && idx < n_syms)
+            {
+                const char *entry = sym_base + idx * IRXBC_ENTRY_SIZE;
+                int slen = (int)(unsigned char)entry[0];
+                app_cstr(buf, bufsz, &pos, " = ");
+                app_str(buf, bufsz, &pos, entry + 1, slen);
+            }
+            app_cstr(buf, bufsz, &pos, " tails=");
+            app_int(buf, bufsz, &pos, tail_cnt);
         }
         else if (sz == 4 && op == OP_DECFOR)
         {

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -937,6 +937,235 @@ int irx_bc_execute(struct envblock *envblock,
                     break;
                 }
 
+                /* ---- Compound variable ops (WP-BC-05 PR C) --------- */
+                case OP_LOAD_STEM:
+                {
+                    int stem_idx = read_u16(pc);
+                    int tail_cnt = (int)pc[2];
+                    const char *stem_data;
+                    int stem_len;
+                    char name_buf[IRXBC_STR_MAX + 1];
+                    int name_pos;
+                    int i;
+                    int vrc;
+
+                    pc += 3;
+
+                    if (sp < tail_cnt || sp >= IRXBC_STACK_DEPTH)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    stem_len =
+                        get_entry(sym_base, n_syms, stem_idx, &stem_data);
+                    if (stem_len < 0 || stem_len > IRXBC_STR_MAX)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+                    /* Build compound name: stem + tails (uppercased). */
+                    memcpy(name_buf, stem_data, (size_t)stem_len);
+                    name_pos = stem_len;
+                    for (i = 0; i < tail_cnt; i++)
+                    {
+                        const char *tv;
+                        int tl;
+                        int j;
+
+                        tv = (const char *)Lpstr(stack[sp - tail_cnt + i].str);
+                        tl = (int)Llen(stack[sp - tail_cnt + i].str);
+                        if (i > 0)
+                        {
+                            if (name_pos >= IRXBC_STR_MAX)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            name_buf[name_pos++] = '.';
+                        }
+                        for (j = 0; j < tl; j++)
+                        {
+                            if (name_pos >= IRXBC_STR_MAX)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            name_buf[name_pos++] =
+                                (char)toupper((unsigned char)tv[j]);
+                        }
+                    }
+                    name_buf[name_pos] = '\0';
+                    /* Pop tails, then push result. */
+                    sp -= tail_cnt;
+                    stack[sp].type_cache = 0;
+                    stack[sp].int_cache = 0;
+                    vrc = vpool_get_buf(vpool, name_buf, name_pos,
+                                        stack[sp].str,
+                                        &stack[sp].type_cache,
+                                        &stack[sp].int_cache);
+                    if (vrc == VPOOL_NOT_FOUND)
+                    {
+                        /* NOVALUE: value is the compound name itself. */
+                        if (slot_set_buf(&stack[sp], alloc,
+                                         name_buf, name_pos) != LSTR_OK)
+                        {
+                            vm_rc = IRXBC_ERR_STOR;
+                            goto done;
+                        }
+                    }
+                    else if (vrc != VPOOL_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    sp++;
+                    break;
+                }
+
+                case OP_STORE_STEM:
+                {
+                    int stem_idx = read_u16(pc);
+                    int tail_cnt = (int)pc[2];
+                    const char *stem_data;
+                    int stem_len;
+                    char name_buf[IRXBC_STR_MAX + 1];
+                    int name_pos;
+                    int i;
+                    int vrc;
+
+                    pc += 3;
+
+                    if (sp < tail_cnt + 1)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    stem_len =
+                        get_entry(sym_base, n_syms, stem_idx, &stem_data);
+                    if (stem_len < 0 || stem_len > IRXBC_STR_MAX)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+                    /* Stack: ..., tail[0], ..., tail[n-1], value
+                     * Value is at sp-1; tails at sp-tail_cnt-1..sp-2. */
+                    memcpy(name_buf, stem_data, (size_t)stem_len);
+                    name_pos = stem_len;
+                    for (i = 0; i < tail_cnt; i++)
+                    {
+                        const char *tv;
+                        int tl;
+                        int j;
+
+                        tv = (const char *)Lpstr(
+                            stack[sp - tail_cnt - 1 + i].str);
+                        tl = (int)Llen(stack[sp - tail_cnt - 1 + i].str);
+                        if (i > 0)
+                        {
+                            if (name_pos >= IRXBC_STR_MAX)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            name_buf[name_pos++] = '.';
+                        }
+                        for (j = 0; j < tl; j++)
+                        {
+                            if (name_pos >= IRXBC_STR_MAX)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            name_buf[name_pos++] =
+                                (char)toupper((unsigned char)tv[j]);
+                        }
+                    }
+                    name_buf[name_pos] = '\0';
+                    /* Pop value (now at stack[sp-1]). */
+                    sp--;
+                    vrc = vpool_set_buf(vpool, name_buf, name_pos,
+                                        stack[sp].str,
+                                        stack[sp].type_cache,
+                                        stack[sp].int_cache);
+                    sp -= tail_cnt; /* pop tails */
+                    if (vrc != VPOOL_OK)
+                    {
+                        vm_rc = IRXBC_ERR_STOR;
+                        goto done;
+                    }
+                    break;
+                }
+
+                case OP_DROP_STEM:
+                {
+                    int stem_idx = read_u16(pc);
+                    int tail_cnt = (int)pc[2];
+                    const char *stem_data;
+                    int stem_len;
+
+                    pc += 3;
+
+                    stem_len =
+                        get_entry(sym_base, n_syms, stem_idx, &stem_data);
+                    if (stem_len < 0 || stem_len > IRXBC_STR_MAX)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+                    if (tail_cnt == 0)
+                    {
+                        /* DROP STEM. — remove all entries with this prefix. */
+                        vpool_drop_stem_all(vpool, stem_data, stem_len);
+                    }
+                    else
+                    {
+                        char name_buf[IRXBC_STR_MAX + 1];
+                        int name_pos;
+                        int i;
+
+                        if (sp < tail_cnt)
+                        {
+                            vm_rc = IRXBC_ERR_STACK;
+                            goto done;
+                        }
+                        memcpy(name_buf, stem_data, (size_t)stem_len);
+                        name_pos = stem_len;
+                        for (i = 0; i < tail_cnt; i++)
+                        {
+                            const char *tv;
+                            int tl;
+                            int j;
+
+                            tv = (const char *)Lpstr(
+                                stack[sp - tail_cnt + i].str);
+                            tl = (int)Llen(stack[sp - tail_cnt + i].str);
+                            if (i > 0)
+                            {
+                                if (name_pos >= IRXBC_STR_MAX)
+                                {
+                                    vm_rc = IRXBC_ERR_STOR;
+                                    goto done;
+                                }
+                                name_buf[name_pos++] = '.';
+                            }
+                            for (j = 0; j < tl; j++)
+                            {
+                                if (name_pos >= IRXBC_STR_MAX)
+                                {
+                                    vm_rc = IRXBC_ERR_STOR;
+                                    goto done;
+                                }
+                                name_buf[name_pos++] =
+                                    (char)toupper((unsigned char)tv[j]);
+                            }
+                        }
+                        name_buf[name_pos] = '\0';
+                        sp -= tail_cnt;
+                        vpool_drop_buf(vpool, name_buf, name_pos);
+                    }
+                    break;
+                }
+
                 /* ---- Arithmetic ------------------------------------ */
                 case OP_ADD:
                 case OP_SUB:

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -991,3 +991,62 @@ int vpool_drop_buf(struct irx_vpool *pool, const char *name_data, int name_len)
 
     return vpool_drop(pool, &name);
 }
+
+int vpool_drop_stem_all(struct irx_vpool *pool,
+                        const char *stem_data, int stem_len)
+{
+    Lstr stem_lstr;
+    int b;
+    struct vpool_entry *e, *prev, *next;
+
+    if (pool == NULL || stem_data == NULL || stem_len <= 0)
+    {
+        return VPOOL_BADARG;
+    }
+
+    stem_lstr.pstr = (unsigned char *)stem_data;
+    stem_lstr.len = (size_t)stem_len;
+    stem_lstr.maxlen = (size_t)stem_len;
+    stem_lstr.type = LSTRING_TY;
+
+    /* If this stem is exposed to a parent pool, delegate there. */
+    if (matches_exposed_stem(pool, &stem_lstr) && pool->parent != NULL)
+    {
+        return vpool_drop_stem_all(pool->parent, stem_data, stem_len);
+    }
+
+    for (b = 0; b < pool->bucket_count; b++)
+    {
+        prev = NULL;
+        e = pool->buckets[b];
+        while (e != NULL)
+        {
+            next = e->next;
+            if (name_matches_stem(&e->name, &stem_lstr))
+            {
+                /* For exposed refs, also remove the backing entry in parent. */
+                if ((e->flags & VPOOL_EXPOSED_REF) && pool->parent != NULL)
+                {
+                    vpool_drop(pool->parent, &e->name);
+                }
+                /* Unlink from bucket chain. */
+                if (prev != NULL)
+                {
+                    prev->next = next;
+                }
+                else
+                {
+                    pool->buckets[b] = next;
+                }
+                pool->entry_count--;
+                vp_entry_free(pool->alloc, e);
+            }
+            else
+            {
+                prev = e;
+            }
+            e = next;
+        }
+    }
+    return VPOOL_OK;
+}

--- a/test/mvs/tstbcom.c
+++ b/test/mvs/tstbcom.c
@@ -1,0 +1,558 @@
+/* ------------------------------------------------------------------ */
+/*  tstbcom.c - WP-BC-05 PR C: Compound Variable Tests                */
+/*                                                                    */
+/*  Tests OP_LOAD_STEM / OP_STORE_STEM / OP_DROP_STEM in the         */
+/*  bytecode compiler and VM.  Uses bc_only() for tests where the     */
+/*  token-walk interpreter behaviour matches, and equiv() for         */
+/*  cross-validation.                                                 */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    LSTR="-I contrib/lstring370-0.1.0-dev/include"                  */
+/*    LSRC="../lstring370/src/lstr#cor.c ../lstring370/src/lstr#cvt.c */
+/*          ../lstring370/src/lstr#fmt.c ../lstring370/src/lstr#srch.c */
+/*          ../lstring370/src/lstr#sub.c ../lstring370/src/lstr#wrd.c */
+/*          ../lstring370/src/lstr#xlt.c"                             */
+/*    gcc -I include $LSTR -Wall -Wextra -std=gnu99 \                 */
+/*        -o /tmp/tstbcom test/mvs/tstbcom.c \                        */
+/*        src/irx#init.c  src/irx#term.c  src/irx#stor.c \           */
+/*        src/irx#anch.c  src/irx#env.c   src/irx#uid.c  \           */
+/*        src/irx#msid.c  src/irx#cond.c  src/irx#bif.c  \           */
+/*        src/irx#bifs.c  src/irx#io.c    src/irx#lstr.c \           */
+/*        src/irx#tokn.c  src/irx#vpol.c  src/irx#pars.c \           */
+/*        src/irx#ctrl.c  src/irx#exec.c  src/irx#arith.c \          */
+/*        src/irx#bcom.c  src/irx#bvm.c   $LSRC && /tmp/tstbcom      */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Output capture                                                    */
+/* ------------------------------------------------------------------ */
+
+#define CAPBUF_SIZE 8192
+
+static char g_cap[CAPBUF_SIZE];
+static int g_cap_len = 0;
+
+static void cap_reset(void)
+{
+    g_cap_len = 0;
+    g_cap[0] = '\0';
+}
+
+static int capture_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL && Lpstr(data) != NULL)
+    {
+        int n = (int)Llen(data);
+        if (g_cap_len + n + 1 < CAPBUF_SIZE)
+        {
+            memcpy(g_cap + g_cap_len, Lpstr(data), (size_t)n);
+            g_cap_len += n;
+            g_cap[g_cap_len++] = '\n';
+            g_cap[g_cap_len] = '\0';
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  bc_only: run only via bytecode VM; check expected output.         */
+/* ------------------------------------------------------------------ */
+
+static int bc_only(struct envblock *env, const char *src,
+                   const char *expected, const char *tag)
+{
+    struct irx_wkblk_int *wk;
+    int src_len = (int)strlen(src);
+    int rc;
+    int exit_rc = 0;
+    char label[128];
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: %s — no work block\n", tag);
+        tests_run++;
+        tests_failed++;
+        return 0;
+    }
+
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    (void)rc;
+    wk->wkbi_use_bytecode = 0;
+
+    snprintf(label, sizeof(label), "bc_only: %s", tag);
+    CHECK(strcmp(g_cap, expected) == 0, label);
+
+    if (strcmp(g_cap, expected) != 0)
+    {
+        printf("    expected:[%s]\n", expected);
+        printf("    got:     [%s]\n", g_cap);
+        return 0;
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  equiv: run via token-walk and bytecode; check outputs match.      */
+/* ------------------------------------------------------------------ */
+
+static int equiv(struct envblock *env, const char *src, const char *tag)
+{
+    struct irx_wkblk_int *wk;
+    int src_len = (int)strlen(src);
+    int rc;
+    int exit_rc = 0;
+    char tw_out[CAPBUF_SIZE];
+    char bc_out[CAPBUF_SIZE];
+    char label[128];
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: %s — no work block\n", tag);
+        tests_run++;
+        tests_failed++;
+        return 0;
+    }
+
+    cap_reset();
+    wk->wkbi_use_bytecode = 0;
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    (void)rc;
+    memcpy(tw_out, g_cap, (size_t)(g_cap_len + 1));
+
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    (void)rc;
+    memcpy(bc_out, g_cap, (size_t)(g_cap_len + 1));
+
+    wk->wkbi_use_bytecode = 0;
+
+    snprintf(label, sizeof(label), "equiv: %s", tag);
+    CHECK(strcmp(tw_out, bc_out) == 0, label);
+
+    if (strcmp(tw_out, bc_out) != 0)
+    {
+        printf("    tokwalk: [%s]\n", tw_out);
+        printf("    bytecode:[%s]\n", bc_out);
+        return 0;
+    }
+    return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Basic compound read / write                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_basic(struct envblock *env)
+{
+    printf("\n[Compound variable — basic read/write]\n");
+
+    /* Constant tail: A.1 = "one"; say A.1 */
+    equiv(env,
+          "A.1 = \"one\"\nSAY A.1\n",
+          "A.1 constant tail store and load");
+
+    /* Variable tail: I = 1; A.I = "val"; say A.I */
+    equiv(env,
+          "I = 1\nA.I = \"val\"\nSAY A.I\n",
+          "A.I variable tail store and load");
+
+    /* NOVALUE: unset compound returns compound name */
+    bc_only(env,
+            "I = \"X\"\nSAY A.I\n",
+            "A.X\n",
+            "NOVALUE returns compound name A.X");
+
+    /* NOVALUE: unset A.1 returns "A.1" */
+    bc_only(env,
+            "SAY A.1\n",
+            "A.1\n",
+            "NOVALUE constant tail returns A.1");
+
+    /* Stem default: A. = \"miss\"; I unset → A.I → \"miss\" */
+    bc_only(env,
+            "A. = \"miss\"\nI = \"X\"\nSAY A.I\n",
+            "miss\n",
+            "stem default used when entry absent");
+
+    /* Explicit entry overrides stem default */
+    bc_only(env,
+            "A. = \"miss\"\nI = \"X\"\nA.X = \"found\"\nSAY A.I\n",
+            "found\n",
+            "explicit entry overrides stem default");
+
+    /* Bare stem read: A. = \"stemval\"; say A. */
+    equiv(env,
+          "A. = \"stemval\"\nSAY A.\n",
+          "bare stem read");
+
+    /* Bare stem write via compound assignment */
+    bc_only(env,
+            "A. = \"default\"\nSAY A.\n",
+            "default\n",
+            "bare stem write A. = value");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Multi-level compound variables                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_multilevel(struct envblock *env)
+{
+    printf("\n[Compound variable — multi-level]\n");
+
+    /* A.B.C with all variable tails */
+    equiv(env,
+          "I = 1\nJ = 2\nA.I.J = \"nested\"\nSAY A.I.J\n",
+          "A.I.J two variable tails store/load");
+
+    /* A.1.2 constant tails */
+    bc_only(env,
+            "A.1.2 = \"deep\"\nSAY A.1.2\n",
+            "deep\n",
+            "A.1.2 constant tails store/load");
+
+    /* Mixed: A.1.J */
+    bc_only(env,
+            "J = \"Y\"\nA.1.Y = \"mix\"\nSAY A.1.J\n",
+            "mix\n",
+            "A.1.J mixed constant and variable tail");
+
+    /* Three-level: A.I.J.K */
+    bc_only(env,
+            "I = \"X\"\nJ = \"Y\"\nK = \"Z\"\nA.X.Y.Z = \"three\"\nSAY A.I.J.K\n",
+            "three\n",
+            "A.I.J.K three variable tails");
+
+    /* Tail value uppercased: B = \"hello\"; A.B → A.HELLO */
+    bc_only(env,
+            "B = \"hello\"\nA.HELLO = \"up\"\nSAY A.B\n",
+            "up\n",
+            "tail value uppercased for lookup");
+
+    /* NOVALUE multi-level */
+    bc_only(env,
+            "I = 1\nJ = 2\nSAY A.I.J\n",
+            "A.1.2\n",
+            "NOVALUE multi-level returns compound name");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Stem default fallback chain                                        */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_stem_default(struct envblock *env)
+{
+    printf("\n[Compound variable — stem default]\n");
+
+    /* Default read: A. = \"def\"; various tails → \"def\" */
+    bc_only(env,
+            "A. = \"def\"\nSAY A.1\nSAY A.X\nSAY A.1.2\n",
+            "def\ndef\ndef\n",
+            "stem default returned for all unset tails");
+
+    /* Default does not apply to set tails */
+    bc_only(env,
+            "A. = \"def\"\nA.2 = \"two\"\nSAY A.1\nSAY A.2\n",
+            "def\ntwo\n",
+            "stem default does not override explicitly set tail");
+
+    /* Chained indirect: J = I; A.J should resolve via J's value */
+    bc_only(env,
+            "I = 1\nJ = I\nA.1 = \"ok\"\nSAY A.J\n",
+            "ok\n",
+            "variable tail resolves via J = I = 1");
+}
+
+/* ------------------------------------------------------------------ */
+/*  DROP statement                                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_drop(struct envblock *env)
+{
+    printf("\n[Compound variable — DROP]\n");
+
+    /* DROP simple variable */
+    bc_only(env,
+            "X = \"hello\"\nDROP X\nSAY X\n",
+            "X\n",
+            "DROP simple variable → NOVALUE");
+
+    /* DROP specific compound entry: DROP A.1 */
+    bc_only(env,
+            "A.1 = \"one\"\nDROP A.1\nSAY A.1\n",
+            "A.1\n",
+            "DROP A.1 → entry removed, NOVALUE");
+
+    /* DROP A.I where I is a variable */
+    bc_only(env,
+            "I = 1\nA.1 = \"set\"\nDROP A.I\nSAY A.1\n",
+            "A.1\n",
+            "DROP A.I (I=1) removes A.1");
+
+    /* DROP STEM. removes all entries */
+    bc_only(env,
+            "A.1 = \"one\"\nA.2 = \"two\"\nA. = \"def\"\nDROP A.\nSAY A.1\n",
+            "A.1\n",
+            "DROP A. removes all stem entries");
+
+    /* After DROP STEM., stem default also gone */
+    bc_only(env,
+            "A. = \"def\"\nDROP A.\nSAY A.X\n",
+            "A.X\n",
+            "DROP A. removes stem default too");
+
+    /* DROP multiple variables in one statement */
+    bc_only(env,
+            "X = \"x\"\nY = \"y\"\nDROP X Y\nSAY X\nSAY Y\n",
+            "X\nY\n",
+            "DROP multiple simple variables");
+
+    /* DROP mix: simple and compound in one statement */
+    bc_only(env,
+            "X = \"x\"\nA.1 = \"one\"\nDROP X A.1\nSAY X\nSAY A.1\n",
+            "X\nA.1\n",
+            "DROP mix simple and compound");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Compound variables in expressions                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_expr(struct envblock *env)
+{
+    printf("\n[Compound variable — in expressions]\n");
+
+    /* Arithmetic with compound variable */
+    bc_only(env,
+            "A.1 = 10\nA.2 = 20\nSAY A.1 + A.2\n",
+            "30\n",
+            "A.1 + A.2 arithmetic");
+
+    /* Compound in IF condition */
+    bc_only(env,
+            "I = 1\nA.I = \"yes\"\nIF A.I = \"yes\" THEN SAY \"ok\"\n",
+            "ok\n",
+            "compound in IF condition");
+
+    /* Compound as SAY target without assignment */
+    bc_only(env,
+            "A.3 = \"three\"\nI = 3\nSAY A.I\n",
+            "three\n",
+            "SAY A.I where I=3 and A.3 set");
+
+    /* Each tail is resolved independently — no chained compound lookup.
+     * B.A.I → B.(val A).(val I); A unset → "A", I=2 → name "B.A.2". */
+    bc_only(env,
+            "I = 2\nSAY B.A.I\n",
+            "B.A.2\n",
+            "B.A.I tails resolved independently (no chaining)");
+
+    /* Concatenation with compound */
+    equiv(env,
+          "I = 1\nA.1 = \"val\"\nSAY \"result=\" || A.I\n",
+          "compound in concat expression");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Compound variables in DO loops                                     */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_do(struct envblock *env)
+{
+    printf("\n[Compound variable — in DO loops]\n");
+
+    /* Build array via compound assignment in loop */
+    bc_only(env,
+            "DO I = 1 TO 3\n"
+            "  A.I = I * 10\n"
+            "END\n"
+            "SAY A.1\nSAY A.2\nSAY A.3\n",
+            "10\n20\n30\n",
+            "compound array built in DO loop");
+
+    /* Traverse array via compound read in loop */
+    bc_only(env,
+            "A.1 = \"one\"\nA.2 = \"two\"\nA.3 = \"three\"\n"
+            "DO I = 1 TO 3\n"
+            "  SAY A.I\n"
+            "END\n",
+            "one\ntwo\nthree\n",
+            "compound array traversed in DO loop");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Compound variables across CALL/RETURN                              */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_call(struct envblock *env)
+{
+    printf("\n[Compound variable — across CALL/RETURN]\n");
+
+    /* Caller sets A.1; callee reads A.1 (shared vpool without PROCEDURE) */
+    bc_only(env,
+            "A.1 = \"caller\"\n"
+            "CALL sub\n"
+            "EXIT\n"
+            "sub:\n"
+            "SAY A.1\n"
+            "RETURN\n",
+            "caller\n",
+            "callee reads caller compound variable");
+
+    /* PROCEDURE: callee cannot see caller's compound without EXPOSE */
+    bc_only(env,
+            "A.1 = \"caller\"\n"
+            "CALL sub\n"
+            "EXIT\n"
+            "sub:\n"
+            "PROCEDURE\n"
+            "SAY A.1\n"
+            "RETURN\n",
+            "A.1\n",
+            "PROCEDURE isolates compound variable");
+
+    /* PROCEDURE EXPOSE A.: callee sees all of stem A */
+    bc_only(env,
+            "A.1 = \"hello\"\nA.2 = \"world\"\n"
+            "CALL sub\n"
+            "EXIT\n"
+            "sub:\n"
+            "PROCEDURE EXPOSE A.\n"
+            "SAY A.1\nSAY A.2\n"
+            "RETURN\n",
+            "hello\nworld\n",
+            "PROCEDURE EXPOSE A. exposes all of stem");
+
+    /* PROCEDURE EXPOSE A.: callee can modify stem default */
+    bc_only(env,
+            "A.1 = \"orig\"\n"
+            "CALL sub\n"
+            "SAY A.1\n"
+            "EXIT\n"
+            "sub:\n"
+            "PROCEDURE EXPOSE A.\n"
+            "A.1 = \"modified\"\n"
+            "RETURN\n",
+            "modified\n",
+            "PROCEDURE EXPOSE A. callee modification visible to caller");
+}
+
+/* ------------------------------------------------------------------ */
+/*  PARSE compound-target — must still be rejected (deferred to PR D) */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_compound_still_rejected(struct envblock *env)
+{
+    struct irx_wkblk_int *wk;
+    int src_len;
+    int rc;
+    int exit_rc = 0;
+    const char *src = "PARSE ARG a.1\nSAY a.1\n";
+
+    printf("\n[PARSE compound-target — still rejected (deferred)]\n");
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: no work block\n");
+        tests_run++;
+        tests_failed++;
+        return;
+    }
+
+    src_len = (int)strlen(src);
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    wk->wkbi_use_bytecode = 0;
+
+    CHECK(rc != 0, "PARSE compound target still rejected (IRXBC_ERR_PARSE_COMPOUND)");
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                               */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    struct envblock *env = NULL;
+    struct irxexte *exte;
+    int rc;
+
+    printf("=== WP-BC-05 PR C: Compound Variable Tests ===\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbcom: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+    {
+        exte->io_routine = (void *)capture_io;
+    }
+
+    test_compound_basic(env);
+    test_compound_multilevel(env);
+    test_compound_stem_default(env);
+    test_compound_drop(env);
+    test_compound_expr(env);
+    test_compound_do(env);
+    test_compound_call(env);
+    test_parse_compound_still_rejected(env);
+
+    irxterm(env);
+
+    printf("\n--- Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ---\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Add `OP_LOAD_STEM` / `OP_STORE_STEM` / `OP_DROP_STEM` (4-byte opcodes) for compound variable access in the bytecode compiler and VM
- `vpool_drop_stem_all()` for whole-stem DROP via O(n) bucket traversal
- `DROP` keyword handler in the compiler, compound read/write in expressions and assignments
- 36 new tests in `test/mvs/tstbcom.c`; all four bytecode suites green (33+25+17+36 = 111 tests)

## Design

Each compound name like `A.B.C` is tokenized as a single `TOKF_COMPOUND` symbol. The compiler splits it at dots: the stem `A.` goes in the sym table, each tail is emitted as `OP_PUSH_LIT` (digit-first constant) or `OP_LOAD` (variable), then the stem opcode follows with `tail_count`. The VM builds the resolved name by joining stem + uppercased tail values with dots, then delegates to vpool.

`DROP A.` (bare stem, tail_count=0) → `vpool_drop_stem_all` removes all entries with that prefix including the stem default. `DROP A.X` (tail_count>0) builds the specific compound name and drops only that entry.

PARSE compound-target (e.g. `PARSE ARG a.1`) is deferred: the `bc_parse_frame` / `pframe_assign` infrastructure would need a new `OP_PVAR_STEM` opcode and frame extension. `IRXBC_ERR_PARSE_COMPOUND` rejection is preserved; confirmed by `tstbpse` and `tstbcom`.

## Test plan

- [x] `tstbcal` 33/33 — no regressions
- [x] `tstbpse` 25/25 — PARSE compound rejection still works
- [x] `tstbpro` 17/17 — PROCEDURE EXPOSE unaffected
- [x] `tstbcom` 36/36 — all new compound variable tests pass

Closes #151