### PR TITLE
feat(bytecode): WP-BC-05 PR C — PARSE compound targets + PARSE PULL stub

### DIFF
--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -207,7 +207,7 @@
 #define OP_DROP_STEM  0x90 /* 4 bytes: op + stem_sym:u16 + tail_count:u8 */
 
 /* ================================================================== */
-/*  PARSE sub-VM opcodes (WP-BC-05 PR A)                             */
+/*  PARSE sub-VM opcodes (WP-BC-05 PR A + PR C)                      */
 /*                                                                    */
 /*  PARSE [UPPER] source template [, template ...]                    */
 /*                                                                    */
@@ -215,9 +215,16 @@
 /*  OP_PARSE_BEGIN, which pops it and initialises the parse frame.   */
 /*  OP_PUSH_SOURCE / OP_PUSH_NUMERIC are dedicated pushers for the   */
 /*  SOURCE and NUMERIC sources whose value is VM-state-dependent.    */
+/*  OP_PULL_FROM_QUEUE pushes the next line from the external data   */
+/*  queue (WP-33b stub — returns IRXBC_ERR_UNSUP at runtime).       */
 /*                                                                    */
-/*  Within a template, items (OP_PVAR / OP_PDOT) are each followed   */
-/*  immediately by a trigger opcode that determines how far to scan:  */
+/*  Within a template, items are each followed immediately by a      */
+/*  trigger opcode that determines how far to scan:                   */
+/*    OP_PVAR         — simple variable target (sym_idx:u16)          */
+/*    OP_PVAR_STEM    — compound variable target (stem_sym:u16 +      */
+/*                      tail_count:u8, tails already pushed on stack) */
+/*    OP_PDOT         — dot placeholder (consumes but discards)       */
+/*  Triggers:                                                         */
 /*    OP_TR_SPACE — one word (leading whitespace stripped)            */
 /*    OP_TR_LIT   — up to the first occurrence of a literal string   */
 /*    OP_TR_ABS   — up to an absolute column (1-based; inline u16)   */
@@ -227,8 +234,6 @@
 /*  When no template items precede a position trigger, the compiler   */
 /*  emits OP_PDOT + trigger to silently advance the scan position.   */
 /*                                                                    */
-/*  Compound-variable targets (a.i) are rejected at compile time     */
-/*  with IRXBC_ERR_PARSE_COMPOUND (unlocked in PR C).               */
 /*  Indirect patterns (var) are rejected with IRXBC_ERR_UNSUP.      */
 /* ================================================================== */
 
@@ -243,6 +248,21 @@
 #define OP_TR_END       0x88 /* 1 byte — trigger: rest of string      */
 #define OP_PUSH_SOURCE  0x89 /* 1 byte — push PARSE SOURCE string     */
 #define OP_PUSH_NUMERIC 0x8A /* 1 byte — push PARSE NUMERIC string    */
+
+/* ================================================================== */
+/*  PARSE compound-target opcode (WP-BC-05 PR C)                     */
+/*                                                                    */
+/*  OP_PVAR_STEM is emitted for compound variable targets in PARSE    */
+/*  templates (e.g. PARSE ARG a.1, PARSE VAR x a.i b.j).            */
+/*  Before OP_PVAR_STEM, the compiler pushes tail_count values onto  */
+/*  the eval stack (constant tails via OP_PUSH_LIT, variable tails   */
+/*  via OP_LOAD).  The VM pops them, builds the compound name, and   */
+/*  stores it in the parse frame; the following trigger opcode then   */
+/*  assigns the matched substring to that compound variable.          */
+/* ================================================================== */
+
+#define OP_PVAR_STEM       0x91 /* 4 bytes: op + stem_sym:u16 + tail_count:u8 */
+#define OP_PULL_FROM_QUEUE 0x92 /* 1 byte — push next queue line (WP-33b stub) */
 
 /* ================================================================== */
 /*  Per-opcode size in bytes (including the opcode byte itself)       */
@@ -277,6 +297,7 @@
      ((op) == OP_LOAD_STEM)       ? 4 :         \
      ((op) == OP_STORE_STEM)      ? 4 :         \
      ((op) == OP_DROP_STEM)       ? 4 :         \
+     ((op) == OP_PVAR_STEM)       ? 4 :         \
      1)
 /* clang-format on */
 

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -690,12 +690,61 @@ static void bc_return_stmt(struct bcom_ctx *ctx)
  * and intentionally absent from the test suite.
  */
 #define BPSE_MAX_ITEMS 16
+#define BPSE_MAX_TAILS 8
+
+struct bpse_tail
+{
+    int is_const; /* 1 = constant (push lit), 0 = variable (load sym) */
+    int idx;      /* const_table or sym_table index */
+};
 
 struct bpse_item
 {
     int is_dot;
     int sym_idx;
+    int is_compound; /* 1 if compound variable target */
+    int stem_idx;    /* sym index for stem (e.g. "A.") */
+    int tail_count;
+    struct bpse_tail tails[BPSE_MAX_TAILS];
 };
+
+/* Emit the bytecode for a single parse-template item (no trigger). */
+static void bpse_emit_item(struct bcom_ctx *ctx, const struct bpse_item *it)
+{
+    if (it->is_dot)
+    {
+        emit_byte(ctx, OP_PDOT);
+    }
+    else if (it->is_compound)
+    {
+        int j;
+        for (j = 0; j < it->tail_count; j++)
+        {
+            if (it->tails[j].is_const)
+            {
+                emit_byte(ctx, OP_PUSH_LIT);
+                emit_u16(ctx, it->tails[j].idx);
+            }
+            else
+            {
+                emit_byte(ctx, OP_LOAD);
+                emit_u16(ctx, it->tails[j].idx);
+            }
+            if (ctx->rc != IRXBC_OK)
+            {
+                return;
+            }
+        }
+        emit_byte(ctx, OP_PVAR_STEM);
+        emit_u16(ctx, it->stem_idx);
+        emit_byte(ctx, (unsigned char)it->tail_count);
+    }
+    else
+    {
+        emit_byte(ctx, OP_PVAR);
+        emit_u16(ctx, it->sym_idx);
+    }
+}
 
 static void bpse_flush(struct bcom_ctx *ctx,
                        const struct bpse_item *items, int n_items,
@@ -709,15 +758,7 @@ static void bpse_flush(struct bcom_ctx *ctx,
 
     for (i = 0; i < n_items - 1; i++)
     {
-        if (items[i].is_dot)
-        {
-            emit_byte(ctx, OP_PDOT);
-        }
-        else
-        {
-            emit_byte(ctx, OP_PVAR);
-            emit_u16(ctx, items[i].sym_idx);
-        }
+        bpse_emit_item(ctx, &items[i]);
         emit_byte(ctx, OP_TR_SPACE);
         if (ctx->rc != IRXBC_OK)
         {
@@ -731,16 +772,7 @@ static void bpse_flush(struct bcom_ctx *ctx,
     }
     else
     {
-        int last = n_items - 1;
-        if (items[last].is_dot)
-        {
-            emit_byte(ctx, OP_PDOT);
-        }
-        else
-        {
-            emit_byte(ctx, OP_PVAR);
-            emit_u16(ctx, items[last].sym_idx);
-        }
+        bpse_emit_item(ctx, &items[n_items - 1]);
     }
     if (ctx->rc != IRXBC_OK)
     {
@@ -951,11 +983,13 @@ static void bc_parse_template(struct bcom_ctx *ctx)
             continue;
         }
 
-        /* Symbol: variable name, dot placeholder, or compound (reject) */
+        /* Symbol: variable name, dot placeholder, or compound variable */
         if (t->tok_type == TOK_SYMBOL)
         {
             const char *txt = t->tok_text;
-            int tlen = (int)t->tok_length, j;
+            int tlen = (int)t->tok_length;
+            int dot_pos = -1;
+            int j;
 
             /* Standalone dot */
             if (tlen == 1 && txt[0] == '.')
@@ -964,20 +998,111 @@ static void bc_parse_template(struct bcom_ctx *ctx)
                 {
                     items[n_items].is_dot = 1;
                     items[n_items].sym_idx = -1;
+                    items[n_items].is_compound = 0;
                     n_items++;
                 }
                 ctx->pos++;
                 continue;
             }
 
-            /* Compound variable → reject in PR A */
+            /* Find first dot to detect compound variable */
             for (j = 0; j < tlen; j++)
             {
                 if (txt[j] == '.')
                 {
-                    ctx->rc = IRXBC_ERR_PARSE_COMPOUND;
+                    dot_pos = j;
+                    break;
+                }
+            }
+
+            if (dot_pos >= 0)
+            {
+                /* Compound variable target (e.g. a.1, a.i, a.i.j) */
+                const char *up = (t->tok_upper != NULL) ? t->tok_upper : txt;
+                char stem_buf[IRXBC_STR_MAX + 2];
+                int stem_len = dot_pos + 1; /* includes trailing dot */
+                int stem_si;
+                int k;
+
+                if (stem_len > IRXBC_STR_MAX)
+                {
+                    ctx->rc = IRXBC_ERR_STRTOOLONG;
                     return;
                 }
+                memcpy(stem_buf, up, (size_t)stem_len);
+                stem_buf[stem_len] = '\0';
+                stem_si = add_sym(ctx, stem_buf);
+                if (stem_si < 0)
+                {
+                    return;
+                }
+                if (n_items < BPSE_MAX_ITEMS)
+                {
+                    struct bpse_item *it = &items[n_items];
+                    it->is_dot = 0;
+                    it->sym_idx = -1;
+                    it->is_compound = 1;
+                    it->stem_idx = stem_si;
+                    it->tail_count = 0;
+
+                    k = stem_len;
+                    while (k < tlen)
+                    {
+                        int seg_start = k;
+                        int seg_len;
+                        int is_const_tail;
+
+                        while (k < tlen && up[k] != '.')
+                        {
+                            k++;
+                        }
+                        seg_len = k - seg_start;
+                        if (k < tlen)
+                        {
+                            k++;
+                        }
+                        if (it->tail_count >= BPSE_MAX_TAILS)
+                        {
+                            ctx->rc = IRXBC_ERR_UNSUP;
+                            return;
+                        }
+                        is_const_tail = (seg_len == 0 ||
+                                         isdigit((unsigned char)up[seg_start]));
+                        if (is_const_tail)
+                        {
+                            int ci = add_const(ctx, up + seg_start, seg_len);
+                            if (ci < 0)
+                            {
+                                return;
+                            }
+                            it->tails[it->tail_count].is_const = 1;
+                            it->tails[it->tail_count].idx = ci;
+                        }
+                        else
+                        {
+                            char seg_buf[IRXBC_STR_MAX + 1];
+                            int si2;
+                            if (seg_len > IRXBC_STR_MAX)
+                            {
+                                ctx->rc = IRXBC_ERR_STRTOOLONG;
+                                return;
+                            }
+                            memcpy(seg_buf, up + seg_start, (size_t)seg_len);
+                            seg_buf[seg_len] = '\0';
+                            si2 = add_sym(ctx, seg_buf);
+                            if (si2 < 0)
+                            {
+                                return;
+                            }
+                            it->tails[it->tail_count].is_const = 0;
+                            it->tails[it->tail_count].idx = si2;
+                        }
+                        it->tail_count++;
+                    }
+                    n_items++;
+                }
+                ctx->pos++;
+                continue;
             }
 
             /* Regular variable */
@@ -994,6 +1119,7 @@ static void bc_parse_template(struct bcom_ctx *ctx)
                 {
                     items[n_items].is_dot = 0;
                     items[n_items].sym_idx = si;
+                    items[n_items].is_compound = 0;
                     n_items++;
                 }
             }
@@ -1208,6 +1334,18 @@ static void bc_parse_stmt(struct bcom_ctx *ctx)
         ctx->pos++;
         n = bc_count_parse_templates(ctx);
         emit_byte(ctx, OP_PUSH_NUMERIC);
+        for (i = 1; i < n; i++)
+        {
+            emit_byte(ctx, OP_DUP);
+        }
+    }
+    else if (tok_kw(ctx, 0, "PULL"))
+    {
+        /* WP-33b: external data queue — compiled but unsupported at runtime. */
+        int n, i;
+        ctx->pos++;
+        n = bc_count_parse_templates(ctx);
+        emit_byte(ctx, OP_PULL_FROM_QUEUE);
         for (i = 1; i < n; i++)
         {
             emit_byte(ctx, OP_DUP);

--- a/src/irx#bctl.c
+++ b/src/irx#bctl.c
@@ -90,6 +90,8 @@ static const struct { unsigned char op; const char *name; } op_names[] = {
     { OP_LOAD_STEM,        "LOAD_STEM"        },
     { OP_STORE_STEM,       "STORE_STEM"       },
     { OP_DROP_STEM,        "DROP_STEM"        },
+    { OP_PVAR_STEM,        "PVAR_STEM"        },
+    { OP_PULL_FROM_QUEUE,  "PULL_FROM_QUEUE"  },
 };
 
 /* clang-format on */
@@ -222,7 +224,7 @@ int irx_bc_disasm(const struct irx_bc_execblk *bc, char *buf, int bufsz)
             app_int(buf, bufsz, &pos, nargs);
         }
         else if (sz == 4 && (op == OP_LOAD_STEM || op == OP_STORE_STEM ||
-                             op == OP_DROP_STEM))
+                             op == OP_DROP_STEM || op == OP_PVAR_STEM))
         {
             /* stem_sym:u16 + tail_count:u8 */
             int idx = (int)code[pc + 1] | ((int)code[pc + 2] << 8);

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -436,9 +436,11 @@ struct bc_parse_frame
     int source_len;
     int scan;
     int upper;
-    int cur_sym; /* sym_idx of pending PVAR, or -1 */
-    int cur_dot; /* 1 if pending PDOT */
-    int active;  /* 1 while inside a PARSE_BEGIN/PARSE_END pair */
+    int cur_sym;                      /* sym_idx of pending PVAR, or -1 */
+    int cur_dot;                      /* 1 if pending PDOT */
+    int active;                       /* 1 while inside PARSE_BEGIN/PARSE_END */
+    char cur_cmpd[IRXBC_STR_MAX + 1]; /* compound name for pending PVAR_STEM */
+    int cur_cmpd_len;                 /* 0 = no compound pending */
 };
 
 /*
@@ -507,6 +509,7 @@ static int pframe_assign(struct bc_parse_frame *pframe,
     {
         pframe->cur_dot = 0;
         pframe->cur_sym = -1;
+        pframe->cur_cmpd_len = 0;
         return IRXBC_OK;
     }
 
@@ -539,8 +542,33 @@ static int pframe_assign(struct bc_parse_frame *pframe,
             return IRXBC_ERR_STOR;
         }
     }
+    else if (pframe->cur_cmpd_len > 0)
+    {
+        /* Compound variable target set by OP_PVAR_STEM */
+        Lzeroinit(&val);
+        if (value_end > content_start)
+        {
+            size_t vlen = (size_t)(value_end - content_start);
+            if (Lfx(alloc, &val, vlen) != LSTR_OK)
+            {
+                pframe->cur_cmpd_len = 0;
+                return IRXBC_ERR_STOR;
+            }
+            memcpy(Lpstr(&val), src + content_start, vlen);
+            Llen(&val) = vlen;
+        }
+        vrc = vpool_set_buf(vpool, pframe->cur_cmpd, pframe->cur_cmpd_len,
+                            &val, 0, 0);
+        Lfree(alloc, &val);
+        if (vrc != VPOOL_OK)
+        {
+            pframe->cur_cmpd_len = 0;
+            return IRXBC_ERR_STOR;
+        }
+    }
     pframe->cur_sym = -1;
     pframe->cur_dot = 0;
+    pframe->cur_cmpd_len = 0;
     return IRXBC_OK;
 }
 
@@ -2089,13 +2117,82 @@ int irx_bc_execute(struct envblock *envblock,
                     pframe.active = 0;
                     pframe.source_len = 0;
                     pframe.scan = 0;
+                    pframe.cur_cmpd_len = 0;
                     break;
 
                 case OP_PVAR:
                     pframe.cur_sym = read_u16(pc);
                     pc += 2;
                     pframe.cur_dot = 0;
+                    pframe.cur_cmpd_len = 0;
                     break;
+
+                case OP_PVAR_STEM:
+                {
+                    int stem_idx = read_u16(pc);
+                    int tail_cnt = (int)pc[2];
+                    const char *stem_data;
+                    int stem_len;
+                    char name_buf[IRXBC_STR_MAX + 1];
+                    int name_pos;
+                    int k;
+
+                    pc += 3;
+
+                    if (sp < tail_cnt)
+                    {
+                        vm_rc = IRXBC_ERR_STACK;
+                        goto done;
+                    }
+                    stem_len =
+                        get_entry(sym_base, n_syms, stem_idx, &stem_data);
+                    if (stem_len < 0 || stem_len > IRXBC_STR_MAX)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+                    memcpy(name_buf, stem_data, (size_t)stem_len);
+                    name_pos = stem_len;
+                    for (k = 0; k < tail_cnt; k++)
+                    {
+                        const char *tv;
+                        int tl, m;
+                        tv = (const char *)Lpstr(
+                            stack[sp - tail_cnt + k].str);
+                        tl = (int)Llen(stack[sp - tail_cnt + k].str);
+                        if (k > 0)
+                        {
+                            if (name_pos >= IRXBC_STR_MAX)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            name_buf[name_pos++] = '.';
+                        }
+                        for (m = 0; m < tl; m++)
+                        {
+                            if (name_pos >= IRXBC_STR_MAX)
+                            {
+                                vm_rc = IRXBC_ERR_STOR;
+                                goto done;
+                            }
+                            name_buf[name_pos++] =
+                                (char)toupper((unsigned char)tv[m]);
+                        }
+                    }
+                    name_buf[name_pos] = '\0';
+                    sp -= tail_cnt;
+                    memcpy(pframe.cur_cmpd, name_buf, (size_t)name_pos);
+                    pframe.cur_cmpd_len = name_pos;
+                    pframe.cur_sym = -1;
+                    pframe.cur_dot = 0;
+                    break;
+                }
+
+                case OP_PULL_FROM_QUEUE:
+                    /* WP-33b: external data queue not yet implemented. */
+                    vm_rc = IRXBC_ERR_UNSUP;
+                    goto done;
 
                 case OP_PDOT:
                     pframe.cur_sym = -1;

--- a/test/mvs/tstbcom.c
+++ b/test/mvs/tstbcom.c
@@ -480,35 +480,74 @@ static void test_compound_call(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
-/*  PARSE compound-target — must still be rejected (deferred to PR D) */
+/*  Compound variable targets in PARSE templates (WP-BC-05 PR C)      */
 /* ------------------------------------------------------------------ */
 
-static void test_parse_compound_still_rejected(struct envblock *env)
+static void test_parse_compound_in_parse(struct envblock *env)
 {
-    struct irx_wkblk_int *wk;
-    int src_len;
-    int rc;
-    int exit_rc = 0;
-    const char *src = "PARSE ARG a.1\nSAY a.1\n";
+    printf("\n[Compound variable targets in PARSE templates]\n");
 
-    printf("\n[PARSE compound-target — still rejected (deferred)]\n");
+    /* Constant tail target: PARSE ARG a.1 */
+    bc_only(env,
+            "CALL sub \"hello\"\nEXIT\n"
+            "sub:\n"
+            "PARSE ARG a.1\n"
+            "SAY a.1\n"
+            "RETURN\n",
+            "hello\n",
+            "PARSE ARG constant compound target a.1");
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
-    if (wk == NULL)
-    {
-        printf("  FAIL: no work block\n");
-        tests_run++;
-        tests_failed++;
-        return;
-    }
+    /* Variable tail target: PARSE ARG a.i (i=3 at call time) */
+    bc_only(env,
+            "i = 3\n"
+            "CALL sub \"value\"\nEXIT\n"
+            "sub:\n"
+            "PARSE ARG a.i\n"
+            "SAY a.3\n"
+            "RETURN\n",
+            "value\n",
+            "PARSE ARG variable tail compound target a.i");
 
-    src_len = (int)strlen(src);
-    cap_reset();
-    wk->wkbi_use_bytecode = 1;
-    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
-    wk->wkbi_use_bytecode = 0;
+    /* Two compound targets in one template */
+    bc_only(env,
+            "PARSE VALUE \"first second\" WITH a.1 b.1\n"
+            "SAY a.1\n"
+            "SAY b.1\n",
+            "first\nsecond\n",
+            "PARSE VALUE two compound targets in template");
 
-    CHECK(rc != 0, "PARSE compound target still rejected (IRXBC_ERR_PARSE_COMPOUND)");
+    /* Multi-template PARSE with compound targets */
+    bc_only(env,
+            "CALL sub \"x\", \"y\"\nEXIT\n"
+            "sub:\n"
+            "PARSE ARG a.1, b.1\n"
+            "SAY a.1\n"
+            "SAY b.1\n"
+            "RETURN\n",
+            "x\ny\n",
+            "PARSE ARG compound targets in multi-template");
+
+    /* Multi-level compound target: a.1.2 */
+    bc_only(env,
+            "PARSE VALUE \"deep\" WITH a.1.2\n"
+            "SAY a.1.2\n",
+            "deep\n",
+            "PARSE VALUE multi-level compound target a.1.2");
+
+    /* PARSE UPPER compound target: value uppercased */
+    bc_only(env,
+            "PARSE UPPER VALUE \"hello\" WITH a.1\n"
+            "SAY a.1\n",
+            "HELLO\n",
+            "PARSE UPPER compound target value uppercased");
+
+    /* Variable tail resolves at runtime (i=1 → a.1) */
+    bc_only(env,
+            "i = 1\n"
+            "PARSE VALUE \"result\" WITH a.i\n"
+            "SAY a.1\n",
+            "result\n",
+            "PARSE VALUE compound target a.i resolves i=1 to a.1");
 }
 
 /* ------------------------------------------------------------------ */
@@ -543,7 +582,7 @@ int main(void)
     test_compound_expr(env);
     test_compound_do(env);
     test_compound_call(env);
-    test_parse_compound_still_rejected(env);
+    test_parse_compound_in_parse(env);
 
     irxterm(env);
 

--- a/test/mvs/tstbpse.c
+++ b/test/mvs/tstbpse.c
@@ -442,16 +442,62 @@ static void test_parse_special(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
-/*  Compound variable targets — must return compile error             */
+/*  Compound variable targets in PARSE templates (WP-BC-05 PR C)      */
 /* ------------------------------------------------------------------ */
 
-static void test_parse_compound_reject(struct envblock *env)
+static void test_parse_compound_target(struct envblock *env)
+{
+    printf("\n[PARSE compound-variable targets]\n");
+
+    /* Constant tail: PARSE ARG a.1 */
+    bc_only(env,
+            "CALL sub \"hello\"\nEXIT\n"
+            "sub:\n"
+            "PARSE ARG a.1\n"
+            "SAY a.1\n"
+            "RETURN\n",
+            "hello\n",
+            "PARSE ARG a.1 constant tail target");
+
+    /* Variable tail: PARSE ARG a.i where i=2 at call time */
+    bc_only(env,
+            "i = 2\n"
+            "CALL sub \"world\"\nEXIT\n"
+            "sub:\n"
+            "PARSE ARG a.i\n"
+            "SAY a.2\n"
+            "RETURN\n",
+            "world\n",
+            "PARSE ARG a.i variable tail target");
+
+    /* Two compound targets in one template */
+    bc_only(env,
+            "PARSE VALUE \"first second\" WITH a.1 b.1\n"
+            "SAY a.1\n"
+            "SAY b.1\n",
+            "first\nsecond\n",
+            "PARSE VALUE two compound targets in template");
+
+    /* Compound and simple targets mixed */
+    bc_only(env,
+            "PARSE VALUE \"one two\" WITH a.1 b\n"
+            "SAY a.1\n"
+            "SAY b\n",
+            "one\ntwo\n",
+            "PARSE VALUE compound and simple targets mixed");
+}
+
+/* ------------------------------------------------------------------ */
+/*  PARSE PULL — WP-33b stub (compiles; fails at runtime)             */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_pull(struct envblock *env)
 {
     struct irx_wkblk_int *wk;
     int src_len, rc, exit_rc = 0;
-    const char *src = "PARSE ARG a.1\nSAY a.1\n";
+    const char *src = "PARSE PULL x\nSAY x\n";
 
-    printf("\n[PARSE compound reject]\n");
+    printf("\n[PARSE PULL — WP-33b stub]\n");
 
     wk = (struct irx_wkblk_int *)env->envblock_userfield;
     if (wk == NULL)
@@ -468,8 +514,7 @@ static void test_parse_compound_reject(struct envblock *env)
     rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
     wk->wkbi_use_bytecode = 0;
 
-    /* Expect a non-zero rc (compile error IRXBC_ERR_PARSE_COMPOUND) */
-    CHECK(rc != 0, "compound target rejected by bytecode compiler");
+    CHECK(rc != 0, "PARSE PULL returns error at runtime (WP-33b not implemented)");
 }
 
 /* ------------------------------------------------------------------ */
@@ -482,7 +527,7 @@ int main(void)
     struct irxexte *exte;
     int rc;
 
-    printf("=== WP-BC-05 PR A: PARSE sub-VM Tests ===\n");
+    printf("=== WP-BC-05 PR A + PR C: PARSE sub-VM Tests ===\n");
 
     rc = irxinit(NULL, &env);
     if (rc != 0 || env == NULL)
@@ -505,7 +550,8 @@ int main(void)
     test_parse_abs(env);
     test_parse_value(env);
     test_parse_special(env);
-    test_parse_compound_reject(env);
+    test_parse_compound_target(env);
+    test_parse_pull(env);
 
     irxterm(env);
 


### PR DESCRIPTION
## Summary

- Implements compound variable targets in `PARSE` templates (`PARSE ARG a.1`, `PARSE VAR x a.i b.j`, etc.) via new opcode `OP_PVAR_STEM`
- Adds `PARSE PULL` support: compiles cleanly, returns `IRXBC_ERR_UNSUP` at runtime (WP-33b placeholder)
- Removes the `IRXBC_ERR_PARSE_COMPOUND` compile-time reject that previously blocked compound PARSE targets

## Changes

| File | What changed |
|------|-------------|
| `include/irxbops.h` | `OP_PVAR_STEM` (0x91, 4 bytes), `OP_PULL_FROM_QUEUE` (0x92, 1 byte); `OP_SIZE` updated |
| `src/irx#bcom.c` | `bpse_item` extended for compound info; `bpse_emit_item()` helper; compound parsing in `bc_parse_template()`; PULL branch in `bc_parse_stmt()` |
| `src/irx#bvm.c` | `bc_parse_frame` extended with `cur_cmpd`; `pframe_assign()` compound branch; `OP_PVAR_STEM` and `OP_PULL_FROM_QUEUE` VM cases |
| `src/irx#bctl.c` | New opcodes in disassembler name table and stem-op branch |
| `test/mvs/tstbpse.c` | Compound target tests (4) + PARSE PULL error test (1) — 29/29 |
| `test/mvs/tstbcom.c` | Compound-in-PARSE tests (7) — 42/42 |

## Test plan

- [x] `tstbpse` — 29/29 (was 25/25 with compound-reject test)
- [x] `tstbcom` — 42/42 (was 36/36 with still-rejected test)
- [x] `tstbcal` — 33/33 (no regression)
- [x] `tstbpro` — 17/17 (no regression)
- [x] Full suite (16 binaries) — 1250 tests green

Fixes #155