### PR TITLE
feat(bytecode): WP-BC-06 — OC-07 constant type-cache + docs + REXXCPS driver

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -684,6 +684,19 @@ The bytecode phase replaces the token-walk interpreter with a compile-then-execu
 pipeline. Expected throughput gain: 5–6× on top of the Phase 3 optimisations
 (2.86× REXXCPS speedup achieved by WP-PERF-02..05A).
 
+**Work package status (as of WP-BC-06):**
+
+| WP | Scope | Status |
+|----|-------|--------|
+| WP-BC-01 | EXECBLK container, skeleton compiler + VM | done |
+| WP-BC-02 | Stack, variable pool, arithmetic/compare/string opcodes | done |
+| WP-BC-03 | Control flow (JMP/JF/JT), SAY, DO loops | done |
+| WP-BC-04 | CALL/RETURN, BIF dispatch, label table, proxy parser | done |
+| WP-BC-05 PR A | PARSE sub-VM (all template types) | done |
+| WP-BC-05 PR B | PROCEDURE EXPOSE | done |
+| WP-BC-05 PR C | Compound variables + PARSE PULL stub | done |
+| WP-BC-06 | OC-07: constant type-cache pre-computation | done |
+
 ## 15.1 EXECBLK container format
 
 ```
@@ -696,11 +709,14 @@ Offset  Size  Field
   16      4   code_length bytecode length in bytes
   20      4   entry_offset offset within bytecode of entry point
   24      4   trace_map_offset offset to trace map (0 = absent)
- [28]    ... Constants Table  (count × length-prefixed Lstring)
-         ... Symbol Table     (count × length-prefixed uppercased name)
-         ... Bytecode          (code_length bytes)
-         ... Trace Map         (optional, absent in Phase 1)
+ [28]    ... Constants Table  (const_count × IRXBC_ENTRY_SIZE bytes each)
+         ... Symbol Table     (symbol_count × IRXBC_ENTRY_SIZE bytes each)
+         ... Bytecode         (code_length bytes)
+         ... Trace Map        (optional, absent currently)
 ```
+
+Each Constants Table and Symbol Table entry is exactly `IRXBC_ENTRY_SIZE` (64)
+bytes: a 1-byte length followed by up to 63 bytes of data (`IRXBC_STR_MAX = 63`).
 
 All operands in the bytecode are indices or relative offsets — no
 absolute pointers. The container is position-independent and will be
@@ -710,43 +726,172 @@ The C definition is in `include/irxexbl.h` as `struct irx_bc_execblk`.
 Note: this is **distinct** from the IBM-defined `struct execblk` in
 `include/irx.h`, which is the IRXEXEC parameter block.
 
-## 15.2 Opcode encoding
+Access macros (`include/irxexbl.h`):
 
-All opcodes are defined in `include/irxbops.h`.
+| Macro | Returns |
+|-------|---------|
+| `IRXBC_CONST_TBL(bc)` | `char *` pointer to start of Constants Table |
+| `IRXBC_SYM_TBL(bc)` | `char *` pointer to start of Symbol Table |
+| `IRXBC_CODE(bc)` | `unsigned char *` pointer to start of bytecode |
+| `IRXBC_ENTRY(bc)` | `unsigned char *` pointer to bytecode entry point |
+| `IRXBC_TOTAL(n_consts, n_syms, code_len)` | total allocation size |
 
-Phase 1 opcodes (1 byte each, no operands):
+## 15.2 Opcode table
 
-| Opcode | Byte | Description |
-|--------|------|-------------|
-| `OP_NOP` | 0x00 | No operation, advance PC |
-| `OP_EXIT` | 0x01 | Terminate execution, RC=0 |
-| `OP_NEWCLAUSE` | 0x02 | Clause boundary (TRACE hook, no-op in Phase 1) |
+All opcodes are defined in `include/irxbops.h`.  Error codes are
+`IRXBC_OK=0` through `IRXBC_ERR_PARSE_COMPOUND=31`.
 
-Future work packages extend the opcode table with operand-bearing
-instructions for literals, variable access, arithmetic, control flow, etc.
+### Phase 1 — basics
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_NOP` | 0x00 | 1 | No operation |
+| `OP_EXIT` | 0x01 | 1 | Terminate, RC=0 |
+| `OP_EXIT_RC` | 0x03 | 1 | Terminate, pop RC from stack |
+| `OP_NEWCLAUSE` | 0x02 | 1 | Clause boundary (TRACE hook) |
+| `OP_LABEL` | 0x04 | 3 | Internal label definition (`sym_idx:u16`) |
+
+### Phase 2 — stack and variables
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_PUSH_LIT` | 0x10 | 3 | Push constant by index (`const_idx:u16`) |
+| `OP_POP` | 0x11 | 2 | Pop N slots (`n:u8`) |
+| `OP_DUP` | 0x12 | 1 | Duplicate top slot |
+| `OP_LOAD` | 0x20 | 3 | Load variable (`sym_idx:u16`) |
+| `OP_STORE` | 0x21 | 3 | Store variable (`sym_idx:u16`) |
+| `OP_DROP` | 0x22 | 3 | DROP variable (`sym_idx:u16`) |
+
+### Phase 2 — arithmetic and comparison
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_ADD` | 0x30 | 1 | `b = pop; a = pop; push a+b` |
+| `OP_SUB` | 0x31 | 1 | `push a-b` |
+| `OP_MUL` | 0x32 | 1 | `push a*b` |
+| `OP_DIV` | 0x33 | 1 | `push a/b` |
+| `OP_IDIV` | 0x34 | 1 | `push a%/%b` (integer divide) |
+| `OP_MOD` | 0x35 | 1 | `push a//b` (remainder) |
+| `OP_POW` | 0x36 | 1 | `push a**b` |
+| `OP_NEG` | 0x37 | 1 | Unary minus |
+| `OP_EQ` | 0x40 | 1 | `push (a=b)` |
+| `OP_NE` | 0x41 | 1 | `push (a\=b)` |
+| `OP_LT` | 0x42 | 1 | `push (a<b)` |
+| `OP_LE` | 0x43 | 1 | `push (a<=b)` |
+| `OP_GT` | 0x44 | 1 | `push (a>b)` |
+| `OP_GE` | 0x45 | 1 | `push (a>=b)` |
+| `OP_SEQ` | 0x46 | 1 | `push (a==b)` (strict equal) |
+| `OP_SNE` | 0x47 | 1 | `push (a\==b)` |
+| `OP_SLT` | 0x48 | 1 | `push (a<<b)` |
+| `OP_SLE` | 0x49 | 1 | `push (a<<=b)` |
+| `OP_SGT` | 0x4A | 1 | `push (a>>b)` |
+| `OP_SGE` | 0x4B | 1 | `push (a>>=b)` |
+| `OP_AND` | 0x50 | 1 | Logical AND |
+| `OP_OR` | 0x51 | 1 | Logical OR |
+| `OP_XOR` | 0x52 | 1 | Logical XOR |
+| `OP_NOT` | 0x53 | 1 | Logical NOT |
+| `OP_CONCAT` | 0x60 | 1 | String concatenate (`\|\|`) |
+| `OP_BCONCAT` | 0x61 | 1 | Concatenate with one blank |
+| `OP_SAY` | 0x70 | 1 | Output top of stack via IRXINOUT |
+
+### Phase 3 — control flow (WP-BC-03)
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_JMP` | 0x71 | 3 | Unconditional jump (`off:i16`) |
+| `OP_JF` | 0x72 | 3 | Jump if top-of-stack false (`off:i16`) |
+| `OP_JT` | 0x73 | 3 | Jump if top-of-stack true (`off:i16`) |
+| `OP_FORINIT` | 0x74 | 1 | Initialize DO-count frame |
+| `OP_BYINIT` | 0x75 | 3 | Initialize DO-TO-BY frame (`sym_idx:u16`) |
+| `OP_DECFOR` | 0x76 | 3 | Decrement/test DO-count frame |
+| `OP_DECINC` | 0x77 | 3 | Step/test DO-TO-BY frame |
+| `OP_FOREND` | 0x78 | 1 | Destroy top DO frame |
+| `OP_NOVALUE` | 0x7F | 3 | Push variable name for NOVALUE signal |
+
+### Phase 4 — CALL/RETURN (WP-BC-04)
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_CALL` | 0x80 | 4 | Internal CALL (`sym_idx:u16`, `nargs:u8`) |
+| `OP_RETURN` | 0x81 | 1 | RETURN (no value) |
+| `OP_RETURNV` | 0x82 | 1 | RETURN value (pop stack) |
+| `OP_CALL_BIF` | 0x83 | 4 | BIF call (`bif_id:u16`, `nargs:u8`) |
+| `OP_PROC` | 0x7D | 1 | PROCEDURE (isolate scope) |
+| `OP_EXPOSE` | 0x7E | 3 | EXPOSE one variable (`sym_idx:u16`) |
+| `OP_EXPOSE_INDIRECT` | 0x7B | 3 | EXPOSE via name-variable (`sym_idx:u16`) |
+
+### Phase 5 — PARSE sub-VM (WP-BC-05 PR A)
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_PARSE_BEGIN` | 0x90 | 3 | Start PARSE block (`src_sym_idx:u16`) |
+| `OP_PARSE_BEGIN_UPPER` | 0x91 | 3 | PARSE UPPER (uppercases source) |
+| `OP_PARSE_BEGIN_ARG` | 0x92 | 1 | PARSE ARG (uses ARG(1)) |
+| `OP_PARSE_BEGIN_ARG_UPPER` | 0x93 | 1 | PARSE UPPER ARG |
+| `OP_PARSE_BEGIN_VALUE` | 0x94 | 1 | PARSE VALUE (pops source from stack) |
+| `OP_PARSE_BEGIN_VALUE_UPPER` | 0x95 | 1 | PARSE UPPER VALUE |
+| `OP_PARSE_PULL_STUB` | 0x96 | 1 | PARSE PULL (stub — raises UNSUP at runtime) |
+| `OP_PARSE_END` | 0x97 | 1 | End PARSE block |
+| `OP_PVAR` | 0xA0 | 3 | Assign next word/segment to variable (`sym_idx:u16`) |
+| `OP_PDOT` | 0xA1 | 1 | Placeholder (`.`) — discard segment |
+| `OP_PVAR_STEM` | 0xA2 | 3 | Assign to compound variable target (`const_idx:u16` = resolved name) |
+| `OP_TR_LIT` | 0x85 | 3 | Trigger: literal delimiter (`const_idx:u16`) |
+| `OP_TR_ABS` | 0x86 | 3 | Trigger: absolute column (`col:u16`, 1-based) |
+| `OP_TR_REL` | 0x87 | 3 | Trigger: relative offset (`off:i16`) |
+| `OP_TR_END` | 0x88 | 1 | Trigger: rest of string |
+| `OP_TR_SPACE` | 0x84 | 1 | Trigger: one word (leading blank stripped) |
+
+### Phase 5 — compound variables (WP-BC-05 PR C)
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_LOAD_CMPD` | 0xB0 | 3 | Load compound variable (`n_tails:u8` tails on stack, `stem_idx:u16`) |
+| `OP_STORE_CMPD` | 0xB1 | 3 | Store compound variable |
+| `OP_DROP_CMPD` | 0xB2 | 3 | DROP compound variable |
+| `OP_NOVALUE_CMPD` | 0xB3 | 3 | Push compound name for NOVALUE |
+| `OP_DROP_STEM` | 0xB4 | 3 | DROP entire stem (`stem_idx:u16`) |
 
 ## 15.3 Evaluation stack
 
 The evaluation stack type is `struct bc_stack_slot` (defined in
-`include/irxbvm.h`), 24 bytes per slot:
+`include/irxbvm.h`):
 
 ```c
 struct bc_stack_slot {
     PLstr   str;        /* canonical string form; always valid */
-    int32_t type_cache; /* 0=none, LINTEGER_TY, etc.          */
-    int64_t int_cache;  /* integer fast-path value             */
+    int32_t type_cache; /* 0=none, IRXBC_STACK_LINTEGER=1     */
+    int32_t int_cache;  /* integer fast-path value             */
 };
 ```
 
-`type_cache` enables an arithmetic fast path: when a value was recently
-computed as an integer, subsequent operations can skip the string→integer
-parse. On `OP_STORE`, `type_cache` is written to the variable pool so
-that `OP_LOAD` can repopulate the cache slot.
+`type_cache == IRXBC_STACK_LINTEGER` means `int_cache` holds the integer
+value of `str`, allowing arithmetic and comparison operations to bypass
+string parsing. On `OP_STORE`, the cache is written to the variable pool
+(`vpool_set_buf`), and `OP_LOAD` reads it back via `vpool_get_buf`.
 
-Phase 1 does not allocate a stack — no opcode pushes or pops yet.
-WP-BC-02 introduces the first stack-consuming opcode.
+The stack is 256 slots deep (`IRXBC_STACK_DEPTH`). SP points to the next
+free slot; push writes to `stack[sp++]`, pop reads from `stack[--sp]`.
 
-## 15.4 Compiler entry point
+## 15.4 OC-07: constant type-cache pre-computation (WP-BC-06)
+
+At VM init time, after the label pre-scan, `irx_bc_execute()` allocates
+two parallel `int32_t` arrays indexed by constant-pool index:
+
+```
+const_type_cache[n_consts]   — IRXBC_STACK_LINTEGER or 0
+const_int_cache[n_consts]    — pre-parsed integer value
+```
+
+Each constant is parsed once with the same logic as `try_parse_int_cache()`.
+On `OP_PUSH_LIT`, instead of calling `try_parse_int_cache()`, the VM copies
+the pre-computed values from these arrays — one array lookup instead of a
+full digit loop per push.
+
+This eliminates the per-execution parse cost for constants such as `1`, `0`,
+`14`, `100` that appear in loop bounds, comparisons, and stem indices. The
+gain is proportional to how often numeric constants appear in the inner loop.
+
+## 15.5 Compiler entry point
 
 ```
 irx_bc_compile(envblock, source, source_len, &bc_out)
@@ -754,12 +899,21 @@ irx_bc_compile(envblock, source, source_len, &bc_out)
 
 Located in `src/irx#bcom.c` (PDS member `IRX#BCOM`).
 
-Phase 1: tokenises the source, walks the token stream, emits opcodes
-into a local buffer, then allocates an EXECBLK container via `irxstor`
-and copies the bytecode in. The caller must free the returned container
-with `irxstor(RXSMFRE, 0, &p, envblock)`.
+Tokenises the source, walks the token stream clause by clause, and emits
+bytecode into a local growable buffer. When done, allocates an EXECBLK
+container via `irxstor` and copies the bytecode in. The caller frees the
+returned container with `irxstor(RXSMFRE, 0, &p, envblock)`.
 
-## 15.5 VM loop
+**Compiler limitations (currently returns `IRXBC_ERR_UNSUP` for):**
+
+- `SIGNAL ON condition` / `SIGNAL OFF condition`
+- `TRACE value_expression` (trace is a no-op; `TRACE OFF` is accepted)
+- `ADDRESS environment expression`
+- `PARSE LINEIN` / `PARSE PULL` (stub emits `OP_PARSE_PULL_STUB`)
+- Semicolons as clause separators on the same source line
+- Variable delimiters `(varname)` in PARSE templates
+
+## 15.6 VM loop
 
 ```
 irx_bc_execute(envblock, bc, &rc_out)
@@ -771,13 +925,18 @@ Uses a big-switch dispatch on an unsigned char opcode byte. c2asm370
 generates an optimised branch table from this pattern. The PC starts
 at `IRXBC_ENTRY(bc)` (= start of bytecode + `entry_offset`).
 
-## 15.6 Integration
+VM limits: stack depth 256, DO nesting 16, CALL depth 16.
+
+## 15.7 Integration
 
 `irx_exec_run()` in `src/irx#exec.c` checks `wkbi_use_bytecode` on
 the work block before invoking the token-walk pipeline. When the flag
 is set, it routes to `irx_bc_compile` + `irx_bc_execute` instead.
 The flag defaults to 0 (token-walk path). Setting it to 1 enables A/B
 benchmarking while both paths coexist.
+
+The default remains 0 until MVS REXXCPS measurement confirms the
+expected speedup and all remaining compiler limitations are resolved.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -741,115 +741,114 @@ Access macros (`include/irxexbl.h`):
 All opcodes are defined in `include/irxbops.h`.  Error codes are
 `IRXBC_OK=0` through `IRXBC_ERR_PARSE_COMPOUND=31`.
 
-### Phase 1 — basics
+### Phase 1 + 2 — basics, stack, variables
 
 | Opcode | Byte | Size | Description |
 |--------|------|------|-------------|
 | `OP_NOP` | 0x00 | 1 | No operation |
 | `OP_EXIT` | 0x01 | 1 | Terminate, RC=0 |
-| `OP_EXIT_RC` | 0x03 | 1 | Terminate, pop RC from stack |
 | `OP_NEWCLAUSE` | 0x02 | 1 | Clause boundary (TRACE hook) |
-| `OP_LABEL` | 0x04 | 3 | Internal label definition (`sym_idx:u16`) |
-
-### Phase 2 — stack and variables
-
-| Opcode | Byte | Size | Description |
-|--------|------|------|-------------|
+| `OP_EXIT_RC` | 0x03 | 1 | Pop TOS, terminate with RC |
+| `OP_JMP` | 0x04 | 3 | Unconditional jump (`off:i16`) |
+| `OP_JF` | 0x05 | 3 | Jump if top-of-stack false, pop (`off:i16`) |
+| `OP_JT` | 0x06 | 3 | Jump if top-of-stack true, pop (`off:i16`) |
 | `OP_PUSH_LIT` | 0x10 | 3 | Push constant by index (`const_idx:u16`) |
-| `OP_POP` | 0x11 | 2 | Pop N slots (`n:u8`) |
-| `OP_DUP` | 0x12 | 1 | Duplicate top slot |
-| `OP_LOAD` | 0x20 | 3 | Load variable (`sym_idx:u16`) |
-| `OP_STORE` | 0x21 | 3 | Store variable (`sym_idx:u16`) |
+| `OP_PUSH_TMP` | 0x11 | 1 | Reserved |
+| `OP_POP` | 0x12 | 2 | Discard N slots (`n:u8`) |
+| `OP_DUP` | 0x13 | 1 | Duplicate top slot |
+| `OP_LOAD` | 0x20 | 3 | Load variable into slot (`sym_idx:u16`) |
+| `OP_STORE` | 0x21 | 3 | Pop TOS, store into variable (`sym_idx:u16`) |
 | `OP_DROP` | 0x22 | 3 | DROP variable (`sym_idx:u16`) |
 
-### Phase 2 — arithmetic and comparison
+### Phase 2 — arithmetic, comparison, logical, string
+
+All 1 byte.  Binary ops pop two slots and push one result; unary pop one.
+
+| Opcode | Byte | REXX |
+|--------|------|------|
+| `OP_ADD` | 0x30 | `a + b` |
+| `OP_SUB` | 0x31 | `a - b` |
+| `OP_MUL` | 0x32 | `a * b` |
+| `OP_DIV` | 0x33 | `a / b` |
+| `OP_IDIV` | 0x34 | `a % b` (integer divide) |
+| `OP_MOD` | 0x35 | `a // b` (remainder) |
+| `OP_POW` | 0x36 | `a ** b` |
+| `OP_NEG` | 0x37 | `-a` (unary) |
+| `OP_EQ` | 0x40 | `a = b` |
+| `OP_NE` | 0x41 | `a \= b` |
+| `OP_LT` | 0x42 | `a < b` |
+| `OP_LE` | 0x43 | `a <= b` |
+| `OP_GT` | 0x44 | `a > b` |
+| `OP_GE` | 0x45 | `a >= b` |
+| `OP_DEQ` | 0x46 | `a == b` (strict equal) |
+| `OP_DNE` | 0x47 | `a \== b` |
+| `OP_DLT` | 0x48 | `a << b` |
+| `OP_DLE` | 0x49 | `a <<= b` |
+| `OP_DGT` | 0x4A | `a >> b` |
+| `OP_DGE` | 0x4B | `a >>= b` |
+| `OP_AND` | 0x50 | `a & b` |
+| `OP_OR` | 0x51 | `a \| b` |
+| `OP_XOR` | 0x52 | `a && b` |
+| `OP_NOT` | 0x53 | `\a` (unary) |
+| `OP_CONCAT` | 0x60 | `a \|\| b` |
+| `OP_BCONCAT` | 0x61 | `a b` (with blank) |
+
+### Phase 3 — I/O, DO loops, iteration (WP-BC-03)
 
 | Opcode | Byte | Size | Description |
 |--------|------|------|-------------|
-| `OP_ADD` | 0x30 | 1 | `b = pop; a = pop; push a+b` |
-| `OP_SUB` | 0x31 | 1 | `push a-b` |
-| `OP_MUL` | 0x32 | 1 | `push a*b` |
-| `OP_DIV` | 0x33 | 1 | `push a/b` |
-| `OP_IDIV` | 0x34 | 1 | `push a%/%b` (integer divide) |
-| `OP_MOD` | 0x35 | 1 | `push a//b` (remainder) |
-| `OP_POW` | 0x36 | 1 | `push a**b` |
-| `OP_NEG` | 0x37 | 1 | Unary minus |
-| `OP_EQ` | 0x40 | 1 | `push (a=b)` |
-| `OP_NE` | 0x41 | 1 | `push (a\=b)` |
-| `OP_LT` | 0x42 | 1 | `push (a<b)` |
-| `OP_LE` | 0x43 | 1 | `push (a<=b)` |
-| `OP_GT` | 0x44 | 1 | `push (a>b)` |
-| `OP_GE` | 0x45 | 1 | `push (a>=b)` |
-| `OP_SEQ` | 0x46 | 1 | `push (a==b)` (strict equal) |
-| `OP_SNE` | 0x47 | 1 | `push (a\==b)` |
-| `OP_SLT` | 0x48 | 1 | `push (a<<b)` |
-| `OP_SLE` | 0x49 | 1 | `push (a<<=b)` |
-| `OP_SGT` | 0x4A | 1 | `push (a>>b)` |
-| `OP_SGE` | 0x4B | 1 | `push (a>>=b)` |
-| `OP_AND` | 0x50 | 1 | Logical AND |
-| `OP_OR` | 0x51 | 1 | Logical OR |
-| `OP_XOR` | 0x52 | 1 | Logical XOR |
-| `OP_NOT` | 0x53 | 1 | Logical NOT |
-| `OP_CONCAT` | 0x60 | 1 | String concatenate (`\|\|`) |
-| `OP_BCONCAT` | 0x61 | 1 | Concatenate with one blank |
-| `OP_SAY` | 0x70 | 1 | Output top of stack via IRXINOUT |
-
-### Phase 3 — control flow (WP-BC-03)
-
-| Opcode | Byte | Size | Description |
-|--------|------|------|-------------|
-| `OP_JMP` | 0x71 | 3 | Unconditional jump (`off:i16`) |
-| `OP_JF` | 0x72 | 3 | Jump if top-of-stack false (`off:i16`) |
-| `OP_JT` | 0x73 | 3 | Jump if top-of-stack true (`off:i16`) |
-| `OP_FORINIT` | 0x74 | 1 | Initialize DO-count frame |
-| `OP_BYINIT` | 0x75 | 3 | Initialize DO-TO-BY frame (`sym_idx:u16`) |
-| `OP_DECFOR` | 0x76 | 3 | Decrement/test DO-count frame |
-| `OP_DECINC` | 0x77 | 3 | Step/test DO-TO-BY frame |
-| `OP_FOREND` | 0x78 | 1 | Destroy top DO frame |
-| `OP_NOVALUE` | 0x7F | 3 | Push variable name for NOVALUE signal |
+| `OP_SAY` | 0x70 | 1 | Pop TOS, write via IRXINOUT |
+| `OP_TOINT` | 0x71 | 1 | Coerce TOS to integer string |
+| `OP_FORINIT` | 0x72 | 2 | Pop count → frame[`n:u8`]; push bool (count>0) |
+| `OP_BYINIT` | 0x73 | 2 | Reserved (`n:u8`) |
+| `OP_DECFOR` | 0x74 | 4 | Decrement frame[`n:u8`]; jump-if-done (`off:i16`) |
+| `OP_DOTEST` | 0x75 | 1 | Reserved (WHILE/UNTIL via JF) |
+| `OP_ITERATE` | 0x76 | 3 | Jump to iterate point (`off:i16`) |
+| `OP_LEAVE` | 0x77 | 3 | Jump to loop end (`off:i16`) |
 
 ### Phase 4 — CALL/RETURN (WP-BC-04)
 
 | Opcode | Byte | Size | Description |
 |--------|------|------|-------------|
-| `OP_CALL` | 0x80 | 4 | Internal CALL (`sym_idx:u16`, `nargs:u8`) |
-| `OP_RETURN` | 0x81 | 1 | RETURN (no value) |
-| `OP_RETURNV` | 0x82 | 1 | RETURN value (pop stack) |
-| `OP_CALL_BIF` | 0x83 | 4 | BIF call (`bif_id:u16`, `nargs:u8`) |
-| `OP_PROC` | 0x7D | 1 | PROCEDURE (isolate scope) |
-| `OP_EXPOSE` | 0x7E | 3 | EXPOSE one variable (`sym_idx:u16`) |
-| `OP_EXPOSE_INDIRECT` | 0x7B | 3 | EXPOSE via name-variable (`sym_idx:u16`) |
+| `OP_LABEL` | 0x78 | 3 | Call target definition (`sym_idx:u16`) |
+| `OP_CALL` | 0x79 | 4 | CALL statement (`sym_idx:u16`, `nargs:u8`) |
+| `OP_CALL_BIF` | 0x7A | 4 | Expression BIF call (`sym_idx:u16`, `nargs:u8`) |
+| `OP_RETURN` | 0x7B | 1 | Return, no value |
+| `OP_RETURNV` | 0x7C | 1 | Pop TOS, return as RESULT |
 
-### Phase 5 — PARSE sub-VM (WP-BC-05 PR A)
+### Phase 5 — PARSE sub-VM (WP-BC-05 PR A + PR C)
 
 | Opcode | Byte | Size | Description |
 |--------|------|------|-------------|
-| `OP_PARSE_BEGIN` | 0x90 | 3 | Start PARSE block (`src_sym_idx:u16`) |
-| `OP_PARSE_BEGIN_UPPER` | 0x91 | 3 | PARSE UPPER (uppercases source) |
-| `OP_PARSE_BEGIN_ARG` | 0x92 | 1 | PARSE ARG (uses ARG(1)) |
-| `OP_PARSE_BEGIN_ARG_UPPER` | 0x93 | 1 | PARSE UPPER ARG |
-| `OP_PARSE_BEGIN_VALUE` | 0x94 | 1 | PARSE VALUE (pops source from stack) |
-| `OP_PARSE_BEGIN_VALUE_UPPER` | 0x95 | 1 | PARSE UPPER VALUE |
-| `OP_PARSE_PULL_STUB` | 0x96 | 1 | PARSE PULL (stub — raises UNSUP at runtime) |
-| `OP_PARSE_END` | 0x97 | 1 | End PARSE block |
-| `OP_PVAR` | 0xA0 | 3 | Assign next word/segment to variable (`sym_idx:u16`) |
-| `OP_PDOT` | 0xA1 | 1 | Placeholder (`.`) — discard segment |
-| `OP_PVAR_STEM` | 0xA2 | 3 | Assign to compound variable target (`const_idx:u16` = resolved name) |
-| `OP_TR_LIT` | 0x85 | 3 | Trigger: literal delimiter (`const_idx:u16`) |
+| `OP_PARSE_BEGIN` | 0x80 | 2 | Start PARSE block (`flags:u8`, bit0=UPPER); pops source |
+| `OP_PARSE_END` | 0x81 | 1 | End PARSE block |
+| `OP_PVAR` | 0x82 | 3 | Assign segment to variable (`sym_idx:u16`) |
+| `OP_PDOT` | 0x83 | 1 | Dot placeholder — discard segment |
+| `OP_TR_SPACE` | 0x84 | 1 | Trigger: one word |
+| `OP_TR_LIT` | 0x85 | 3 | Trigger: literal delimiter (`lit_idx:u16`) |
 | `OP_TR_ABS` | 0x86 | 3 | Trigger: absolute column (`col:u16`, 1-based) |
 | `OP_TR_REL` | 0x87 | 3 | Trigger: relative offset (`off:i16`) |
 | `OP_TR_END` | 0x88 | 1 | Trigger: rest of string |
-| `OP_TR_SPACE` | 0x84 | 1 | Trigger: one word (leading blank stripped) |
+| `OP_PUSH_SOURCE` | 0x89 | 1 | Push PARSE SOURCE string |
+| `OP_PUSH_NUMERIC` | 0x8A | 1 | Push PARSE NUMERIC string |
+
+### Phase 5 — PROCEDURE EXPOSE (WP-BC-05 PR B)
+
+| Opcode | Byte | Size | Description |
+|--------|------|------|-------------|
+| `OP_PROC` | 0x8B | 2 | PROCEDURE — isolate scope (`nexposed:u8`) |
+| `OP_EXPOSE` | 0x8C | 3 | EXPOSE one variable (`sym_idx:u16`) |
+| `OP_EXPOSE_INDIRECT` | 0x8D | 3 | EXPOSE via name-variable (`sym_idx:u16`) |
 
 ### Phase 5 — compound variables (WP-BC-05 PR C)
 
 | Opcode | Byte | Size | Description |
 |--------|------|------|-------------|
-| `OP_LOAD_CMPD` | 0xB0 | 3 | Load compound variable (`n_tails:u8` tails on stack, `stem_idx:u16`) |
-| `OP_STORE_CMPD` | 0xB1 | 3 | Store compound variable |
-| `OP_DROP_CMPD` | 0xB2 | 3 | DROP compound variable |
-| `OP_NOVALUE_CMPD` | 0xB3 | 3 | Push compound name for NOVALUE |
-| `OP_DROP_STEM` | 0xB4 | 3 | DROP entire stem (`stem_idx:u16`) |
+| `OP_LOAD_STEM` | 0x8E | 4 | Load compound var (`stem_sym:u16`, `tail_count:u8`) |
+| `OP_STORE_STEM` | 0x8F | 4 | Store compound var |
+| `OP_DROP_STEM` | 0x90 | 4 | DROP compound or entire stem (`tail_count=0` → all) |
+| `OP_PVAR_STEM` | 0x91 | 4 | PARSE target: compound var (`stem_sym:u16`, `tail_count:u8`) |
+| `OP_PULL_FROM_QUEUE` | 0x92 | 1 | Push next queue line (WP-33b stub; raises UNSUP) |
 
 ## 15.3 Evaluation stack
 
@@ -909,7 +908,7 @@ returned container with `irxstor(RXSMFRE, 0, &p, envblock)`.
 - `SIGNAL ON condition` / `SIGNAL OFF condition`
 - `TRACE value_expression` (trace is a no-op; `TRACE OFF` is accepted)
 - `ADDRESS environment expression`
-- `PARSE LINEIN` / `PARSE PULL` (stub emits `OP_PARSE_PULL_STUB`)
+- `PARSE LINEIN` / `PARSE PULL` (`OP_PULL_FROM_QUEUE` stub raises `IRXBC_ERR_UNSUP` at runtime)
 - Semicolons as clause separators on the same source line
 - Variable delimiters `(varname)` in PARSE templates
 

--- a/docs/bytecode-format.md
+++ b/docs/bytecode-format.md
@@ -1,0 +1,337 @@
+# REXX/370 Bytecode Format Reference
+
+This document describes the EXECBLK container layout, the complete opcode
+table, and the VM evaluation model as of WP-BC-06.
+
+See `docs/architecture.md §15` for the design rationale.
+Implementation files: `include/irxbops.h`, `include/irxexbl.h`,
+`include/irxbvm.h`, `src/irx#bcom.c`, `src/irx#bvm.c`.
+
+---
+
+## 1. EXECBLK Container Layout
+
+```
+struct irx_bc_execblk {
+    char          magic[4];         /* "RX37" eye-catcher           */
+    uint16_t      version;          /* format version = 1           */
+    uint16_t      flags;            /* reserved, zero               */
+    uint32_t      const_count;      /* number of constant entries   */
+    uint32_t      symbol_count;     /* number of symbol entries     */
+    uint32_t      code_length;      /* bytecode length in bytes     */
+    uint32_t      entry_offset;     /* offset of entry point in     */
+                                    /* bytecode (usually 0)         */
+    uint32_t      trace_map_offset; /* offset to trace map; 0=none  */
+    /* followed by: Constants Table, Symbol Table, Bytecode */
+};
+```
+
+Immediately after the header:
+
+```
++----------------------------------+
+| Constants Table                  |  const_count × 64 bytes
+|  entry[0]: len(1) + data(63)     |
+|  entry[1]: len(1) + data(63)     |
+|  ...                             |
++----------------------------------+
+| Symbol Table                     |  symbol_count × 64 bytes
+|  entry[0]: len(1) + upper(63)    |  (uppercased variable names)
+|  ...                             |
++----------------------------------+
+| Bytecode                         |  code_length bytes
+|  ...                             |
++----------------------------------+
+| Trace Map (if present)           |  currently unused
++----------------------------------+
+```
+
+Constants: source literals (strings and numbers) exactly as written.
+Symbols: variable names and internal label names, uppercased.
+
+Each entry is exactly `IRXBC_ENTRY_SIZE = 64` bytes.  The first byte is
+the data length (0–63); the remaining 63 bytes hold the data (`IRXBC_STR_MAX = 63`).
+Strings longer than 63 bytes are not representable and cause a compile error.
+
+### Access macros (`include/irxexbl.h`)
+
+```c
+IRXBC_CONST_TBL(bc)   /* char *    — start of Constants Table */
+IRXBC_SYM_TBL(bc)     /* char *    — start of Symbol Table    */
+IRXBC_CODE(bc)         /* unsigned char * — start of bytecode  */
+IRXBC_ENTRY(bc)        /* unsigned char * — entry point        */
+IRXBC_TOTAL(nc,ns,cl)  /* size_t   — total allocation size     */
+```
+
+---
+
+## 2. Opcode Encoding
+
+All opcodes are 1-byte values in the range 0x00–0xFF.  Operands follow
+the opcode byte and are encoded little-endian:
+
+- `u8`  — unsigned 8-bit (1 byte)
+- `u16` — unsigned 16-bit little-endian (2 bytes)
+- `i16` — signed 16-bit little-endian (2 bytes), relative jump offset
+
+Jump offsets are relative to the byte **after the complete instruction**
+(i.e. after the operand bytes).
+
+The `OP_SIZE(op)` macro in `irxbops.h` returns the total byte size
+(opcode + operands) for opcode `op`.
+
+---
+
+## 3. Complete Opcode Table
+
+### 3.1 Phase 1 — Basics (WP-BC-01)
+
+| Opcode | Hex | Size | Stack effect | Description |
+|--------|-----|------|--------------|-------------|
+| `OP_NOP` | 0x00 | 1 | — | No operation |
+| `OP_EXIT` | 0x01 | 1 | — | Terminate, `*rc_out = 0` |
+| `OP_NEWCLAUSE` | 0x02 | 1 | — | Clause boundary (TRACE hook) |
+| `OP_EXIT_RC` | 0x03 | 1 | pop → RC | Terminate, RC from top of stack |
+| `OP_LABEL` | 0x04 | 3 | — | `sym_idx:u16` — label definition point |
+
+### 3.2 Phase 2 — Stack and Variables (WP-BC-02)
+
+| Opcode | Hex | Size | Stack effect | Description |
+|--------|-----|------|--------------|-------------|
+| `OP_PUSH_LIT` | 0x10 | 3 | → val | `const_idx:u16`; push constant from table |
+| `OP_POP` | 0x11 | 2 | pop n → | `n:u8`; discard N slots |
+| `OP_DUP` | 0x12 | 1 | val → val val | Duplicate top slot |
+| `OP_LOAD` | 0x20 | 3 | → val | `sym_idx:u16`; load variable into slot |
+| `OP_STORE` | 0x21 | 3 | val → | `sym_idx:u16`; store top into variable (no pop) |
+| `OP_DROP` | 0x22 | 3 | — | `sym_idx:u16`; DROP variable |
+
+**STORE does not pop.** The value remains on the stack for use in
+chained assignments or expression context.
+
+### 3.3 Phase 2 — Arithmetic (WP-BC-02)
+
+Binary ops pop two slots, push one result.  Slots carry `type_cache` and
+`int_cache` for the integer fast path (`try_arith_fast`).
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_ADD` | 0x30 | 1 | `a + b` |
+| `OP_SUB` | 0x31 | 1 | `a - b` |
+| `OP_MUL` | 0x32 | 1 | `a * b` |
+| `OP_DIV` | 0x33 | 1 | `a / b` (REXX numeric division) |
+| `OP_IDIV` | 0x34 | 1 | `a %/% b` (integer divide, `%/%` in REXX is `%`) |
+| `OP_MOD` | 0x35 | 1 | `a // b` (remainder) |
+| `OP_POW` | 0x36 | 1 | `a ** b` |
+| `OP_NEG` | 0x37 | 1 | Unary minus (pop 1, push 1) |
+
+### 3.4 Phase 2 — Comparison (WP-BC-02)
+
+Pop two slots, push "0" or "1".
+
+| Opcode | Hex | Size | REXX operator |
+|--------|-----|------|---------------|
+| `OP_EQ` | 0x40 | 1 | `a = b` |
+| `OP_NE` | 0x41 | 1 | `a \= b` |
+| `OP_LT` | 0x42 | 1 | `a < b` |
+| `OP_LE` | 0x43 | 1 | `a <= b` |
+| `OP_GT` | 0x44 | 1 | `a > b` |
+| `OP_GE` | 0x45 | 1 | `a >= b` |
+| `OP_SEQ` | 0x46 | 1 | `a == b` (strict) |
+| `OP_SNE` | 0x47 | 1 | `a \== b` |
+| `OP_SLT` | 0x48 | 1 | `a << b` |
+| `OP_SLE` | 0x49 | 1 | `a <<= b` |
+| `OP_SGT` | 0x4A | 1 | `a >> b` |
+| `OP_SGE` | 0x4B | 1 | `a >>= b` |
+
+### 3.5 Phase 2 — Logical and String (WP-BC-02)
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_AND` | 0x50 | 1 | Logical AND (pops 2, pushes "0"/"1") |
+| `OP_OR` | 0x51 | 1 | Logical OR |
+| `OP_XOR` | 0x52 | 1 | Logical XOR |
+| `OP_NOT` | 0x53 | 1 | Logical NOT (pops 1, pushes "0"/"1") |
+| `OP_CONCAT` | 0x60 | 1 | `a \|\| b` — concatenate without separator |
+| `OP_BCONCAT` | 0x61 | 1 | `a b` — concatenate with one blank |
+| `OP_SAY` | 0x70 | 1 | Output top of stack via IRXINOUT, pop |
+
+### 3.6 Phase 3 — Control Flow (WP-BC-03)
+
+Jump offsets are signed 16-bit, relative to the byte after the instruction.
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_JMP` | 0x71 | 3 | `off:i16` — unconditional jump |
+| `OP_JF` | 0x72 | 3 | `off:i16` — jump if top-of-stack false, pop |
+| `OP_JT` | 0x73 | 3 | `off:i16` — jump if top-of-stack true, pop |
+| `OP_FORINIT` | 0x74 | 1 | Initialize count-loop frame (pops count) |
+| `OP_BYINIT` | 0x75 | 3 | `sym_idx:u16` — init TO-BY loop (loop var) |
+| `OP_DECFOR` | 0x76 | 3 | `off:i16` — decrement count frame; jump if done |
+| `OP_DECINC` | 0x77 | 3 | `off:i16` — step TO-BY frame; jump if done |
+| `OP_FOREND` | 0x78 | 1 | Pop top DO frame |
+| `OP_NOVALUE` | 0x7F | 3 | `sym_idx:u16` — push variable name (for NOVALUE) |
+
+**DO loop protocol:**
+
+- `DO count`: emit expression for count, `OP_FORINIT`, body, `OP_DECFOR` (with back-edge jump).
+- `DO var = start TO limit BY step`: emit start/limit/step stores, `OP_BYINIT`, body, `OP_DECINC`.
+- `DO FOREVER`: `OP_JMP` (forward), body, `OP_JMP` (back).
+- ITERATE: `OP_JMP` to the `OP_DECFOR`/`OP_DECINC` instruction.
+- LEAVE: `OP_FOREND` + `OP_JMP` past the loop.
+
+### 3.7 Phase 4 — CALL/RETURN (WP-BC-04)
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_CALL` | 0x80 | 4 | `sym_idx:u16`, `nargs:u8` — internal label call |
+| `OP_RETURN` | 0x81 | 1 | Return from CALL (no value) |
+| `OP_RETURNV` | 0x82 | 1 | Return from CALL (value on stack) |
+| `OP_CALL_BIF` | 0x83 | 4 | `bif_id:u16`, `nargs:u8` — BIF call |
+| `OP_PROC` | 0x7D | 1 | PROCEDURE (isolate variable scope) |
+| `OP_EXPOSE` | 0x7E | 3 | `sym_idx:u16` — EXPOSE one variable |
+| `OP_EXPOSE_INDIRECT` | 0x7B | 3 | `sym_idx:u16` — EXPOSE via name-variable |
+
+Before `OP_CALL`, args are pushed on the eval stack (arg N first, arg 1
+last).  The VM saves them into the call frame and pops them.  On `OP_RETURN`/
+`OP_RETURNV` the call frame is popped; with a return value, it lands on the
+eval stack of the caller.
+
+`OP_PROC` must be the first instruction in a subroutine that uses
+`PROCEDURE [EXPOSE ...]`.
+
+### 3.8 Phase 5 — PARSE Sub-VM (WP-BC-05 PR A)
+
+The PARSE sub-VM operates on a single source string, advancing a scan
+pointer according to trigger instructions, and assigning sub-strings to
+target variables.
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_PARSE_BEGIN` | 0x90 | 3 | `sym_idx:u16` — PARSE VAR (source = variable) |
+| `OP_PARSE_BEGIN_UPPER` | 0x91 | 3 | PARSE UPPER VAR |
+| `OP_PARSE_BEGIN_ARG` | 0x92 | 1 | PARSE ARG (source = ARG(1)) |
+| `OP_PARSE_BEGIN_ARG_UPPER` | 0x93 | 1 | PARSE UPPER ARG |
+| `OP_PARSE_BEGIN_VALUE` | 0x94 | 1 | PARSE VALUE (source = top of stack, popped) |
+| `OP_PARSE_BEGIN_VALUE_UPPER` | 0x95 | 1 | PARSE UPPER VALUE |
+| `OP_PARSE_PULL_STUB` | 0x96 | 1 | PARSE PULL — stub, raises `IRXBC_ERR_UNSUP` at runtime |
+| `OP_PARSE_END` | 0x97 | 1 | End PARSE block |
+
+**Target instructions** (within PARSE block):
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_PVAR` | 0xA0 | 3 | `sym_idx:u16` — assign segment to simple variable |
+| `OP_PDOT` | 0xA1 | 1 | Placeholder (`.`) — discard segment |
+| `OP_PVAR_STEM` | 0xA2 | 3 | `const_idx:u16` — assign to pre-resolved compound name |
+
+**Trigger instructions** (follow a target, delimit the segment):
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_TR_SPACE` | 0x84 | 1 | Word trigger (one word, leading spaces stripped) |
+| `OP_TR_LIT` | 0x85 | 3 | `const_idx:u16` — literal string delimiter |
+| `OP_TR_ABS` | 0x86 | 3 | `col:u16` — absolute column (1-based) |
+| `OP_TR_REL` | 0x87 | 3 | `off:i16` — relative offset |
+| `OP_TR_END` | 0x88 | 1 | Rest of string (end of template) |
+
+Each template item is a target followed by a trigger.  `OP_TR_SPACE` is the
+implicit trigger for bare variable names.  The last item in a template always
+uses `OP_TR_END`.
+
+### 3.9 Phase 5 — Compound Variables (WP-BC-05 PR C)
+
+Compound variables (e.g. `A.I.J`, `STEM.KEY`) push their tail expressions
+onto the eval stack before the compound opcode.
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_LOAD_CMPD` | 0xB0 | 4 | `stem_idx:u16`, `n_tails:u8` — load compound |
+| `OP_STORE_CMPD` | 0xB1 | 4 | Store value (top of stack) into compound |
+| `OP_DROP_CMPD` | 0xB2 | 4 | DROP compound variable |
+| `OP_NOVALUE_CMPD` | 0xB3 | 4 | Push compound name string (for NOVALUE) |
+| `OP_DROP_STEM` | 0xB4 | 3 | `stem_idx:u16` — DROP entire stem |
+
+**Before any compound opcode**, the caller pushes `n_tails` tail values.
+The opcode pops the tails, looks up the stem name from the symbol table,
+concatenates the resolved tail values (after uppercasing) to form the full
+variable name, then calls `vpool_get_buf` / `vpool_set_buf` / `vpool_drop_buf`.
+
+---
+
+## 4. Evaluation Stack
+
+- Depth: 256 slots (`IRXBC_STACK_DEPTH`).
+- Each slot: `struct bc_stack_slot` = `PLstr str` + `int32_t type_cache` + `int32_t int_cache`.
+- `str` points into a parallel `Lstr` array allocated at VM init.
+- SP points to the **next free** slot.  Push: `stack[sp++]`.  Pop: `stack[--sp]`.
+- `type_cache == IRXBC_STACK_LINTEGER (1)` means `int_cache` holds the parsed integer.
+
+---
+
+## 5. VM Resource Limits
+
+| Resource | Limit | Configured by |
+|----------|-------|---------------|
+| Eval stack depth | 256 | `IRXBC_STACK_DEPTH` |
+| DO loop nesting | 16 | `IRXBC_DO_DEPTH` |
+| CALL depth | 16 | `IRXBC_CALL_DEPTH` |
+| ARG() max arguments | `IRX_MAX_ARGS` | `include/irxfunc.h` |
+| Constant/symbol name length | 63 bytes | `IRXBC_STR_MAX` |
+
+---
+
+## 6. Constant Type-Cache (OC-07, WP-BC-06)
+
+At VM init, `irx_bc_execute()` allocates two `int32_t[n_consts]` arrays:
+
+```
+const_type_cache[i]  — IRXBC_STACK_LINTEGER or 0
+const_int_cache[i]   — parsed integer value for const i
+```
+
+Each constant is pre-parsed using the same digit-scan logic as
+`try_parse_int_cache()`.  On `OP_PUSH_LIT`, instead of calling the parse
+function at runtime, the VM reads the pre-computed values directly:
+
+```c
+stack[sp].type_cache = const_type_cache[idx];
+stack[sp].int_cache  = const_int_cache[idx];
+```
+
+This eliminates repeated digit-parsing of constants such as loop bounds
+(`1`, `14`, `100`), comparison values (`0`, `5`), and BIF arguments.
+
+---
+
+## 7. Compiler Limitations (current)
+
+The following constructs cause `IRXBC_ERR_UNSUP` from the compiler:
+
+- `SIGNAL ON condition` / `SIGNAL OFF`
+- `TRACE value_expression`
+- `ADDRESS environment expression`
+- `PARSE PULL` / `PARSE LINEIN` (emits `OP_PARSE_PULL_STUB`, which raises UNSUP at runtime)
+- Semicolons as clause separators within a source line
+- Variable delimiter `(varname)` in PARSE templates
+
+These limitations are tracked as follow-up items for WP-BC-07+.
+
+---
+
+## 8. Error Codes
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `IRXBC_OK` | 0 | Success |
+| `IRXBC_ERR_STOR` | 20 | `irxstor` allocation failed |
+| `IRXBC_ERR_TOKN` | 21 | Tokenizer returned an error |
+| `IRXBC_ERR_UNSUP` | 22 | Unsupported construct (compile-time) |
+| `IRXBC_ERR_OPCODE` | 23 | Unknown opcode (VM runtime) |
+| `IRXBC_ERR_ARITH` | 24 | Arithmetic error (type, divide-by-zero) |
+| `IRXBC_ERR_STACK` | 25 | Stack underflow or overflow |
+| `IRXBC_ERR_PATCH` | 26 | Too many forward-jump patches |
+| `IRXBC_ERR_LOOP` | 27 | DO nesting too deep |
+| `IRXBC_ERR_IO` | 28 | I/O routine call failed |
+| `IRXBC_ERR_STRTOOLONG` | 29 | Literal/symbol exceeds `IRXBC_STR_MAX` |
+| `IRXBC_ERR_CALL` | 30 | CALL stack overflow |
+| `IRXBC_ERR_PARSE_COMPOUND` | 31 | Compound variable target in PARSE template |

--- a/docs/bytecode-format.md
+++ b/docs/bytecode-format.md
@@ -91,22 +91,19 @@ The `OP_SIZE(op)` macro in `irxbops.h` returns the total byte size
 | `OP_NOP` | 0x00 | 1 | — | No operation |
 | `OP_EXIT` | 0x01 | 1 | — | Terminate, `*rc_out = 0` |
 | `OP_NEWCLAUSE` | 0x02 | 1 | — | Clause boundary (TRACE hook) |
-| `OP_EXIT_RC` | 0x03 | 1 | pop → RC | Terminate, RC from top of stack |
-| `OP_LABEL` | 0x04 | 3 | — | `sym_idx:u16` — label definition point |
+| `OP_EXIT_RC` | 0x03 | 1 | pop → RC | Pop TOS, convert to int, terminate |
 
 ### 3.2 Phase 2 — Stack and Variables (WP-BC-02)
 
 | Opcode | Hex | Size | Stack effect | Description |
 |--------|-----|------|--------------|-------------|
 | `OP_PUSH_LIT` | 0x10 | 3 | → val | `const_idx:u16`; push constant from table |
-| `OP_POP` | 0x11 | 2 | pop n → | `n:u8`; discard N slots |
-| `OP_DUP` | 0x12 | 1 | val → val val | Duplicate top slot |
+| `OP_PUSH_TMP` | 0x11 | 1 | — | Reserved |
+| `OP_POP` | 0x12 | 2 | pop n → | `n:u8`; discard N slots |
+| `OP_DUP` | 0x13 | 1 | val → val val | Duplicate top slot |
 | `OP_LOAD` | 0x20 | 3 | → val | `sym_idx:u16`; load variable into slot |
-| `OP_STORE` | 0x21 | 3 | val → | `sym_idx:u16`; store top into variable (no pop) |
+| `OP_STORE` | 0x21 | 3 | val → | `sym_idx:u16`; pop TOS and store into variable |
 | `OP_DROP` | 0x22 | 3 | — | `sym_idx:u16`; DROP variable |
-
-**STORE does not pop.** The value remains on the stack for use in
-chained assignments or expression context.
 
 ### 3.3 Phase 2 — Arithmetic (WP-BC-02)
 
@@ -119,7 +116,7 @@ Binary ops pop two slots, push one result.  Slots carry `type_cache` and
 | `OP_SUB` | 0x31 | 1 | `a - b` |
 | `OP_MUL` | 0x32 | 1 | `a * b` |
 | `OP_DIV` | 0x33 | 1 | `a / b` (REXX numeric division) |
-| `OP_IDIV` | 0x34 | 1 | `a %/% b` (integer divide, `%/%` in REXX is `%`) |
+| `OP_IDIV` | 0x34 | 1 | `a % b` (integer divide, truncate-to-zero) |
 | `OP_MOD` | 0x35 | 1 | `a // b` (remainder) |
 | `OP_POW` | 0x36 | 1 | `a ** b` |
 | `OP_NEG` | 0x37 | 1 | Unary minus (pop 1, push 1) |
@@ -130,30 +127,30 @@ Pop two slots, push "0" or "1".
 
 | Opcode | Hex | Size | REXX operator |
 |--------|-----|------|---------------|
-| `OP_EQ` | 0x40 | 1 | `a = b` |
+| `OP_EQ` | 0x40 | 1 | `a = b` (fuzzy equal) |
 | `OP_NE` | 0x41 | 1 | `a \= b` |
 | `OP_LT` | 0x42 | 1 | `a < b` |
 | `OP_LE` | 0x43 | 1 | `a <= b` |
 | `OP_GT` | 0x44 | 1 | `a > b` |
 | `OP_GE` | 0x45 | 1 | `a >= b` |
-| `OP_SEQ` | 0x46 | 1 | `a == b` (strict) |
-| `OP_SNE` | 0x47 | 1 | `a \== b` |
-| `OP_SLT` | 0x48 | 1 | `a << b` |
-| `OP_SLE` | 0x49 | 1 | `a <<= b` |
-| `OP_SGT` | 0x4A | 1 | `a >> b` |
-| `OP_SGE` | 0x4B | 1 | `a >>= b` |
+| `OP_DEQ` | 0x46 | 1 | `a == b` (strict equal) |
+| `OP_DNE` | 0x47 | 1 | `a \== b` |
+| `OP_DLT` | 0x48 | 1 | `a << b` |
+| `OP_DLE` | 0x49 | 1 | `a <<= b` |
+| `OP_DGT` | 0x4A | 1 | `a >> b` |
+| `OP_DGE` | 0x4B | 1 | `a >>= b` |
 
 ### 3.5 Phase 2 — Logical and String (WP-BC-02)
 
 | Opcode | Hex | Size | Description |
 |--------|-----|------|-------------|
-| `OP_AND` | 0x50 | 1 | Logical AND (pops 2, pushes "0"/"1") |
-| `OP_OR` | 0x51 | 1 | Logical OR |
-| `OP_XOR` | 0x52 | 1 | Logical XOR |
-| `OP_NOT` | 0x53 | 1 | Logical NOT (pops 1, pushes "0"/"1") |
+| `OP_AND` | 0x50 | 1 | `a & b` — logical AND (pops 2, pushes "0"/"1") |
+| `OP_OR` | 0x51 | 1 | `a \| b` — logical OR |
+| `OP_XOR` | 0x52 | 1 | `a && b` — logical XOR |
+| `OP_NOT` | 0x53 | 1 | `\a` — logical NOT (pops 1, pushes "0"/"1") |
 | `OP_CONCAT` | 0x60 | 1 | `a \|\| b` — concatenate without separator |
 | `OP_BCONCAT` | 0x61 | 1 | `a b` — concatenate with one blank |
-| `OP_SAY` | 0x70 | 1 | Output top of stack via IRXINOUT, pop |
+| `OP_SAY` | 0x70 | 1 | Pop TOS, output via IRXINOUT |
 
 ### 3.6 Phase 3 — Control Flow (WP-BC-03)
 
@@ -161,100 +158,97 @@ Jump offsets are signed 16-bit, relative to the byte after the instruction.
 
 | Opcode | Hex | Size | Description |
 |--------|-----|------|-------------|
-| `OP_JMP` | 0x71 | 3 | `off:i16` — unconditional jump |
-| `OP_JF` | 0x72 | 3 | `off:i16` — jump if top-of-stack false, pop |
-| `OP_JT` | 0x73 | 3 | `off:i16` — jump if top-of-stack true, pop |
-| `OP_FORINIT` | 0x74 | 1 | Initialize count-loop frame (pops count) |
-| `OP_BYINIT` | 0x75 | 3 | `sym_idx:u16` — init TO-BY loop (loop var) |
-| `OP_DECFOR` | 0x76 | 3 | `off:i16` — decrement count frame; jump if done |
-| `OP_DECINC` | 0x77 | 3 | `off:i16` — step TO-BY frame; jump if done |
-| `OP_FOREND` | 0x78 | 1 | Pop top DO frame |
-| `OP_NOVALUE` | 0x7F | 3 | `sym_idx:u16` — push variable name (for NOVALUE) |
+| `OP_JMP` | 0x04 | 3 | `off:i16` — unconditional jump |
+| `OP_JF` | 0x05 | 3 | `off:i16` — jump if top-of-stack false, pop |
+| `OP_JT` | 0x06 | 3 | `off:i16` — jump if top-of-stack true, pop |
+| `OP_TOINT` | 0x71 | 1 | Coerce TOS to integer string |
+| `OP_FORINIT` | 0x72 | 2 | `n:u8` — pop count → frame[n]; push bool (count>0) |
+| `OP_BYINIT` | 0x73 | 2 | `n:u8` — reserved |
+| `OP_DECFOR` | 0x74 | 4 | `n:u8` + `off:i16` — decrement frame[n]; jump-if-done |
+| `OP_DOTEST` | 0x75 | 1 | Reserved (WHILE/UNTIL via JF) |
+| `OP_ITERATE` | 0x76 | 3 | `off:i16` — jump to iterate point |
+| `OP_LEAVE` | 0x77 | 3 | `off:i16` — jump to loop end |
 
-**DO loop protocol:**
+**DO count loop protocol:**
 
-- `DO count`: emit expression for count, `OP_FORINIT`, body, `OP_DECFOR` (with back-edge jump).
-- `DO var = start TO limit BY step`: emit start/limit/step stores, `OP_BYINIT`, body, `OP_DECINC`.
-- `DO FOREVER`: `OP_JMP` (forward), body, `OP_JMP` (back).
-- ITERATE: `OP_JMP` to the `OP_DECFOR`/`OP_DECINC` instruction.
-- LEAVE: `OP_FOREND` + `OP_JMP` past the loop.
+- Push count expression, `OP_FORINIT n` (pops count, pushes bool), `OP_JF exit`.
+- Body, `OP_DECFOR n exit_off` (decrements; if done jumps forward to exit).
+- `OP_JMP` back to top of body.
+- ITERATE: `OP_ITERATE` (offset to `OP_DECFOR`).
+- LEAVE: `OP_LEAVE` (offset to after the loop).
+- `DO FOREVER`: `OP_JMP` back to top of body unconditionally.
 
 ### 3.7 Phase 4 — CALL/RETURN (WP-BC-04)
 
 | Opcode | Hex | Size | Description |
 |--------|-----|------|-------------|
-| `OP_CALL` | 0x80 | 4 | `sym_idx:u16`, `nargs:u8` — internal label call |
-| `OP_RETURN` | 0x81 | 1 | Return from CALL (no value) |
-| `OP_RETURNV` | 0x82 | 1 | Return from CALL (value on stack) |
-| `OP_CALL_BIF` | 0x83 | 4 | `bif_id:u16`, `nargs:u8` — BIF call |
-| `OP_PROC` | 0x7D | 1 | PROCEDURE (isolate variable scope) |
-| `OP_EXPOSE` | 0x7E | 3 | `sym_idx:u16` — EXPOSE one variable |
-| `OP_EXPOSE_INDIRECT` | 0x7B | 3 | `sym_idx:u16` — EXPOSE via name-variable |
+| `OP_LABEL` | 0x78 | 3 | `sym_idx:u16` — call target definition (no-op at runtime) |
+| `OP_CALL` | 0x79 | 4 | `sym_idx:u16`, `nargs:u8` — CALL statement |
+| `OP_CALL_BIF` | 0x7A | 4 | `sym_idx:u16`, `nargs:u8` — expression BIF call (pushes result) |
+| `OP_RETURN` | 0x7B | 1 | Return from CALL (no value) |
+| `OP_RETURNV` | 0x7C | 1 | Pop TOS, store as RESULT, return from CALL |
 
-Before `OP_CALL`, args are pushed on the eval stack (arg N first, arg 1
-last).  The VM saves them into the call frame and pops them.  On `OP_RETURN`/
-`OP_RETURNV` the call frame is popped; with a return value, it lands on the
-eval stack of the caller.
-
-`OP_PROC` must be the first instruction in a subroutine that uses
-`PROCEDURE [EXPOSE ...]`.
+Before `OP_CALL`/`OP_CALL_BIF`, args are pushed on the eval stack (arg N first,
+arg 1 last).  The VM saves them into the call frame and pops them.  On
+`OP_RETURN`/`OP_RETURNV` the call frame is popped; with a return value it lands
+on the eval stack of the caller.
 
 ### 3.8 Phase 5 — PARSE Sub-VM (WP-BC-05 PR A)
 
-The PARSE sub-VM operates on a single source string, advancing a scan
-pointer according to trigger instructions, and assigning sub-strings to
-target variables.
+The PARSE sub-VM operates on a single source string.  The source is pushed on
+the eval stack before `OP_PARSE_BEGIN`, which pops it.  The `flags:u8` operand
+encodes the parse variant: bit 0 = UPPER.  Template items are pairs of target +
+trigger.
 
 | Opcode | Hex | Size | Description |
 |--------|-----|------|-------------|
-| `OP_PARSE_BEGIN` | 0x90 | 3 | `sym_idx:u16` — PARSE VAR (source = variable) |
-| `OP_PARSE_BEGIN_UPPER` | 0x91 | 3 | PARSE UPPER VAR |
-| `OP_PARSE_BEGIN_ARG` | 0x92 | 1 | PARSE ARG (source = ARG(1)) |
-| `OP_PARSE_BEGIN_ARG_UPPER` | 0x93 | 1 | PARSE UPPER ARG |
-| `OP_PARSE_BEGIN_VALUE` | 0x94 | 1 | PARSE VALUE (source = top of stack, popped) |
-| `OP_PARSE_BEGIN_VALUE_UPPER` | 0x95 | 1 | PARSE UPPER VALUE |
-| `OP_PARSE_PULL_STUB` | 0x96 | 1 | PARSE PULL — stub, raises `IRXBC_ERR_UNSUP` at runtime |
-| `OP_PARSE_END` | 0x97 | 1 | End PARSE block |
+| `OP_PARSE_BEGIN` | 0x80 | 2 | `flags:u8` — start PARSE block; pop source from stack |
+| `OP_PARSE_END` | 0x81 | 1 | End PARSE block, free source |
+| `OP_PVAR` | 0x82 | 3 | `sym_idx:u16` — assign segment to simple variable |
+| `OP_PDOT` | 0x83 | 1 | Dot placeholder — discard segment |
+| `OP_TR_SPACE` | 0x84 | 1 | Trigger: one word (leading whitespace stripped) |
+| `OP_TR_LIT` | 0x85 | 3 | `lit_idx:u16` — trigger: literal string delimiter |
+| `OP_TR_ABS` | 0x86 | 3 | `col:u16` — trigger: absolute column (1-based) |
+| `OP_TR_REL` | 0x87 | 3 | `off:i16` — trigger: relative offset |
+| `OP_TR_END` | 0x88 | 1 | Trigger: rest of string (last item) |
+| `OP_PUSH_SOURCE` | 0x89 | 1 | Push PARSE SOURCE string |
+| `OP_PUSH_NUMERIC` | 0x8A | 1 | Push PARSE NUMERIC string |
 
-**Target instructions** (within PARSE block):
+Each template item is a target (`OP_PVAR`, `OP_PDOT`) followed immediately by a
+trigger.  `OP_TR_SPACE` is the implicit trigger for bare variable names.  The
+last item in a template always ends with `OP_TR_END`.
 
-| Opcode | Hex | Size | Description |
-|--------|-----|------|-------------|
-| `OP_PVAR` | 0xA0 | 3 | `sym_idx:u16` — assign segment to simple variable |
-| `OP_PDOT` | 0xA1 | 1 | Placeholder (`.`) — discard segment |
-| `OP_PVAR_STEM` | 0xA2 | 3 | `const_idx:u16` — assign to pre-resolved compound name |
+Variable delimiters `(varname)` in templates are rejected with
+`IRXBC_ERR_UNSUP`.
 
-**Trigger instructions** (follow a target, delimit the segment):
-
-| Opcode | Hex | Size | Description |
-|--------|-----|------|-------------|
-| `OP_TR_SPACE` | 0x84 | 1 | Word trigger (one word, leading spaces stripped) |
-| `OP_TR_LIT` | 0x85 | 3 | `const_idx:u16` — literal string delimiter |
-| `OP_TR_ABS` | 0x86 | 3 | `col:u16` — absolute column (1-based) |
-| `OP_TR_REL` | 0x87 | 3 | `off:i16` — relative offset |
-| `OP_TR_END` | 0x88 | 1 | Rest of string (end of template) |
-
-Each template item is a target followed by a trigger.  `OP_TR_SPACE` is the
-implicit trigger for bare variable names.  The last item in a template always
-uses `OP_TR_END`.
-
-### 3.9 Phase 5 — Compound Variables (WP-BC-05 PR C)
-
-Compound variables (e.g. `A.I.J`, `STEM.KEY`) push their tail expressions
-onto the eval stack before the compound opcode.
+### 3.9 Phase 5 — PROCEDURE EXPOSE (WP-BC-05 PR B)
 
 | Opcode | Hex | Size | Description |
 |--------|-----|------|-------------|
-| `OP_LOAD_CMPD` | 0xB0 | 4 | `stem_idx:u16`, `n_tails:u8` — load compound |
-| `OP_STORE_CMPD` | 0xB1 | 4 | Store value (top of stack) into compound |
-| `OP_DROP_CMPD` | 0xB2 | 4 | DROP compound variable |
-| `OP_NOVALUE_CMPD` | 0xB3 | 4 | Push compound name string (for NOVALUE) |
-| `OP_DROP_STEM` | 0xB4 | 3 | `stem_idx:u16` — DROP entire stem |
+| `OP_PROC` | 0x8B | 2 | `nexposed:u8` — PROCEDURE: isolate variable scope |
+| `OP_EXPOSE` | 0x8C | 3 | `sym_idx:u16` — EXPOSE one named variable |
+| `OP_EXPOSE_INDIRECT` | 0x8D | 3 | `sym_idx:u16` — EXPOSE via name-variable |
 
-**Before any compound opcode**, the caller pushes `n_tails` tail values.
-The opcode pops the tails, looks up the stem name from the symbol table,
-concatenates the resolved tail values (after uppercasing) to form the full
-variable name, then calls `vpool_get_buf` / `vpool_set_buf` / `vpool_drop_buf`.
+`OP_PROC` is emitted immediately after the function label.  `nexposed` is the
+count of following `OP_EXPOSE`/`OP_EXPOSE_INDIRECT` instructions (informational).
+
+### 3.10 Phase 5 — Compound Variables (WP-BC-05 PR C)
+
+Compound variables (e.g. `A.I.J`) push `tail_count` tail expressions onto the
+eval stack before the compound opcode.
+
+| Opcode | Hex | Size | Description |
+|--------|-----|------|-------------|
+| `OP_LOAD_STEM` | 0x8E | 4 | `stem_sym:u16`, `tail_count:u8` — load compound var |
+| `OP_STORE_STEM` | 0x8F | 4 | `stem_sym:u16`, `tail_count:u8` — store compound var |
+| `OP_DROP_STEM` | 0x90 | 4 | `stem_sym:u16`, `tail_count:u8` — DROP; `tail_count=0` drops all |
+| `OP_PVAR_STEM` | 0x91 | 4 | `stem_sym:u16`, `tail_count:u8` — PARSE target: compound var |
+| `OP_PULL_FROM_QUEUE` | 0x92 | 1 | Push next external queue line (WP-33b stub; raises `IRXBC_ERR_UNSUP`) |
+
+Before any stem opcode, the caller pushes `tail_count` tail values (constants
+via `OP_PUSH_LIT`, variables via `OP_LOAD`).  The opcode pops them, uppercases
+them, concatenates with the stem name to form the full variable name, then calls
+`vpool_get_buf` / `vpool_set_buf` / `vpool_drop_buf`.
 
 ---
 
@@ -310,7 +304,7 @@ The following constructs cause `IRXBC_ERR_UNSUP` from the compiler:
 - `SIGNAL ON condition` / `SIGNAL OFF`
 - `TRACE value_expression`
 - `ADDRESS environment expression`
-- `PARSE PULL` / `PARSE LINEIN` (emits `OP_PARSE_PULL_STUB`, which raises UNSUP at runtime)
+- `PARSE PULL` / `PARSE LINEIN` (`OP_PULL_FROM_QUEUE` stub raises `IRXBC_ERR_UNSUP` at runtime)
 - Semicolons as clause separators within a source line
 - Variable delimiter `(varname)` in PARSE templates
 

--- a/project.toml
+++ b/project.toml
@@ -1241,6 +1241,52 @@ include = [
 "mvslovers/lstring370" = "*"
 
 # ---------------------------------------------------------------
+# TSTBCRXC - WP-BC-06 REXXCPS-derived bytecode correctness driver.
+# Runs a stripped REXXCPS inner kernel via token-walk and bytecode,
+# verifies both paths produce identical output.  On MVS, increase
+# the 'count' variable in the kernel and measure job elapsed time
+# to compare token-walk vs bytecode wall-clock performance.
+#
+# Invocation:
+#   TSO    :  CALL 'hlq.LOAD(TSTBCRXC)'
+#   Batch  :  EXEC PGM=TSTBCRXC
+#
+# Expected: CC=0
+#
+# WP-BC-06 / GitHub mvslovers/rexx370#157.
+# ---------------------------------------------------------------
+[[link.module]]
+name = "TSTBCRXC"
+entry = "@@CRT0"
+options = ["LIST", "MAP", "XREF", "RENT"]
+include = [
+  "@@CRT1",
+  "TSTBCRXC",
+  "IRX#INIT",
+  "IRX#TERM",
+  "IRX#STOR",
+  "IRX#ANCH",
+  "IRX#UID",
+  "IRX#MSID",
+  "IRX#COND",
+  "IRX#BIF",
+  "IRX#BIFS",
+  "IRX#IO",
+  "IRX#LSTR",
+  "IRX#TOKN",
+  "IRX#VPOL",
+  "IRX#PARS",
+  "IRX#CTRL",
+  "IRX#EXEC",
+  "IRX#BCOM",
+  "IRX#BVM",
+  "IRX#ARIT",
+]
+
+[link.module.dep_includes]
+"mvslovers/lstring370" = "*"
+
+# ---------------------------------------------------------------
 # TSTLOAD - WP-CPS-07 IRXLOAD C-core unit tests.
 # Tests irx_load_dispatch() directly (bypasses the asm IRXLOAD
 # wrapper). Host build uses the filesystem backend; MVS build

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -597,6 +597,9 @@ int irx_bc_execute(struct envblock *envblock,
     void *call_frame_mem = NULL;
     void *proxy_parser_mem = NULL;
     void *label_pc_mem = NULL;
+    int32_t *const_type_cache = NULL;
+    int32_t *const_int_cache = NULL;
+    void *const_cache_mem = NULL;
     int sp = 0; /* next free slot */
     int call_sp = 0;
     int n_consts;
@@ -725,6 +728,36 @@ int irx_bc_execute(struct envblock *envblock,
         }
     }
 
+    /* --- OC-07: pre-compute integer cache for all constants (WP-BC-06) */
+    if (n_consts > 0)
+    {
+        if (irxstor(RXSMGET, 2 * n_consts * (int)sizeof(int32_t),
+                    &const_cache_mem, envblock) != 0)
+        {
+            vm_rc = IRXBC_ERR_STOR;
+            goto done;
+        }
+        memset(const_cache_mem, 0,
+               (size_t)(2 * n_consts) * sizeof(int32_t));
+        const_type_cache = (int32_t *)const_cache_mem;
+        const_int_cache = const_type_cache + n_consts;
+        for (i = 0; i < n_consts; i++)
+        {
+            const char *cdata;
+            int clen = get_entry(const_base, n_consts, i, &cdata);
+            if (clen > 0)
+            {
+                struct bc_stack_slot s;
+                s.str = NULL;
+                s.type_cache = 0;
+                s.int_cache = 0;
+                try_parse_int_cache(&s, cdata, clen);
+                const_type_cache[i] = s.type_cache;
+                const_int_cache[i] = s.int_cache;
+            }
+        }
+    }
+
     /* --- Proxy parser for BIF dispatch (WP-BC-04) -------------------- */
     if (irxstor(RXSMGET, (int)sizeof(struct irx_parser),
                 &proxy_parser_mem, envblock) != 0)
@@ -834,7 +867,15 @@ int irx_bc_execute(struct envblock *envblock,
                         vm_rc = IRXBC_ERR_STOR;
                         goto done;
                     }
-                    try_parse_int_cache(&stack[sp], data, len);
+                    if (const_type_cache != NULL)
+                    {
+                        stack[sp].type_cache = const_type_cache[idx];
+                        stack[sp].int_cache = const_int_cache[idx];
+                    }
+                    else
+                    {
+                        try_parse_int_cache(&stack[sp], data, len);
+                    }
                     sp++;
                     break;
                 }
@@ -2624,6 +2665,11 @@ done:
     }
 
     /* Free heap arrays */
+    if (const_cache_mem != NULL)
+    {
+        void *p = const_cache_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
     if (label_pc_mem != NULL)
     {
         void *p = label_pc_mem;

--- a/test/host/tstbc_rexxcps.c
+++ b/test/host/tstbc_rexxcps.c
@@ -226,12 +226,10 @@ int main(int argc, char *argv[])
         irxterm(env);
         return 1;
     }
+    struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
     {
-        struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
-        if (exte != NULL)
-        {
-            exte->io_routine = (void *)capture_io;
-        }
+        exte->io_routine = (void *)capture_io;
     }
 
     /* ---- Token-walk run ------------------------------------------- */

--- a/test/host/tstbc_rexxcps.c
+++ b/test/host/tstbc_rexxcps.c
@@ -1,0 +1,292 @@
+/* ------------------------------------------------------------------ */
+/*  test/host/tstbc_rexxcps.c — WP-BC-06 bytecode REXXCPS driver      */
+/*                                                                     */
+/*  Runs a stripped REXXCPS-derived kernel via token-walk and the      */
+/*  bytecode path.  Verifies that both paths produce identical output  */
+/*  and reports wall-clock timing for each.                            */
+/*                                                                     */
+/*  The kernel is derived from the inner body of REXXCPS 2.2:          */
+/*  timing BIFs (TIME), trace instructions (TRACE VALUE), and          */
+/*  SIGNAL/ADDRESS constructs are removed so the bytecode compiler     */
+/*  can compile the whole source without IRXBC_ERR_UNSUP.              */
+/*                                                                     */
+/*  Build (Linux):                                                      */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \         */
+/*        -Wall -Wextra -std=gnu99 -O2 \                               */
+/*        -o /tmp/tstbc_rexxcps test/host/tstbc_rexxcps.c \            */
+/*        'src/irx#bvm.c'   'src/irx#bcom.c'  'src/irx#bctl.c' \      */
+/*        'src/irx#init.c'  'src/irx#term.c'  'src/irx#stor.c' \      */
+/*        'src/irx#anch.c'  'src/irx#env.c'   'src/irx#uid.c'  \      */
+/*        'src/irx#msid.c'  'src/irx#cond.c'  'src/irx#bif.c'  \      */
+/*        'src/irx#bifs.c'  'src/irx#io.c'    'src/irx#lstr.c' \      */
+/*        'src/irx#tokn.c'  'src/irx#vpol.c'  'src/irx#pars.c' \      */
+/*        'src/irx#ctrl.c'  'src/irx#exec.c'  'src/irx#arith.c' \     */
+/*        '../lstring370/src/lstr#cor.c'  \                            */
+/*        '../lstring370/src/lstr#cvt.c'  \                            */
+/*        '../lstring370/src/lstr#fmt.c'  \                            */
+/*        '../lstring370/src/lstr#srch.c' \                            */
+/*        '../lstring370/src/lstr#sub.c'  \                            */
+/*        '../lstring370/src/lstr#wrd.c'  \                            */
+/*        '../lstring370/src/lstr#xlt.c'  \                            */
+/*        && /tmp/tstbc_rexxcps                                         */
+/*                                                                     */
+/*  Usage:                                                              */
+/*    ./tstbc_rexxcps [--iterations=N]                                  */
+/*                                                                     */
+/*  (c) 2026 mvslovers - REXX/370 Project                              */
+/* ------------------------------------------------------------------ */
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "irx.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+/* ------------------------------------------------------------------ */
+/*  REXXCPS inner kernel (stripped version)                            */
+/*                                                                     */
+/*  Removed from the original REXXCPS 2.2:                            */
+/*   - SIGNAL ON NOVALUE (bytecode UNSUP)                              */
+/*   - TRACE VALUE / TRACE OFF (bytecode UNSUP)                        */
+/*   - ADDRESS VALUE ADDRESS() (bytecode UNSUP)                        */
+/*   - TIME('R') calibration and adjustment loops (no timing BIF)      */
+/*   - DO J=1.1 TO 2.2 BY 1.1 simplified to DO J=1 TO 2              */
+/*     (avoids decimal loop parameters in the inner hot path)          */
+/*   - Second CALL argument group (commas in CALL: bytecode UNSUP)     */
+/*                                                                     */
+/*  The outer iteration count is set by the 'count' variable.          */
+/*  Increase N (--iterations) to extend the measurement window.       */
+/* ------------------------------------------------------------------ */
+static const char KERNEL_PREFIX[] =
+    "count = ";
+
+/*  Note: PARSE variable-delimiter (varname) is not yet supported in   */
+/*  the bytecode compiler.  The kernel uses only literal/absolute/     */
+/*  relative and word-split PARSE templates.                           */
+static const char KERNEL_BODY[] =
+    "\n"
+    "do i = 1 to count\n"
+    "  flag = 0\n"
+    "  do loop = 1 to 14\n"
+    "    key1 = 'Key Bee'\n"
+    "    acompound.key1.loop = substr(12345678, 6, 2)\n"
+    "    if flag = acompound.key1.loop then say 'Failed1'\n"
+    "    do j = 1 to 2\n"
+    "      if j > acompound.key1.loop then say 'Failed2'\n"
+    "      if 17 < length(j) - 1 then say 'Failed3'\n"
+    "      if j = 'foobar' then say 'Failed4'\n"
+    "      if substr(1234, 1, 1) = 9 then say 'Failed5'\n"
+    "      if word(key1, 1) = '?' then say 'Failed6'\n"
+    "      if j < 5 then do\n"
+    "        acompound.key1.loop = acompound.key1.loop + 1\n"
+    "        if j = 2 then leave\n"
+    "      end\n"
+    "      iterate\n"
+    "    end\n"
+    "    avar. = 1\n"
+    "    select\n"
+    "      when flag = 'string' then say 'FailedS1'\n"
+    "      when avar.flag.2 = 0 then say 'FailedS2'\n"
+    "      when flag = 5 + 99 then say 'FailedS3'\n"
+    "      when flag then avar.1.2 = avar.1.2 * 1.1\n"
+    "      when flag == 0 then flag = 0\n"
+    "    end\n"
+    "    if 1 then flag = 1\n"
+    "    select\n"
+    "      when flag == 'ring' then say 'FailedT1'\n"
+    "      when avar.flag.3 = 0 then say 'FailedT2'\n"
+    "      when flag then avar.1.2 = avar.1.2 * 1.1\n"
+    "      when flag == 0 then flag = 1\n"
+    "    end\n"
+    "    parse value 'Foo Bar' with v1 +5 v2 .\n"
+    "    call subroutine 'with' 2 'args'\n"
+    "    parse value 'This is an awfully boring program' with p1 p2 p3 p4 p5\n"
+    "  end loop\n"
+    "end\n"
+    "say count\n"
+    "exit\n"
+    "subroutine:\n"
+    "  parse upper arg a1 a2 a3 .\n"
+    "  parse var a3 b1 b2 b3 .\n"
+    "  do 1\n"
+    "    rc = a1 a2 a3\n"
+    "    parse var rc c1 c2 c3\n"
+    "  end\n"
+    "  return\n";
+
+/* ------------------------------------------------------------------ */
+/*  Output capture                                                     */
+/* ------------------------------------------------------------------ */
+
+#define CAPBUF 16384
+
+static char g_cap[CAPBUF];
+static int g_cap_len;
+
+static void cap_reset(void)
+{
+    g_cap_len = 0;
+    g_cap[0] = '\0';
+}
+
+static int capture_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL && Lpstr(data) != NULL)
+    {
+        int n = (int)Llen(data);
+        if (g_cap_len + n + 1 < CAPBUF)
+        {
+            memcpy(g_cap + g_cap_len, Lpstr(data), (size_t)n);
+            g_cap_len += n;
+            g_cap[g_cap_len++] = '\n';
+            g_cap[g_cap_len] = '\0';
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Elapsed wall-clock in seconds (CLOCK_MONOTONIC).                  */
+/* ------------------------------------------------------------------ */
+static double wall_seconds(struct timespec *t0, struct timespec *t1)
+{
+    return (double)(t1->tv_sec - t0->tv_sec) +
+           (double)(t1->tv_nsec - t0->tv_nsec) / 1.0e9;
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                               */
+/* ------------------------------------------------------------------ */
+int main(int argc, char *argv[])
+{
+    int iterations = 10;
+    char src[2048];
+    int src_len;
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    char tw_out[CAPBUF];
+    char bc_out[CAPBUF];
+    struct timespec t0, t1;
+    double tw_wall, bc_wall;
+    int rc;
+    int exit_rc = 0;
+    int i;
+
+    for (i = 1; i < argc; i++)
+    {
+        if (strncmp(argv[i], "--iterations=", 13) == 0)
+        {
+            iterations = atoi(argv[i] + 13);
+            if (iterations < 1)
+            {
+                iterations = 1;
+            }
+        }
+        else
+        {
+            fprintf(stderr,
+                    "tstbc_rexxcps: unknown option '%s'\n", argv[i]);
+            fprintf(stderr, "usage: tstbc_rexxcps [--iterations=N]\n");
+            return 1;
+        }
+    }
+
+    /* Build source: "count = N\n<BODY>" */
+    src_len = snprintf(src, sizeof(src), "%s%d%s",
+                       KERNEL_PREFIX, iterations, KERNEL_BODY);
+    if (src_len < 0 || src_len >= (int)sizeof(src))
+    {
+        fprintf(stderr, "tstbc_rexxcps: source buffer overflow\n");
+        return 1;
+    }
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbc_rexxcps: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    /* Install output capture */
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        fprintf(stderr, "tstbc_rexxcps: no work block\n");
+        irxterm(env);
+        return 1;
+    }
+    {
+        struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
+        if (exte != NULL)
+        {
+            exte->io_routine = (void *)capture_io;
+        }
+    }
+
+    /* ---- Token-walk run ------------------------------------------- */
+    cap_reset();
+    wk->wkbi_use_bytecode = 0;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    tw_wall = wall_seconds(&t0, &t1);
+    memcpy(tw_out, g_cap, (size_t)(g_cap_len + 1));
+    if (rc != 0)
+    {
+        fprintf(stderr,
+                "tstbc_rexxcps: token-walk failed rc=%d exit=%d\n",
+                rc, exit_rc);
+        irxterm(env);
+        return 1;
+    }
+
+    /* ---- Bytecode run --------------------------------------------- */
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    rc = irx_exec_run(src, src_len, NULL, 0, &exit_rc, env);
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    wk->wkbi_use_bytecode = 0;
+    bc_wall = wall_seconds(&t0, &t1);
+    memcpy(bc_out, g_cap, (size_t)(g_cap_len + 1));
+    if (rc != 0)
+    {
+        fprintf(stderr,
+                "tstbc_rexxcps: bytecode run failed rc=%d exit=%d\n",
+                rc, exit_rc);
+        irxterm(env);
+        return 1;
+    }
+
+    irxterm(env);
+
+    /* ---- Results -------------------------------------------------- */
+    printf("REXXCPS kernel: %d iterations\n", iterations);
+    printf("  token-walk  : %.3f s\n", tw_wall);
+    printf("  bytecode    : %.3f s\n", bc_wall);
+    if (bc_wall > 0.0)
+    {
+        printf("  speedup     : %.2fx\n", tw_wall / bc_wall);
+    }
+
+    if (strcmp(tw_out, bc_out) != 0)
+    {
+        fprintf(stderr, "FAIL: output mismatch\n");
+        fprintf(stderr, "  token-walk: [%s]\n", tw_out);
+        fprintf(stderr, "  bytecode:   [%s]\n", bc_out);
+        return 1;
+    }
+    printf("  output      : match\n");
+    return 0;
+}

--- a/test/mvs/tstbcrxc.c
+++ b/test/mvs/tstbcrxc.c
@@ -1,0 +1,245 @@
+/* ------------------------------------------------------------------ */
+/*  tstbcrxc.c - WP-BC-06 REXXCPS bytecode path driver                */
+/*                                                                     */
+/*  Verifies that the REXXCPS-derived kernel executes correctly via    */
+/*  the bytecode path and produces output identical to the token-walk  */
+/*  path.  Intended to be run as a standalone load module on MVS to   */
+/*  measure wall-clock time with a larger iteration count (set count   */
+/*  to 100+ on MVS before timing).                                     */
+/*                                                                     */
+/*  Cross-compile build (Linux/gcc):                                   */
+/*    LSTR="-I contrib/lstring370-0.1.0-dev/include"                   */
+/*    LSRC="../lstring370/src/lstr#cor.c ../lstring370/src/lstr#cvt.c  */
+/*          ../lstring370/src/lstr#fmt.c ../lstring370/src/lstr#srch.c */
+/*          ../lstring370/src/lstr#sub.c ../lstring370/src/lstr#wrd.c  */
+/*          ../lstring370/src/lstr#xlt.c"                              */
+/*    gcc -I include $LSTR -Wall -Wextra -std=gnu99 \                  */
+/*        -o /tmp/tstbcrxc test/mvs/tstbcrxc.c \                       */
+/*        src/irx#init.c  src/irx#term.c  src/irx#stor.c \            */
+/*        src/irx#anch.c  src/irx#env.c   src/irx#uid.c  \            */
+/*        src/irx#msid.c  src/irx#cond.c  src/irx#bif.c  \            */
+/*        src/irx#bifs.c  src/irx#io.c    src/irx#lstr.c \            */
+/*        src/irx#tokn.c  src/irx#vpol.c  src/irx#pars.c \            */
+/*        src/irx#ctrl.c  src/irx#exec.c  src/irx#arith.c \           */
+/*        src/irx#bcom.c  src/irx#bvm.c   $LSRC && /tmp/tstbcrxc      */
+/*                                                                     */
+/*  MVS usage (JCL):                                                   */
+/*    //TSTBCRXC EXEC PGM=TSTBCRXC                                     */
+/*                                                                     */
+/*  (c) 2026 mvslovers - REXX/370 Project                              */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+/* ------------------------------------------------------------------ */
+/*  Test counters                                                       */
+/* ------------------------------------------------------------------ */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Output capture                                                     */
+/* ------------------------------------------------------------------ */
+
+#define CAPBUF 4096
+
+static char g_cap[CAPBUF];
+static int g_cap_len;
+
+static void cap_reset(void)
+{
+    g_cap_len = 0;
+    g_cap[0] = '\0';
+}
+
+static int capture_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL && Lpstr(data) != NULL)
+    {
+        int n = (int)Llen(data);
+        if (g_cap_len + n + 1 < CAPBUF)
+        {
+            memcpy(g_cap + g_cap_len, Lpstr(data), (size_t)n);
+            g_cap_len += n;
+            g_cap[g_cap_len++] = '\n';
+            g_cap[g_cap_len] = '\0';
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  REXXCPS-derived inner kernel                                       */
+/*                                                                     */
+/*  Stripped of timing BIFs, SIGNAL ON, TRACE, and ADDRESS.           */
+/*  Uses only constructs supported by the current bytecode compiler:   */
+/*  compound variables, SELECT/WHEN, PARSE VALUE/VAR/UPPER ARG,       */
+/*  CALL/RETURN, BIF calls (substr, length, word).                     */
+/*                                                                     */
+/*  count = 5 is used for the correctness test (fast).                 */
+/*  On MVS, rebuild with a higher count (e.g. 100) to time the path.  */
+/* ------------------------------------------------------------------ */
+static const char KERNEL_SMALL[] =
+    "count = 5\n"
+    "do i = 1 to count\n"
+    "  flag = 0\n"
+    "  do loop = 1 to 14\n"
+    "    key1 = 'Key Bee'\n"
+    "    acompound.key1.loop = substr(12345678, 6, 2)\n"
+    "    if flag = acompound.key1.loop then say 'Failed1'\n"
+    "    do j = 1 to 2\n"
+    "      if j > acompound.key1.loop then say 'Failed2'\n"
+    "      if 17 < length(j) - 1 then say 'Failed3'\n"
+    "      if j = 'foobar' then say 'Failed4'\n"
+    "      if substr(1234, 1, 1) = 9 then say 'Failed5'\n"
+    "      if word(key1, 1) = '?' then say 'Failed6'\n"
+    "      if j < 5 then do\n"
+    "        acompound.key1.loop = acompound.key1.loop + 1\n"
+    "        if j = 2 then leave\n"
+    "      end\n"
+    "      iterate\n"
+    "    end\n"
+    "    avar. = 1\n"
+    "    select\n"
+    "      when flag = 'string' then say 'FailedS1'\n"
+    "      when avar.flag.2 = 0 then say 'FailedS2'\n"
+    "      when flag = 5 + 99 then say 'FailedS3'\n"
+    "      when flag then avar.1.2 = avar.1.2 * 1.1\n"
+    "      when flag == 0 then flag = 0\n"
+    "    end\n"
+    "    if 1 then flag = 1\n"
+    "    select\n"
+    "      when flag == 'ring' then say 'FailedT1'\n"
+    "      when avar.flag.3 = 0 then say 'FailedT2'\n"
+    "      when flag then avar.1.2 = avar.1.2 * 1.1\n"
+    "      when flag == 0 then flag = 1\n"
+    "    end\n"
+    "    parse value 'Foo Bar' with v1 +5 v2 .\n"
+    "    call subroutine 'with' 2 'args'\n"
+    "    parse value 'This is an awfully boring program' with p1 p2 p3 p4 p5\n"
+    "  end loop\n"
+    "end\n"
+    "say count\n"
+    "exit\n"
+    "subroutine:\n"
+    "  parse upper arg a1 a2 a3 .\n"
+    "  parse var a3 b1 b2 b3 .\n"
+    "  do 1\n"
+    "    rc = a1 a2 a3\n"
+    "    parse var rc c1 c2 c3\n"
+    "  end\n"
+    "  return\n";
+
+/* ------------------------------------------------------------------ */
+/*  Equivalence helper: token-walk vs bytecode                         */
+/* ------------------------------------------------------------------ */
+
+static void test_equiv(struct envblock *env)
+{
+    struct irx_wkblk_int *wk;
+    int src_len = (int)strlen(KERNEL_SMALL);
+    int rc;
+    int exit_rc = 0;
+    char tw_out[CAPBUF];
+    int tw_len;
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        CHECK(0, "work block available");
+        return;
+    }
+
+    /* Token-walk run */
+    cap_reset();
+    wk->wkbi_use_bytecode = 0;
+    rc = irx_exec_run(KERNEL_SMALL, src_len, NULL, 0, &exit_rc, env);
+    memcpy(tw_out, g_cap, (size_t)(g_cap_len + 1));
+    tw_len = g_cap_len;
+    CHECK(rc == 0, "token-walk run succeeds");
+    CHECK(exit_rc == 0, "token-walk exit rc == 0");
+    CHECK(tw_len > 0, "token-walk produces output");
+
+    /* Bytecode run */
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    rc = irx_exec_run(KERNEL_SMALL, src_len, NULL, 0, &exit_rc, env);
+    wk->wkbi_use_bytecode = 0;
+    CHECK(rc == 0, "bytecode run succeeds");
+    CHECK(exit_rc == 0, "bytecode exit rc == 0");
+    CHECK(strcmp(tw_out, g_cap) == 0, "bytecode output matches token-walk");
+
+    if (strcmp(tw_out, g_cap) != 0)
+    {
+        printf("    token-walk: [%s]\n", tw_out);
+        printf("    bytecode:   [%s]\n", g_cap);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                               */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    struct envblock *env = NULL;
+    struct irxexte *exte;
+    int rc;
+
+    printf("=== WP-BC-06: REXXCPS kernel token-walk vs bytecode ===\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbcrxc: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+    {
+        exte->io_routine = (void *)capture_io;
+    }
+
+    test_equiv(env);
+
+    irxterm(env);
+
+    printf("\n--- Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ---\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- **OC-07 (irx#bvm.c)**: At VM init, pre-parse all constants into `int32_t const_type_cache[]` and `const_int_cache[]` arrays. `OP_PUSH_LIT` reads the pre-computed values instead of calling `try_parse_int_cache()` on every execution — eliminates the digit-scan loop for numeric constants such as `1`, `14`, `100` used in loop bounds and comparisons.
- **REXXCPS test driver (tstbcrxc.c + tstbc_rexxcps.c)**: Stripped REXXCPS inner kernel (no `SIGNAL ON`, `TRACE VALUE`, `ADDRESS`, `TIME()`) runs via both token-walk and bytecode; outputs verified identical. Registered in project.toml as `TSTBCRXC`. Makes the MVS measurement session a 5-minute step.
- **docs/architecture.md §15**: Expanded WP-BC status table, complete opcode reference (all phases), OC-07 description, compiler limitations documented.
- **docs/bytecode-format.md**: New reference document — EXECBLK layout, full opcode table with encoding details, stack model, resource limits, error codes.

## Out of scope (deferred to follow-up)

- OC-06 variable-slot-cache (needs vpool API extension to expose entry pointers)
- Default switch `wkbi_use_bytecode = 1` (requires MVS REXXCPS measurement data)
- Final performance report (AC1, AC3, AC7 require MVS baseline)

## Test plan

- [x] All 22 cross-compile tests pass (1219 total)
- [x] `tstbcrxc` 6/6 pass — REXXCPS kernel token-walk == bytecode output
- [x] `tstbc_rexxcps --iterations=50` builds and shows "output: match"
- [x] `clang-format --dry-run --Werror` clean on all changed files
- [ ] MVS build (TSTBCRXC) — verify CC=0 on MVS 3.8j

Fixes #157