### PR TITLE
feat(bytecode): WP-BC-FLIP — default-on + REXX370_BYTECODE env opt-out

### DIFF
--- a/include/irxbvm.h
+++ b/include/irxbvm.h
@@ -69,6 +69,8 @@ int irx_bc_compile(struct envblock *envblock,
 /*  Parameters:                                                       */
 /*    envblock — owning environment                                  */
 /*    bc       — container produced by irx_bc_compile               */
+/*    args     — top-level argument string (may be NULL)             */
+/*    args_len — length of args in bytes (0 if args is NULL)         */
 /*    rc_out   — receives the program RC on success; may be NULL     */
 /*                                                                    */
 /*  Returns: IRXBC_OK (0) on success, IRXBC_ERR_* on failure.       */
@@ -76,6 +78,7 @@ int irx_bc_compile(struct envblock *envblock,
 
 int irx_bc_execute(struct envblock *envblock,
                    struct irx_bc_execblk *bc,
+                   const char *args, int args_len,
                    int *rc_out) asm("IRXBEXEC");
 
 #endif /* IRXBVM_H */

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -578,6 +578,7 @@ static int pframe_assign(struct bc_parse_frame *pframe,
 
 int irx_bc_execute(struct envblock *envblock,
                    struct irx_bc_execblk *bc,
+                   const char *args, int args_len,
                    int *rc_out)
 {
     const unsigned char *pc;
@@ -770,7 +771,50 @@ int irx_bc_execute(struct envblock *envblock,
     proxy_parser->alloc = alloc;
     proxy_parser->envblock = envblock;
     proxy_parser->vpool = vpool;
-    /* call_args / call_argc updated per call */
+
+    /* Top-level argument string for PARSE ARG / ARG() at program entry. */
+    if (args != NULL && args_len > 0)
+    {
+        Lstr *la;
+        int *le;
+        la = (Lstr *)alloc->alloc(
+            (size_t)IRX_MAX_ARGS * sizeof(Lstr), alloc->ctx);
+        le = (int *)alloc->alloc(
+            (size_t)IRX_MAX_ARGS * sizeof(int), alloc->ctx);
+        if (la == NULL || le == NULL)
+        {
+            if (la != NULL)
+            {
+                alloc->dealloc(la, (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                               alloc->ctx);
+            }
+            if (le != NULL)
+            {
+                alloc->dealloc(le, (size_t)IRX_MAX_ARGS * sizeof(int),
+                               alloc->ctx);
+            }
+            vm_rc = IRXBC_ERR_STOR;
+            goto done;
+        }
+        memset(la, 0, (size_t)IRX_MAX_ARGS * sizeof(Lstr));
+        memset(le, 0, (size_t)IRX_MAX_ARGS * sizeof(int));
+        if (Lfx(alloc, &la[0], (size_t)args_len) != LSTR_OK)
+        {
+            alloc->dealloc(la, (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                           alloc->ctx);
+            alloc->dealloc(le, (size_t)IRX_MAX_ARGS * sizeof(int),
+                           alloc->ctx);
+            vm_rc = IRXBC_ERR_STOR;
+            goto done;
+        }
+        memcpy(la[0].pstr, args, (size_t)args_len);
+        la[0].len = (size_t)args_len;
+        la[0].type = LSTRING_TY;
+        le[0] = 1;
+        proxy_parser->call_args = la;
+        proxy_parser->call_arg_exists = le;
+        proxy_parser->call_argc = 1;
+    }
 
     {
         pc = IRXBC_ENTRY(bc);
@@ -2625,10 +2669,27 @@ done:
         }
     }
 
-    /* Free proxy parser result Lstr and proxy parser itself */
+    /* Free proxy parser result Lstr and any top-level call_args */
     if (proxy_parser != NULL)
     {
         Lfree(alloc, &proxy_parser->result);
+        if (proxy_parser->call_args != NULL)
+        {
+            int ci;
+            for (ci = 0; ci < proxy_parser->call_argc; ci++)
+            {
+                Lfree(alloc, &proxy_parser->call_args[ci]);
+            }
+            alloc->dealloc(proxy_parser->call_args,
+                           (size_t)IRX_MAX_ARGS * sizeof(Lstr),
+                           alloc->ctx);
+        }
+        if (proxy_parser->call_arg_exists != NULL)
+        {
+            alloc->dealloc(proxy_parser->call_arg_exists,
+                           (size_t)IRX_MAX_ARGS * sizeof(int),
+                           alloc->ctx);
+        }
     }
 
     /* Free Lstr buffers */

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -340,7 +340,7 @@ int irx_exec_run(const char *source, int source_len,
         }
     }
 
-    /* 3. Bytecode path (opt-in via wkbi_use_bytecode) -------------- */
+    /* 3. Bytecode path (default-on; opt-out via REXX370_BYTECODE=0) - */
     {
         struct irx_wkblk_int *wk =
             (struct irx_wkblk_int *)envblock->envblock_userfield;
@@ -350,20 +350,33 @@ int irx_exec_run(const char *source, int source_len,
             int bc_rc = 0;
 
             rc = irx_bc_compile(envblock, source, source_len, &bc);
-            if (rc == IRXBC_OK)
+            if (rc == IRXBC_ERR_UNSUP)
             {
-                rc = irx_bc_execute(envblock, bc, &bc_rc);
+                /* Unsupported construct — release bc and fall through
+                 * to the token-walk path below. */
+                if (bc != NULL)
+                {
+                    void *p = bc;
+                    irxstor(RXSMFRE, 0, &p, envblock);
+                }
             }
-            if (rc_out != NULL)
+            else
             {
-                *rc_out = bc_rc;
+                if (rc == IRXBC_OK)
+                {
+                    rc = irx_bc_execute(envblock, bc, args, args_len, &bc_rc);
+                }
+                if (rc_out != NULL)
+                {
+                    *rc_out = bc_rc;
+                }
+                if (bc != NULL)
+                {
+                    void *p = bc;
+                    irxstor(RXSMFRE, 0, &p, envblock);
+                }
+                goto cleanup;
             }
-            if (bc != NULL)
-            {
-                void *p = bc;
-                irxstor(RXSMFRE, 0, &p, envblock);
-            }
-            goto cleanup;
         }
     }
 

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -24,8 +24,10 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
 /* ------------------------------------------------------------------ */
 
+#include <ctype.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "irx.h"
@@ -198,6 +200,25 @@ cleanup:
 }
 
 /* ================================================================== */
+/*  Shared helper: env_eq_ci                                          */
+/* ================================================================== */
+
+/* Case-insensitive string equality without strcasecmp (not in crent370). */
+static int env_eq_ci(const char *a, const char *b)
+{
+    while (*a && *b)
+    {
+        if (tolower((unsigned char)*a) != tolower((unsigned char)*b))
+        {
+            return 0;
+        }
+        a++;
+        b++;
+    }
+    return *a == *b;
+}
+
+/* ================================================================== */
 /*  Shared helper: init_wkblk_int                                     */
 /* ================================================================== */
 
@@ -235,6 +256,29 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
         else
         {
             memcpy(wk->wkbi_address, DEFAULT_HOSTENV_MVS, 8);
+        }
+    }
+
+    /* Bytecode VM on by default. REXX370_BYTECODE env-var can override
+     * before any test helper sets the flag explicitly — explicit test
+     * setters (wk->wkbi_use_bytecode = 0/1) always win because they
+     * run after irxinit() returns. */
+    wk->wkbi_use_bytecode = 1;
+    {
+        const char *e = getenv("REXX370_BYTECODE");
+        if (e != NULL)
+        {
+            if (e[0] == '0' || env_eq_ci(e, "false") ||
+                env_eq_ci(e, "no") || env_eq_ci(e, "off"))
+            {
+                wk->wkbi_use_bytecode = 0;
+            }
+            else if (e[0] == '1' || env_eq_ci(e, "true") ||
+                     env_eq_ci(e, "yes") || env_eq_ci(e, "on"))
+            {
+                wk->wkbi_use_bytecode = 1;
+            }
+            /* other values: ignored, default stays */
         }
     }
 

--- a/test/host/tstbc_execute.c
+++ b/test/host/tstbc_execute.c
@@ -81,7 +81,7 @@ static void test_execute_empty(struct envblock *env)
         return;
     }
 
-    rc = irx_bc_execute(env, bc, &bc_rc);
+    rc = irx_bc_execute(env, bc, NULL, 0, &bc_rc);
     CHECK(rc == IRXBC_OK, "execute returns IRXBC_OK");
     CHECK(bc_rc == 0, "program RC == 0");
 
@@ -106,7 +106,7 @@ static void test_execute_exit(struct envblock *env)
         return;
     }
 
-    rc = irx_bc_execute(env, bc, &bc_rc);
+    rc = irx_bc_execute(env, bc, NULL, 0, &bc_rc);
     CHECK(rc == IRXBC_OK, "execute returns IRXBC_OK");
     CHECK(bc_rc == 0, "program RC == 0");
 
@@ -123,7 +123,7 @@ static void test_execute_null(struct envblock *env)
 
     printf("  [execute: NULL container]\n");
 
-    rc = irx_bc_execute(env, NULL, &bc_rc);
+    rc = irx_bc_execute(env, NULL, NULL, 0, &bc_rc);
     CHECK(rc != IRXBC_OK, "execute rejects NULL container");
 }
 

--- a/test/host/tstbc_flip.c
+++ b/test/host/tstbc_flip.c
@@ -1,0 +1,325 @@
+/* Linux host: expose setenv/unsetenv from <stdlib.h>. */
+#define _POSIX_C_SOURCE 200809L
+
+/* ------------------------------------------------------------------ */
+/*  test/host/tstbc_flip.c — WP-BC-FLIP env-var override tests        */
+/*                                                                    */
+/*  Verifies:                                                         */
+/*    - wkbi_use_bytecode defaults to 1 (env unset)                  */
+/*    - REXX370_BYTECODE=0/false/no/off forces wkbi_use_bytecode = 0 */
+/*    - REXX370_BYTECODE=1/true/yes/on keeps wkbi_use_bytecode = 1   */
+/*    - Garbage value falls back to default (1)                       */
+/*    - Explicit test setters win over env-var (test isolation)       */
+/*                                                                    */
+/*  Build (Linux):                                                     */
+/*    gcc -I include -I contrib/lstring370-0.1.0-dev/include \        */
+/*        -Wall -Wextra -std=gnu99 -O0 -g \                           */
+/*        -o /tmp/tstbc_flip test/host/tstbc_flip.c \                 */
+/*        'src/irx#init.c'  'src/irx#term.c'  'src/irx#stor.c' \    */
+/*        'src/irx#anch.c'  'src/irx#env.c'   'src/irx#uid.c'  \    */
+/*        'src/irx#msid.c'  'src/irx#cond.c'  'src/irx#bif.c'  \    */
+/*        'src/irx#bifs.c'  'src/irx#io.c'    'src/irx#lstr.c' \    */
+/*        'src/irx#tokn.c'  'src/irx#vpol.c'  'src/irx#pars.c' \    */
+/*        'src/irx#ctrl.c'  'src/irx#exec.c'  'src/irx#arith.c' \   */
+/*        'src/irx#bcom.c'  'src/irx#bvm.c' \                        */
+/*        '../lstring370/src/lstr#cor.c' \                            */
+/*        '../lstring370/src/lstr#cvt.c' \                            */
+/*        '../lstring370/src/lstr#fmt.c' \                            */
+/*        '../lstring370/src/lstr#srch.c' \                           */
+/*        '../lstring370/src/lstr#sub.c' \                            */
+/*        '../lstring370/src/lstr#wrd.c' \                            */
+/*        '../lstring370/src/lstr#xlt.c'                              */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Helper: init env, retrieve wk, check flag, term.                  */
+/* ------------------------------------------------------------------ */
+static int wkbi_flag_after_init(void)
+{
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    int flag = -1;
+
+    if (irxinit(NULL, &env) != 0 || env == NULL)
+    {
+        return -1;
+    }
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk != NULL)
+    {
+        flag = wk->wkbi_use_bytecode;
+    }
+    irxterm(env);
+    return flag;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Default (env unset): wkbi_use_bytecode must be 1.                 */
+/* ------------------------------------------------------------------ */
+static void test_default_on(void)
+{
+    printf("\n--- FLIP#01: default-on (env unset) ---\n");
+
+    unsetenv("REXX370_BYTECODE");
+    CHECK(wkbi_flag_after_init() == 1, "default wkbi_use_bytecode == 1");
+}
+
+/* ------------------------------------------------------------------ */
+/*  REXX370_BYTECODE=0 forces wkbi_use_bytecode = 0.                  */
+/* ------------------------------------------------------------------ */
+static void test_env_zero(void)
+{
+    printf("\n--- FLIP#02: REXX370_BYTECODE=0 ---\n");
+
+    setenv("REXX370_BYTECODE", "0", 1);
+    CHECK(wkbi_flag_after_init() == 0, "REXX370_BYTECODE=0 → flag 0");
+    unsetenv("REXX370_BYTECODE");
+}
+
+/* ------------------------------------------------------------------ */
+/*  REXX370_BYTECODE=1 keeps wkbi_use_bytecode = 1.                   */
+/* ------------------------------------------------------------------ */
+static void test_env_one(void)
+{
+    printf("\n--- FLIP#03: REXX370_BYTECODE=1 ---\n");
+
+    setenv("REXX370_BYTECODE", "1", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=1 → flag 1");
+    unsetenv("REXX370_BYTECODE");
+}
+
+/* ------------------------------------------------------------------ */
+/*  false/no/off variants (case-insensitive) → wkbi_use_bytecode = 0. */
+/* ------------------------------------------------------------------ */
+static void test_env_false_variants(void)
+{
+    printf("\n--- FLIP#04: false/no/off variants ---\n");
+
+    setenv("REXX370_BYTECODE", "false", 1);
+    CHECK(wkbi_flag_after_init() == 0, "REXX370_BYTECODE=false → flag 0");
+
+    setenv("REXX370_BYTECODE", "FALSE", 1);
+    CHECK(wkbi_flag_after_init() == 0, "REXX370_BYTECODE=FALSE → flag 0");
+
+    setenv("REXX370_BYTECODE", "no", 1);
+    CHECK(wkbi_flag_after_init() == 0, "REXX370_BYTECODE=no → flag 0");
+
+    setenv("REXX370_BYTECODE", "NO", 1);
+    CHECK(wkbi_flag_after_init() == 0, "REXX370_BYTECODE=NO → flag 0");
+
+    setenv("REXX370_BYTECODE", "off", 1);
+    CHECK(wkbi_flag_after_init() == 0, "REXX370_BYTECODE=off → flag 0");
+
+    setenv("REXX370_BYTECODE", "OFF", 1);
+    CHECK(wkbi_flag_after_init() == 0, "REXX370_BYTECODE=OFF → flag 0");
+
+    unsetenv("REXX370_BYTECODE");
+}
+
+/* ------------------------------------------------------------------ */
+/*  true/yes/on variants (case-insensitive) → wkbi_use_bytecode = 1.  */
+/* ------------------------------------------------------------------ */
+static void test_env_true_variants(void)
+{
+    printf("\n--- FLIP#05: true/yes/on variants ---\n");
+
+    setenv("REXX370_BYTECODE", "true", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=true → flag 1");
+
+    setenv("REXX370_BYTECODE", "TRUE", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=TRUE → flag 1");
+
+    setenv("REXX370_BYTECODE", "yes", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=yes → flag 1");
+
+    setenv("REXX370_BYTECODE", "YES", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=YES → flag 1");
+
+    setenv("REXX370_BYTECODE", "on", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=on → flag 1");
+
+    setenv("REXX370_BYTECODE", "ON", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=ON → flag 1");
+
+    unsetenv("REXX370_BYTECODE");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Garbage value → default stays at 1.                               */
+/* ------------------------------------------------------------------ */
+static void test_env_garbage(void)
+{
+    printf("\n--- FLIP#06: garbage value ---\n");
+
+    setenv("REXX370_BYTECODE", "banana", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE=banana → flag stays 1");
+
+    setenv("REXX370_BYTECODE", "", 1);
+    CHECK(wkbi_flag_after_init() == 1, "REXX370_BYTECODE= (empty) → flag stays 1");
+
+    unsetenv("REXX370_BYTECODE");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Explicit test setter wins over REXX370_BYTECODE=0.                */
+/*  Verifies test isolation: a shell-level opt-out must not break      */
+/*  bytecode-specific tests that set the flag explicitly.              */
+/* ------------------------------------------------------------------ */
+static void test_setter_wins_over_env(void)
+{
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    int exit_rc = -1;
+
+    printf("\n--- FLIP#07: explicit setter wins over REXX370_BYTECODE=0 ---\n");
+
+    setenv("REXX370_BYTECODE", "0", 1);
+
+    if (irxinit(NULL, &env) != 0 || env == NULL)
+    {
+        printf("  FAIL: irxinit failed\n");
+        tests_run++;
+        tests_failed++;
+        unsetenv("REXX370_BYTECODE");
+        return;
+    }
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: wk is NULL\n");
+        tests_run++;
+        tests_failed++;
+        irxterm(env);
+        unsetenv("REXX370_BYTECODE");
+        return;
+    }
+
+    /* After init, env-var drove flag to 0. */
+    CHECK(wk->wkbi_use_bytecode == 0, "env-var set flag to 0 at init");
+
+    /* Explicit setter overrides — simulates what bytecode tests do. */
+    wk->wkbi_use_bytecode = 1;
+    CHECK(wk->wkbi_use_bytecode == 1, "explicit setter overrides env-var");
+
+    /* Run a simple program to confirm the bytecode path executes. */
+    exit_rc = -1;
+    CHECK(irx_exec_run("exit 0", (int)strlen("exit 0"),
+                       NULL, 0, &exit_rc, env) == 0,
+          "bytecode exec_run returns 0 after explicit setter");
+    CHECK(exit_rc == 0, "exit_rc == 0 via bytecode path");
+
+    irxterm(env);
+    unsetenv("REXX370_BYTECODE");
+}
+
+/* ------------------------------------------------------------------ */
+/*  Explicit setter = 0 wins over REXX370_BYTECODE=1.                 */
+/* ------------------------------------------------------------------ */
+static void test_setter_zero_wins_over_env(void)
+{
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    int exit_rc = -1;
+
+    printf("\n--- FLIP#08: explicit setter=0 wins over REXX370_BYTECODE=1 ---\n");
+
+    setenv("REXX370_BYTECODE", "1", 1);
+
+    if (irxinit(NULL, &env) != 0 || env == NULL)
+    {
+        printf("  FAIL: irxinit failed\n");
+        tests_run++;
+        tests_failed++;
+        unsetenv("REXX370_BYTECODE");
+        return;
+    }
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: wk is NULL\n");
+        tests_run++;
+        tests_failed++;
+        irxterm(env);
+        unsetenv("REXX370_BYTECODE");
+        return;
+    }
+
+    /* Env-var drove flag to 1 at init. */
+    CHECK(wk->wkbi_use_bytecode == 1, "env-var set flag to 1 at init");
+
+    /* Explicit setter forces token-walk. */
+    wk->wkbi_use_bytecode = 0;
+    CHECK(wk->wkbi_use_bytecode == 0, "explicit setter=0 overrides env-var");
+
+    exit_rc = -1;
+    CHECK(irx_exec_run("exit 0", (int)strlen("exit 0"),
+                       NULL, 0, &exit_rc, env) == 0,
+          "token-walk exec_run returns 0 after explicit setter=0");
+    CHECK(exit_rc == 0, "exit_rc == 0 via token-walk path");
+
+    irxterm(env);
+    unsetenv("REXX370_BYTECODE");
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+int main(void)
+{
+    printf("=== WP-BC-FLIP env-var override tests ===\n");
+
+    test_default_on();
+    test_env_zero();
+    test_env_one();
+    test_env_false_variants();
+    test_env_true_variants();
+    test_env_garbage();
+    test_setter_wins_over_env();
+    test_setter_zero_wins_over_env();
+
+    printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ===\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Closes the WP-BC-FLIP work package.

## Summary

- **Default flip** — `wkbi_use_bytecode` now initialises to `1` in `init_wkblk_int()` (`src/irx#init.c`). Every REXX execution (IRXJCL, TSO, `irx_exec_run`) runs through the bytecode VM unless explicitly overridden.
- **UNSUP fallback** — `irx_exec_run()` now falls through to token-walk when `irx_bc_compile()` returns `IRXBC_ERR_UNSUP`. This was the safety guarantee assumed by WP-BC-04/05/PARSE-X but never implemented; it is now in place.
- **Env-var opt-out** — `REXX370_BYTECODE=0` (also `false`/`no`/`off`, case-insensitive) disables the bytecode path at init time. `1`/`true`/`yes`/`on` forces it on. Garbage values are ignored and the default holds.
- **Top-level arg forwarding** — `irx_bc_execute()` gains `const char *args, int args_len` parameters; the VM now initialises `proxy_parser->call_args` from them so `PARSE ARG` and `ARG()` work at program entry.
- **New test** — `test/host/tstbc_flip.c` (25/25 checks across FLIP#01–08) verifies the env-var override behaviour exhaustively.

## Where the default-init was changed

`src/irx#init.c` — `init_wkblk_int()`, after the ADDRESS block setup and before `*wk_out = wk; return 0;`:

```c
wk->wkbi_use_bytecode = 1;
{
    const char *e = getenv("REXX370_BYTECODE");
    if (e != NULL)
    {
        if (e[0] == '0' || env_eq_ci(e, "false") || ...)
            wk->wkbi_use_bytecode = 0;
        else if (e[0] == '1' || env_eq_ci(e, "true") || ...)
            wk->wkbi_use_bytecode = 1;
    }
}
```

The env-var check runs inside `irxinit()`. Any explicit assignment to `wk->wkbi_use_bytecode` made *after* `irxinit()` returns (as all tests do) wins unconditionally — no special test-mode flag needed.

## Why test setters win

The env-var is read exactly once, during `init_wkblk_int()`. Tests call `irxinit()`, then assign `wk->wkbi_use_bytecode = 0` (or 1). That post-init assignment is the last write; the env-var has no further influence. This is the standard REXX/370 pattern: init sets defaults, callers override.

## Tests that started failing

None. After implementing the UNSUP fallback (the previously missing safety net), all 8 implicit-default tests run 100% green through the bytecode VM:

| Test binary | Before this WP | After |
|---|---|---|
| tstarit | 128/128 | 128/128 |
| tstbifs | 427/427 | 427/427 |
| tstctrl | 93/93 | 93/93 |
| tstparse | 74/74 | 74/74 |
| tstproc | 53/53 | 53/53 |
| tsthelo | 16/16 | 16/16 |
| tstprsr | 39/39 | 39/39 |
| tstlstr | 50/50 | 50/50 |

Explicit bytecode tests (tstbcal/bpse/bpro/bcom/bcrxc): 127/127 — unchanged.
tstbc_flip (new): 25/25.
Pre-existing: tstbc_compile 20/23, tstbc_expr 129/130 — unchanged from before this WP.

## getenv() on MVS

`getenv()` is provided by crent370 `<stdlib.h>` and works on MVS 3.8j. On MVS, `REXX370_BYTECODE` would be set via the C runtime environment (e.g. a DD name or ENVAR() in EXEC PGM JCL). First MVS run via IRXJCL will confirm the live behaviour; this PR does not block on that.

## Files changed

| File | Change |
|---|---|
| `include/irxbvm.h` | Added `const char *args, int args_len` to `irx_bc_execute` |
| `src/irx#bvm.c` | Accept args params; init `proxy_parser->call_args` from them; cleanup |
| `src/irx#exec.c` | UNSUP fallback (fall through to token-walk); updated call site; comment |
| `src/irx#init.c` | Default=1; `env_eq_ci()` helper; `REXX370_BYTECODE` env check |
| `test/host/tstbc_execute.c` | Updated 3 `irx_bc_execute` call sites (new args params) |
| `test/host/tstbc_flip.c` | New: 25-test env-var override verification (FLIP#01–08) |