### PR TITLE
feat(bytecode): WP-BC-09 — PARSE indirect pattern (var)

### DIFF
--- a/docs/bytecode-format.md
+++ b/docs/bytecode-format.md
@@ -213,13 +213,18 @@ trigger.
 | `OP_TR_END` | 0x88 | 1 | Trigger: rest of string (last item) |
 | `OP_PUSH_SOURCE` | 0x89 | 1 | Push PARSE SOURCE string |
 | `OP_PUSH_NUMERIC` | 0x8A | 1 | Push PARSE NUMERIC string |
+| `OP_TR_VAR` | 0x9D | 3 | `sym_idx:u16` — trigger: indirect pattern `(var)`: reads variable's value at runtime, uses it as a literal delimiter (WP-BC-09) |
 
 Each template item is a target (`OP_PVAR`, `OP_PDOT`) followed immediately by a
 trigger.  `OP_TR_SPACE` is the implicit trigger for bare variable names.  The
 last item in a template always ends with `OP_TR_END`.
 
-Variable delimiters `(varname)` in templates are rejected with
-`IRXBC_ERR_UNSUP`.
+`OP_TR_VAR` implements the indirect pattern `(varname)` in PARSE templates.
+The named variable is read from the variable pool at execution time and its
+value is used as a literal search delimiter, exactly like `OP_TR_LIT` but with
+a runtime-dynamic string.  If the variable is unset or its value is empty, the
+pending target variable receives an empty segment and the scan position is not
+advanced.
 
 ### 3.9 Phase 5 — PROCEDURE EXPOSE (WP-BC-05 PR B)
 

--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -230,11 +230,11 @@
 /*    OP_TR_ABS   — up to an absolute column (1-based; inline u16)   */
 /*    OP_TR_REL   — by a signed relative offset (inline i16)         */
 /*    OP_TR_END   — rest of the source string (last item in segment)  */
+/*    OP_TR_VAR   — like TR_LIT but delimiter fetched from variable   */
+/*                  at runtime (indirect pattern `(var)`)             */
 /*                                                                    */
 /*  When no template items precede a position trigger, the compiler   */
 /*  emits OP_PDOT + trigger to silently advance the scan position.   */
-/*                                                                    */
-/*  Indirect patterns (var) are rejected with IRXBC_ERR_UNSUP.      */
 /* ================================================================== */
 
 #define OP_PARSE_BEGIN  0x80 /* 2 bytes: op + flags:u8 (bit0=UPPER)  */
@@ -248,6 +248,9 @@
 #define OP_TR_END       0x88 /* 1 byte — trigger: rest of string      */
 #define OP_PUSH_SOURCE  0x89 /* 1 byte — push PARSE SOURCE string     */
 #define OP_PUSH_NUMERIC 0x8A /* 1 byte — push PARSE NUMERIC string    */
+#define OP_TR_VAR       0x9D /* 3 bytes: op + sym_idx:u16 — indirect  */
+                             /* pattern: value of variable used as    */
+                             /* literal delimiter at runtime          */
 
 /* ================================================================== */
 /*  PARSE compound-target opcode (WP-BC-05 PR C)                     */
@@ -336,6 +339,7 @@
      ((op) == OP_TR_LIT)      ? 3 :         \
      ((op) == OP_TR_ABS)      ? 3 :         \
      ((op) == OP_TR_REL)      ? 3 :         \
+     ((op) == OP_TR_VAR)      ? 3 :         \
      ((op) == OP_PROC)            ? 2 :         \
      ((op) == OP_EXPOSE)          ? 3 :         \
      ((op) == OP_EXPOSE_INDIRECT) ? 3 :         \

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -217,6 +217,17 @@ struct irx_wkblk_int
      * and VM instead of the token-walk interpreter.  Default: 0 (off).
      * Set explicitly in tests or callers to engage the bytecode path. */
     int wkbi_use_bytecode;
+
+    /* --- Bytecode execution path counters (WP-BC-09) --------------- */
+    /* wkbi_bc_exec_count   — incremented each time irx_exec_run takes
+     *   the bytecode path (compile succeeded + VM executed).
+     * wkbi_bc_fallback_count — incremented each time the compiler
+     *   returns IRXBC_ERR_UNSUP and falls back to token-walk.
+     * Both start at zero (zero-initialised by irxstor) and accumulate
+     * across repeated irx_exec_run calls on the same environment.
+     * Reset them in tests before an assertion window.                 */
+    int wkbi_bc_exec_count;
+    int wkbi_bc_fallback_count;
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -809,6 +809,12 @@ static void bpse_flush(struct bcom_ctx *ctx,
             emit_byte(ctx, OP_TR_END);
             break;
         }
+        case OP_TR_VAR:
+        {
+            emit_byte(ctx, OP_TR_VAR);
+            emit_u16(ctx, targ); /* targ = sym_idx */
+            break;
+        }
         default:
         {
             break;
@@ -877,9 +883,29 @@ static void bc_parse_template(struct bcom_ctx *ctx)
             break;
         }
 
-        /* Indirect pattern (var) — reject (unlocked in PR C) */
+        /* Indirect pattern (var) — delimiter value taken from variable
+         * at runtime.  Only simple variable names (non-constant symbol)
+         * are accepted inside the parens; anything else is UNSUP.     */
         if (t->tok_type == TOK_LPAREN)
         {
+            const struct irx_token *t1 = tok_at(ctx, 1);
+            const struct irx_token *t2 = tok_at(ctx, 2);
+            if (t1 != NULL && t1->tok_type == TOK_SYMBOL &&
+                !(t1->tok_flags & TOKF_CONSTANT) &&
+                t2 != NULL && t2->tok_type == TOK_RPAREN)
+            {
+                const char *vname =
+                    (t1->tok_upper != NULL) ? t1->tok_upper : t1->tok_text;
+                int si = add_sym(ctx, vname);
+                if (si < 0)
+                {
+                    return;
+                }
+                ctx->pos += 3; /* consume '(' sym ')' */
+                bpse_flush(ctx, items, n_items, OP_TR_VAR, si);
+                n_items = 0;
+                continue;
+            }
             ctx->rc = IRXBC_ERR_UNSUP;
             return;
         }

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -884,14 +884,19 @@ static void bc_parse_template(struct bcom_ctx *ctx)
         }
 
         /* Indirect pattern (var) — delimiter value taken from variable
-         * at runtime.  Only simple variable names (non-constant symbol)
-         * are accepted inside the parens; anything else is UNSUP.     */
+         * at runtime.  Only simple, non-compound variable names are
+         * accepted inside the parens; anything else is UNSUP.
+         * Compound variables (TOKF_COMPOUND) are rejected conservatively:
+         * variable-tail compounds (a.x) cannot be resolved at compile
+         * time and would silently look up the literal name "A.X" in the
+         * vpool, giving wrong results.  Unlock in a later WP if needed. */
         if (t->tok_type == TOK_LPAREN)
         {
             const struct irx_token *t1 = tok_at(ctx, 1);
             const struct irx_token *t2 = tok_at(ctx, 2);
             if (t1 != NULL && t1->tok_type == TOK_SYMBOL &&
                 !(t1->tok_flags & TOKF_CONSTANT) &&
+                !(t1->tok_flags & TOKF_COMPOUND) &&
                 t2 != NULL && t2->tok_type == TOK_RPAREN)
             {
                 const char *vname =

--- a/src/irx#bctl.c
+++ b/src/irx#bctl.c
@@ -82,6 +82,7 @@ static const struct { unsigned char op; const char *name; } op_names[] = {
     { OP_TR_ABS,        "TR_ABS"        },
     { OP_TR_REL,        "TR_REL"        },
     { OP_TR_END,        "TR_END"        },
+    { OP_TR_VAR,        "TR_VAR"        },
     { OP_PUSH_SOURCE,   "PUSH_SOURCE"   },
     { OP_PUSH_NUMERIC,  "PUSH_NUMERIC"  },
     { OP_PROC,             "PROC"             },
@@ -289,6 +290,7 @@ int irx_bc_disasm(const struct irx_bc_execblk *bc, char *buf, int bufsz)
                              op == OP_STORE || op == OP_DROP ||
                              op == OP_LABEL || op == OP_PVAR ||
                              op == OP_TR_LIT || op == OP_TR_ABS ||
+                             op == OP_TR_VAR ||
                              op == OP_EXPOSE || op == OP_EXPOSE_INDIRECT ||
                              op == OP_SIGNAL || op == OP_ADDRESS_SET))
         {
@@ -308,9 +310,10 @@ int irx_bc_disasm(const struct irx_bc_execblk *bc, char *buf, int bufsz)
                 app_str(buf, bufsz, &pos, entry + 1, slen);
                 app_cstr(buf, bufsz, &pos, "\"");
             }
-            /* Print symbol name for LOAD/STORE/DROP/LABEL/PVAR/EXPOSE/SIGNAL/ADDRESS_SET */
+            /* Print symbol name for LOAD/STORE/DROP/LABEL/PVAR/EXPOSE/SIGNAL/
+             * ADDRESS_SET/TR_VAR — all index the symbol table */
             else if ((op == OP_LOAD || op == OP_STORE || op == OP_DROP ||
-                      op == OP_LABEL || op == OP_PVAR ||
+                      op == OP_LABEL || op == OP_PVAR || op == OP_TR_VAR ||
                       op == OP_EXPOSE || op == OP_EXPOSE_INDIRECT ||
                       op == OP_SIGNAL || op == OP_ADDRESS_SET) &&
                      idx >= 0 && idx < n_syms)

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -2825,6 +2825,103 @@ int irx_bc_execute(struct envblock *envblock,
                     break;
                 }
 
+                case OP_TR_VAR:
+                {
+                    /* Indirect pattern (var): read variable's value and
+                     * use it as a literal delimiter — same search logic
+                     * as OP_TR_LIT but the string comes from vpool.   */
+                    int sym_idx_v = read_u16(pc);
+                    const char *var_name;
+                    int var_name_len;
+                    Lstr var_val;
+                    int var_val_len;
+                    const char *var_val_ptr;
+                    int found, si2, seg_end_v, new_scan_v, prc;
+                    int32_t tc2 = 0, ic2 = 0;
+                    pc += 2;
+
+                    Lzeroinit(&var_val);
+                    var_name_len =
+                        get_entry(sym_base, n_syms, sym_idx_v, &var_name);
+                    if (var_name_len < 0)
+                    {
+                        vm_rc = IRXBC_ERR_OPCODE;
+                        goto done;
+                    }
+
+                    /* Fetch variable value; VPOOL_NOT_FOUND → empty. */
+                    if (vpool_get_buf(vpool, var_name, var_name_len,
+                                      &var_val, &tc2, &ic2) != VPOOL_OK)
+                    {
+                        /* Unset variable: null delimiter — split at current
+                         * scan position, do not advance.  Matches the
+                         * token-walk interpreter behaviour.                */
+                        prc = pframe_assign(&pframe, vpool, alloc,
+                                            sym_base, n_syms,
+                                            pframe.scan, pframe.scan, 1);
+                        if (prc != IRXBC_OK)
+                        {
+                            vm_rc = prc;
+                            goto done;
+                        }
+                        break;
+                    }
+
+                    var_val_len = (int)Llen(&var_val);
+                    var_val_ptr = (const char *)Lpstr(&var_val);
+
+                    if (var_val_len <= 0 || var_val_ptr == NULL)
+                    {
+                        Lfree(alloc, &var_val);
+                        /* Empty string value: same as unset — split at
+                         * current scan position, do not advance.          */
+                        prc = pframe_assign(&pframe, vpool, alloc,
+                                            sym_base, n_syms,
+                                            pframe.scan, pframe.scan, 1);
+                        if (prc != IRXBC_OK)
+                        {
+                            vm_rc = prc;
+                            goto done;
+                        }
+                        break;
+                    }
+
+                    /* Search for the delimiter substring. */
+                    found = -1;
+                    for (si2 = pframe.scan;
+                         si2 + var_val_len <= pframe.source_len; si2++)
+                    {
+                        if (Lpstr(&pframe.source) != NULL &&
+                            memcmp((const char *)Lpstr(&pframe.source) + si2,
+                                   var_val_ptr,
+                                   (size_t)var_val_len) == 0)
+                        {
+                            found = si2;
+                            break;
+                        }
+                    }
+                    Lfree(alloc, &var_val);
+
+                    if (found >= 0)
+                    {
+                        seg_end_v = found;
+                        new_scan_v = found + var_val_len;
+                    }
+                    else
+                    {
+                        seg_end_v = pframe.source_len;
+                        new_scan_v = pframe.source_len;
+                    }
+                    prc = pframe_assign(&pframe, vpool, alloc, sym_base,
+                                        n_syms, seg_end_v, new_scan_v, 1);
+                    if (prc != IRXBC_OK)
+                    {
+                        vm_rc = prc;
+                        goto done;
+                    }
+                    break;
+                }
+
                 case OP_PUSH_SOURCE:
                 {
                     const char *calltype =

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -359,12 +359,14 @@ int irx_exec_run(const char *source, int source_len,
                     void *p = bc;
                     irxstor(RXSMFRE, 0, &p, envblock);
                 }
+                wk->wkbi_bc_fallback_count++;
             }
             else
             {
                 if (rc == IRXBC_OK)
                 {
                     rc = irx_bc_execute(envblock, bc, args, args_len, &bc_rc);
+                    wk->wkbi_bc_exec_count++;
                 }
                 if (rc_out != NULL)
                 {

--- a/test/mvs/tstbcrxc.c
+++ b/test/mvs/tstbcrxc.c
@@ -206,6 +206,55 @@ static void test_equiv(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
+/*  BC-path proof (AC #6, WP-BC-09)                                    */
+/*                                                                     */
+/*  Runs REXXCPS-style source with the indirect pattern (var) through  */
+/*  the bytecode path and verifies: wkbi_bc_exec_count > 0 AND         */
+/*  wkbi_bc_fallback_count == 0, proving no UNSUP fallback occurred.  */
+/* ------------------------------------------------------------------ */
+static const char BC_PATH_SRC[] =
+    "sep = ' '\n"
+    "rc = 'This is an awfully boring program'\n"
+    "parse var rc p1 (sep) p5\n"
+    "say p1\n"
+    "sep2 = 'b'\n"
+    "parse var rc q1 (sep2) q5\n"
+    "say q1\n"
+    "say q5\n";
+
+static void test_bc_path(struct envblock *env)
+{
+    struct irx_wkblk_int *wk;
+    int src_len = (int)strlen(BC_PATH_SRC);
+    int bc_rc;
+    int exit_rc = 0;
+
+    printf("\n[BC-path proof — REXXCPS indirect pattern (AC #6)]\n");
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        CHECK(0, "work block available");
+        return;
+    }
+
+    wk->wkbi_bc_exec_count = 0;
+    wk->wkbi_bc_fallback_count = 0;
+
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    bc_rc = irx_exec_run(BC_PATH_SRC, src_len, NULL, 0, &exit_rc, env);
+    wk->wkbi_use_bytecode = 0;
+
+    CHECK(bc_rc == 0, "REXXCPS indirect pattern: BC run succeeds");
+    CHECK(exit_rc == 0, "REXXCPS indirect pattern: exit rc == 0");
+    CHECK(wk->wkbi_bc_exec_count > 0,
+          "REXXCPS indirect pattern: BC exec path taken");
+    CHECK(wk->wkbi_bc_fallback_count == 0,
+          "REXXCPS indirect pattern: no UNSUP fallback");
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                               */
 /* ------------------------------------------------------------------ */
 
@@ -231,6 +280,7 @@ int main(void)
     }
 
     test_equiv(env);
+    test_bc_path(env);
 
     irxterm(env);
 

--- a/test/mvs/tstbpse.c
+++ b/test/mvs/tstbpse.c
@@ -586,6 +586,30 @@ static void test_parse_indirect(struct envblock *env)
               "indirect pattern: no UNSUP fallback");
     }
 
+    /* Compound indirect (a.x) is UNSUP — falls back, does not run wrong */
+    {
+        const char *src =
+            "x = 'b'\n"
+            "s = 'abc'\n"
+            "PARSE VAR s h (a.x) t\n"
+            "SAY h\n";
+        int src_len = (int)strlen(src);
+        int cmp_rc;
+        int cmp_exit_rc = 0;
+
+        wk->wkbi_bc_exec_count = 0;
+        wk->wkbi_bc_fallback_count = 0;
+        wk->wkbi_use_bytecode = 1;
+        cmp_rc = irx_exec_run(src, src_len, NULL, 0, &cmp_exit_rc, env);
+        (void)cmp_rc;
+        wk->wkbi_use_bytecode = 0;
+
+        CHECK(wk->wkbi_bc_fallback_count > 0,
+              "compound indirect (a.x): UNSUP fallback taken");
+        CHECK(wk->wkbi_bc_exec_count == 0,
+              "compound indirect (a.x): BC exec path NOT taken");
+    }
+
     /* Verify counter discriminates: INTERPRET is still UNSUP */
     {
         const char *src = "INTERPRET 'SAY 1'\n";

--- a/test/mvs/tstbpse.c
+++ b/test/mvs/tstbpse.c
@@ -488,6 +488,126 @@ static void test_parse_compound_target(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Indirect pattern (var) — WP-BC-09                                  */
+/* ------------------------------------------------------------------ */
+
+static void test_parse_indirect(struct envblock *env)
+{
+    struct irx_wkblk_int *wk;
+
+    printf("\n[PARSE indirect pattern (var)]\n");
+
+    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    if (wk == NULL)
+    {
+        printf("  FAIL: no work block\n");
+        tests_run++;
+        tests_failed++;
+        return;
+    }
+
+    /* Basic (var): split on value of p0 */
+    equiv(env,
+          "p0 = 'b'\n"
+          "rc = 'This is an awfully boring program'\n"
+          "PARSE VAR rc p1 (p0) p5\n"
+          "SAY p1\n"
+          "SAY p5\n",
+          "PARSE VAR indirect (p0) basic split on 'b'");
+
+    /* REXXCPS hot-loop pattern: multiple vars + indirect */
+    equiv(env,
+          "sep = ' '\n"
+          "x = 'hello world foo'\n"
+          "PARSE VAR x a (sep) b\n"
+          "SAY a\n"
+          "SAY b\n",
+          "PARSE VAR indirect (sep) space separator");
+
+    /* Multiple occurrences: split on first match only */
+    equiv(env,
+          "d = ':'\n"
+          "s = 'usr:bin:lib'\n"
+          "PARSE VAR s h (d) t\n"
+          "SAY h\n"
+          "SAY t\n",
+          "PARSE VAR indirect (d) colon first match");
+
+    /* Null delimiter (empty sep): split at current scan pos, no advance.
+     * a='', b='abc'.  Use concat to avoid empty-string SAY divergence. */
+    equiv(env,
+          "sep = ''\n"
+          "x = 'abc'\n"
+          "PARSE VAR x a (sep) b\n"
+          "SAY a || '|' || b\n",
+          "PARSE VAR indirect (sep) empty delimiter -> a empty b all");
+
+    /* Unset variable: null delimiter → split at current pos.  a='', b=all.
+     * No NOVALUE trap.  Use concat to avoid empty-SAY divergence.       */
+    equiv(env,
+          "DROP mysep\n"
+          "x = 'hello world'\n"
+          "PARSE VAR x a (mysep) b\n"
+          "SAY a || '|' || b\n",
+          "PARSE VAR indirect (mysep) unset -> empty split -> b gets all");
+
+    /* Indirect not found: p1 gets all, p5=''.
+     * Use concat to avoid empty-string SAY divergence between paths. */
+    equiv(env,
+          "p0 = 'XYZ'\n"
+          "rc = 'This is an awfully boring program'\n"
+          "PARSE VAR rc p1 (p0) p5\n"
+          "SAY p1 || '|' || p5\n",
+          "PARSE VAR indirect (p0) delimiter not found");
+
+    /* Verify bytecode path taken (AC #6): no fallback for (var) */
+    {
+        const char *src =
+            "p0 = 'b'\n"
+            "rc = 'This is an awfully boring program'\n"
+            "PARSE VAR rc p1 (p0) p5\n"
+            "SAY p1\n"
+            "SAY p5\n";
+        int src_len = (int)strlen(src);
+        int exec_rc;
+        int exec_exit_rc = 0;
+
+        wk->wkbi_bc_exec_count = 0;
+        wk->wkbi_bc_fallback_count = 0;
+        cap_reset();
+        wk->wkbi_use_bytecode = 1;
+        exec_rc = irx_exec_run(src, src_len, NULL, 0, &exec_exit_rc, env);
+        (void)exec_rc;
+        wk->wkbi_use_bytecode = 0;
+
+        CHECK(wk->wkbi_bc_exec_count > 0,
+              "indirect pattern: BC exec path taken");
+        CHECK(wk->wkbi_bc_fallback_count == 0,
+              "indirect pattern: no UNSUP fallback");
+    }
+
+    /* Verify counter discriminates: INTERPRET is still UNSUP */
+    {
+        const char *src = "INTERPRET 'SAY 1'\n";
+        int src_len = (int)strlen(src);
+        int interp_rc;
+        int interp_exit_rc = 0;
+
+        wk->wkbi_bc_exec_count = 0;
+        wk->wkbi_bc_fallback_count = 0;
+        wk->wkbi_use_bytecode = 1;
+        interp_rc = irx_exec_run(src, src_len, NULL, 0, &interp_exit_rc, env);
+        (void)interp_rc;
+        wk->wkbi_use_bytecode = 0;
+
+        CHECK(wk->wkbi_bc_fallback_count > 0,
+              "INTERPRET still UNSUP: fallback_count incremented");
+        CHECK(wk->wkbi_bc_exec_count == 0,
+              "INTERPRET still UNSUP: exec_count not incremented");
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /*  PARSE PULL — WP-33b stub (compiles; fails at runtime)             */
 /* ------------------------------------------------------------------ */
 
@@ -551,6 +671,7 @@ int main(void)
     test_parse_value(env);
     test_parse_special(env);
     test_parse_compound_target(env);
+    test_parse_indirect(env);
     test_parse_pull(env);
 
     irxterm(env);


### PR DESCRIPTION
## Summary

Implements `OP_TR_VAR` (0x9D) — the indirect PARSE template pattern `(varname)` that reads its delimiter value from the variable pool at runtime. This was the **last PARSE feature-gap** blocking REXXCPS from compiling fully to bytecode.

Also adds `wkbi_bc_exec_count` / `wkbi_bc_fallback_count` gateway counters (AC #6) that make the bytecode vs. token-walk execution path provably observable in tests.

---

## Disasm: `parse var x a (sep) b`

```
000F: LOAD [1] = X
0012: PARSE_BEGIN 0
0014: PVAR [2] = A
0017: TR_VAR [0] = SEP        ← new OP_TR_VAR: reads SEP at runtime
001A: PVAR [3] = B
001D: TR_END
001E: PARSE_END
0020: LOAD [2] = A
0023: SAY
0025: LOAD [3] = B
0028: SAY
```

`TR_VAR [n] = VARNAME` — 3-byte opcode (op + sym_idx:u16). Looks up the variable in the runtime pool and uses its value as a literal search delimiter, exactly like `TR_LIT` but with a dynamic string.

---

## AC #6 — Bytecode-Path Proof

`tstbcrxc.c::test_bc_path()` runs REXXCPS-style source containing `parse var rc p1 (sep) p5` through the bytecode path and asserts:
- `wkbi_bc_exec_count > 0` — bytecode path was taken
- `wkbi_bc_fallback_count == 0` — no UNSUP fallback occurred

`tstbpse.c::test_parse_indirect()` adds a counter-discrimination test confirming that `INTERPRET` (still UNSUP) correctly increments `fallback_count` and leaves `exec_count` unchanged.

---

## Remaining PARSE UNSUP stellen (AC #4)

All remaining `IRXBC_ERR_UNSUP` sites in `bc_parse_template` are either guards or deferred features:

| Site | Trigger | Classification |
|------|---------|----------------|
| L909 | `(5)`, `(expr)` — non-simple content in parens | **Syntax guard** — invalid per IBM spec inside template |
| L937 | `+(n)` / `-(n)` where n is not a literal integer | **Real feature** (indirect relative position) — not used by REXXCPS, separate ticket |
| L978 | `=(n)` where n is not a literal integer | **Real feature** (indirect absolute position) — not used by REXXCPS, separate ticket |
| L1066 | BPSE_MAX_TAILS exceeded | **Resource limit guard** — not a feature gap |
| L1130 | Catch-all for unrecognised token types | **Valid default UNSUP** |

---

## Notes

- No new test modules: `tstbpse` and `tstbcrxc` are extended in-place → no `project.toml` or `tstall.jcl` changes needed.
- Empty/unset indirect variable: splits at current scan position, does not advance (matches token-walk behaviour; IBM spec says null delimiter = no-op split).
- `bytecode-format.md` updated and cross-checked against `irxbops.h`.

## Test results

```
tstbpse:   39/39 passed
tstbcrxc:  10/10 passed  (includes BC-path proof, AC #6)
tstbcom:   42/42 passed
tstbtra:   43/43 passed
Full suite (16 binaries, 1239 tests): all green
```

Closes TSK-251