### PR TITLE
feat(bytecode): WP-BC-DBG — REXX370_BCDEBUG path diagnostic

### DIFF
--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -228,6 +228,13 @@ struct irx_wkblk_int
      * Reset them in tests before an assertion window.                 */
     int wkbi_bc_exec_count;
     int wkbi_bc_fallback_count;
+
+    /* --- Bytecode path diagnostic (WP-BC-DBG) ----------------------- */
+    /* When non-zero, irxterm() emits one line to stdout:
+     *   [bc] exec=N fallback=M
+     * Activated by setting REXX370_BCDEBUG=1 (or true/yes/on)
+     * in the environment before IRXINIT.  No effect otherwise.        */
+    int wkbi_bc_debug;
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -284,6 +284,22 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
         }
     }
 
+    /* Bytecode path diagnostic. REXX370_BCDEBUG=1 (or true/yes/on)
+     * causes irxterm() to emit "[bc] exec=N fallback=M" to stdout.
+     * Default off; no output, no overhead when not set. */
+    wk->wkbi_bc_debug = 0;
+    {
+        const char *e = getenv("REXX370_BCDEBUG");
+        if (e != NULL)
+        {
+            if (e[0] == '1' || env_eq_ci(e, "true") ||
+                env_eq_ci(e, "yes") || env_eq_ci(e, "on"))
+            {
+                wk->wkbi_bc_debug = 1;
+            }
+        }
+    }
+
     *wk_out = wk;
     return 0;
 

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -20,6 +20,7 @@
 /*  (c) 2026 mvslovers - REXX/370 Project                             */
 /* ------------------------------------------------------------------ */
 
+#include <stdio.h>
 #include <string.h>
 
 #include "irx.h"
@@ -159,6 +160,19 @@ int irxterm(struct envblock *envblk)
 
         /* Release all pooled lstring buffers before freeing wkbi. */
         irx_lstr_pool_teardown(envblk);
+
+        /* Bytecode path diagnostic (REXX370_BCDEBUG=1) — emit before
+         * wkbi is freed so the counters are still readable.  stdout
+         * on MVS/IRXJCL already points at SYSTSPRT at this point
+         * (irx_jcl_dispatch_main redirected it before exec; fclose
+         * happens after irxterm returns). */
+        if (wkbi->wkbi_bc_debug)
+        {
+            printf("[bc] exec=%d fallback=%d\n",
+                   wkbi->wkbi_bc_exec_count,
+                   wkbi->wkbi_bc_fallback_count);
+            fflush(stdout);
+        }
 
         /* Free the lstring370 allocator bridge if it was installed. */
         if (wkbi->wkbi_lstr_alloc != NULL)


### PR DESCRIPTION
## Summary

Implements WP-BC-DBG (TSK-256): a debug mechanism that makes the bytecode path counters visible during a real IRXJCL/REXXCPS run.

## How to activate

Set `REXX370_BCDEBUG=1` (also accepts `true`/`yes`/`on`) in the environment before the REXX run. At environment teardown, one line is written to `stdout`:

```
[bc] exec=N fallback=M
```

- **N** = number of `irx_exec_run` calls that took the bytecode path (compile succeeded + VM executed)
- **M** = number that fell back to the token-walk interpreter (IRXBC_ERR_UNSUP)

On MVS with `EXEC PGM=IRXJCL`, this line lands in **SYSTSPRT** — `irx_jcl_dispatch_main` redirects `stdout` to SYSTSPRT before exec and only calls `fclose` after `irxterm` returns, so the line is guaranteed in the spool output.

## Without the flag

No output, no overhead, no behaviour change. The flag is read once at IRXINIT time; the check at teardown is a single integer test.

## Implementation

- `include/irxwkblk.h`: adds `wkbi_bc_debug` flag field
- `src/irx#init.c`: reads `REXX370_BCDEBUG` alongside `REXX370_BYTECODE` (same `getenv` + `env_eq_ci` pattern)
- `src/irx#term.c`: emits `[bc] exec=N fallback=M` in `irxterm()` just before `wkbi` is freed (counters still readable)

## Verification

```sh
# No flag → no output
/tmp/tsthelo               # 16/16 passed, no [bc] line

# With flag → diagnostic line per environment
REXX370_BCDEBUG=1 /tmp/tsthelo   # [bc] exec=1 fallback=0 (x7 envs)
```

Full suite stays green: 1278 tests across 16 binaries.

Closes #167