### PR TITLE
feat(bytecode): WP-BC-DIAG — compiler UNSUP reason+line diagnostic

### DIFF
--- a/include/irxbvm.h
+++ b/include/irxbvm.h
@@ -50,18 +50,41 @@ struct bc_stack_slot
 /*  construct returns IRXBC_ERR_UNSUP.                               */
 /*                                                                    */
 /*  Parameters:                                                       */
-/*    envblock   — owning environment (used for irxstor)             */
-/*    source     — REXX source text (need not be NUL-terminated)     */
-/*    source_len — length in bytes                                   */
-/*    bc_out     — receives pointer to allocated irx_bc_execblk on   */
-/*                 success; caller must free with irxstor(RXSMFRE)   */
+/*    envblock        — owning environment (used for irxstor)        */
+/*    source          — REXX source text (need not be NUL-terminated)*/
+/*    source_len      — length in bytes                              */
+/*    bc_out          — receives pointer to allocated irx_bc_execblk */
+/*                      on success; caller frees with irxstor(RXSMFRE)*/
+/*    unsup_reason_out — optional (may be NULL); on IRXBC_ERR_UNSUP  */
+/*                      receives a bc_unsup_reason code identifying   */
+/*                      the construct the compiler could not handle.  */
+/*                      0 (BC_UNSUP_NONE) on any other outcome.       */
+/*    unsup_line_out  — optional (may be NULL); on IRXBC_ERR_UNSUP   */
+/*                      receives the 1-based source line of the       */
+/*                      offending construct.  0 on any other outcome. */
+/*                                                                    */
+/*  The reason/line pair is purely diagnostic (WP-BC-DIAG) — pass    */
+/*  NULL for both when the caller does not need it.                   */
 /*                                                                    */
 /*  Returns: IRXBC_OK (0) on success, IRXBC_ERR_* on failure.       */
 /* ================================================================== */
 
 int irx_bc_compile(struct envblock *envblock,
                    const char *source, int source_len,
-                   struct irx_bc_execblk **bc_out) asm("IRXBCOMP");
+                   struct irx_bc_execblk **bc_out,
+                   int *unsup_reason_out,
+                   int *unsup_line_out) asm("IRXBCOMP");
+
+/* ================================================================== */
+/*  irx_bc_unsup_text — map a bc_unsup_reason code to short text      */
+/*                                                                    */
+/*  Returns a static, never-NULL human-readable string for a reason  */
+/*  code reported by irx_bc_compile via unsup_reason_out.  Out-of-    */
+/*  range or unmapped codes return "unknown".  Used only for the     */
+/*  REXX370_BCDEBUG diagnostic output; not on any hot path.          */
+/* ================================================================== */
+
+const char *irx_bc_unsup_text(int reason) asm("IRXBCUTX");
 
 /* ================================================================== */
 /*  irx_bc_execute — execute a compiled bytecode container           */

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -235,6 +235,19 @@ struct irx_wkblk_int
      * Activated by setting REXX370_BCDEBUG=1 (or true/yes/on)
      * in the environment before IRXINIT.  No effect otherwise.        */
     int wkbi_bc_debug;
+
+    /* --- Bytecode UNSUP diagnostic (WP-BC-DIAG) --------------------- */
+    /* The reason code (bc_unsup_reason) and 1-based source line of the
+     * FIRST construct that forced a token-walk fallback.  Recorded by
+     * irx_exec_run from irx_bc_compile's out-params; first fallback
+     * wins so the earliest/outermost cause is reported.  When
+     * REXX370_BCDEBUG is set and at least one fallback occurred,
+     * irxterm() emits a second line:
+     *   [bc] unsup: line N, <reason text>
+     * wkbi_bc_unsup_reason stays 0 (BC_UNSUP_NONE) until the first
+     * fallback.                                                        */
+    int wkbi_bc_unsup_reason;
+    int wkbi_bc_unsup_line;
 };
 
 #define WKBLK_INT_ID "WKBI"

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -112,6 +112,70 @@ struct bcom_ctx
 
     int rc;
     int hit_exit;
+
+    /* WP-BC-DIAG: set together at every UNSUP site via BC_FAIL_UNSUP.
+     * unsup_reason holds a bc_unsup_reason code (see below); unsup_line
+     * is the 1-based source line of the offending token, captured by
+     * bc_cur_line() at the moment the compiler gives up.  Both stay at
+     * their zero-initialised defaults (BC_UNSUP_NONE / 0) unless an
+     * UNSUP is hit. */
+    int unsup_reason;
+    int unsup_line;
+};
+
+/* ================================================================== */
+/*  UNSUP reason codes (WP-BC-DIAG)                                    */
+/*                                                                    */
+/*  Each of the IRXBC_ERR_UNSUP sites in this file records one of     */
+/*  these codes so the REXX370_BCDEBUG diagnostic can report WHICH    */
+/*  construct forced the token-walk fallback (and on which line).     */
+/*  Codes are MVS-memory-friendly: the call sites carry only the      */
+/*  small integer; the human-readable strings live once, centrally,   */
+/*  in bc_unsup_text[] (see irx_bc_unsup_text below).                 */
+/*                                                                    */
+/*  Some sites are defensive syntax guards and legitimately share a   */
+/*  coarse code; others mark real feature gaps and get a specific     */
+/*  one.  BC_UNSUP_COUNT is the table-sizing sentinel — keep it last. */
+/* ================================================================== */
+
+enum bc_unsup_reason
+{
+    BC_UNSUP_NONE = 0,             /* no UNSUP recorded                 */
+    BC_UNSUP_INTERNAL,             /* API misuse / internal guard       */
+    BC_UNSUP_STATEMENT,            /* unrecognised statement keyword    */
+    BC_UNSUP_EXPR_OPERAND,         /* unsupported expression operand    */
+    BC_UNSUP_EXPR_PAREN,           /* ')' expected in (sub)expression   */
+    BC_UNSUP_TOO_MANY_ARGS,        /* argument count exceeds limit      */
+    BC_UNSUP_FUNC_ARG_SEP,         /* malformed function-call arg list  */
+    BC_UNSUP_CALL_TARGET,          /* CALL target is not a plain label  */
+    BC_UNSUP_CALL_ARG_SEP,         /* malformed CALL argument list      */
+    BC_UNSUP_PARSE_INDIRECT,       /* PARSE indirect pattern (var)      */
+    BC_UNSUP_PARSE_RELPOS,         /* PARSE relative position (+n/-n)   */
+    BC_UNSUP_PARSE_ABSPOS,         /* PARSE absolute position (=n)      */
+    BC_UNSUP_PARSE_TOO_MANY_TAILS, /* template tail count limit       */
+    BC_UNSUP_PARSE_TEMPLATE,       /* unsupported PARSE template item   */
+    BC_UNSUP_PARSE_VAR,            /* PARSE VAR target not a symbol     */
+    BC_UNSUP_PARSE_VALUE_WITH,     /* PARSE VALUE without WITH          */
+    BC_UNSUP_PARSE_SOURCE,         /* unsupported PARSE source keyword  */
+    BC_UNSUP_EXPOSE_INDIRECT,      /* PROCEDURE EXPOSE indirect (var)   */
+    BC_UNSUP_EXPOSE_LIMIT,         /* PROCEDURE EXPOSE count limit      */
+    BC_UNSUP_COMPOUND_TAIL_LIMIT,  /* compound variable tail limit     */
+    BC_UNSUP_IF_THEN,              /* IF condition not followed by THEN */
+    BC_UNSUP_WHEN_THEN,            /* WHEN condition not followed by THEN*/
+    BC_UNSUP_SELECT_BODY,          /* unexpected token in SELECT body   */
+    BC_UNSUP_DO_CONTROL,           /* unsupported controlled-DO clause  */
+    BC_UNSUP_ITERATE_TARGET,       /* ITERATE has no matching loop      */
+    BC_UNSUP_LEAVE_TARGET,         /* LEAVE has no matching loop/SELECT */
+    BC_UNSUP_TRACE_VALUE,          /* TRACE VALUE with empty expression */
+    BC_UNSUP_TRACE_SETTING,        /* empty/invalid TRACE setting word  */
+    BC_UNSUP_TRACE_FORM,           /* unsupported TRACE form            */
+    BC_UNSUP_ADDRESS_VALUE,        /* ADDRESS VALUE with empty expr     */
+    BC_UNSUP_ADDRESS_FORM,         /* unsupported ADDRESS form          */
+    BC_UNSUP_SIGNAL_CONDITION,     /* SIGNAL ON/OFF unknown condition   */
+    BC_UNSUP_SIGNAL_NAME,          /* SIGNAL ON ... NAME not a symbol   */
+    BC_UNSUP_SIGNAL_TARGET,        /* SIGNAL label is not a symbol      */
+    BC_UNSUP_DROP_TARGET,          /* DROP target is not a symbol       */
+    BC_UNSUP_COUNT                 /* sentinel — table size; keep last  */
 };
 
 /* ================================================================== */
@@ -277,6 +341,48 @@ static void consume_eoc(struct bcom_ctx *ctx)
         ctx->pos++;
     }
 }
+
+/* ================================================================== */
+/*  UNSUP diagnostic helpers (WP-BC-DIAG)                             */
+/* ================================================================== */
+
+/* Source line of the token the compiler is currently looking at.
+ * Clamps pos into range and steps back over the TOK_EOF sentinel
+ * (whose tok_line is upbuf_cap, not a real line) so an UNSUP raised
+ * at end-of-source still reports the last meaningful line. */
+static int bc_cur_line(const struct bcom_ctx *ctx)
+{
+    int p = ctx->pos;
+
+    if (ctx->tokens == NULL || ctx->tok_count <= 0)
+    {
+        return 0;
+    }
+    if (p < 0)
+    {
+        p = 0;
+    }
+    if (p >= ctx->tok_count)
+    {
+        p = ctx->tok_count - 1;
+    }
+    while (p > 0 && ctx->tokens[p].tok_type == TOK_EOF)
+    {
+        p--;
+    }
+    return ctx->tokens[p].tok_line;
+}
+
+/* Record an unsupported construct: set rc plus the diagnostic
+ * reason/line in one place.  Control flow (return / break / return -1)
+ * stays explicit at each call site because it differs per site. */
+#define BC_FAIL_UNSUP(ctx, reason)            \
+    do                                        \
+    {                                         \
+        (ctx)->rc = IRXBC_ERR_UNSUP;          \
+        (ctx)->unsup_reason = (reason);       \
+        (ctx)->unsup_line = bc_cur_line(ctx); \
+    } while (0)
 
 /* ================================================================== */
 /*  Symbol / constant table                                           */
@@ -550,7 +656,7 @@ static void bc_funcall(struct bcom_ctx *ctx, int sym_idx)
         }
         if (nargs >= IRX_MAX_ARGS)
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_TOO_MANY_ARGS);
             return;
         }
         bc_exp0(ctx);
@@ -570,7 +676,7 @@ static void bc_funcall(struct bcom_ctx *ctx, int sym_idx)
             ctx->pos++;
             continue;
         }
-        ctx->rc = IRXBC_ERR_UNSUP;
+        BC_FAIL_UNSUP(ctx, BC_UNSUP_FUNC_ARG_SEP);
         return;
     }
 
@@ -598,7 +704,7 @@ static void bc_call_stmt(struct bcom_ctx *ctx)
     if (t == NULL || t->tok_type != TOK_SYMBOL ||
         (t->tok_flags & TOKF_CONSTANT))
     {
-        ctx->rc = IRXBC_ERR_UNSUP;
+        BC_FAIL_UNSUP(ctx, BC_UNSUP_CALL_TARGET);
         return;
     }
 
@@ -621,7 +727,7 @@ static void bc_call_stmt(struct bcom_ctx *ctx)
             }
             if (nargs >= IRX_MAX_ARGS)
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_TOO_MANY_ARGS);
                 return;
             }
             bc_exp0(ctx);
@@ -639,7 +745,7 @@ static void bc_call_stmt(struct bcom_ctx *ctx)
                 ctx->pos++;
                 continue;
             }
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_CALL_ARG_SEP);
             return;
         }
     }
@@ -911,7 +1017,7 @@ static void bc_parse_template(struct bcom_ctx *ctx)
                 n_items = 0;
                 continue;
             }
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_INDIRECT);
             return;
         }
 
@@ -939,7 +1045,7 @@ static void bc_parse_template(struct bcom_ctx *ctx)
                 n_items = 0;
                 continue;
             }
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_RELPOS);
             return;
         }
 
@@ -980,7 +1086,7 @@ static void bc_parse_template(struct bcom_ctx *ctx)
                 n_items = 0;
                 continue;
             }
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_ABSPOS);
             return;
         }
 
@@ -1094,7 +1200,7 @@ static void bc_parse_template(struct bcom_ctx *ctx)
                         }
                         if (it->tail_count >= BPSE_MAX_TAILS)
                         {
-                            ctx->rc = IRXBC_ERR_UNSUP;
+                            BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_TOO_MANY_TAILS);
                             return;
                         }
                         is_const_tail = (seg_len == 0 ||
@@ -1158,7 +1264,7 @@ static void bc_parse_template(struct bcom_ctx *ctx)
             continue;
         }
 
-        ctx->rc = IRXBC_ERR_UNSUP;
+        BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_TEMPLATE);
         return;
     }
 
@@ -1262,7 +1368,7 @@ static void bc_parse_stmt(struct bcom_ctx *ctx)
         if (vt == NULL || vt->tok_type != TOK_SYMBOL ||
             (vt->tok_flags & TOKF_CONSTANT))
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_VAR);
             return;
         }
         vname = (vt->tok_upper != NULL) ? vt->tok_upper : vt->tok_text;
@@ -1312,7 +1418,7 @@ static void bc_parse_stmt(struct bcom_ctx *ctx)
         }
         if (with_pos < 0)
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_VALUE_WITH);
             return;
         }
         saved_count = ctx->tok_count;
@@ -1384,7 +1490,7 @@ static void bc_parse_stmt(struct bcom_ctx *ctx)
     }
     else
     {
-        ctx->rc = IRXBC_ERR_UNSUP;
+        BC_FAIL_UNSUP(ctx, BC_UNSUP_PARSE_SOURCE);
         return;
     }
 
@@ -1476,7 +1582,7 @@ static void bc_procedure_stmt(struct bcom_ctx *ctx)
             if (t == NULL || t->tok_type != TOK_SYMBOL ||
                 (t->tok_flags & TOKF_CONSTANT))
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_EXPOSE_INDIRECT);
                 return;
             }
             iname = (t->tok_upper != NULL) ? t->tok_upper : t->tok_text;
@@ -1489,7 +1595,7 @@ static void bc_procedure_stmt(struct bcom_ctx *ctx)
             t = tok_at(ctx, 0);
             if (t == NULL || t->tok_type != TOK_RPAREN)
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_EXPOSE_INDIRECT);
                 return;
             }
             ctx->pos++; /* consume ) */
@@ -1505,7 +1611,7 @@ static void bc_procedure_stmt(struct bcom_ctx *ctx)
             }
             if (++nexposed > 255)
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_EXPOSE_LIMIT);
                 return;
             }
         }
@@ -1531,7 +1637,7 @@ static void bc_procedure_stmt(struct bcom_ctx *ctx)
             }
             if (++nexposed > 255)
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_EXPOSE_LIMIT);
                 return;
             }
             ctx->pos++;
@@ -1605,7 +1711,7 @@ static int bc_compound_tails(struct bcom_ctx *ctx,
 
         if (tail_count == 255)
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_COMPOUND_TAIL_LIMIT);
             return -1;
         }
 
@@ -1671,7 +1777,7 @@ static void bc_exp8(struct bcom_ctx *ctx)
         t = tok_at(ctx, 0);
         if (t == NULL || t->tok_type != TOK_RPAREN)
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_EXPR_PAREN);
             return;
         }
         ctx->pos++;
@@ -1777,7 +1883,7 @@ static void bc_exp8(struct bcom_ctx *ctx)
         return;
     }
 
-    ctx->rc = IRXBC_ERR_UNSUP;
+    BC_FAIL_UNSUP(ctx, BC_UNSUP_EXPR_OPERAND);
 }
 
 static void bc_exp7(struct bcom_ctx *ctx)
@@ -2295,7 +2401,7 @@ static void C_if_bc(struct bcom_ctx *ctx)
 
     if (!tok_kw(ctx, 0, "THEN"))
     {
-        ctx->rc = IRXBC_ERR_UNSUP;
+        BC_FAIL_UNSUP(ctx, BC_UNSUP_IF_THEN);
         return;
     }
     ctx->pos++; /* consume THEN */
@@ -2381,7 +2487,7 @@ static void C_select_bc(struct bcom_ctx *ctx)
 
             if (!tok_kw(ctx, 0, "THEN"))
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_WHEN_THEN);
                 break;
             }
             ctx->pos++; /* consume THEN */
@@ -2422,7 +2528,7 @@ static void C_select_bc(struct bcom_ctx *ctx)
         }
         else
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_SELECT_BODY);
             break;
         }
     }
@@ -2568,7 +2674,7 @@ static void C_do_bc(struct bcom_ctx *ctx)
         /* Expect TO */
         if (!tok_kw(ctx, 0, "TO"))
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_DO_CONTROL);
             return;
         }
         ctx->pos++; /* consume TO */
@@ -2849,7 +2955,7 @@ static void C_iterate_bc(struct bcom_ctx *ctx)
     lf = loop_find(ctx, label[0] ? label : NULL);
     if (lf == NULL)
     {
-        ctx->rc = IRXBC_ERR_UNSUP;
+        BC_FAIL_UNSUP(ctx, BC_UNSUP_ITERATE_TARGET);
         return;
     }
 
@@ -2899,7 +3005,7 @@ static void C_leave_bc(struct bcom_ctx *ctx)
         lf = select_frame(ctx);
         if (lf == NULL)
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_LEAVE_TARGET);
             return;
         }
     }
@@ -2945,7 +3051,7 @@ static void bc_trace_stmt(struct bcom_ctx *ctx)
         ctx->pos++; /* consume VALUE */
         if (tok_ends_clause(ctx))
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_TRACE_VALUE);
             return;
         }
         bc_exp0(ctx);
@@ -2991,7 +3097,7 @@ static void bc_trace_stmt(struct bcom_ctx *ctx)
         }
         if (idx >= n)
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_TRACE_SETTING);
             return;
         }
         c = (char)toupper((unsigned char)text[idx]);
@@ -2999,7 +3105,7 @@ static void bc_trace_stmt(struct bcom_ctx *ctx)
             const char *p = strchr(allowed, c);
             if (p == NULL)
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_TRACE_SETTING);
                 return;
             }
             /* Encode as letter-index (0-8) in bits 0-3, interactive in bit 4.
@@ -3014,7 +3120,7 @@ static void bc_trace_stmt(struct bcom_ctx *ctx)
         return;
     }
 
-    ctx->rc = IRXBC_ERR_UNSUP;
+    BC_FAIL_UNSUP(ctx, BC_UNSUP_TRACE_FORM);
 }
 
 /* ================================================================== */
@@ -3046,7 +3152,7 @@ static void bc_address_stmt(struct bcom_ctx *ctx)
         ctx->pos++; /* consume VALUE */
         if (tok_ends_clause(ctx))
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_ADDRESS_VALUE);
             return;
         }
         bc_exp0(ctx);
@@ -3115,7 +3221,7 @@ static void bc_address_stmt(struct bcom_ctx *ctx)
         return;
     }
 
-    ctx->rc = IRXBC_ERR_UNSUP;
+    BC_FAIL_UNSUP(ctx, BC_UNSUP_ADDRESS_FORM);
 }
 
 static void bc_signal_stmt(struct bcom_ctx *ctx)
@@ -3165,7 +3271,7 @@ static void bc_signal_stmt(struct bcom_ctx *ctx)
         }
         else
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_SIGNAL_CONDITION);
             return;
         }
         ctx->pos++; /* consume condition name */
@@ -3178,7 +3284,7 @@ static void bc_signal_stmt(struct bcom_ctx *ctx)
             nt = tok_at(ctx, 0);
             if (nt == NULL || nt->tok_type != TOK_SYMBOL)
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_SIGNAL_NAME);
                 return;
             }
             lname = (nt->tok_upper != NULL) ? nt->tok_upper : nt->tok_text;
@@ -3238,7 +3344,7 @@ static void bc_signal_stmt(struct bcom_ctx *ctx)
         }
         else
         {
-            ctx->rc = IRXBC_ERR_UNSUP;
+            BC_FAIL_UNSUP(ctx, BC_UNSUP_SIGNAL_CONDITION);
             return;
         }
         ctx->pos++; /* consume condition name */
@@ -3265,7 +3371,7 @@ static void bc_signal_stmt(struct bcom_ctx *ctx)
     t = tok_at(ctx, 0);
     if (t == NULL || t->tok_type != TOK_SYMBOL)
     {
-        ctx->rc = IRXBC_ERR_UNSUP;
+        BC_FAIL_UNSUP(ctx, BC_UNSUP_SIGNAL_TARGET);
         return;
     }
     {
@@ -3511,7 +3617,7 @@ static void bc_stmt(struct bcom_ctx *ctx)
             if (td->tok_type != TOK_SYMBOL ||
                 (td->tok_flags & TOKF_CONSTANT))
             {
-                ctx->rc = IRXBC_ERR_UNSUP;
+                BC_FAIL_UNSUP(ctx, BC_UNSUP_DROP_TARGET);
                 return;
             }
             if (td->tok_flags & TOKF_COMPOUND)
@@ -3617,7 +3723,7 @@ static void bc_stmt(struct bcom_ctx *ctx)
         return;
     }
 
-    ctx->rc = IRXBC_ERR_UNSUP;
+    BC_FAIL_UNSUP(ctx, BC_UNSUP_STATEMENT);
 }
 
 /* ================================================================== */
@@ -3675,12 +3781,71 @@ static void bc_program(struct bcom_ctx *ctx)
 }
 
 /* ================================================================== */
+/*  UNSUP reason → text (WP-BC-DIAG)                                  */
+/*                                                                    */
+/*  Central, compact lookup used only by the REXX370_BCDEBUG          */
+/*  diagnostic.  Designated initialisers key each string to its enum  */
+/*  value, so the mapping cannot drift if the enum is reordered; any  */
+/*  gap falls through to "unknown" in irx_bc_unsup_text().            */
+/* ================================================================== */
+
+static const char *const bc_unsup_text[BC_UNSUP_COUNT] = {
+    [BC_UNSUP_NONE] = "(none)",
+    [BC_UNSUP_INTERNAL] = "internal/API guard",
+    [BC_UNSUP_STATEMENT] = "unsupported statement",
+    [BC_UNSUP_EXPR_OPERAND] = "unsupported expression operand",
+    [BC_UNSUP_EXPR_PAREN] = "')' expected in expression",
+    [BC_UNSUP_TOO_MANY_ARGS] = "too many call arguments",
+    [BC_UNSUP_FUNC_ARG_SEP] = "malformed function argument list",
+    [BC_UNSUP_CALL_TARGET] = "CALL target is not a label",
+    [BC_UNSUP_CALL_ARG_SEP] = "malformed CALL argument list",
+    [BC_UNSUP_PARSE_INDIRECT] = "PARSE indirect pattern (var)",
+    [BC_UNSUP_PARSE_RELPOS] = "PARSE relative position (+n/-n)",
+    [BC_UNSUP_PARSE_ABSPOS] = "PARSE absolute position (=n)",
+    [BC_UNSUP_PARSE_TOO_MANY_TAILS] = "PARSE template tail limit",
+    [BC_UNSUP_PARSE_TEMPLATE] = "unsupported PARSE template item",
+    [BC_UNSUP_PARSE_VAR] = "PARSE VAR target is not a symbol",
+    [BC_UNSUP_PARSE_VALUE_WITH] = "PARSE VALUE without WITH",
+    [BC_UNSUP_PARSE_SOURCE] = "unsupported PARSE source",
+    [BC_UNSUP_EXPOSE_INDIRECT] = "PROCEDURE EXPOSE indirect (var)",
+    [BC_UNSUP_EXPOSE_LIMIT] = "PROCEDURE EXPOSE count limit",
+    [BC_UNSUP_COMPOUND_TAIL_LIMIT] = "compound variable tail limit",
+    [BC_UNSUP_IF_THEN] = "IF without THEN",
+    [BC_UNSUP_WHEN_THEN] = "WHEN without THEN",
+    [BC_UNSUP_SELECT_BODY] = "unexpected token in SELECT",
+    [BC_UNSUP_DO_CONTROL] = "unsupported controlled DO",
+    [BC_UNSUP_ITERATE_TARGET] = "ITERATE has no matching loop",
+    [BC_UNSUP_LEAVE_TARGET] = "LEAVE has no matching loop/SELECT",
+    [BC_UNSUP_TRACE_VALUE] = "TRACE VALUE with empty expression",
+    [BC_UNSUP_TRACE_SETTING] = "invalid TRACE setting",
+    [BC_UNSUP_TRACE_FORM] = "unsupported TRACE form",
+    [BC_UNSUP_ADDRESS_VALUE] = "ADDRESS VALUE with empty expression",
+    [BC_UNSUP_ADDRESS_FORM] = "unsupported ADDRESS form",
+    [BC_UNSUP_SIGNAL_CONDITION] = "unsupported SIGNAL condition",
+    [BC_UNSUP_SIGNAL_NAME] = "SIGNAL ... NAME is not a symbol",
+    [BC_UNSUP_SIGNAL_TARGET] = "SIGNAL label is not a symbol",
+    [BC_UNSUP_DROP_TARGET] = "DROP target is not a symbol",
+};
+
+const char *irx_bc_unsup_text(int reason)
+{
+    if (reason < 0 || reason >= BC_UNSUP_COUNT ||
+        bc_unsup_text[reason] == NULL)
+    {
+        return "unknown";
+    }
+    return bc_unsup_text[reason];
+}
+
+/* ================================================================== */
 /*  irx_bc_compile                                                    */
 /* ================================================================== */
 
 int irx_bc_compile(struct envblock *envblock,
                    const char *source, int source_len,
-                   struct irx_bc_execblk **bc_out)
+                   struct irx_bc_execblk **bc_out,
+                   int *unsup_reason_out,
+                   int *unsup_line_out)
 {
     struct irx_token *tokens = NULL;
     int tok_count = 0;
@@ -3696,8 +3861,22 @@ int irx_bc_compile(struct envblock *envblock,
 
     memset(&tok_err, 0, sizeof(tok_err));
 
+    /* Default the diagnostic out-params; only an UNSUP overwrites them. */
+    if (unsup_reason_out != NULL)
+    {
+        *unsup_reason_out = BC_UNSUP_NONE;
+    }
+    if (unsup_line_out != NULL)
+    {
+        *unsup_line_out = 0;
+    }
+
     if (bc_out == NULL)
     {
+        if (unsup_reason_out != NULL)
+        {
+            *unsup_reason_out = BC_UNSUP_INTERNAL;
+        }
         return IRXBC_ERR_UNSUP;
     }
     *bc_out = NULL;
@@ -3724,6 +3903,18 @@ int irx_bc_compile(struct envblock *envblock,
 
     bc_program(ctx);
     rc = ctx->rc;
+    if (rc == IRXBC_ERR_UNSUP)
+    {
+        /* Capture the reason/line before cleanup frees ctx. */
+        if (unsup_reason_out != NULL)
+        {
+            *unsup_reason_out = ctx->unsup_reason;
+        }
+        if (unsup_line_out != NULL)
+        {
+            *unsup_line_out = ctx->unsup_line;
+        }
+    }
     if (rc != IRXBC_OK)
     {
         goto cleanup;

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -348,8 +348,11 @@ int irx_exec_run(const char *source, int source_len,
         {
             struct irx_bc_execblk *bc = NULL;
             int bc_rc = 0;
+            int unsup_reason = 0;
+            int unsup_line = 0;
 
-            rc = irx_bc_compile(envblock, source, source_len, &bc);
+            rc = irx_bc_compile(envblock, source, source_len, &bc,
+                                &unsup_reason, &unsup_line);
             if (rc == IRXBC_ERR_UNSUP)
             {
                 /* Unsupported construct — release bc and fall through
@@ -360,6 +363,14 @@ int irx_exec_run(const char *source, int source_len,
                     irxstor(RXSMFRE, 0, &p, envblock);
                 }
                 wk->wkbi_bc_fallback_count++;
+                /* Record the FIRST fallback's reason/line for the
+                 * REXX370_BCDEBUG diagnostic (WP-BC-DIAG).  First wins
+                 * so the earliest cause survives later fallbacks. */
+                if (wk->wkbi_bc_unsup_reason == 0)
+                {
+                    wk->wkbi_bc_unsup_reason = unsup_reason;
+                    wk->wkbi_bc_unsup_line = unsup_line;
+                }
             }
             else
             {

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -27,6 +27,7 @@
 #include "irx_init.h"
 #include "irxanchr.h"
 #include "irxbif.h"
+#include "irxbvm.h"
 #include "irxfunc.h"
 #include "irxlstr.h"
 #include "irxwkblk.h"
@@ -171,6 +172,14 @@ int irxterm(struct envblock *envblk)
             printf("[bc] exec=%d fallback=%d\n",
                    wkbi->wkbi_bc_exec_count,
                    wkbi->wkbi_bc_fallback_count);
+            /* On a token-walk fallback, name the construct that forced
+             * it and the source line (WP-BC-DIAG). */
+            if (wkbi->wkbi_bc_fallback_count > 0)
+            {
+                printf("[bc] unsup: line %d, %s\n",
+                       wkbi->wkbi_bc_unsup_line,
+                       irx_bc_unsup_text(wkbi->wkbi_bc_unsup_reason));
+            }
             fflush(stdout);
         }
 

--- a/test/host/tstbc_clean.c
+++ b/test/host/tstbc_clean.c
@@ -144,7 +144,7 @@ static void test_strtoolong(struct envblock *env)
     src[70] = '\0';
 
     printf("  [long literal (64 bytes) rejected]\n");
-    rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+    rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
     CHECK(rc == IRXBC_ERR_STRTOOLONG, "compile returns IRXBC_ERR_STRTOOLONG");
     CHECK(bc == NULL, "bc is NULL on strtoolong error");
 
@@ -163,7 +163,7 @@ static void test_strtoolong(struct envblock *env)
     src[69] = '\0';
 
     bc = NULL;
-    rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+    rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "63-byte literal compiles OK");
     if (bc != NULL)
     {

--- a/test/host/tstbc_compile.c
+++ b/test/host/tstbc_compile.c
@@ -71,7 +71,7 @@ static void test_compile_empty(struct envblock *env)
     printf("  [compile: empty source]\n");
 
     rc = irx_bc_compile(env, "/* nothing */",
-                        (int)strlen("/* nothing */"), &bc);
+                        (int)strlen("/* nothing */"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
     CHECK(bc != NULL, "bc pointer is non-NULL");
 
@@ -109,7 +109,7 @@ static void test_compile_exit(struct envblock *env)
 
     printf("  [compile: exit]\n");
 
-    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), &bc);
+    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
     CHECK(bc != NULL, "bc pointer is non-NULL");
 
@@ -145,7 +145,7 @@ static void test_compile_unsupported(struct envblock *env)
     printf("  [compile: unsupported construct]\n");
 
     /* CALL is not yet handled by the bytecode compiler. */
-    rc = irx_bc_compile(env, "CALL foo", (int)strlen("CALL foo"), &bc);
+    rc = irx_bc_compile(env, "CALL foo", (int)strlen("CALL foo"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_ERR_UNSUP,
           "compile returns IRXBC_ERR_UNSUP for unsupported construct");
     CHECK(bc == NULL, "bc is NULL on error");
@@ -157,7 +157,7 @@ static void test_compile_null_out(struct envblock *env)
 
     printf("  [compile: NULL bc_out]\n");
 
-    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), NULL);
+    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), NULL, NULL, NULL);
     CHECK(rc != IRXBC_OK, "compile rejects NULL bc_out");
 }
 

--- a/test/host/tstbc_execute.c
+++ b/test/host/tstbc_execute.c
@@ -74,7 +74,7 @@ static void test_execute_empty(struct envblock *env)
     printf("  [execute: empty source]\n");
 
     rc = irx_bc_compile(env, "/* nothing */",
-                        (int)strlen("/* nothing */"), &bc);
+                        (int)strlen("/* nothing */"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile succeeds");
     if (bc == NULL)
     {
@@ -99,7 +99,7 @@ static void test_execute_exit(struct envblock *env)
 
     printf("  [execute: exit]\n");
 
-    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), &bc);
+    rc = irx_bc_compile(env, "exit", (int)strlen("exit"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile succeeds");
     if (bc == NULL)
     {

--- a/test/host/tstbc_expr.c
+++ b/test/host/tstbc_expr.c
@@ -140,7 +140,7 @@ static void test_compile_assignment(struct envblock *env)
 
     printf("  [compile: x = 5]\n");
 
-    rc = irx_bc_compile(env, "x = 5", (int)strlen("x = 5"), &bc);
+    rc = irx_bc_compile(env, "x = 5", (int)strlen("x = 5"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
     CHECK(bc != NULL, "bc pointer is non-NULL");
 
@@ -178,7 +178,7 @@ static void test_compile_expr(struct envblock *env)
 
     printf("  [compile: x = 3 + 4]\n");
 
-    rc = irx_bc_compile(env, "x = 3 + 4", (int)strlen("x = 3 + 4"), &bc);
+    rc = irx_bc_compile(env, "x = 3 + 4", (int)strlen("x = 3 + 4"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
     CHECK(bc != NULL, "bc pointer is non-NULL");
 
@@ -212,7 +212,7 @@ static void test_compile_exit_rc(struct envblock *env)
 
     printf("  [compile: EXIT 7]\n");
 
-    rc = irx_bc_compile(env, "EXIT 7", (int)strlen("EXIT 7"), &bc);
+    rc = irx_bc_compile(env, "EXIT 7", (int)strlen("EXIT 7"), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile returns IRXBC_OK");
     CHECK(bc != NULL, "bc pointer is non-NULL");
 

--- a/test/mvs/tstbcrxc.c
+++ b/test/mvs/tstbcrxc.c
@@ -33,6 +33,8 @@
 #include <string.h>
 
 #include "irx.h"
+#include "irxbops.h"
+#include "irxbvm.h"
 #include "irxexec.h"
 #include "irxfunc.h"
 #include "irxwkblk.h"
@@ -255,6 +257,34 @@ static void test_bc_path(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
+/*  UNSUP diagnostic mechanism (WP-BC-DIAG)                            */
+/*                                                                     */
+/*  Locks in the reason/line diagnostic: a ';' clause separator forces */
+/*  a token-walk fallback (REXXCPS line 91 `do count; end`), and       */
+/*  irx_bc_compile must report WHICH construct and WHERE via its       */
+/*  out-params — mapped to human text by irx_bc_unsup_text.            */
+/* ------------------------------------------------------------------ */
+static void test_unsup_diag(struct envblock *env)
+{
+    static const char SRC[] = "say 1; end";
+    struct irx_bc_execblk *bc = NULL;
+    int reason = -1;
+    int line = -1;
+    int rc;
+
+    printf("\n[UNSUP diagnostic — WP-BC-DIAG]\n");
+
+    rc = irx_bc_compile(env, SRC, (int)strlen(SRC), &bc, &reason, &line);
+
+    CHECK(rc == IRXBC_ERR_UNSUP, "';' clause separator -> IRXBC_ERR_UNSUP");
+    CHECK(bc == NULL, "no execblk produced on UNSUP");
+    CHECK(reason != 0, "unsup_reason recorded (non-NONE)");
+    CHECK(line == 1, "unsup_line == 1");
+    CHECK(strcmp(irx_bc_unsup_text(reason), "unknown") != 0,
+          "reason maps to known text");
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                               */
 /* ------------------------------------------------------------------ */
 
@@ -281,6 +311,7 @@ int main(void)
 
     test_equiv(env);
     test_bc_path(env);
+    test_unsup_diag(env);
 
     irxterm(env);
 

--- a/test/mvs/tstbctl.c
+++ b/test/mvs/tstbctl.c
@@ -354,7 +354,7 @@ static void test_disasm(struct envblock *env)
 
     printf("\n[disasm]\n");
 
-    rc = irx_bc_compile(env, "SAY \"hi\"", (int)strlen("SAY \"hi\""), &bc);
+    rc = irx_bc_compile(env, "SAY \"hi\"", (int)strlen("SAY \"hi\""), &bc, NULL, NULL);
     CHECK(rc == IRXBC_OK, "compile SAY for disasm");
     if (bc != NULL)
     {

--- a/test/mvs/tstbsig.c
+++ b/test/mvs/tstbsig.c
@@ -345,7 +345,7 @@ static void test_signal_sigl(struct envblock *env)
 
     wk->wkbi_sigl = 999; /* set a sentinel before SIGNAL */
 
-    rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+    rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
     if (rc == IRXBC_OK && bc != NULL)
     {
         rc = irx_bc_execute(env, bc, NULL, 0, &exit_rc);

--- a/test/mvs/tstbtra.c
+++ b/test/mvs/tstbtra.c
@@ -455,7 +455,7 @@ static void test_disasm(struct envblock *env)
     /* TRACE Off -> TRACE_SET opcode. */
     {
         const char *src = "trace off\n";
-        rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+        rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
         CHECK(rc == 0, "TRACE Off compiles OK");
         if (rc == 0 && bc != NULL)
         {
@@ -471,7 +471,7 @@ static void test_disasm(struct envblock *env)
     /* Bare TRACE -> TRACE_TOGGLE. */
     {
         const char *src = "trace\n";
-        rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+        rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
         CHECK(rc == 0, "bare TRACE compiles OK");
         if (rc == 0 && bc != NULL)
         {
@@ -487,7 +487,7 @@ static void test_disasm(struct envblock *env)
     /* TRACE VALUE x -> TRACE_VALUE. */
     {
         const char *src = "trace value x\n";
-        rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+        rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
         CHECK(rc == 0, "TRACE VALUE compiles OK");
         if (rc == 0 && bc != NULL)
         {
@@ -503,7 +503,7 @@ static void test_disasm(struct envblock *env)
     /* ADDRESS TSO -> ADDRESS_SET with sym name. */
     {
         const char *src = "address tso\n";
-        rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+        rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
         CHECK(rc == 0, "ADDRESS TSO compiles OK");
         if (rc == 0 && bc != NULL)
         {
@@ -521,7 +521,7 @@ static void test_disasm(struct envblock *env)
     /* Bare ADDRESS -> ADDRESS_TOGGLE. */
     {
         const char *src = "address\n";
-        rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+        rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
         CHECK(rc == 0, "bare ADDRESS compiles OK");
         if (rc == 0 && bc != NULL)
         {
@@ -537,7 +537,7 @@ static void test_disasm(struct envblock *env)
     /* ADDRESS VALUE x -> ADDRESS_VALUE. */
     {
         const char *src = "address value x\n";
-        rc = irx_bc_compile(env, src, (int)strlen(src), &bc);
+        rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
         CHECK(rc == 0, "ADDRESS VALUE compiles OK");
         if (rc == 0 && bc != NULL)
         {


### PR DESCRIPTION
Extends the `REXX370_BCDEBUG` path diagnostic (WP-BC-DBG, #168): the bytecode
compiler now reports **which** construct forced a token-walk fallback and **on
which line** — solving the root instead of bisecting from outside. (TSK-257)

## What

- **`enum bc_unsup_reason` + `unsup_reason`/`unsup_line` on `bcom_ctx`** — MVS
  memory-friendly: each site carries a small integer code, not a string.
- **`BC_FAIL_UNSUP(ctx, reason)`** records `rc` + reason + the offending line in
  one place. `bc_cur_line()` clamps `pos` and steps over the `TOK_EOF` sentinel.
- **Central `irx_bc_unsup_text()`** — one designated-initialiser table maps each
  code to short text (`"unknown"` for any gap), sized by `BC_UNSUP_COUNT`.
- **`irx_bc_compile`** gains two optional out-params `(reason, line)`; the gateway
  records the **first** fallback on the work block; `irxterm()` emits a second
  line under BCDEBUG only.
- **No behaviour/output change** when `REXX370_BCDEBUG` is unset.

Output:
```
[bc] exec=0 fallback=1
[bc] unsup: line 91, unsupported statement
```

## The 39 UNSUP sites

`grep -c 'BC_FAIL_UNSUP(ctx,'` = **39** (38 annotated call sites + the macro
definition). Plus the lone `bc_out == NULL` API guard, which is a `return
IRXBC_ERR_UNSUP` and sets the out-param to `BC_UNSUP_INTERNAL` directly.
**38 macro sites + 1 API-guard return = 39 UNSUP exits**, every one recording a
distinguishable reason + line. Defensive syntax guards share coarse codes (e.g.
`BC_UNSUP_TOO_MANY_ARGS`); real feature gaps get specific ones.

## REXXCPS trigger identified (AC #6)

`test/host/tstcps_host.c --source=test/rexxcps.rexx` with `REXX370_BCDEBUG=1`:

> **`[bc] unsup: line 91, unsupported statement`** — `test/rexxcps.rexx:91` is
> `do count; end`.

Root cause: the tokenizer maps **both `;` and `:` to `TOK_SEMICOLON` (0x0E)**,
distinct from `TOK_EOC` (0x10). The bytecode clause drivers (`bc_program`,
`bc_stmts_until` via `skip_eoc`, `consume_eoc`) only consume `TOK_EOC`, so a clause
terminated by `;` leaves a stray `TOK_SEMICOLON` → the `bc_stmt` catch-all. **Not**
`DO count` (which compiles); the `;` clause separator is the trigger. Confirmed by
bisection: `say 1; end`, `x=1; y=2`, trailing `say 1;` all fall back; newline-
separated equivalents compile.

## Fix follow-up ticket

Out of scope here (this WP delivers the diagnosis + identification). Created:
- **#169** — WP-BC-SEMI: `;` clause separator forces token-walk fallback.
  Fix sites: `bc_program`, `skip_eoc`, `consume_eoc` — treat `TOK_SEMICOLON` as a
  clause boundary while preserving the `SYMBOL ':'` label case.

## Tests

- `tstbcrxc` gains a WP-BC-DIAG assertion (a `;` program yields a recorded
  reason + line + known text) → **15/15**.
- Host suites green: tstphas1, tsttokn, tstvpol, tstprsr, tstsay, tstctrl,
  tstparse, tstproc, tsthelo, tstarit, tstbif, tstbifs (427/427), tsttrace,
  tstaddr, tstexec, and all bytecode tests (tstbcom, tstbctl, tstbsig, tstbtra,
  tstbtrp, tstbcal, tstbpro, tstbpse, tstbc_execute/clean/flip/rexxcps).
- Pre-existing, unrelated: `tstbc_compile` (20/23) and `tstbc_expr` (129/130)
  fail identically on clean `main` (stale codegen-size expectations).

Closes TSK-257.