### PR TITLE
feat(bytecode): WP-BC-OC09 — BIF direct dispatch

### DIFF
--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -156,6 +156,71 @@ static int get_entry(const char *table_base, int table_count, int idx,
 }
 
 /* ================================================================== */
+/*  WP-BC-OC09: BIF direct dispatch via per-symbol resolution cache.  */
+/*                                                                    */
+/*  Resolve the BIF named by sym_idx, using and populating a cache    */
+/*  array indexed by sym_idx (one slot per symbol-table entry, NULL = */
+/*  not yet resolved).  This replaces the per-call linear walk of the */
+/*  BIF registry (irx_bif_find, a linked list with a name-compare and */
+/*  a node->next pointer-chase per node) with an O(1) pointer load on  */
+/*  every call after the first for a given sym_idx.                   */
+/*                                                                    */
+/*  Why the cache is sound (the registry-static assumption):          */
+/*   - The BIF registry is built one-shot at environment init and is  */
+/*     immutable thereafter — see irx#bifs.c: "Registration is one-   */
+/*     shot via irx_bif_register_all()".  A name therefore resolves    */
+/*     to the same entry for the life of the environment.             */
+/*   - label_pc[sym_idx] is fixed for the whole run, so a given        */
+/*     sym_idx is consistently either a user label (handled before we  */
+/*     ever get here — see OP_CALL/OP_CALL_BIF) or a BIF.  The user-   */
+/*     defined-function path is never reached through this helper, so  */
+/*     it is left completely untouched.                               */
+/*   - Only found (non-NULL) entries are cached.  An unknown name      */
+/*     (irx_bif_find -> NULL) is the caller's error path and ends the  */
+/*     run without re-dispatching that sym_idx, so caching NULL is     */
+/*     unnecessary and a NULL slot safely means "not yet resolved".   */
+/*                                                                    */
+/*  *bad_idx is set when sym_idx does not name a symbol-table entry    */
+/*  (corrupt bytecode) so the caller can raise IRXBC_ERR_OPCODE rather */
+/*  than IRXBC_ERR_UNSUP, preserving the existing error semantics.    */
+/* ================================================================== */
+
+static const struct irx_bif_entry *
+bvm_resolve_bif(struct envblock *envblock, const char *sym_base,
+                int n_syms, const struct irx_bif_entry **bif_cache,
+                int sym_idx, int *bad_idx)
+{
+    const char *name_data;
+    int name_len;
+    int valid_idx = (bif_cache != NULL && sym_idx >= 0 && sym_idx < n_syms);
+
+    *bad_idx = 0;
+
+    /* Hot path: previously resolved — no symbol lookup, no registry walk. */
+    if (valid_idx && bif_cache[sym_idx] != NULL)
+    {
+        return bif_cache[sym_idx];
+    }
+
+    name_len = get_entry(sym_base, n_syms, sym_idx, &name_data);
+    if (name_len < 0)
+    {
+        *bad_idx = 1;
+        return NULL;
+    }
+
+    const struct irx_bif_entry *bife = irx_bif_find(
+        bvm_get_bif_registry(envblock),
+        (const unsigned char *)name_data, (size_t)name_len);
+
+    if (bife != NULL && valid_idx)
+    {
+        bif_cache[sym_idx] = bife;
+    }
+    return bife;
+}
+
+/* ================================================================== */
 /*  Lstr helpers                                                      */
 /* ================================================================== */
 
@@ -631,6 +696,7 @@ int irx_bc_execute(struct envblock *envblock,
     struct bc_call_frame *call_frames = NULL;
     struct irx_parser *proxy_parser = NULL;
     int *label_pc = NULL;
+    const struct irx_bif_entry **bif_cache = NULL; /* WP-BC-OC09 */
     Lstr *lstrs = NULL;
     void *stack_mem = NULL;
     void *lstr_mem = NULL;
@@ -638,6 +704,7 @@ int irx_bc_execute(struct envblock *envblock,
     void *call_frame_mem = NULL;
     void *proxy_parser_mem = NULL;
     void *label_pc_mem = NULL;
+    void *bif_cache_mem = NULL; /* WP-BC-OC09 */
     int32_t *const_type_cache = NULL;
     int32_t *const_int_cache = NULL;
     void *const_cache_mem = NULL;
@@ -772,6 +839,25 @@ int irx_bc_execute(struct envblock *envblock,
                 scan_pos += opsz;
             }
         }
+    }
+
+    /* --- WP-BC-OC09: per-symbol BIF resolution cache ---------------- */
+    /* One pointer slot per symbol, indexed by sym_idx parallel to      */
+    /* label_pc.  NULL means "not yet resolved"; bvm_resolve_bif()       */
+    /* fills a slot on the first BIF dispatch for that symbol and        */
+    /* returns it directly on every later call (see the helper above).   */
+    if (n_syms > 0)
+    {
+        if (irxstor(RXSMGET,
+                    n_syms * (int)sizeof(const struct irx_bif_entry *),
+                    &bif_cache_mem, envblock) != 0)
+        {
+            vm_rc = IRXBC_ERR_STOR;
+            goto done;
+        }
+        memset(bif_cache_mem, 0,
+               (size_t)n_syms * sizeof(const struct irx_bif_entry *));
+        bif_cache = (const struct irx_bif_entry **)bif_cache_mem;
     }
 
     /* --- OC-07: pre-compute integer cache for all constants (WP-BC-06) */
@@ -2016,29 +2102,20 @@ int irx_bc_execute(struct envblock *envblock,
                     else
                     {
                         /* BIF fallback for CALL stmt */
-                        const struct irx_bif_registry *reg;
                         const struct irx_bif_entry *bife;
-                        const char *name_data;
-                        int name_len;
                         PLstr argv_arr[IRX_MAX_ARGS];
                         int ci;
                         int brc;
+                        int bad_idx;
 
-                        name_len = get_entry(sym_base, n_syms,
-                                             sym_idx, &name_data);
-                        if (name_len < 0)
-                        {
-                            vm_rc = IRXBC_ERR_OPCODE;
-                            goto done;
-                        }
-                        reg = bvm_get_bif_registry(envblock);
-                        bife = irx_bif_find(
-                            reg,
-                            (const unsigned char *)name_data,
-                            (size_t)name_len);
+                        /* WP-BC-OC09: cached per-symbol dispatch in place
+                         * of a per-call linear registry walk. */
+                        bife = bvm_resolve_bif(envblock, sym_base, n_syms,
+                                               bif_cache, sym_idx, &bad_idx);
                         if (bife == NULL)
                         {
-                            vm_rc = IRXBC_ERR_UNSUP;
+                            vm_rc = bad_idx ? IRXBC_ERR_OPCODE
+                                            : IRXBC_ERR_UNSUP;
                             goto done;
                         }
                         if (nargs < bife->min_args ||
@@ -2080,8 +2157,6 @@ int irx_bc_execute(struct envblock *envblock,
                                   sym_idx < n_syms)
                                      ? label_pc[sym_idx]
                                      : -1;
-                    const char *name_data;
-                    int name_len;
                     int ci;
 
                     pc += 3;
@@ -2144,10 +2219,10 @@ int irx_bc_execute(struct envblock *envblock,
                     else
                     {
                         /* BIF dispatch */
-                        const struct irx_bif_registry *reg;
                         const struct irx_bif_entry *bife;
                         PLstr argv_arr[IRX_MAX_ARGS];
                         int brc;
+                        int bad_idx;
 
                         /* net stack delta = -nargs+1; overflow only when nargs==0 */
                         if (sp - nargs + 1 > IRXBC_STACK_DEPTH)
@@ -2155,21 +2230,14 @@ int irx_bc_execute(struct envblock *envblock,
                             vm_rc = IRXBC_ERR_STACK;
                             goto done;
                         }
-                        name_len = get_entry(sym_base, n_syms,
-                                             sym_idx, &name_data);
-                        if (name_len < 0)
-                        {
-                            vm_rc = IRXBC_ERR_OPCODE;
-                            goto done;
-                        }
-                        reg = bvm_get_bif_registry(envblock);
-                        bife = irx_bif_find(
-                            reg,
-                            (const unsigned char *)name_data,
-                            (size_t)name_len);
+                        /* WP-BC-OC09: cached per-symbol dispatch in place
+                         * of a per-call linear registry walk. */
+                        bife = bvm_resolve_bif(envblock, sym_base, n_syms,
+                                               bif_cache, sym_idx, &bad_idx);
                         if (bife == NULL)
                         {
-                            vm_rc = IRXBC_ERR_UNSUP;
+                            vm_rc = bad_idx ? IRXBC_ERR_OPCODE
+                                            : IRXBC_ERR_UNSUP;
                             goto done;
                         }
                         if (nargs < bife->min_args ||
@@ -3475,6 +3543,11 @@ done:
     if (label_pc_mem != NULL)
     {
         void *p = label_pc_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+    if (bif_cache_mem != NULL)
+    {
+        void *p = bif_cache_mem;
         irxstor(RXSMFRE, 0, &p, envblock);
     }
     if (proxy_parser_mem != NULL)

--- a/test/mvs/tstbcal.c
+++ b/test/mvs/tstbcal.c
@@ -398,6 +398,105 @@ static void test_bif_contexts(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
+/*  WP-BC-OC09: BIF direct-dispatch cache                              */
+/*                                                                    */
+/*  The VM caches BIF resolution per symbol index, replacing a per-    */
+/*  call linear registry walk.  These cases pin the properties that    */
+/*  the cache must not break: a user-defined routine shadows a same-   */
+/*  named BIF (the cache is never consulted for that symbol), repeated */
+/*  and mixed BIF calls stay correct, the cache is shared across the   */
+/*  expression (OP_CALL_BIF) and CALL (OP_CALL) forms, and an unknown  */
+/*  name still falls through to the not-found error instead of being   */
+/*  swallowed.                                                         */
+/* ------------------------------------------------------------------ */
+
+static void test_bif_dispatch_cache(struct envblock *env)
+{
+    struct irx_bc_execblk *bc = NULL;
+    int unsup_reason = 0;
+    int unsup_line = 0;
+    int bc_rc = 0;
+    int rc;
+    const char *unknown_src = "SAY ZZNOSUCH(\"x\")";
+
+    printf("\n[WP-BC-OC09 BIF dispatch cache]\n");
+
+    /* A user-defined routine shadows a same-named BIF.  label_pc wins,
+     * so the BIF cache for this symbol is never populated or used. */
+    equiv(env,
+          "CALL length \"ignored\"\n"
+          "SAY RESULT\n"
+          "EXIT\n"
+          "length:\n"
+          "  RETURN \"user-length\"\n",
+          "user routine shadows BIF (CALL form)");
+
+    /* Same shadow in expression form (OP_CALL_BIF).  Token-walk has no
+     * user-defined func() in expr context, so this is bytecode-only. */
+    bc_only(env,
+            "SAY length(\"ignored\")\n"
+            "EXIT\n"
+            "length:\n"
+            "  RETURN \"user-length\"\n",
+            "user-length\n",
+            "user routine shadows BIF (expr form)");
+
+    /* Repeated calls of one BIF exercise the cache hot path. */
+    equiv(env,
+          "DO i = 1 TO 4\n"
+          "  SAY LENGTH(\"abcd\")\n"
+          "END",
+          "repeated BIF call (hot path)");
+
+    /* Distinct BIFs populate distinct cache slots. */
+    equiv(env,
+          "SAY SUBSTR(\"abcdef\", 2, 3)\n"
+          "SAY LENGTH(\"hello\")\n"
+          "SAY WORD(\"alpha beta gamma\", 2)\n"
+          "SAY FORMAT(3.14159, 2, 2)\n"
+          "SAY REVERSE(\"xyz\")",
+          "mixed distinct BIFs (SUBSTR/LENGTH/WORD/FORMAT/REVERSE)");
+
+    /* The same BIF reached through both the expression form and the
+     * CALL-statement form shares one cache slot (same symbol index). */
+    equiv(env,
+          "SAY LENGTH(\"abcde\")\n"
+          "CALL LENGTH \"xy\"\n"
+          "SAY RESULT\n"
+          "SAY LENGTH(\"abcde\")",
+          "shared cache across expr + CALL forms");
+
+    /* A user routine and a real BIF with different names keep separate
+     * slots and resolutions in the same run. */
+    equiv(env,
+          "CALL mylen \"abc\"\n"
+          "SAY RESULT\n"
+          "SAY LENGTH(\"abcd\")\n"
+          "EXIT\n"
+          "mylen:\n"
+          "  RETURN ARG(1)\n",
+          "user routine and BIF coexist");
+
+    /* Unknown name: resolution returns NULL on every call, so the VM
+     * still reports the not-found error (IRXBC_ERR_UNSUP).  Driven
+     * directly through the VM so the exec-layer token-walk fallback
+     * does not mask the bytecode behavior — this confirms the fast-path
+     * does not swallow unknown names. */
+    rc = irx_bc_compile(env, unknown_src, (int)strlen(unknown_src),
+                        &bc, &unsup_reason, &unsup_line);
+    CHECK(rc == IRXBC_OK && bc != NULL,
+          "unknown BIF compiles (compiler is BIF-agnostic)");
+    if (rc == IRXBC_OK && bc != NULL)
+    {
+        rc = irx_bc_execute(env, bc, NULL, 0, &bc_rc);
+        CHECK(rc == IRXBC_ERR_UNSUP,
+              "unknown BIF -> not-found error (not swallowed)");
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+/* ------------------------------------------------------------------ */
 /*  main                                                               */
 /* ------------------------------------------------------------------ */
 
@@ -428,6 +527,7 @@ int main(void)
     test_arg_bif(env);
     test_return_top(env);
     test_bif_contexts(env);
+    test_bif_dispatch_cache(env);
 
     irxterm(env);
 


### PR DESCRIPTION
## WP-BC-OC09 — BIF direct dispatch (eliminate per-call registry lookup)

Closes the Cluster C hotspot from WP-PERF-PROFILE (PR #179): `irx_bif_find`
walked the BIF registry — a **linked list** — node-by-node on *every* BIF
call, doing an EBCDIC name-compare plus a `node->next` pointer-chase per
node (~57.3M `ebcdic_eq` calls, ~8.2% self time in the rexxcps profile).

### Chosen solution path: (a) per-symbol slot cache

I evaluated all three paths and chose **(a)**. Rationale (source-verified,
escalated and confirmed before implementation):

- **(b) compile-time resolve is not format-neutral.** The compiler emits
  `OP_CALL_BIF sym_idx nargs` for *every* `name(args)` call (`bc_funcall`,
  `irx#bcom.c`) and has zero BIF-awareness — the BIF-vs-user-function
  decision is made entirely at runtime via `label_pc[sym_idx]`. To carry a
  resolved index, `sym_idx` is still needed at runtime (label override +
  error reporting), so (b) requires a **new opcode / wider `OP_CALL_BIF`
  operand** — a versioned bytecode-format change — plus a canonical
  BIF-index table (the registry is a per-env prepend-order linked list with
  **no stable index** today) and compiler label-awareness it lacks. That is
  the documented escalation trigger; it buys negligible per-call gain over
  (a) after warmup.
- **(c) array+binary-search** improves only the cold lookup; it still
  searches on every one of the ~1.5M calls.
- **(a) slot cache** reaches the same O(1) per-call dispatch after warmup,
  with **no format change**, mirroring the WP-BC-OC12 slot-cache pattern
  (+20.4% on System B).

`bvm_resolve_bif()` caches the resolved `struct irx_bif_entry *` in a
pointer array indexed by `sym_idx`, allocated parallel to `label_pc` and
freed in the same cleanup path. **Sound because** the registry is built
one-shot at env init and immutable thereafter (`irx#bifs.c`:
"Registration is one-shot via `irx_bif_register_all()`"), and
`label_pc[sym_idx]` is fixed for the run — a given `sym_idx` is
consistently either a user label or a BIF. The registry-static assumption
is documented at the helper.

### Correctness — user-function path untouched

- The user-defined-function path (`label_pc[sym_idx] >= 0`) is **never
  reached through the helper**, so a routine shadowing a same-named BIF
  still wins and is never cached. **Test evidence** (`tstbcal`):
  `user routine shadows BIF (CALL form)` and `(expr form)` — a `length:`
  label correctly overrides the `LENGTH` BIF in both call forms.
- Unknown names resolve to `NULL` on every call and still fall through to
  the existing not-found error — the fast-path does not swallow them.
  **Test evidence:** `unknown BIF -> not-found error (not swallowed)`,
  driven directly through the VM (`irx_bc_compile`/`irx_bc_execute`) so the
  exec-layer token-walk fallback does not mask the bytecode behavior.
- Both dispatch sites (`OP_CALL` fallback, `OP_CALL_BIF`) preserve their
  distinct error codes (`OPCODE` for a bad symbol index, `UNSUP`
  otherwise).
- Bytecode format, `irxbops.h`, and the token-walk reference path
  (`irx#pars.c`, CON-18 frozen) are **unchanged** → `bytecode-format.md`
  needs no update.

### Tests

8 new equivalence/behavior cases in `test/mvs/tstbcal.c` (BIF shadowing in
CALL + expr form, hot-path repetition, mixed BIFs SUBSTR/LENGTH/WORD/
FORMAT/REVERSE, shared cache across both call forms, unknown-name
fall-through). No new test file → no `tstall.jcl`/`project.toml`
registration needed.

Green locally: `tstbcal 41/41`, `tstbcmp 36/36`, `tstbcom 42/42`,
`tstbcat 17/17`, `tstbcont 19/19`, `tstbcrxc 15/15`, `tstbctl 43/43`,
`tstbsig 18/18`, `tstbtrp 26/26`, `tstbpro 17/17`, `tstbif 29/29`,
`tstbifs 427/427`, host `tstbc_clean/execute/flip`. (`tstbc_compile`
20/23 and `tstbc_expr` 129/130 fail identically on `origin/main` — pre-
existing compiler-test failures, unrelated to this runtime change.)

### Host profile — iteration indicator (not a perf statement)

gprof is unavailable on the dev host, so this is a call-count indicator
from an out-of-tree instrumented build over the REXXCPS kernel (bytecode
run isolated):

| iterations | baseline `irx_bif_find` | baseline `ebcdic_eq` | **this PR** find | **this PR** ebcdic_eq |
|---|---|---|---|---|
| 100  | 11,200  | 564,200   | **4** | **173** |
| 300  | 33,600  | 1,692,600 | **4** | **173** |
| 1000 | 112,000 | 5,642,000 | **4** | **173** |

Baseline scales linearly with iterations; this PR is **constant** (4 cold
lookups for the 4 distinct BIF symbols, then pure cache hits) — i.e. O(1)
per call after warmup. token-walk ↔ bytecode output still matches.

### ⏳ Pending: MVS measurement (Mike)

The real cps measurement is on **MVS System B against the 11,558
WP-BC-OC12 baseline** (not System-A numbers). To be recorded in CON-12.
