### PR TITLE
fix(bytecode): WP-BC-STEMRESET — bare-stem assignment clears existing tails (#183)

### DIFF
--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -1489,6 +1489,18 @@ int irx_bc_execute(struct envblock *envblock,
                     name_buf[name_pos] = '\0';
                     /* Pop value (now at stack[sp-1]). */
                     sp--;
+                    /* A bare-stem assignment (A. = value) resets the whole
+                     * stem: every previously assigned tail is discarded and
+                     * the new value becomes the default for all tails. Drop
+                     * the existing tails first — this must precede the set,
+                     * since vpool_drop_stem_all also removes the default
+                     * entry "A." we are about to write. Identical call to the
+                     * OP_DROP_STEM handler (full stem incl. trailing dot, so
+                     * "A." matches A.1/A.2/... but never AB.x). */
+                    if (tail_cnt == 0)
+                    {
+                        vpool_drop_stem_all(vpool, stem_data, stem_len);
+                    }
                     vrc = vpool_set_buf(vpool, name_buf, name_pos,
                                         stack[sp].str,
                                         stack[sp].type_cache,

--- a/test/mvs/tstbcom.c
+++ b/test/mvs/tstbcom.c
@@ -306,6 +306,58 @@ static void test_compound_stem_default(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Bare-stem assignment resets the stem (WP-BC-STEMRESET, #183)        */
+/*                                                                    */
+/*  REXX (SC28-1883-0): assigning to a bare stem (A. = value) sets    */
+/*  the default for every tail AND discards all previously assigned   */
+/*  tails. The VM fix drops the existing tails before writing the new */
+/*  default.                                                          */
+/*                                                                    */
+/*  Token-walk shares this bug and is frozen under CON-18, so the     */
+/*  diverging cases (1 and 4) use bc_only() with explicit expected    */
+/*  output as the authoritative check. equiv() is used only for the   */
+/*  cases where token-walk and bytecode already agree and are correct */
+/*  (2 and 3), to confirm the fix does not disturb that agreement.    */
+/* ------------------------------------------------------------------ */
+
+static void test_compound_stem_reset(struct envblock *env)
+{
+    printf("\n[Compound variable — bare-stem assignment resets tails]\n");
+
+    /* (1) Core bug: bare-stem default clears a previously set tail. */
+    bc_only(env,
+            "A.1 = 5\nA. = 0\nSAY A.1\n",
+            "0\n",
+            "bare-stem default clears existing tail A.1");
+
+    /* (2) A tail assigned AFTER the default still takes effect. */
+    bc_only(env,
+            "A. = 0\nA.1 = 5\nSAY A.1\n",
+            "5\n",
+            "tail assigned after stem default overrides it");
+
+    /* (3) The default applies to never-assigned tails. */
+    bc_only(env,
+            "A. = 0\nSAY A.99\n",
+            "0\n",
+            "stem default returned for never-assigned tail");
+
+    /* (4) All prior tails cleared; new default covers every tail. */
+    bc_only(env,
+            "A.1 = 5\nA.2 = 7\nA. = 9\nSAY A.1 A.2 A.3\n",
+            "9 9 9\n",
+            "bare-stem default clears all tails and applies everywhere");
+
+    /* Equivalence against token-walk for the non-diverging cases only.
+     * Cases 1 and 4 diverge after the fix (token-walk shares the bug,
+     * frozen under CON-18) and are covered by bc_only() above. */
+    equiv(env, "A. = 0\nA.1 = 5\nSAY A.1\n",
+          "stem reset: tail after default (tokwalk agrees)");
+    equiv(env, "A. = 0\nSAY A.99\n",
+          "stem reset: default for unset tail (tokwalk agrees)");
+}
+
+/* ------------------------------------------------------------------ */
 /*  DROP statement                                                     */
 /* ------------------------------------------------------------------ */
 
@@ -578,6 +630,7 @@ int main(void)
     test_compound_basic(env);
     test_compound_multilevel(env);
     test_compound_stem_default(env);
+    test_compound_stem_reset(env);
     test_compound_drop(env);
     test_compound_expr(env);
     test_compound_do(env);

--- a/test/mvs/tstbcom.c
+++ b/test/mvs/tstbcom.c
@@ -348,6 +348,14 @@ static void test_compound_stem_reset(struct envblock *env)
             "9 9 9\n",
             "bare-stem default clears all tails and applies everywhere");
 
+    /* (5) The reset matches the full stem incl. its dot, so a sibling
+     * stem whose name shares the leading characters (AB. vs A.) is NOT
+     * affected. Guards against an over-broad prefix match. */
+    bc_only(env,
+            "AB.1 = 7\nA.1 = 5\nA. = 0\nSAY A.1 AB.1\n",
+            "0 7\n",
+            "bare-stem reset does not touch sibling stem AB.");
+
     /* Equivalence against token-walk for the non-diverging cases only.
      * Cases 1 and 4 diverge after the fix (token-walk shares the bug,
      * frozen under CON-18) and are covered by bc_only() above. */


### PR DESCRIPTION
## Summary

Fixes #183. A bare-stem assignment (`A. = value`) must, per SC28-1883-0, set
the default for **every** tail and **discard all previously assigned tails**.
The bytecode VM only set the default entry `A.` and left existing tails (e.g.
`A.1`, `A.2`) in place, so a common REXX idiom diverged from the standard:

```rexx
a.1 = 5
a.  = 0
say a.1      /* was 5, REXX requires 0 */
```

Because bytecode is default-on, this bug was active in the default behaviour.

## Root cause

The compiler is **correct** — it already emits `OP_STORE_STEM` with
`tail_count=0` for a bare-stem assignment. The bug is VM-only: the
`OP_STORE_STEM` handler in `irx#bvm.c` wrote only the `A.` default entry via
`vpool_set_buf` and never cleared the existing tails.

## Fix (VM-only, ~10 lines)

In the `OP_STORE_STEM` handler, when `tail_cnt == 0`, drop all existing tails
with `vpool_drop_stem_all(vpool, stem_data, stem_len)` **before** writing the
new default. The drop must precede the set, since `vpool_drop_stem_all` also
removes the `A.` entry being written.

This **reuses the exact call** the `OP_DROP_STEM` handler already makes — the
prefix match (`name_matches_stem`) is over the full stem **including the
trailing dot**, so `A.` matches `A.1`/`A.2`/… and the `A.` default itself, but
never `AB.x`. Indexed stores (`tail_cnt > 0`, e.g. `a.1 = 5`) are untouched.

Token-walk is left frozen under CON-18; bytecode default-on makes the
user-facing default behaviour correct.

## Token-walk shares the bug (reported, not fixed here)

Verified empirically: token-walk also returns the old tails for these cases
(`a.1=5; a.=0; say a.1` → `5`; `a.1=5; a.2=7; a.=9; say a.1 a.2 a.3` →
`5 7 9`). Token-walk is frozen under CON-18, so this PR fixes only the VM and
flags the divergence for a future joint fix with spec citation — the same
pattern as the decimal-DO and doubled-quote divergences.

## Tests

`test_compound_stem_reset` added to `tstbcom.c`:

- **5 × `bc_only()`** with explicit spec-correct expected output (the
  authoritative teeth): core bug, tail-after-default, default-for-unset-tail,
  full reset (`a.1=5; a.2=7; a.=9; say a.1 a.2 a.3` → `9 9 9`), and a
  **sibling-stem guard** (`AB.1=7; A.1=5; A.=0; say A.1 AB.1` → `0 7`) proving
  the reset never over-matches `AB.`.
- **2 × `equiv()`** against token-walk for the two cases where token-walk
  already agrees and is correct (tail-after-default, default-for-unset). The
  two diverging cases are intentionally **not** run through `equiv()` (token-
  walk is frozen-buggy → would be permanently red).

Verification:

- `tstbcom` 42 → **49/49**.
- Bytecode + vpool regression suites green: `tstbcal` 41/41, `tstbcat` 17/17,
  `tstbcmp` 36/36, `tstbcont` 19/19, `tstbctl` 43/43, `tstbcrxc` 36/36,
  `tstvpol` 47/47; `tstproc` 53/53, `tstparse` 74/74, `tstbifs` 427/427.
- **Teeth:** reverting the VM fix turns exactly the two diverging `bc_only`
  cases red (46/48), confirming the tests fail without the fix.

`TSTBCOM` is already registered in `project.toml` + `tstall.jcl`; extending the
existing test file needs no registration change.

This is a correctness fix (#183), not a performance WP — no cps measurement
needed.
