### PR TITLE
docs: mark WP-BC-NUMERIC closed in ROADMAP + add ROADMAP-update rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -402,6 +402,15 @@ next.** Read it first. It orders all open work into five axes (Performance,
 Decommission/Correctness, Spec-Completeness, Environment/Anchor, Infrastructure)
 and tracks which design docs (CONs) are current vs. stale.
 
+**ROADMAP is part of the deliverable, not a separate chore.** If a PR closes or
+materially changes a work package that ROADMAP names, the *same PR* must update
+the ROADMAP entry — move a finished item to its axis's "Closed gates"/"Recently
+shipped" note (Decommission axis) or remove it (other axes), and refresh the
+"Last updated" date. The truth lives in the repo, so a PR that ships the code but
+leaves ROADMAP saying the work is still open has left the source of truth wrong.
+Same class of always-do as the test-registration rule below (`tstall.jcl` +
+`project.toml`).
+
 `docs/workpackages.md` holds the historical Phase 1-3 per-WP definitions and is
 **frozen/stale** — do not treat its status table as current.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,13 +85,13 @@ The cleanest way to scope this: **every `BC_FAIL_UNSUP` trigger in the bytecode
 compiler is a decommission gate** — each is a construct that still forces a
 whole-program fallback to token-walk.
 
+**Closed gates** (constructs that no longer force a token-walk fallback):
+- ~~**WP-BC-NUMERIC**~~ — `NUMERIC DIGITS/FUZZ/FORM` statement (PR #188, 2026-06-03).
+  Writes `wkbi_digits/fuzz/form` in the VM; the arith engine and the OC-ARITH/OC-12
+  fast-path gates read them automatically. The gates correctly disable the integer
+  fast-path at DIGITS≠9 / FUZZ>0 and must not be removed.
+
 Open items:
-- **WP-BC-NUMERIC** — the `NUMERIC DIGITS/FUZZ/FORM` statement is not implemented
-  in the bytecode compiler (the only `NUMERIC` handler is `PARSE NUMERIC`, a
-  different construct). Any program using a `NUMERIC` statement falls back to
-  token-walk. *Note: when implemented, the VM will run at DIGITS≠9 for the first
-  time — the OC-ARITH fast-path gate (`bc_numeric_digits == DEFAULT`) handles
-  this correctly and must not be removed.*
 - **WP-BC-INT** — bytecode INTERPRET (runtime compilation). Depends on the
   token-walk INTERPRET work (WP-23). The largest functional gap.
 - **WP-BC-RT03** — quote de-doubling for string literals (`'p''q''r'`).


### PR DESCRIPTION
WP-BC-NUMERIC shipped in #188 but the ROADMAP still listed it as open work — the source of truth was left stale by the implementing PR.

- ROADMAP: move WP-BC-NUMERIC from Decommission 'Open items' to a new 'Closed gates' note (the construct no longer forces a token-walk fallback).
- CLAUDE.md: add an explicit rule that a PR closing a ROADMAP-named work package must update the ROADMAP entry in the same PR — same always-do class as the tstall.jcl + project.toml test-registration rule.