### PR TITLE
docs: defer INTERPRET / WP-23 won't-do — INTERPRET goes straight to bytecode

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -92,8 +92,14 @@ whole-program fallback to token-walk.
   fast-path at DIGITS≠9 / FUZZ>0 and must not be removed.
 
 Open items:
-- **WP-BC-INT** — bytecode INTERPRET (runtime compilation). Depends on the
-  token-walk INTERPRET work (WP-23). The largest functional gap.
+- **WP-BC-INT** — bytecode INTERPRET (runtime compilation). Deferred (low
+  priority): INTERPRET is absent from BOTH the bytecode and the token-walk path,
+  so it is NOT a decommission blocker — the token-walk fallback offers nothing
+  here that would be lost. WP-23 (token-walk INTERPRET) is won't-do; INTERPRET
+  goes straight to bytecode, tested against the spec / bc_only (no token-walk
+  reference will ever exist). Design is captured in the WP-BC-INT ticket
+  (CON-17 §8.4: separate EXECBLK per call, recursive compile→execute→free,
+  reentrant via heap-allocated bcom_ctx).
 - **WP-BC-RT03** — quote de-doubling for string literals (`'p''q''r'`).
 - **WP-CPS-09a-FU** — SIGNAL/CALL condition-trap *activation* (the parser-only
   baseline is done via #131; the runtime trap machinery — NOVALUE hook,

--- a/docs/workpackages.md
+++ b/docs/workpackages.md
@@ -31,7 +31,7 @@ Reference: [Architecture Design v0.2.0](https://www.notion.so/3283d9938787811ba3
 | WP-21a | String BIFs (IRXBIFS) | 3 | DONE (29/29 + 87/87) — PR #26 |
 | WP-21b | Misc BIFs | 3 | DONE — 23 BIFs across Phases A (#28, registry), B (#30, IRXARITH API), C (#36, numeric), D (#38, conversion), E (#39, reflection), F (#42, environment); Phase H closes the work package. Suite: 1156 total across 14 cross-compile binaries |
 | WP-22 | Built-in misc functions | 3 | OPEN |
-| WP-23 | INTERPRET instruction | 3 | OPEN |
+| WP-23 | INTERPRET instruction | 3 | WON'T DO — superseded by WP-BC-INT; INTERPRET goes straight to bytecode (token-walk is frozen, CON-18, so no INTERPRET is built there). Not a decommission blocker: INTERPRET is absent from BOTH paths. |
 | WP-30 | EXECIO command | 4 | OPEN |
 | WP-31 | Data stack (IRXSTK) | 4 | OPEN |
 | WP-32 | Host command envs (TSO/MVS/LINK) | 4 | OPEN |


### PR DESCRIPTION
Reflect the decision that INTERPRET is deferred and goes straight to bytecode (WP-23 won't-do). INTERPRET is absent from both paths, so it is not a decommission blocker.

## Changes (docs only)

- **`docs/workpackages.md`** — WP-23 (INTERPRET instruction) status changed from `OPEN` to `WON'T DO`: superseded by WP-BC-INT; the token-walk path is frozen (CON-18) so no INTERPRET is built there.
- **`docs/ROADMAP.md`** — WP-BC-INT entry (Axis 2) reworded. It no longer states a dependency on the token-walk INTERPRET work (WP-23). INTERPRET is absent from BOTH the bytecode and the token-walk path, so it is **not** a decommission blocker — the fallback offers nothing here that would be lost. INTERPRET goes straight to bytecode, tested against the spec / bc_only (no token-walk reference will ever exist).

No code or test changes.