### PR TITLE
fix: WP-VLIST-WPOOL — attach Work Block on module IRXINIT path + enlarge VLIST-wrapper WPOOL (S0C4)

### DIFF
--- a/asm/irxexec.asm
+++ b/asm/irxexec.asm
@@ -327,8 +327,14 @@ WPARMS   DS    10F                 bare addresses from 10-slot VLIST
 WFLAGS   DS    F                   parse flags (X'80' = P10 present)
 WDP10    DS    F                   saved P10 bare address
 WCPLIST  DS    11F                 C plist: 10 dispatch args + sentinel
-*  Stack pool for nested c2asm370 PDPPRLG frames.
-WPOOL    DS    2048F               8 KB scratchpad
+*  Stack pool for nested c2asm370 PDPPRLG frames.  A real exec's
+*  recursive-descent compile (bc_exp0..bc_exp8, ~9 frames/level) plus
+*  the VM + Lstr chain nests well past 8 KB — WP-VLIST-WPOOL measured
+*  a modest 14-level nested expression at a ~16.2 KB high-water, and
+*  8 KB overflowed into the adjacent GETMAIN storage -> S0C4.  WAREA is
+*  GETMAIN'd and FREEMAIN'd per call, so the larger pool costs only
+*  transient region, not static module storage.  WP-VLIST-WPOOL.
+WPOOL    DS    16384F              64 KB scratchpad (WP-VLIST-WPOOL)
 WALEN    EQU   *-WAREA
 *
          END   IRXEXEC

--- a/asm/irxinit.asm
+++ b/asm/irxinit.asm
@@ -315,12 +315,15 @@ WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
 WPREV    DS    F                   saved R0 in (previous-env hint)
 WPARMS   DS    7F                  bare addresses parsed from VLIST
 WCPLIST  DS    6F                  parameter list for IRXIDISP call
-*  Stack pool for nested c2asm370 PDPPRLG frames. Sized for typical
-*  IRXIDISP call depth (5-10 nested frames @ 88-300 bytes each); 8 KB
-*  has comfortable margin. Intentionally not zero-filled — c2asm370-
-*  emitted code SAVE-writes R14-R12 before reading any frame slot, so
-*  XC initialization would cost 8 KB without functional benefit.
-WPOOL    DS    2048F               8 KB scratchpad
+*  Stack pool for nested c2asm370 PDPPRLG frames.  IRXINIT's own path
+*  is shallow (env setup, no tokenizing), but all four VLIST wrappers
+*  carry one uniform 64 KB pool (WP-VLIST-WPOOL): it costs only
+*  transient GETMAIN region, keeps one value/one pattern across the
+*  family, and future-proofs a wrapper that later grows a deep path.
+*  Intentionally not zero-filled — c2asm370-emitted code SAVE-writes
+*  R14-R12 before reading any frame slot, so XC init would cost 64 KB
+*  without functional benefit.
+WPOOL    DS    16384F              64 KB scratchpad (WP-VLIST-WPOOL)
 WALEN    EQU   *-WAREA
 *
          END   IRXINIT

--- a/asm/irxload.asm
+++ b/asm/irxload.asm
@@ -227,8 +227,12 @@ WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
 *  Wrapper-local storage.
 WPARMS   DS    5F                  bare addresses from 5-slot VLIST
 WCPLIST  DS    5F                  parameter list for IRXLDISP call
-*  Stack pool for nested c2asm370 PDPPRLG frames (see irxinit.asm).
-WPOOL    DS    2048F               8 KB scratchpad
+*  Stack pool for nested c2asm370 PDPPRLG frames.  IRXLOAD's LOAD path
+*  reads REXX source and tokenizes it (irx_load_load), the same deep
+*  C-call tree as IRXEXEC, so it is sized identically to 64 KB — 8 KB
+*  overflows into adjacent GETMAIN storage on a real exec (S0C4).
+*  WAREA is GETMAIN'd/FREEMAIN'd per call.  WP-VLIST-WPOOL.
+WPOOL    DS    16384F              64 KB scratchpad (WP-VLIST-WPOOL)
 WALEN    EQU   *-WAREA
 *
          END   IRXLOAD

--- a/asm/irxterm.asm
+++ b/asm/irxterm.asm
@@ -173,12 +173,14 @@ WDNAB    DS    F                   +76 DSANAB  (must point to WPOOL)
 *  Wrapper-local storage (after the PDP-DSA proper).
 WCPLIST  DS    2F                  C-call plist for IRXITERM
 WREASON  DS    F                   reason-code OUT cell (discarded)
-*  Stack pool for nested c2asm370 PDPPRLG frames. Sized for typical
-*  IRXIDISP call depth (5-10 nested frames @ 88-300 bytes each); 8 KB
-*  has comfortable margin. Intentionally not zero-filled — c2asm370-
-*  emitted code SAVE-writes R14-R12 before reading any frame slot, so
-*  XC initialization would cost 8 KB without functional benefit.
-WPOOL    DS    2048F               8 KB scratchpad
+*  Stack pool for nested c2asm370 PDPPRLG frames.  IRXTERM's own path
+*  is shallow (env teardown), but all four VLIST wrappers carry one
+*  uniform 64 KB pool (WP-VLIST-WPOOL): it costs only transient GETMAIN
+*  region and keeps one value/one pattern across the family.
+*  Intentionally not zero-filled — c2asm370-emitted code SAVE-writes
+*  R14-R12 before reading any frame slot, so XC init would cost 64 KB
+*  without functional benefit.
+WPOOL    DS    16384F              64 KB scratchpad (WP-VLIST-WPOOL)
 WALEN    EQU   *-WAREA
 *
          END   IRXTERM

--- a/include/irxarith.h
+++ b/include/irxarith.h
@@ -93,7 +93,7 @@ int irx_arith_compare(struct envblock *env,
 /*  irx_number stays internal to irx#arith.c. All signatures use      */
 /*  struct envblock * for consistency with irx_arith_op /             */
 /*  irx_arith_compare; the parser-side wk is reachable through        */
-/*  env->envblock_userfield when needed.                              */
+/*  env->envblock_workblok_ext when needed.                              */
 /* ================================================================== */
 
 /* TRUNC(number, decimals): truncate (no rounding) to exactly

--- a/include/irxwkblk.h
+++ b/include/irxwkblk.h
@@ -2,7 +2,7 @@
 /*  irxwkblk.h - Internal Work Block Extension                        */
 /*                                                                    */
 /*  Per-environment interpreter runtime state for REXX/370.           */
-/*  Pointed to by envblock_userfield in the IBM-compatible ENVBLOCK.  */
+/*  Pointed to by envblock_workblok_ext in the IBM-compatible ENVBLOCK.  */
 /*                                                                    */
 /*  This block holds all mutable interpreter state that would be      */
 /*  global variables in a non-reentrant interpreter. Every field      */

--- a/project.toml
+++ b/project.toml
@@ -1812,6 +1812,29 @@ startup = false
 sources = ["test/asm/ttermvl.asm"]
 
 # ---------------------------------------------------------------
+# TEXECVL - Live MVS test caller for IRXINIT + IRXEXEC + IRXTERM.
+# Same shape as TINITVL/TTERMVL: pure HLASM, no C runtime; IRXINIT,
+# IRXEXEC and IRXTERM are all resolved at run time via LOAD EP= from
+# STEPLIB, so the test drives the real production IRXEXEC VLIST wrapper
+# end-to-end with an in-storage REXX exec — coverage the module path
+# never had (only TINITVL/TTERMVL existed). Regression test for both
+# WP-VLIST-WPOOL defects: (A) the standalone IRXINIT never attached the
+# interpreter Work Block (IRXEXEC failed RC=20), and (B) a running deep
+# exec overflowed the 8 KB WPOOL (S0C4). Green only when both are fixed
+# (RC=0, the REXX 'exit 42' echoed as IRXEXEC R15=42).
+#
+# Invocation:
+#   Batch  :  EXEC PGM=TEXECVL  (see test/jcl/texecvl.jcl)
+#
+# WP-VLIST-WPOOL / TSK-279 / consumer: mvslovers/httprexx.
+# ---------------------------------------------------------------
+[[test]]
+name = "TEXECVL"
+entry = "TEXECVL"
+startup = false
+sources = ["test/asm/texecvl.asm"]
+
+# ---------------------------------------------------------------
 # TISTSO - self-validating test for ISTSO (EXTRACT-based TSO detect).
 # is_tso()'s correct result depends on the environment, so the runner passes
 # the EXPECTED value per leg (batch -> "0", TSO/IKJEFT01 -> "1") and the test

--- a/src/irx#arith.c
+++ b/src/irx#arith.c
@@ -101,10 +101,10 @@ static void get_numeric(struct envblock *env,
     *digits = NUMERIC_DIGITS_DEFAULT;
     *fuzz = NUMERIC_FUZZ_DEFAULT;
     *form = NUMFORM_SCIENTIFIC;
-    if (env != NULL && env->envblock_userfield != NULL)
+    if (env != NULL && env->envblock_workblok_ext != NULL)
     {
         struct irx_wkblk_int *wk =
-            (struct irx_wkblk_int *)env->envblock_userfield;
+            (struct irx_wkblk_int *)env->envblock_workblok_ext;
         *digits = wk->wkbi_digits;
         *fuzz = wk->wkbi_fuzz;
         *form = wk->wkbi_form;

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -1362,9 +1362,9 @@ static int bif_random(struct irx_parser *p, int argc, PLstr *argv,
     }
 
     struct irx_wkblk_int *wk = NULL;
-    if (p->envblock != NULL && p->envblock->envblock_userfield != NULL)
+    if (p->envblock != NULL && p->envblock->envblock_workblok_ext != NULL)
     {
-        wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+        wk = (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
     }
 
     if (have_seed)
@@ -2668,11 +2668,11 @@ static int bif_symbol(struct irx_parser *p, int argc, PLstr *argv,
  * the documented defaults (9 / 0 / SCIENTIFIC) apply. */
 static struct irx_wkblk_int *wkbi_from_parser(struct irx_parser *p)
 {
-    if (p->envblock == NULL || p->envblock->envblock_userfield == NULL)
+    if (p->envblock == NULL || p->envblock->envblock_workblok_ext == NULL)
     {
         return NULL;
     }
-    return (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+    return (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
 }
 
 static int bif_digits(struct irx_parser *p, int argc, PLstr *argv,

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -84,11 +84,11 @@ bvm_get_bif_registry(struct envblock *envblock)
 {
     struct irx_wkblk_int *wk;
 
-    if (envblock == NULL || envblock->envblock_userfield == NULL)
+    if (envblock == NULL || envblock->envblock_workblok_ext == NULL)
     {
         return NULL;
     }
-    wk = (struct irx_wkblk_int *)envblock->envblock_userfield;
+    wk = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
     return (const struct irx_bif_registry *)wk->wkbi_bif_registry;
 }
 
@@ -596,10 +596,10 @@ static int try_arith_fast(struct bc_stack_slot *dst,
  * work block is reachable (e.g. a bare batch VM run). */
 static int bc_numeric_fuzz(struct envblock *envblock)
 {
-    if (envblock != NULL && envblock->envblock_userfield != NULL)
+    if (envblock != NULL && envblock->envblock_workblok_ext != NULL)
     {
         const struct irx_wkblk_int *wk =
-            (const struct irx_wkblk_int *)envblock->envblock_userfield;
+            (const struct irx_wkblk_int *)envblock->envblock_workblok_ext;
         return wk->wkbi_fuzz;
     }
     return NUMERIC_FUZZ_DEFAULT;
@@ -618,10 +618,10 @@ static int bc_numeric_fuzz(struct envblock *envblock)
  * NUMERIC DIGITS 20 program would get wrong int32 results. */
 static int bc_numeric_digits(struct envblock *envblock)
 {
-    if (envblock != NULL && envblock->envblock_userfield != NULL)
+    if (envblock != NULL && envblock->envblock_workblok_ext != NULL)
     {
         const struct irx_wkblk_int *wk =
-            (const struct irx_wkblk_int *)envblock->envblock_userfield;
+            (const struct irx_wkblk_int *)envblock->envblock_workblok_ext;
         return wk->wkbi_digits;
     }
     return NUMERIC_DIGITS_DEFAULT;
@@ -2648,7 +2648,7 @@ int irx_bc_execute(struct envblock *envblock,
                     sp = 0;
 
                     /* SIGL — line tracking not yet available; set to 0 */
-                    wk = (struct irx_wkblk_int *)envblock->envblock_userfield;
+                    wk = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         wk->wkbi_sigl = 0;
@@ -2742,7 +2742,7 @@ int irx_bc_execute(struct envblock *envblock,
                     sp = 0;
 
                     /* SIGL — line tracking not yet available; set to 0 */
-                    wk = (struct irx_wkblk_int *)envblock->envblock_userfield;
+                    wk = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         wk->wkbi_sigl = 0;
@@ -2786,7 +2786,7 @@ int irx_bc_execute(struct envblock *envblock,
                 {
                     /* Bare TRACE: toggle wkbi_interactive, keep letter. */
                     struct irx_wkblk_int *wk =
-                        (struct irx_wkblk_int *)envblock->envblock_userfield;
+                        (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         wk->wkbi_interactive ^= 1;
@@ -2804,7 +2804,7 @@ int irx_bc_execute(struct envblock *envblock,
                     unsigned char mode = *pc++;
                     int letter_idx = (int)(mode & 0x0Fu);
                     struct irx_wkblk_int *wk =
-                        (struct irx_wkblk_int *)envblock->envblock_userfield;
+                        (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         wk->wkbi_trace =
@@ -2836,7 +2836,7 @@ int irx_bc_execute(struct envblock *envblock,
                         vm_rc = IRXBC_ERR_UNSUP;
                         goto done;
                     }
-                    wk = (struct irx_wkblk_int *)envblock->envblock_userfield;
+                    wk = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         wk->wkbi_trace = (int)new_letter;
@@ -2849,7 +2849,7 @@ int irx_bc_execute(struct envblock *envblock,
                 {
                     /* Bare ADDRESS: swap current and previous environment. */
                     struct irx_wkblk_int *wk =
-                        (struct irx_wkblk_int *)envblock->envblock_userfield;
+                        (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         char tmp[8];
@@ -2876,7 +2876,7 @@ int irx_bc_execute(struct envblock *envblock,
                         vm_rc = IRXBC_ERR_OPCODE;
                         goto done;
                     }
-                    wk = (struct irx_wkblk_int *)envblock->envblock_userfield;
+                    wk = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         n = (env_len > 8) ? 8 : env_len;
@@ -2905,7 +2905,7 @@ int irx_bc_execute(struct envblock *envblock,
                         goto done;
                     }
                     sp--;
-                    wk = (struct irx_wkblk_int *)envblock->envblock_userfield;
+                    wk = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     if (wk != NULL)
                     {
                         src = (const char *)Lpstr(stack[sp].str);
@@ -2934,7 +2934,7 @@ int irx_bc_execute(struct envblock *envblock,
                      * SYNTAX can trap it. */
                     unsigned char sub = *pc++;
                     struct irx_wkblk_int *wk =
-                        (struct irx_wkblk_int *)envblock->envblock_userfield;
+                        (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
                     long n;
 
                     if (sub == NUMSUB_FORM_SCI)
@@ -3379,10 +3379,10 @@ int irx_bc_execute(struct envblock *envblock,
                     char tmp[12];
                     int blen = 0, n;
                     if (envblock != NULL &&
-                        envblock->envblock_userfield != NULL)
+                        envblock->envblock_workblok_ext != NULL)
                     {
                         wk = (struct irx_wkblk_int *)
-                                 envblock->envblock_userfield;
+                                 envblock->envblock_workblok_ext;
                         digits = wk->wkbi_digits;
                         fuzz = wk->wkbi_fuzz;
                         form = wk->wkbi_form;
@@ -3648,7 +3648,7 @@ int irx_bc_execute(struct envblock *envblock,
             proxy_parser->call_argc = 0;
             sp = 0;
 
-            wk_t = (struct irx_wkblk_int *)envblock->envblock_userfield;
+            wk_t = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
             if (wk_t != NULL)
             {
                 /* SIGL: line tracking deferred (no trace-map yet) */

--- a/src/irx#cond.c
+++ b/src/irx#cond.c
@@ -22,13 +22,13 @@
 void irx_cond_raise(struct envblock *env, int code, int subcode,
                     const char *desc)
 {
-    if (env == NULL || env->envblock_userfield == NULL)
+    if (env == NULL || env->envblock_workblok_ext == NULL)
     {
         return;
     }
 
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)env->envblock_userfield;
+        (struct irx_wkblk_int *)env->envblock_workblok_ext;
     struct irx_condition_info *ci = wk->wkbi_last_condition;
 
     if (ci == NULL)

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -162,7 +162,7 @@ int irx_exec_dispatch(struct execblk *execblk,
                       (int)sizeof(execblk->exec_subcom)))
     {
         struct irx_wkblk_int *wk =
-            (struct irx_wkblk_int *)env->envblock_userfield;
+            (struct irx_wkblk_int *)env->envblock_workblok_ext;
         if (wk != NULL)
         {
             memcpy(wk->wkbi_address, execblk->exec_subcom,
@@ -329,7 +329,7 @@ int irx_exec_run(const char *source, int source_len,
      * clobber an outer invocation's retention. */
     {
         struct irx_wkblk_int *wk =
-            (struct irx_wkblk_int *)envblock->envblock_userfield;
+            (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
         if (wk != NULL)
         {
             saved_source = wk->wkbi_source;
@@ -343,7 +343,7 @@ int irx_exec_run(const char *source, int source_len,
     /* 3. Bytecode path (default-on; opt-out via REXX370_BYTECODE=0) - */
     {
         struct irx_wkblk_int *wk =
-            (struct irx_wkblk_int *)envblock->envblock_userfield;
+            (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
         if (wk != NULL && wk->wkbi_use_bytecode)
         {
             struct irx_bc_execblk *bc = NULL;
@@ -494,7 +494,7 @@ cleanup:
     if (retention_saved && envblock != NULL)
     {
         struct irx_wkblk_int *wk =
-            (struct irx_wkblk_int *)envblock->envblock_userfield;
+            (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
         if (wk != NULL)
         {
             wk->wkbi_source = saved_source;

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -1010,6 +1010,63 @@ int irx_init_chekenvb(struct envblock *envblock, int *out_reason_code)
 /*  Unknown function code: RC=20, RSN=12.                            */
 /* ================================================================== */
 
+/* ================================================================== */
+/*  irx_init_finish — attach the interpreter state to a fresh env      */
+/*                                                                    */
+/*  irx_init_initenvb() builds only the IBM control blocks (ENVBLOCK, */
+/*  PARMBLOCK, IRXEXTE, ECTENVBK anchor).  IRXEXEC additionally needs */
+/*  the interpreter Work Block (anchored in envblock_workblok_ext,    */
+/*  +0x18 — the IBM Work Block Extension slot), the SUBCOMTB and the  */
+/*  BIF registry; without them irx_lstr_init() finds no wkblk and     */
+/*  IRXEXEC fails RC=20.  Shared by the compat irxinit() wrapper and, */
+/*  via irx_init_dispatch(), by the standalone IRXINIT load module —  */
+/*  so both env-creation paths yield an env IRXEXEC can run (the      */
+/*  module path previously skipped this, which is WP-VLIST-WPOOL's    */
+/*  root cause).  WP-VLIST-WPOOL / TSK-279.                           */
+/* ================================================================== */
+static int irx_init_finish(struct envblock *envblk)
+{
+    struct subcomtb_header *subcmd = NULL;
+    struct irx_wkblk_int *wkbi = NULL;
+    struct irx_bif_registry *reg = NULL;
+    int rc;
+
+    /* SUBCOMTB (host command environments). */
+    rc = init_subcomtb(&subcmd, (struct parmblock *)envblk->envblock_parmblock,
+                       envblk);
+    if (rc != 0)
+    {
+        return 20;
+    }
+
+    /* Internal Work Block (interpreter state).  Anchored in the IBM
+     * Work Block Extension slot (envblock_workblok_ext, +0x18) so
+     * envblock_userfield (+0x14) stays free for the caller / exits, as
+     * the spec intends and as consumers (e.g. httprexx) rely on. */
+    rc = init_wkblk_int(&wkbi, envblk);
+    if (rc != 0)
+    {
+        return 20;
+    }
+    envblk->envblock_workblok_ext = wkbi;
+
+    /* BIF registry and core registrations (WP-21a). */
+    rc = irx_bif_create(envblk, &reg);
+    if (rc != 0)
+    {
+        return 20;
+    }
+    wkbi->wkbi_bif_registry = reg;
+
+    rc = irx_bif_register_all(envblk, reg);
+    if (rc != 0)
+    {
+        return 20;
+    }
+
+    return 0;
+}
+
 int irx_init_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
                       struct envblock *prev_envblock,
                       struct parmblock *caller_parmblock,
@@ -1028,8 +1085,14 @@ int irx_init_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
 
     if (memcmp(funccode, "INITENVB", 8) == 0)
     {
-        return irx_init_initenvb(prev_envblock, caller_parmblock,
-                                 user_field, envblock_inout, out_reason_code);
+        int rc = irx_init_initenvb(prev_envblock, caller_parmblock,
+                                   user_field, envblock_inout,
+                                   out_reason_code);
+        if (rc == 0)
+        {
+            rc = irx_init_finish(*envblock_inout);
+        }
+        return rc;
     }
 
     if (memcmp(funccode, "FINDENVB", 8) == 0)
@@ -1072,9 +1135,6 @@ int irx_init_dispatch(const char funccode[IRXINIT_FUNCCODE_LEN],
 int irxinit(void *parms, struct envblock **envblock_ptr)
 {
     struct envblock *envblk = NULL;
-    struct workblok_ext *wkext = NULL;
-    struct subcomtb_header *subcmd = NULL;
-    struct irx_wkblk_int *wkbi = NULL;
     int reason = 0;
     int rc;
 
@@ -1095,57 +1155,18 @@ int irxinit(void *parms, struct envblock **envblock_ptr)
         return 20;
     }
 
-    /* Allocate the Work Block Extension (IBM standard control block). */
-    {
-        void *storage = NULL;
-        rc = irxstor(RXSMGET, (int)sizeof(struct workblok_ext),
-                     &storage, envblk);
-        if (rc != 0)
-        {
-            goto cleanup;
-        }
-        wkext = (struct workblok_ext *)storage;
-    }
-    envblk->envblock_workblok_ext = wkext;
-
     /* IRXEXTE default routine pointers (irxuid, irxmsgid, irxinout_host|mvs)
      * are installed by irx_init_initenvb() step 6. Compat-wrapper-specific
      * IRXEXTE overrides — e.g. self-references to the irxinit / irxterm
      * symbols for Phase 6 — would go here. None today. */
 
-    /* SUBCOMTB (host command environments). */
-    {
-        struct parmblock *pb = (struct parmblock *)envblk->envblock_parmblock;
-        rc = init_subcomtb(&subcmd, pb, envblk);
-        if (rc != 0)
-        {
-            goto cleanup;
-        }
-    }
-
-    /* Internal Work Block (interpreter state). */
-    rc = init_wkblk_int(&wkbi, envblk);
+    /* Attach SUBCOMTB + interpreter Work Block + BIF registry (the same
+     * step the standalone IRXINIT load module runs via
+     * irx_init_dispatch → irx_init_finish). */
+    rc = irx_init_finish(envblk);
     if (rc != 0)
     {
         goto cleanup;
-    }
-    envblk->envblock_userfield = wkbi;
-
-    /* BIF registry and core registrations (WP-21a). */
-    {
-        struct irx_bif_registry *reg = NULL;
-        rc = irx_bif_create(envblk, &reg);
-        if (rc != 0)
-        {
-            goto cleanup;
-        }
-        wkbi->wkbi_bif_registry = reg;
-
-        rc = irx_bif_register_all(envblk, reg);
-        if (rc != 0)
-        {
-            goto cleanup;
-        }
     }
 
     /* Host-only: mirror MVS step 8 ECTENVBK semantics on the

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -42,7 +42,8 @@
 #include "irxwkblk.h"
 
 #ifdef __MVS__
-#include <clibos.h> /* __load(), __delete() — crent370 */
+#include <clibos.h>  /* __load(), __delete() — crent370 */
+#include <clibppa.h> /* __PPAGET() — C-runtime presence check */
 #endif
 
 /* Lock the CON-1 §3.1 ENVBLOCK size on MVS — the IBM-reserved tail
@@ -219,6 +220,30 @@ static int env_eq_ci(const char *a, const char *b)
 }
 
 /* ================================================================== */
+/*  Shared helper: env_get_safe                                       */
+/*                                                                    */
+/*  getenv() reaches the environment through @@GRTGET -> @@CRTGET,    */
+/*  which requires an established C runtime (a CLIBCRT registered in  */
+/*  the PPA).  On the module-entry path — IRXINIT reached via BALR    */
+/*  from IRXTMPW or the VLIST wrappers, not via @@CRT0 — no CRT is    */
+/*  set up, so a plain getenv() logs a spurious                       */
+/*  "__CRTGET ... not found in PPA(00000000)" at every call.  Skip it */
+/*  when no PPA exists (the production default is correct there);     */
+/*  on the host and in @@CRT0-bootstrapped modules a PPA exists and    */
+/*  getenv() works normally.                                          */
+/* ================================================================== */
+static const char *env_get_safe(const char *name)
+{
+#ifdef __MVS__
+    if (__PPAGET() == NULL)
+    {
+        return NULL;
+    }
+#endif
+    return getenv(name);
+}
+
+/* ================================================================== */
 /*  Shared helper: init_wkblk_int                                     */
 /* ================================================================== */
 
@@ -267,7 +292,7 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
      * run after irxinit() returns. */
     wk->wkbi_use_bytecode = 1;
     {
-        const char *e = getenv("REXX370_BYTECODE");
+        const char *e = env_get_safe("REXX370_BYTECODE");
         if (e != NULL)
         {
             if (e[0] == '0' || env_eq_ci(e, "false") ||
@@ -289,7 +314,7 @@ static int init_wkblk_int(struct irx_wkblk_int **wk_out,
      * Default off; no output, no overhead when not set. */
     wk->wkbi_bc_debug = 0;
     {
-        const char *e = getenv("REXX370_BCDEBUG");
+        const char *e = env_get_safe("REXX370_BCDEBUG");
         if (e != NULL)
         {
             if (e[0] == '1' || env_eq_ci(e, "true") ||

--- a/src/irx#jcl.c
+++ b/src/irx#jcl.c
@@ -114,8 +114,8 @@ int irx_jcl_dispatch_main(const char *member,
         if (irx_init_findenvb(&env, &rsn) != 0)
         {
             /* No existing env on this TCB — auto-init a full Phase 2 env.
-             * Must use irxinit() (not irx_init_initenvb) because
-             * irx_exec_run() accesses envblock->envblock_userfield as
+             * Must use irxinit() (not bare irx_init_initenvb) because
+             * irx_exec_run() accesses envblock->envblock_workblok_ext as
              * struct irx_wkblk_int *, which irxinit() populates. */
             if (irxinit(NULL, &env) != 0)
             {

--- a/src/irx#lstr.c
+++ b/src/irx#lstr.c
@@ -118,7 +118,7 @@ static void *rexx_lstr_alloc(size_t size, void *ctx)
     struct irx_wkblk_int *wkbi;
     int bkt;
 
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wkbi != NULL)
     {
         POOL_BUCKET_FOR((int)size, bkt);
@@ -137,7 +137,7 @@ static void rexx_lstr_dealloc(void *ptr, size_t size, void *ctx)
     struct irx_wkblk_int *wkbi;
     int bkt;
 
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wkbi != NULL)
     {
         POOL_BUCKET_FOR((int)size, bkt);
@@ -163,7 +163,7 @@ void irx_lstr_pool_teardown(struct envblock *envblock)
     {
         return;
     }
-    wkbi = (struct irx_wkblk_int *)envblock->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
     if (wkbi == NULL)
     {
         return;
@@ -193,7 +193,7 @@ struct lstr_alloc *irx_lstr_init(struct envblock *envblock)
         return NULL;
     }
 
-    wkbi = (struct irx_wkblk_int *)envblock->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
     if (wkbi == NULL)
     {
         return NULL;

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -503,11 +503,11 @@ static struct irx_bif_registry *get_bif_registry(struct irx_parser *p)
     struct irx_wkblk_int *wk;
 
     if (p == NULL || p->envblock == NULL ||
-        p->envblock->envblock_userfield == NULL)
+        p->envblock->envblock_workblok_ext == NULL)
     {
         return NULL;
     }
-    wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+    wk = (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
     return (struct irx_bif_registry *)wk->wkbi_bif_registry;
 }
 
@@ -3191,9 +3191,9 @@ static int kw_numeric(struct irx_parser *p)
     int kn;
 
     /* Get the work block for updating NUMERIC settings */
-    if (p->envblock != NULL && p->envblock->envblock_userfield != NULL)
+    if (p->envblock != NULL && p->envblock->envblock_workblok_ext != NULL)
     {
-        wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+        wk = (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
     }
 
     /* exec_clause already consumed the NUMERIC keyword token. */
@@ -3474,10 +3474,10 @@ static int kw_parse(struct irx_parser *p)
         advance_tok(p);
 
         if (p->envblock != NULL &&
-            p->envblock->envblock_userfield != NULL)
+            p->envblock->envblock_workblok_ext != NULL)
         {
             struct irx_wkblk_int *wkbi =
-                (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+                (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
             digits = wkbi->wkbi_digits;
             fuzz = wkbi->wkbi_fuzz;
             form = wkbi->wkbi_form;
@@ -3621,9 +3621,9 @@ static int kw_trace(struct irx_parser *p)
     const struct irx_token *t;
     struct irx_wkblk_int *wk = NULL;
 
-    if (p->envblock != NULL && p->envblock->envblock_userfield != NULL)
+    if (p->envblock != NULL && p->envblock->envblock_workblok_ext != NULL)
     {
-        wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+        wk = (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
     }
 
     t = cur_tok(p);
@@ -3759,9 +3759,9 @@ static int kw_address(struct irx_parser *p)
     const struct irx_token *t;
     struct irx_wkblk_int *wk = NULL;
 
-    if (p->envblock != NULL && p->envblock->envblock_userfield != NULL)
+    if (p->envblock != NULL && p->envblock->envblock_workblok_ext != NULL)
     {
-        wk = (struct irx_wkblk_int *)p->envblock->envblock_userfield;
+        wk = (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
     }
 
     t = cur_tok(p);

--- a/src/irx#term.c
+++ b/src/irx#term.c
@@ -152,7 +152,7 @@ int irxterm(struct envblock *envblk)
     /* 2. Term exit — deferred to Phase 6. */
 
     /* 3. Free internal Work Block. */
-    wkbi = (struct irx_wkblk_int *)envblk->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)envblk->envblock_workblok_ext;
     if (wkbi != NULL)
     {
         /* TODO Phase 2+: Free variable pool, data stack,
@@ -198,7 +198,7 @@ int irxterm(struct envblock *envblk)
             wkbi->wkbi_bif_registry = NULL;
         }
 
-        envblk->envblock_userfield = NULL;
+        envblk->envblock_workblok_ext = NULL;
         stor_free((void **)&wkbi, envblk);
     }
 
@@ -215,8 +215,10 @@ int irxterm(struct envblock *envblk)
         }
     }
 
-    /* 5. Free Work Block Extension — allocated by IRXEXEC, freed here. */
-    stor_free((void **)&envblk->envblock_workblok_ext, envblk);
+    /* 5. (WP-VLIST-WPOOL) The interpreter Work Block now lives directly
+     * in envblock_workblok_ext (+0x18); it was freed with the other
+     * per-env state at step 3 above, so there is no separate Work Block
+     * Extension control block to release here. */
 
     /* 6. Delegate IRXEXTE + PARMBLOCK + IRXANCHR + ENVBLOCK to C-core.
      * After this call envblk is freed and must not be dereferenced. */

--- a/test/asm/texecvl.asm
+++ b/test/asm/texecvl.asm
@@ -1,0 +1,396 @@
+         TITLE 'TEXECVL - Live MVS test: IRXINIT + IRXEXEC + IRXTERM'
+*
+*  TEXECVL - Minimal HLASM test caller that drives IRXINIT INITENVB,
+*            then IRXEXEC of an in-storage REXX exec, then IRXTERM,
+*            end-to-end through the production load modules from
+*            STEPLIB.  This is the missing coverage for the IRXEXEC
+*            VLIST-wrapper path (only tinitvl / ttermvl existed).
+*
+*  WP-VLIST-WPOOL / TSK-279.  This test drives the production IRXINIT
+*  -> IRXEXEC -> IRXTERM VLIST wrappers end-to-end (the path httprexx
+*  uses via LINK), which had NO MVS coverage — only tinitvl / ttermvl
+*  existed.  Building it surfaced two stacked defects:
+*
+*    Bug A (prerequisite): the standalone IRXINIT load module reaches
+*    INITENVB through irx_init_dispatch(), which built only the IBM
+*    control blocks and never attached the interpreter Work Block.
+*    IRXEXEC then failed at irx_lstr_init() with RC=20 before the pool
+*    was ever stressed.  Fixed by irx_init_finish() (src/irx#init.c);
+*    the wkblk now lives in envblock_workblok_ext (+0x18).
+*
+*    Bug B (the ticket): with the wkblk attached the exec runs, and a
+*    real exec's recursive-descent compile + VM + Lstr chain nests far
+*    past the 8 KB WPOOL (measured ~16.2 KB high-water for the modest
+*    nested expression below).  The PDPPRLG bump-allocator runs past
+*    WPOOL, corrupts adjacent GETMAIN storage and ABENDs S0C4.  Fixed
+*    by enlarging WPOOL to 64 KB in all four wrappers.
+*
+*  RED (either bug present): RC=20 or ABEND S0C4.  GREEN (both fixed):
+*  the exec runs to REXX 'exit 42' -> IRXEXEC R15 = 42 -> step RC=0.
+*
+*  Step 1: IRXINIT INITENVB via SC28-1883-0 §14 VLIST (7 slots) —
+*          same shape as TINITVL/TTERMVL; yields the ENVBLOCK.
+*
+*  Step 2: IRXEXEC via the z/OS 10-slot VLIST form:
+*            P1  EXECBLK   (NULL — source comes from INSTBLK)
+*            P2  ARGTABLE  (NULL — no args)
+*            P3  FLAGS     (0 — wrapper takes NOFLAG; C ignores flags)
+*            P4  INSTBLK   (-> in-storage source, built below)
+*            P5  reserved  (NULL)
+*            P6  EVALBLOCK (NULL — result ignored)
+*            P7  WORKAREA  (NULL)
+*            P8  USERFIELD (NULL)
+*            P9  ENVBLOCK  (the env from step 1)
+*            P10 REXXRC    (out; VL marker on this slot)
+*          R0 in = ENVBLOCK hint; R15 out = REXX exit value (42).
+*
+*  Step 3: IRXTERM (R0 = ENVBLOCK) to free the environment.
+*
+*  WTO output (50-char fixed layout — keeps the DC inside the IFOX00
+*  col-16-to-col-71 operand window):
+*    TEXECVL OK   ENV=xxxxxxxx RC=xxxxxxxx TRC=xxxxxxxx
+*    TEXECVL FAIL ENV=xxxxxxxx RC=xxxxxxxx TRC=xxxxxxxx
+*  (RC = IRXEXEC R15 = REXX exit value; TRC = IRXTERM RC.)
+*
+*  Return code (R15 to JCL / step COND CODE):
+*     0  IRXINIT ok, IRXEXEC R15 = 42 (exec ran to 'exit 42')
+*     8  LOAD EP= failed for IRXINIT / IRXEXEC / IRXTERM
+*    20  IRXINIT non-zero, eye-catcher mismatch, or IRXEXEC R15 != 42
+*    (a WPOOL overflow ABENDs S0C4 during step 2 and never returns)
+*
+*  Ref: SC28-1883-0 §14; z/OS REXX Reference (IRXEXEC 10-slot form)
+*  Ref: WP-VLIST-WPOOL / TSK-279 / consumer: mvslovers/httprexx
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R5       EQU   5
+R6       EQU   6
+R7       EQU   7
+R8       EQU   8
+R9       EQU   9
+R10      EQU   10
+R11      EQU   11
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+TEXECVL  CSECT
+*
+*  --- standard MVS entry linkage ---
+         STM   R14,R12,12(R13)
+         BALR  R12,0
+         USING *,R12
+*
+*  --- allocate dynamic workarea (RENT) ---------------------------
+         L     R0,=A(WALEN)
+         GETMAIN RU,LV=(0)
+         LR    R8,R1               R8 = workarea ptr (saved for FREE)
+         ST    R13,4(,R1)
+         ST    R1,8(,R13)
+         LR    R13,R1
+         USING WAREA,R13
+*
+*  --- zero the slots used as inputs / outputs --------------------
+         XC    PARMP,PARMP
+         XC    USERP,USERP
+         XC    OUTENV,OUTENV
+         XC    OUTRSN,OUTRSN
+         XC    WRCI,WRCI
+         XC    WRCE,WRCE
+         XC    WRCT,WRCT
+*  IRXEXEC parameter words (the fullwords the VLIST slots point at).
+         XC    PXEXEC,PXEXEC       P1 EXECBLK   = NULL
+         XC    PXARG,PXARG         P2 ARGTABLE  = NULL
+         XC    PXFLAG,PXFLAG       P3 FLAGS     = 0 (-> NOFLAG)
+         XC    PXRES5,PXRES5       P5 reserved  = NULL
+         XC    PXEVAL,PXEVAL       P6 EVALBLOCK = NULL
+         XC    PXWKA,PXWKA         P7 WORKAREA  = NULL
+         XC    PXUSR,PXUSR         P8 USERFIELD = NULL
+         XC    PXENV,PXENV         P9 ENVBLOCK  (set after IRXINIT)
+         XC    PXRXRC,PXRXRC       P10 REXXRC   (out)
+*  P4 INSTBLK ptr = address of the static in-storage source block.
+         LA    R1,INSTBLK
+         ST    R1,PXINST
+*
+*  --- build IRXINIT VLIST (7 slots, VL on slot 7) ----------------
+         LA    R1,FCODE
+         ST    R1,VLIN+0
+         LA    R1,PARMODE
+         ST    R1,VLIN+4
+         LA    R1,PARMP
+         ST    R1,VLIN+8
+         LA    R1,USERP
+         ST    R1,VLIN+12
+         LA    R1,RESVZ
+         ST    R1,VLIN+16
+         LA    R1,OUTENV
+         ST    R1,VLIN+20
+         LA    R1,OUTRSN
+         O     R1,=X'80000000'
+         ST    R1,VLIN+24
+*
+*  --- step 1: LOAD + call IRXINIT --------------------------------
+         LOAD  EP=IRXINIT,ERRET=NOIRXIN
+         LR    R3,R0               R3 = IRXINIT entry-point address
+         SR    R0,R0               no previous-env hint
+         LA    R1,VLIN
+         LR    R15,R3
+         BALR  R14,R15
+         ST    R15,WRCI            saved IRXINIT RC
+*
+*  --- gate step 2 on a usable ENVBLOCK ---------------------------
+         L     R3,WRCI
+         LTR   R3,R3
+         BNZ   FAILED              IRXINIT failed
+         L     R3,OUTENV
+         LTR   R3,R3
+         BZ    FAILED              RC=0 but no envblock
+         CLC   0(8,R3),=CL8'ENVBLOCK'
+         BNE   FAILED              eye-catcher mismatch
+*  P9 ENVBLOCK value = the env we just created.
+         L     R1,OUTENV
+         ST    R1,PXENV
+*
+*  --- build IRXEXEC VLIST (10 slots, VL on slot 10) --------------
+         LA    R1,PXEXEC
+         ST    R1,VLEX+0           P1 EXECBLK
+         LA    R1,PXARG
+         ST    R1,VLEX+4           P2 ARGTABLE
+         LA    R1,PXFLAG
+         ST    R1,VLEX+8           P3 FLAGS
+         LA    R1,PXINST
+         ST    R1,VLEX+12          P4 INSTBLK
+         LA    R1,PXRES5
+         ST    R1,VLEX+16          P5 reserved
+         LA    R1,PXEVAL
+         ST    R1,VLEX+20          P6 EVALBLOCK
+         LA    R1,PXWKA
+         ST    R1,VLEX+24          P7 WORKAREA
+         LA    R1,PXUSR
+         ST    R1,VLEX+28          P8 USERFIELD
+         LA    R1,PXENV
+         ST    R1,VLEX+32          P9 ENVBLOCK
+         LA    R1,PXRXRC
+         O     R1,=X'80000000'     VL marker on last slot (P10)
+         ST    R1,VLEX+36          P10 REXXRC
+*
+*  --- step 2: LOAD + call IRXEXEC (R0 = envblock hint) -----------
+         LOAD  EP=IRXEXEC,ERRET=NOIRXEX
+         LR    R3,R0               R3 = IRXEXEC entry-point address
+         L     R0,OUTENV           R0 = ENVBLOCK hint
+         LA    R1,VLEX
+         LR    R15,R3
+         BALR  R14,R15
+         ST    R15,WRCE            IRXEXEC R15 = REXX exit value
+*
+*  --- step 3: LOAD + call IRXTERM (teardown, R0 = ENVBLOCK) ------
+         LOAD  EP=IRXTERM,ERRET=NOIRXTM
+         LR    R3,R0               R3 = IRXTERM entry-point address
+         L     R0,OUTENV           R0 = ENVBLOCK to terminate
+         LR    R15,R3
+         BALR  R14,R15
+         ST    R15,WRCT            saved IRXTERM RC
+*
+*  --- evaluate: success iff the exec ran to 'exit 42' ------------
+         L     R3,WRCE
+         C     R3,=F'42'
+         BNE   FAILED              IRXEXEC did not return the exit code
+*
+*  --- success path ----------------------------------------------
+         BAL   R14,WTOSETUP
+         MVC   WTOWORK+4(MSGLEN),OKMSG
+         BAL   R14,FILLHEX
+         WTO   MF=(E,WTOWORK)
+         LA    R3,0                exit RC = 0
+         B     EPILOG
+*
+FAILED   EQU   *
+*  --- failure path ----------------------------------------------
+         BAL   R14,WTOSETUP
+         MVC   WTOWORK+4(MSGLEN),FAILMSG
+         BAL   R14,FILLHEX
+         WTO   MF=(E,WTOWORK)
+         LA    R3,20               exit RC = 20
+         B     EPILOG
+*
+*  --- LOAD failure paths ----------------------------------------
+NOIRXIN  EQU   *
+         WTO   'TEXECVL FAIL: LOAD EP=IRXINIT failed (check STEPLIB)'
+         LA    R3,8
+         B     EPILOG
+*
+NOIRXEX  EQU   *
+         WTO   'TEXECVL FAIL: LOAD EP=IRXEXEC failed (check STEPLIB)'
+         LA    R3,8
+         B     EPILOG
+*
+NOIRXTM  EQU   *
+         WTO   'TEXECVL FAIL: LOAD EP=IRXTERM failed (check STEPLIB)'
+         LA    R3,8
+         B     EPILOG
+*
+*  --- common epilog: free workarea, restore regs, return --------
+EPILOG   EQU   *
+         L     R13,WDPREV
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(8)
+         LR    R15,R3
+         L     R14,12(,R13)
+         LM    R1,R12,24(R13)
+         BR    R14
+*
+*  --- WTOSETUP: copy MF=L skeleton from CSECT into workarea ----
+WTOSETUP DS    0H
+         MVC   WTOWORK(WTOSKLEN),WTOSKEL
+         BR    R14
+*
+*  --- FILLHEX: fill ENV@17, RC@29, TRC@42 in text portion ------
+*  Text portion of the WPL starts at WTOWORK+4.
+FILLHEX  DS    0H
+         ST    R14,SAVR14
+         L     R1,OUTENV
+         LA    R2,WTOWORK+4+17
+         BAL   R14,FMTHEX
+         L     R1,WRCE
+         LA    R2,WTOWORK+4+29
+         BAL   R14,FMTHEX
+         L     R1,WRCT
+         LA    R2,WTOWORK+4+42
+         BAL   R14,FMTHEX
+         L     R14,SAVR14
+         BR    R14
+*
+*  --- FMTHEX: R1 -> 8 hex chars at R2 ---------------------------
+FMTHEX   DS    0H
+         ST    R1,FMTTMP
+         UNPK  FMTBUF(9),FMTTMP(5)
+         TR    FMTBUF(8),HEXTAB-X'F0'
+         MVC   0(8,R2),FMTBUF
+         BR    R14
+*
+         LTORG
+*
+*  --- static input data ----------------------------------------
+FCODE    DC    CL8'INITENVB'
+PARMODE  DC    CL8' '
+RESVZ    DC    F'0'                IRXINIT P5 reserved zero
+HEXTAB   DC    C'0123456789ABCDEF'
+*
+*  --- in-storage REXX source (INSTBLK) -------------------------
+*  Read-only (dispatch copies the reconstructed source into its own
+*  pool), so it is RENT-safe as static CSECT data.  The 128-byte
+*  header is followed by an 8-byte entry per source line (statement
+*  address + length); dispatch concatenates the statements with '\n'
+*  separators.  The critical fields dispatch reads (acronym @+0,
+*  instblk_address @+16, instblk_usedlen @+20) use explicit labels,
+*  so the block is robust against any trailing-field alignment.
+INSTBLK  DS    0F
+         DC    CL8'IRXINSTB'       +0   acronym
+         DC    A(128)              +8   hdrlen
+         DC    A(0)                +12  reserved
+         DC    A(IBENTS)           +16  instblk_address -> entries
+         DC    A(IBENTE-IBENTS)    +20  instblk_usedlen (n * 8)
+         DC    CL8' '              +24  member  (PARSE SOURCE)
+         DC    CL8' '              +32  ddname
+         DC    CL8' '              +40  subcom
+         DC    A(0)                +48  reserved
+         DC    A(0)                +52  dsnlen
+         DC    CL54' '             +56  dsname
+         DC    H'0'                +110 reserved
+         DC    A(0)                +112 extname_ptr
+         DC    A(0)                +116 extname_len
+         DC    A(0),A(0)           +120 reserved
+*
+*  --- INSTBLK entries: A(statement), A(length) per source line ---
+IBENTS   DS    0F
+         DC    A(L01),A(L01E-L01)
+         DC    A(L02),A(L02E-L02)
+         DC    A(L03),A(L03E-L03)
+         DC    A(L04),A(L04E-L04)
+         DC    A(L05),A(L05E-L05)
+         DC    A(L06),A(L06E-L06)
+         DC    A(L07),A(L07E-L07)
+IBENTE   EQU   *
+*
+*  --- REXX source lines ----------------------------------------
+*  The deep nested-parenthesis expression (L04) forces the bytecode
+*  recursive-descent compiler (bc_exp0..bc_exp8, ~9 frames/level) far
+*  past the 8 KB WPOOL; 'exit 42' proves clean execution once fixed.
+L01      DC    C'acc = 0'
+L01E     EQU   *
+L02      DC    C'do i = 1 to 3'
+L02E     EQU   *
+L03      DC    C'n = i + 1'
+L03E     EQU   *
+L04      DC    C'x = (1+(2+(3+(4+(5+(6+(7+(8+(9+(1+(2+(3+(4+'
+         DC    C'(n+i))))))))))))))'
+L04E     EQU   *
+L05      DC    C'acc = acc + x'
+L05E     EQU   *
+L06      DC    C'end'
+L06E     EQU   *
+L07      DC    C'exit 42'
+L07E     EQU   *
+*
+*  --- WTO parameter list skeleton (hand-built, SVC-35 standard) -
+*  See asm/tinitvl.asm prologue for the IFOX00 col-71 rationale.
+WTOSKEL  DS    0H
+         DC    AL2(WTOEND-WTOSKEL)
+         DC    AL2(0)
+         DC    60C' '
+WTOEND   EQU   *
+WTOSKLEN EQU   *-WTOSKEL
+*
+*  --- 50-char message templates --------------------------------
+*    01234567890123456789012345678901234567890123456789
+*    0         1         2         3         4
+*    TEXECVL OK   ENV=XXXXXXXX RC=XXXXXXXX TRC=XXXXXXXX
+*                     ^17          ^29          ^42
+OKMSG    DC    CL50'TEXECVL OK   ENV=XXXXXXXX RC=XXXXXXXX TRC=XXXXXXXX'
+FAILMSG  DC    CL50'TEXECVL FAIL ENV=XXXXXXXX RC=XXXXXXXX TRC=XXXXXXXX'
+MSGLEN   EQU   50
+*
+*  --- workarea DSECT -------------------------------------------
+WAREA    DSECT
+WDFLAGS  DS    F
+WDPREV   DS    F
+WDNEXT   DS    F
+         DS    15F
+PARMP    DS    F                   IRXINIT P3 PARMBLOCK ptr (=0)
+USERP    DS    F                   IRXINIT P4 user field
+OUTENV   DS    F                   IRXINIT P6 out: ENVBLOCK
+OUTRSN   DS    F                   IRXINIT P7 out: reason
+WRCI     DS    F                   IRXINIT RC
+WRCE     DS    F                   IRXEXEC RC (= REXX exit value)
+WRCT     DS    F                   IRXTERM RC
+SAVR14   DS    F                   FILLHEX R14 save slot
+*  IRXEXEC parameter words (VLIST slots point at these).
+PXEXEC   DS    F                   P1 EXECBLK   ptr
+PXARG    DS    F                   P2 ARGTABLE  ptr
+PXFLAG   DS    F                   P3 FLAGS     value
+PXINST   DS    F                   P4 INSTBLK   ptr
+PXRES5   DS    F                   P5 reserved
+PXEVAL   DS    F                   P6 EVALBLOCK ptr
+PXWKA    DS    F                   P7 WORKAREA  ptr
+PXUSR    DS    F                   P8 USERFIELD ptr
+PXENV    DS    F                   P9 ENVBLOCK  ptr
+PXRXRC   DS    F                   P10 REXXRC   out
+*  VLISTs.
+VLIN     DS    7F                  IRXINIT VLIST (7 slots)
+VLEX     DS    10F                 IRXEXEC VLIST (10 slots)
+*  FMTHEX scratch (UNPK requires 5-byte source -> 9-byte target).
+FMTTMP   DS    F
+FMTBUF   DS    CL16
+*  Writable WTO parameter list (copied from WTOSKEL at runtime).
+WTOWORK  DS    CL(WTOSKLEN)
+WALEN    EQU   *-WAREA
+*
+         END   TEXECVL

--- a/test/jcl/texecvl.jcl
+++ b/test/jcl/texecvl.jcl
@@ -1,0 +1,24 @@
+//TEXECVL  JOB (A),'IRXEXEC TEST',REGION=8M,
+//           CLASS=A,MSGCLASS=H,MSGLEVEL=(1,1),
+//           NOTIFY=IBMUSER
+//*---------------------------------------------------------------
+//* TEXECVL - Live MVS test of IRXINIT INITENVB, IRXEXEC of an
+//*           in-storage REXX exec, then IRXTERM, through the
+//*           production HLASM wrappers in
+//*           IBMUSER.REXX370.V0R1M0D.LOAD
+//*
+//* Documents the WP-VLIST-WPOOL (TSK-279) reproducer for manual
+//* submission; the mbt v2 runner (make test-mvs) generates its own
+//* batch + TSO steps and does not consume this file.
+//*
+//* See test/asm/texecvl.asm for the VLIST/INSTBLK contracts and the
+//* WTO format. Expected: STEP exits with RC=0; JESLOG shows
+//*   'TEXECVL OK   ENV=xxxxxxxx RC=0000002A TRC=xxxxxxxx'
+//* (RC=0000002A is the REXX 'exit 42'). Against the unfixed 8 KB
+//* WPOOL the step ABENDs S0C4 instead.
+//*---------------------------------------------------------------
+//STEP1   EXEC PGM=TEXECVL,REGION=8M
+//STEPLIB  DD DSN=IBMUSER.REXX370.V0R1M0D.LOAD,DISP=SHR
+//SYSPRINT DD SYSOUT=*
+//SYSTSPRT DD SYSOUT=*
+//

--- a/test/tstaddr.c
+++ b/test/tstaddr.c
@@ -160,7 +160,7 @@ static int var_eq(struct fixture *f, const char *name, const char *want)
 static int wk_address_eq(struct fixture *f, const char *want8)
 {
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)f->env->envblock_userfield;
+        (struct irx_wkblk_int *)f->env->envblock_workblok_ext;
     if (wk == NULL)
     {
         return 0;
@@ -173,7 +173,7 @@ static int wk_address_eq(struct fixture *f, const char *want8)
 static void wk_address_snap(struct fixture *f, char *out)
 {
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)f->env->envblock_userfield;
+        (struct irx_wkblk_int *)f->env->envblock_workblok_ext;
     if (wk != NULL)
     {
         memcpy(out, wk->wkbi_address, sizeof(wk->wkbi_address));
@@ -184,7 +184,7 @@ static void wk_address_snap(struct fixture *f, char *out)
 static int wk_address_eq_buf(struct fixture *f, const char *buf)
 {
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)f->env->envblock_userfield;
+        (struct irx_wkblk_int *)f->env->envblock_workblok_ext;
     if (wk == NULL)
     {
         return 0;

--- a/test/tstbarg.c
+++ b/test/tstbarg.c
@@ -120,7 +120,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[160];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -167,7 +167,7 @@ static int no_fallback(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[160];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -216,7 +216,7 @@ static int ran_bc(struct envblock *env, const char *src, const char *tag)
     int exit_rc = 0;
     char label[160];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbcal.c
+++ b/test/tstbcal.c
@@ -104,7 +104,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -154,7 +154,7 @@ static int bc_only(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbcat.c
+++ b/test/tstbcat.c
@@ -116,7 +116,7 @@ static int capture_io(int function, PLstr data, struct envblock *envblock)
 
 static int equiv(struct envblock *env, const char *src, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     char tw_out[CAPBUF_SIZE];
@@ -164,7 +164,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
 static int bc_exact(struct envblock *env, const char *src,
                     const char *expected, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     int rc;

--- a/test/tstbcexe.c
+++ b/test/tstbcexe.c
@@ -146,7 +146,7 @@ static void test_e2e_bytecode_flag(void)
         return;
     }
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     CHECK(wk != NULL, "work block is present");
     if (wk == NULL)
     {
@@ -186,7 +186,7 @@ static void test_e2e_empty_bytecode(void)
         return;
     }
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         irxterm(env);

--- a/test/tstbcln.c
+++ b/test/tstbcln.c
@@ -83,7 +83,7 @@ static void run_both(const char *desc, const char *src,
     ok = (irxinit(NULL, &env) == 0 && env != NULL);
     if (ok)
     {
-        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
         if (wk != NULL)
         {
             wk->wkbi_use_bytecode = 0;
@@ -101,7 +101,7 @@ static void run_both(const char *desc, const char *src,
     ok = (irxinit(NULL, &env) == 0 && env != NULL);
     if (ok)
     {
-        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
         if (wk != NULL)
         {
             wk->wkbi_use_bytecode = 1;

--- a/test/tstbcmp.c
+++ b/test/tstbcmp.c
@@ -116,7 +116,7 @@ static int capture_io(int function, PLstr data, struct envblock *envblock)
 
 static int equiv(struct envblock *env, const char *src, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     char tw_out[CAPBUF_SIZE];
@@ -164,7 +164,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
 static int bc_exact(struct envblock *env, const char *src,
                     const char *expected, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     int rc;

--- a/test/tstbcnum.c
+++ b/test/tstbcnum.c
@@ -147,7 +147,7 @@ static void numeric_reset(struct irx_wkblk_int *wk)
 
 static int equiv(struct envblock *env, const char *src, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     char tw_out[CAPBUF_SIZE];
@@ -203,7 +203,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
 static int bc_exact(struct envblock *env, const char *src,
                     const char *expected, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     int rc;

--- a/test/tstbcom.c
+++ b/test/tstbcom.c
@@ -104,7 +104,7 @@ static int bc_only(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -145,7 +145,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbcont.c
+++ b/test/tstbcont.c
@@ -124,7 +124,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[160];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -170,7 +170,7 @@ static int no_fallback(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[160];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -218,7 +218,7 @@ static int ran_bc(struct envblock *env, const char *src, const char *tag)
     int exit_rc = 0;
     char label[160];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbcrxc.c
+++ b/test/tstbcrxc.c
@@ -174,7 +174,7 @@ static void test_equiv(struct envblock *env)
     char tw_out[CAPBUF];
     int tw_len;
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         CHECK(0, "work block available");
@@ -233,7 +233,7 @@ static void test_bc_path(struct envblock *env)
 
     printf("\n[BC-path proof — REXXCPS indirect pattern (AC #6)]\n");
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         CHECK(0, "work block available");
@@ -299,7 +299,7 @@ static void run_equiv(struct envblock *env, const char *src,
                       const char *label)
 {
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)env->envblock_userfield;
+        (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int tw_rc;
     int bc_rc;

--- a/test/tstbctl.c
+++ b/test/tstbctl.c
@@ -108,7 +108,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbcxpr.c
+++ b/test/tstbcxpr.c
@@ -85,7 +85,7 @@ static void run_both(const char *desc, const char *src,
     ok = (irxinit(NULL, &env) == 0 && env != NULL);
     if (ok)
     {
-        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
         if (wk != NULL)
         {
             wk->wkbi_use_bytecode = 0;
@@ -103,7 +103,7 @@ static void run_both(const char *desc, const char *src,
     ok = (irxinit(NULL, &env) == 0 && env != NULL);
     if (ok)
     {
-        wk = (struct irx_wkblk_int *)env->envblock_userfield;
+        wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
         if (wk != NULL)
         {
             wk->wkbi_use_bytecode = 1;

--- a/test/tstbdq.c
+++ b/test/tstbdq.c
@@ -122,7 +122,7 @@ static int capture_io(int function, PLstr data, struct envblock *envblock)
 
 static int equiv(struct envblock *env, const char *src, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     char tw_out[CAPBUF_SIZE];
@@ -171,7 +171,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
 static int bc_exact(struct envblock *env, const char *src,
                     const char *expected, const char *tag)
 {
-    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     int src_len = (int)strlen(src);
     int exit_rc = 0;
     int rc;

--- a/test/tstbif.c
+++ b/test/tstbif.c
@@ -213,7 +213,7 @@ static void test_core_bifs_registered(void)
 
     printf("\n--- BIF#7: irxinit registers core BIFs ---\n");
     CHECK(irxinit(NULL, &env) == 0, "irxinit OK");
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     CHECK(wk != NULL && wk->wkbi_bif_registry != NULL,
           "wkbi_bif_registry populated");
     reg = (struct irx_bif_registry *)wk->wkbi_bif_registry;

--- a/test/tstbifs.c
+++ b/test/tstbifs.c
@@ -365,7 +365,7 @@ static int run_expect_fail(const char *src, int want_code,
     rc = run_src(&fx, src);
 
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)fx.env->envblock_userfield;
+        (struct irx_wkblk_int *)fx.env->envblock_workblok_ext;
     if (wk != NULL && wk->wkbi_last_condition != NULL &&
         wk->wkbi_last_condition->valid)
     {
@@ -495,7 +495,7 @@ static void test_find_phrase_cap(void)
     }
     int rc = run_src(&fx, buf);
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)fx.env->envblock_userfield;
+        (struct irx_wkblk_int *)fx.env->envblock_workblok_ext;
     int code = 0;
     int subcode = 0;
     if (wk != NULL && wk->wkbi_last_condition != NULL &&
@@ -1627,7 +1627,7 @@ static void sourceline_set_retention(struct fixture *fx,
                                      const char *src)
 {
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)fx->env->envblock_userfield;
+        (struct irx_wkblk_int *)fx->env->envblock_workblok_ext;
     wk->wkbi_source = (void *)src;
     wk->wkbi_source_len = (int)strlen(src);
 }
@@ -1704,7 +1704,7 @@ static void test_phase_f_sourceline(void)
         int rc = run_src(&fx, "y = SOURCELINE(3)\n");
         CHECK(rc != IRXPARS_OK, "SOURCELINE(3) on 2-line source rejects");
         struct irx_wkblk_int *wk =
-            (struct irx_wkblk_int *)fx.env->envblock_userfield;
+            (struct irx_wkblk_int *)fx.env->envblock_workblok_ext;
         int code = (wk && wk->wkbi_last_condition &&
                     wk->wkbi_last_condition->valid)
                        ? wk->wkbi_last_condition->code
@@ -1832,7 +1832,7 @@ static void test_phase_f_sourceline(void)
 
         /* Verify wkbi_source was cleared after exec_run returned. */
         struct irx_wkblk_int *wk =
-            (struct irx_wkblk_int *)env->envblock_userfield;
+            (struct irx_wkblk_int *)env->envblock_workblok_ext;
         CHECK(wk->wkbi_source == NULL,
               "SOURCELINE: wkbi_source cleared on cleanup");
         CHECK(wk->wkbi_source_len == 0,

--- a/test/tstbpro.c
+++ b/test/tstbpro.c
@@ -104,7 +104,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -152,7 +152,7 @@ static int bc_only(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbpse.c
+++ b/test/tstbpse.c
@@ -104,7 +104,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -152,7 +152,7 @@ static int bc_only(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -497,7 +497,7 @@ static void test_parse_indirect(struct envblock *env)
 
     printf("\n[PARSE indirect pattern (var)]\n");
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: no work block\n");
@@ -643,7 +643,7 @@ static void test_parse_pull(struct envblock *env)
 
     printf("\n[PARSE PULL — WP-33b stub]\n");
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: no work block\n");

--- a/test/tstbsem.c
+++ b/test/tstbsem.c
@@ -116,7 +116,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -168,7 +168,7 @@ static int no_fallback(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[160];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbsig.c
+++ b/test/tstbsig.c
@@ -108,7 +108,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -156,7 +156,7 @@ static int bc_only(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -336,7 +336,7 @@ static void test_signal_sigl(struct envblock *env)
 
     printf("\n--- SIGL special variable ---\n");
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         CHECK(0, "SIGL: no work block");

--- a/test/tstbtra.c
+++ b/test/tstbtra.c
@@ -117,7 +117,7 @@ static int equiv(struct envblock *env, const char *src, const char *tag)
     char bc_out[CAPBUF_SIZE];
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);
@@ -165,7 +165,7 @@ static int bc_only(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s — no work block\n", tag);

--- a/test/tstbtrp.c
+++ b/test/tstbtrp.c
@@ -110,7 +110,7 @@ static int bc_only(struct envblock *env, const char *src,
     int exit_rc = 0;
     char label[128];
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: %s - no work block\n", tag);

--- a/test/tstexec.c
+++ b/test/tstexec.c
@@ -741,7 +741,7 @@ static void test_execblk_subcom(void)
 
     CHECK(rc == 0, "SUBCOM override: exit 0 -> RC=0");
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk != NULL)
     {
         CHECK(memcmp(wk->wkbi_address, "ISPF    ",

--- a/test/tstflip.c
+++ b/test/tstflip.c
@@ -43,7 +43,7 @@
 #include "irxwkblk.h"
 
 #ifdef __MVS__
-#include <clibenv.h>   /* setenv/unsetenv on crent370 (host gets them from
+#include <clibenv.h> /* setenv/unsetenv on crent370 (host gets them from
                           <stdlib.h> via _POSIX_C_SOURCE above) */
 #endif
 
@@ -84,7 +84,7 @@ static int wkbi_flag_after_init(void)
     {
         return -1;
     }
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk != NULL)
     {
         flag = wk->wkbi_use_bytecode;
@@ -224,7 +224,7 @@ static void test_setter_wins_over_env(void)
         return;
     }
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: wk is NULL\n");
@@ -275,7 +275,7 @@ static void test_setter_zero_wins_over_env(void)
         return;
     }
 
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         printf("  FAIL: wk is NULL\n");

--- a/test/tstinit.c
+++ b/test/tstinit.c
@@ -357,7 +357,7 @@ static void test_t7_irxinit_compat_wrapper(void)
         }
 
         /* Compat wrapper installs interpreter Work Block. */
-        CHECK(envblk->envblock_userfield != NULL,
+        CHECK(envblk->envblock_workblok_ext != NULL,
               "compat wrapper installed internal Work Block");
 
         rc = irxterm(envblk);

--- a/test/tstlstr.c
+++ b/test/tstlstr.c
@@ -241,7 +241,7 @@ static void test_allocator_bridge(void)
     alloc2 = irx_lstr_init(env);
     CHECK(alloc2 == alloc, "second irx_lstr_init returns cached pointer");
 
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     CHECK(wkbi != NULL && wkbi->wkbi_lstr_alloc == alloc,
           "wkbi->wkbi_lstr_alloc points at the allocator");
 

--- a/test/tstphas1.c
+++ b/test/tstphas1.c
@@ -152,7 +152,7 @@ static void test_single_env(void)
     }
 
     /* Validate internal Work Block */
-    wkbi = (struct irx_wkblk_int *)envblk->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)envblk->envblock_workblok_ext;
     CHECK(wkbi != NULL, "internal wkblk is linked via userfield");
     if (wkbi != NULL)
     {

--- a/test/tstpool.c
+++ b/test/tstpool.c
@@ -89,7 +89,7 @@ static void test_pool_basic(void)
     CHECK(env != NULL, "env created");
 
     a = irx_lstr_init(env);
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
 
     CHECK(a != NULL, "lstr allocator initialized");
     CHECK(wkbi != NULL, "wkbi reachable");
@@ -133,7 +133,7 @@ static void test_pool_grow_path(void)
     printf("\n[test_pool_grow_path]\n");
 
     a = irx_lstr_init(env);
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
 
     /* Alloc a 16-byte buffer and deposit it in the pool. */
     Lzeroinit(&s);
@@ -182,7 +182,7 @@ static void test_pool_100k_cycles(void)
     printf("\n[test_pool_100k_cycles]\n");
 
     a = irx_lstr_init(env);
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
 
     for (i = 0; i < 100000; i++)
     {
@@ -231,7 +231,7 @@ static void test_pool_max_items(void)
     printf("\n[test_pool_max_items]\n");
 
     a = irx_lstr_init(env);
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
 
     /* Allocate n items, then free them all — the pool takes the first
      * LSTR_POOL_MAX_PER_BUCKET and the remaining 10 fall through to
@@ -267,7 +267,7 @@ static void test_pool_teardown(void)
     printf("\n[test_pool_teardown]\n");
 
     a = irx_lstr_init(env);
-    wkbi = (struct irx_wkblk_int *)env->envblock_userfield;
+    wkbi = (struct irx_wkblk_int *)env->envblock_workblok_ext;
 
     /* Deposit one item into each of buckets 0, 1, 2. */
     Lzeroinit(&s);

--- a/test/tstrxcps.c
+++ b/test/tstrxcps.c
@@ -163,6 +163,7 @@ static int capture_io(int function, PLstr data, struct envblock *envblock)
 /* ------------------------------------------------------------------ */
 #ifndef __MVS__
 #include <time.h>
+
 static double now_s(void)
 {
     struct timespec t;
@@ -170,7 +171,10 @@ static double now_s(void)
     return (double)t.tv_sec + (double)t.tv_nsec / 1.0e9;
 }
 #else
-static double now_s(void) { return 0.0; }
+static double now_s(void)
+{
+    return 0.0;
+}
 #endif
 
 /* ------------------------------------------------------------------ */
@@ -227,7 +231,7 @@ int main(int argc, char *argv[])
     }
 
     /* Install output capture */
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     if (wk == NULL)
     {
         fprintf(stderr, "tstbc_rexxcps: no work block\n");

--- a/test/tstsay.c
+++ b/test/tstsay.c
@@ -130,7 +130,7 @@ static int run_source(struct envblock *env, const char *src)
     }
 
     /* Obtain (or create) the variable pool from the work block */
-    wk = (struct irx_wkblk_int *)env->envblock_userfield;
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
     pool = (struct irx_vpool *)wk->wkbi_varpool;
     if (pool == NULL)
     {

--- a/test/tstterm.c
+++ b/test/tstterm.c
@@ -322,7 +322,7 @@ static void test_t7_irxterm_minimal_init(void)
 
     /* wkbi is NULL (not set by irx_init_initenvb), IRXEXTE is a
      * placeholder.  irxterm must handle both gracefully. */
-    CHECK(envblk->envblock_userfield == NULL,
+    CHECK(envblk->envblock_workblok_ext == NULL,
           "pre-term: no wkbi (irx_init_initenvb path)");
 
     rc = irxterm(envblk);
@@ -358,8 +358,8 @@ static void test_t8_irxterm_full_init(void)
         return;
     }
 
-    /* irxinit installs the Work Block (wkbi) via envblock_userfield. */
-    CHECK(envblk->envblock_userfield != NULL,
+    /* irxinit installs the Work Block (wkbi) via envblock_workblok_ext. */
+    CHECK(envblk->envblock_workblok_ext != NULL,
           "pre-term: wkbi installed by irxinit");
 
     rc = irxterm(envblk);

--- a/test/tsttim.c
+++ b/test/tsttim.c
@@ -342,7 +342,7 @@ static int run_expect_fail(const char *src, int want_code,
     int code = 0;
     int subcode = 0;
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)fx.env->envblock_userfield;
+        (struct irx_wkblk_int *)fx.env->envblock_workblok_ext;
     if (wk != NULL && wk->wkbi_last_condition != NULL &&
         wk->wkbi_last_condition->valid)
     {

--- a/test/tsttrace.c
+++ b/test/tsttrace.c
@@ -171,7 +171,7 @@ static int run_expect_fail(const char *src, int want_code,
     int code = 0;
     int subcode = 0;
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)fx.env->envblock_userfield;
+        (struct irx_wkblk_int *)fx.env->envblock_workblok_ext;
     if (wk != NULL && wk->wkbi_last_condition != NULL &&
         wk->wkbi_last_condition->valid)
     {
@@ -507,14 +507,14 @@ static void test_trace_empty_arg(void)
 static int wk_letter(struct fixture *f)
 {
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)f->env->envblock_userfield;
+        (struct irx_wkblk_int *)f->env->envblock_workblok_ext;
     return (wk != NULL) ? wk->wkbi_trace : (int)TRACE_NORMAL;
 }
 
 static int wk_interactive(struct fixture *f)
 {
     struct irx_wkblk_int *wk =
-        (struct irx_wkblk_int *)f->env->envblock_userfield;
+        (struct irx_wkblk_int *)f->env->envblock_workblok_ext;
     return (wk != NULL) ? wk->wkbi_interactive : 0;
 }
 


### PR DESCRIPTION
Resolves **WP-VLIST-WPOOL (TSK-279)**. Building the reproducer for the ticket's
S0C4 surfaced that the WPOOL bug was gated behind a previously-unknown, higher-
severity prerequisite (**#198**). Both are fixed here as two separate commits.

## Bug A (#198) — prerequisite

The standalone **IRXINIT load module** never attached the interpreter Work Block:
`irx_init_dispatch()` → `irx_init_initenvb()` built only the IBM control blocks,
while only the in-process `irxinit()` compat wrapper attached the Work Block
(duplicated logic → the module path silently lacked it). `IRXEXEC` then failed at
`irx_lstr_init()` with **RC=20** before running any REXX — breaking every
module-path IRXEXEC (the path `httprexx` uses) and masking Bug B.

Fix: extract the shared post-INITENVB setup into `irx_init_finish()` (called by
both paths), and move the Work Block from `envblock_userfield` (+0x14, the IBM
"user field", which consumers legitimately use) to `envblock_workblok_ext`
(+0x18, the IBM Work Block Extension slot). The vestigial `workblok_ext` struct
that occupied +0x18 (fields never read) is dropped.

## Bug B (TSK-279) — the ticket

With the Work Block attached, a real exec runs and its recursive-descent compile
+ VM + Lstr chain nests far past the **8 KB** WPOOL, overflowing into adjacent
GETMAIN storage → **S0C4**. Enlarged WPOOL to **64 KB** uniformly in all four
wrappers (irxexec/irxload need it; irxinit/irxterm for consistency). WAREA is
GETMAIN'd/FREEMAIN'd per call, so this costs only transient region.

Added **texecvl**, the first MVS test of the IRXINIT → IRXEXEC → IRXTERM VLIST
path (only tinitvl/ttermvl existed), driving a deep in-storage exec that asserts
the REXX `exit 42` echoes back as `IRXEXEC R15=42`.

## Evidence / teeth

- **Bug A:** host module-path `irx_init_dispatch` → RC=20 vs compat `irxinit()` →
  RC=42 (identical code, only env-creation path differs); MVS RC=20 with the
  WPOOL barely touched (608 B) → failure precedes any deep work.
- **Bug B:** measured high-water ~**16.2 KB** (2× the 8 KB pool). **RED** (8 KB,
  wkblk-fixed): batch `ABEND S0C4`, TSO RC=20. **GREEN** (64 KB): RC=0 on both
  legs — the only change between the two runs was the pool size.
- **Regression:** full MVS suite — 53 modules × {batch, TSO} = 106 steps, 1323
  assertions, **all green**; host suite — 2474 assertions, **all green**.

## Acceptance criteria (TSK-279)

| # | Criterion | Status |
|---|-----------|--------|
| 1 | texecvl.asm + .jcl exist, registered | ✅ `[[test]]` in project.toml + manual `test/jcl/texecvl.jcl` (the ticket's `tstall.jcl` is dead under mbt v2) |
| 2 | RED without fix, GREEN with fix | ✅ RED S0C4/RC=20 @ 8 KB → GREEN RC=0 @ 64 KB |
| 3 | High-water measured + documented | ✅ ~16.2 KB (stack-paint of a 128 KB pool) |
| 4 | WPOOL enlarged in irxexec + irxload | ✅ 64 KB |
| 5 | irxinit + irxterm same value | ✅ 64 KB |
| 6 | Real exec runs without S0C4 | ✅ |
| 7 | Existing suites green (tstbc*, tinitvl, ttermvl) | ✅ full suite |
| 8 | httprexx runs unchanged | ⚠️ **not yet verified** — see below |

## Open item — AC#8 (httprexx)

Not verified in this PR (requires deploying httprexx as a CGI under a running
httpd — a separate multi-project step). httprexx needs **no code change**: it
uses `envblock_userfield` (+0x14) for its request context, which the field move
now frees, and its `irxbind.h` view is unchanged (no rebuild needed — the
production LINKLIB is already deployed). The +0x14/+0x18 collision was very
likely the true cause of its reported S0C4. **Recommended closing check:** a live
`httpd + httprexx` smoke-test (curl one REXX request).
