### PR TITLE
fix(bif): local BIF dispatch — resolve handlers in the running module (S0C1 on parse/words/word)

### DIFF
--- a/include/irxbif.h
+++ b/include/irxbif.h
@@ -87,6 +87,14 @@ const struct irx_bif_entry *
 irx_bif_find(const struct irx_bif_registry *reg,
              const unsigned char *name, size_t len) asm("IRXBIFFN");
 
+/* Resolve a BIF by its upper-case name to the handler linked into THIS
+ * module — bypassing the env registry, whose handler pointers are
+ * cross-module when IRXINIT built the env and IRXEXEC runs the exec
+ * (issue #200). Covers the static core-BIF table + ARG. NULL if not a
+ * known BIF. */
+const struct irx_bif_entry *
+irx_bif_find_local(const unsigned char *name, size_t len) asm("IRXBIFFL");
+
 /* Bulk-register every entry in a static table. Stops at the first
  * entry whose name field is empty. */
 int irx_bif_register_table(struct envblock *env,

--- a/project.toml
+++ b/project.toml
@@ -1835,6 +1835,26 @@ startup = false
 sources = ["test/asm/texecvl.asm"]
 
 # ---------------------------------------------------------------
+# TREXXVL - httprexx-shaped reproducer: runs an in-storage EBCDIC exec
+# through the IRXINIT/IRXEXEC VLIST via __linkds (LINK) with an
+# io_routine override for SAY — exactly the mechanism httprexx uses,
+# in C. Complements the pure-HLASM TEXECVL: TEXECVL stresses the WPOOL
+# with a deep exec, TREXXVL mirrors the real consumer's call shape
+# (LINK + io_routine + in-storage INSTBLK) and is the AC#8 proxy.
+#
+# A [[test]] (not a [[module]]): the runner deploys it to the TESTLIB
+# and runs it with STEPLIB = TESTLIB + LINKLIB, so the LINKs to the
+# production IRXINIT/IRXEXEC resolve. It returns RC 0 on success.
+#
+# WP-VLIST-WPOOL / TSK-279 / consumer: mvslovers/httprexx.
+# ---------------------------------------------------------------
+[[test]]
+name = "TREXXVL"
+startup = "crt1"
+host = false                # MVS-only (uses __linkds/LINK); skipped by test-host
+sources = ["test/trexxvl.c"]
+
+# ---------------------------------------------------------------
 # TISTSO - self-validating test for ISTSO (EXTRACT-based TSO detect).
 # is_tso()'s correct result depends on the environment, so the runner passes
 # the EXPECTED value per leg (batch -> "0", TSO/IKJEFT01 -> "1") and the test

--- a/src/irx#bifs.c
+++ b/src/irx#bifs.c
@@ -3671,3 +3671,59 @@ int irx_bif_register_all(struct envblock *env, struct irx_bif_registry *reg)
      * built-ins. */
     return irx_bif_register(env, reg, "ARG", 0, 2, irx_pars_bif_arg);
 }
+
+/* ================================================================== */
+/*  irx_bif_find_local — resolve a BIF to a handler in THIS module     */
+/*                                                                    */
+/*  Issue #200: BIF dispatch must call the handler compiled into the   */
+/*  module that runs the VM (IRXEXEC), not the cross-module pointer    */
+/*  stored in the env registry — that registry is populated by IRXINIT */
+/*  and its handlers point into IRXINIT's copy of this file, so calling */
+/*  them from a separately-linked IRXEXEC wild-branches (S0C1).  These  */
+/*  static tables are re-linked into every module, so this always      */
+/*  resolves to a local, callable handler.  Covers g_bifstr_table plus */
+/*  ARG (handler in irx#pars.c, linked into the same load module).     */
+/* ================================================================== */
+
+/* ARG(): handler lives in irx#pars.c but links into this same module. */
+static const struct irx_bif_entry g_bif_arg_entry = {"ARG", 0, 2,
+                                                     irx_pars_bif_arg};
+
+/* Exact, length-delimited match (mirrors irx#bif.c's ebcdic_eq); BIF
+ * names reach dispatch already upper-cased. */
+static int bif_name_match(const char *tbl, const unsigned char *name,
+                          size_t len)
+{
+    size_t i;
+    for (i = 0; i < len; i++)
+    {
+        if ((unsigned char)tbl[i] != name[i])
+        {
+            return 0;
+        }
+    }
+    return tbl[len] == '\0';
+}
+
+const struct irx_bif_entry *irx_bif_find_local(const unsigned char *name,
+                                               size_t len)
+{
+    int i;
+
+    if (name == NULL || len == 0 || len >= IRX_BIF_NAME_MAX)
+    {
+        return NULL;
+    }
+    for (i = 0; i < BIFSTR_COUNT; i++)
+    {
+        if (bif_name_match(g_bifstr_table[i].name, name, len))
+        {
+            return &g_bifstr_table[i];
+        }
+    }
+    if (bif_name_match(g_bif_arg_entry.name, name, len))
+    {
+        return &g_bif_arg_entry;
+    }
+    return NULL;
+}

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -76,21 +76,15 @@ struct bc_call_frame
 };
 
 /* ================================================================== */
-/*  BIF registry access (WP-BC-04)                                   */
+/*  BIF dispatch (WP-BC-04; local resolution per issue #200)          */
+/*                                                                    */
+/*  Handlers are resolved with irx_bif_find_local() (irx#bifs.c),      */
+/*  which returns an entry whose handler is linked into THIS module —  */
+/*  never the env registry's stored pointer, which is cross-module     */
+/*  when IRXINIT built the env and IRXEXEC runs the exec (wild branch  */
+/*  -> S0C1).  The env registry is still built (irxinit) and used by   */
+/*  the public irx_bif_find() API, just not for VM dispatch.           */
 /* ================================================================== */
-
-static const struct irx_bif_registry *
-bvm_get_bif_registry(struct envblock *envblock)
-{
-    struct irx_wkblk_int *wk;
-
-    if (envblock == NULL || envblock->envblock_workblok_ext == NULL)
-    {
-        return NULL;
-    }
-    wk = (struct irx_wkblk_int *)envblock->envblock_workblok_ext;
-    return (const struct irx_bif_registry *)wk->wkbi_bif_registry;
-}
 
 /* ================================================================== */
 /*  Read a little-endian u16 from the bytecode stream.               */
@@ -196,8 +190,10 @@ bvm_resolve_bif(struct envblock *envblock, const char *sym_base,
     int valid_idx = (bif_cache != NULL && sym_idx >= 0 && sym_idx < n_syms);
 
     *bad_idx = 0;
+    (void)envblock; /* handlers are resolved locally, not via the env
+                     * registry's cross-module pointers (issue #200) */
 
-    /* Hot path: previously resolved — no symbol lookup, no registry walk. */
+    /* Hot path: previously resolved — no symbol lookup, no table walk. */
     if (valid_idx && bif_cache[sym_idx] != NULL)
     {
         return bif_cache[sym_idx];
@@ -210,8 +206,7 @@ bvm_resolve_bif(struct envblock *envblock, const char *sym_base,
         return NULL;
     }
 
-    const struct irx_bif_entry *bife = irx_bif_find(
-        bvm_get_bif_registry(envblock),
+    const struct irx_bif_entry *bife = irx_bif_find_local(
         (const unsigned char *)name_data, (size_t)name_len);
 
     if (bife != NULL && valid_idx)

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -497,20 +497,6 @@ int irx_pars_bif_arg(struct irx_parser *p, int argc, PLstr *argv,
                : fail(p, IRXPARS_NOMEM);
 }
 
-/* Fetch the registry hanging off the parser's environment. */
-static struct irx_bif_registry *get_bif_registry(struct irx_parser *p)
-{
-    struct irx_wkblk_int *wk;
-
-    if (p == NULL || p->envblock == NULL ||
-        p->envblock->envblock_workblok_ext == NULL)
-    {
-        return NULL;
-    }
-    wk = (struct irx_wkblk_int *)p->envblock->envblock_workblok_ext;
-    return (struct irx_bif_registry *)wk->wkbi_bif_registry;
-}
-
 /* ------------------------------------------------------------------ */
 /*  SAY keyword handler (WP-14)                                       */
 /*                                                                    */
@@ -1724,7 +1710,9 @@ static int bif_dispatch(struct irx_parser *p,
 {
     const struct irx_bif_entry *bif;
 
-    bif = irx_bif_find(get_bif_registry(p), name, name_len);
+    /* Resolve to a handler linked into THIS module, not the env
+     * registry's cross-module pointer (issue #200). */
+    bif = irx_bif_find_local(name, name_len);
     if (bif == NULL)
     {
         return -1;

--- a/test/jcl/trexxvl.jcl
+++ b/test/jcl/trexxvl.jcl
@@ -1,0 +1,30 @@
+//TREXXVL  JOB (A),'IRXEXEC LINK TEST',REGION=4M,
+//           CLASS=A,MSGCLASS=H,MSGLEVEL=(1,1),
+//           NOTIFY=IBMUSER
+//*---------------------------------------------------------------
+//* TREXXVL - reproduce the httprexx IRXEXEC-via-LINK path in batch.
+//*
+//* Runs a hardcoded EBCDIC "say" exec through IRXINIT + IRXEXEC using
+//* the VLIST (LINK) interface -- the exact path httprexx uses -- with
+//* no httpd, no UFS, no encoding variable. See test/trexxvl.c.
+//*
+//* STEPLIB must point at the REXX370 LOAD library that holds
+//* IRXINIT/IRXEXEC (the SAME library httpd loads them from) AND the
+//* TREXXVL module (deploy it there with `make deploy` after
+//* `make trexxvl`). Adjust the DSN below to your installation.
+//*
+//* Expected (bug in rexx370 IRXEXEC path):
+//*   ... TREXXVL: IRXINIT link=0 rc=0 env=xxxxxxxx
+//*   ... TREXXVL: calling IRXEXEC ...
+//*   S0C1/S0C4 in IRXEXEC/IRXBEXEC  <-- reproduces httprexx
+//*
+//* Expected (rexx370 fine -> httprexx issue is UFS encoding):
+//*   ... TREXXVL SAY: hello from irxexec via link
+//*   ... TREXXVL: IRXEXEC link=0 rc=0 rexxrc=0
+//*   ... TREXXVL: done OK      (STEP RC=0)
+//*---------------------------------------------------------------
+//STEP1   EXEC PGM=TREXXVL,REGION=4M
+//STEPLIB  DD DSN=IBMUSER.REXX370.V1R0M0D.LINKLIB,DISP=SHR
+//SYSPRINT DD SYSOUT=*
+//SYSTSPRT DD SYSOUT=*
+//

--- a/test/trexxvl.c
+++ b/test/trexxvl.c
@@ -1,0 +1,190 @@
+/* trexxvl.c - standalone reproducer for the httprexx IRXEXEC-via-LINK crash.
+ *
+ * Runs in-storage REXX execs through the IRXINIT / IRXEXEC VLIST (LINK)
+ * interface -- exactly the path httprexx uses -- as a batch program with
+ * HARDCODED EBCDIC sources. This removes httpd, UFS, and the file encoding
+ * from the equation.
+ *
+ * Two cases, escalating:
+ *   1. a single "say" line (baseline);
+ *   2. the exact REXX that httprexx's transpiler produces for hello.rxp
+ *      (multi-line: parse/if, say with ||, a do-loop over words()/word()).
+ *
+ *   - if case 2 abends in IRXEXEC/IRXBEXEC, the bug is that CONTENT on the
+ *     rexx370 VLIST/in-storage path (VM/WPOOL/BIF), reproduced standalone;
+ *   - if both print their SAY lines and exit clean, rexx370 is fine and the
+ *     httprexx failure is upstream (the transpiler's EBCDIC output on MVS, or
+ *     the file read) -- add debug output in httprexx to see it.
+ *
+ * Build: [[module]] TREXXVL (startup=crt1), deployed into the REXX370 LOAD lib.
+ * Run:   test/jcl/trexxvl.jcl (STEPLIB = the REXX370 LOAD lib).
+ */
+#include <cliblink.h>
+#include <clibwto.h>
+#include <string.h>
+
+#include "lstring.h"
+#include "irx.h"
+#include "irxwkblk.h"
+
+int main(void);
+
+/* WTO each SAY line so a successful run is visible in the joblog. */
+static int repro_io(int function, PLstr data, struct envblock *env)
+{
+    (void)env;
+    if (function == RXFWRITE && data != NULL && Lpstr(data) != NULL)
+    {
+        wtof("TREXXVL SAY: %.*s", (int)Llen(data), (char *)Lpstr(data));
+    }
+    return 0;
+}
+
+/* Run one exec (nlines source lines) through IRXINIT + IRXEXEC via LINK,
+ * building a multi-entry INSTBLK exactly like httprexx. Returns 0 on success. */
+static int run_lines(const char *label, const char *lines[], int nlines)
+{
+    struct instblk        ib;
+    struct instblk_entry  ents[16];
+    int                   i;
+
+    static const char fcode[] = "INITENVB";
+    void            *p_parmmod = NULL;
+    void            *p_userfld = NULL;
+    void            *p_wkblk   = NULL;
+    void            *p_resv    = NULL;
+    struct envblock *env       = NULL;
+    int              reason    = 0;
+    unsigned         vinit[7];
+
+    void            *p_execblk = NULL;
+    void            *p_argtab  = NULL;
+    int              p_flags   = IRXEXEC_SUBROUTINE;
+    void            *p_instblk;
+    void            *p_resv5   = NULL;
+    void            *p_evalblk = NULL;
+    void            *p_wkarea  = NULL;
+    void            *p_usrfld  = NULL;
+    void            *p_envblk;
+    int              rexxrc    = 0;
+    unsigned         vexec[10];
+
+    int prc = 0;
+    int rc;
+
+    if (nlines > 16)
+    {
+        return 99;
+    }
+
+    /* --- IRXINIT --- */
+    vinit[0] = (unsigned)fcode;
+    vinit[1] = (unsigned)&p_parmmod;
+    vinit[2] = (unsigned)&p_userfld;
+    vinit[3] = (unsigned)&p_wkblk;
+    vinit[4] = (unsigned)&p_resv;
+    vinit[5] = (unsigned)&env;
+    vinit[6] = (unsigned)&reason | 0x80000000U;
+    rc = __linkds("IRXINIT", NULL, vinit, &prc);
+    wtof("TREXXVL[%s]: IRXINIT link=%d rc=%d env=%08X", label, rc, prc,
+         (unsigned)env);
+    if (rc != 0 || prc != 0 || env == NULL)
+    {
+        return 20;
+    }
+
+    /* --- override the I/O routine (SAY -> repro_io) --- */
+    {
+        struct irxexte *exte = (struct irxexte *)env->envblock_irxexte;
+        if (exte != NULL)
+        {
+            exte->io_routine = (void *)repro_io;
+            exte->irxinout   = (void *)repro_io;
+        }
+    }
+
+    /* --- build the multi-entry INSTBLK (one entry per line) --- */
+    memset(&ib, 0, sizeof(ib));
+    memcpy(ib.instblk_acronym, INSTBLK_ID, 8);
+    ib.instblk_hdrlen  = INSTBLK_HDRLEN;
+    ib.instblk_address = ents;
+    ib.instblk_usedlen = nlines * (int)sizeof(struct instblk_entry);
+    memset(ib.instblk_member, ' ', 8);
+    memset(ib.instblk_ddname, ' ', 8);
+    memset(ib.instblk_subcom, ' ', 8);
+    for (i = 0; i < nlines; i++)
+    {
+        ents[i].instblk_stmt_   = (void *)lines[i];
+        ents[i].instblk_stmtlen = (int)strlen(lines[i]);
+    }
+
+    /* --- IRXEXEC --- */
+    p_instblk = &ib;
+    p_envblk  = env;
+    vexec[0] = (unsigned)&p_execblk;
+    vexec[1] = (unsigned)&p_argtab;
+    vexec[2] = (unsigned)&p_flags;
+    vexec[3] = (unsigned)&p_instblk;
+    vexec[4] = (unsigned)&p_resv5;
+    vexec[5] = (unsigned)&p_evalblk;
+    vexec[6] = (unsigned)&p_wkarea;
+    vexec[7] = (unsigned)&p_usrfld;
+    vexec[8] = (unsigned)&p_envblk;
+    vexec[9] = (unsigned)&rexxrc | 0x80000000U;
+
+    wtof("TREXXVL[%s]: IRXEXEC %d line(s), instblk=%08X", label, nlines,
+         (unsigned)&ib);
+    rc = __linkds("IRXEXEC", NULL, vexec, &prc);
+    wtof("TREXXVL[%s]: IRXEXEC link=%d rc=%d rexxrc=%d", label, rc, prc, rexxrc);
+
+    return (rc == 0 && prc == 0) ? 0 : 8;
+}
+
+int main(void)
+{
+    /* Escalating cases, simplest first. The FIRST one that abends pinpoints
+     * the construct the rexx370 bytecode VM (IRXBEXEC) mishandles on the
+     * IRXEXEC/in-storage path. Each runs under its own fresh LPE. */
+    static const char *c_say[]    = { "say 'plain say'" };
+    static const char *c_cat[]    = { "say 'a' || 'b'" };
+    static const char *c_catex[]  = { "say 'x=' || (1 + 1) || '.'" };
+    static const char *c_parse[]  = { "parse arg name",
+                                      "say 'name=[' || name || ']'" };
+    static const char *c_words[]  = { "x = 'a b c'",
+                                      "say words(x)" };
+    static const char *c_word[]   = { "x = 'a b c'",
+                                      "say word(x, 2)" };
+    static const char *c_do[]     = { "do i = 1 to 3",
+                                      "say 'i=' || i",
+                                      "end" };
+    static const char *c_hello[]  = {
+        "parse arg name; if name = '' then name = 'World'",
+        "say '<h1>Hello, ' || (name) || '!</h1>'",
+        "items = 'Hercules MVS REXX'",
+        "do i = 1 to words(items)",
+        "say '  <li>' || (word(items, i)) || '</li>'",
+        "end"
+    };
+
+    int rc = 0;
+
+    wtof("TREXXVL: === 1. plain say ===");
+    rc |= run_lines("say",   c_say,   1);
+    wtof("TREXXVL: === 2. literal || literal ===");
+    rc |= run_lines("cat",   c_cat,   1);
+    wtof("TREXXVL: === 3. literal || (expr) ===");
+    rc |= run_lines("catex", c_catex, 1);
+    wtof("TREXXVL: === 4. parse arg + || ===");
+    rc |= run_lines("parse", c_parse, 2);
+    wtof("TREXXVL: === 5. words() BIF ===");
+    rc |= run_lines("words", c_words, 2);
+    wtof("TREXXVL: === 6. word() BIF ===");
+    rc |= run_lines("word",  c_word,  2);
+    wtof("TREXXVL: === 7. do-loop + || ===");
+    rc |= run_lines("do",    c_do,    3);
+    wtof("TREXXVL: === 8. full transpiled hello.rxp ===");
+    rc |= run_lines("hello", c_hello, 6);
+
+    wtof("TREXXVL: all cases done rc=%d", rc);
+    return rc ? 8 : 0;
+}


### PR DESCRIPTION
Fixes the S0C1 that blocked the **httprexx** consumer (issue #200), surfaced by
the `TREXXVL` reproducer once the WP-VLIST-WPOOL fixes (#198/#199) let the module
IRXEXEC path actually run.

## Root cause

The bytecode VM (and the token-walk parser) dispatch a built-in via the handler
pointer stored in the per-env BIF registry. That registry is populated by
`irx_bif_register_all()`, which on the production path runs inside the **IRXINIT**
load module — so the handler pointers resolve into IRXINIT's copy of `irx#bifs.c`.
When a separately-linked **IRXEXEC** runs the exec and calls a BIF, it branches
**cross-module** and wild-branches → **ABEND S0C1**. It hit `words()`/`word()` and
`parse arg` (which fetches its source via the ARG BIF). In-process callers (unit
tests, IRXJCL) never saw it — there init and exec are one module, so the pointers
are local.

## Fix — local BIF dispatch

Resolve the handler **locally at dispatch time**: `irx_bif_find_local()`
(irx#bifs.c) looks the name up in the static core-BIF table + ARG and returns an
entry whose handler is linked into the running module. `bvm_resolve_bif()` and the
parser's `bif_dispatch()` use it. The env registry is still built and remains
exposed through the public `irx_bif_find()` API — just not used for dispatch.

## Verification

- **TREXXVL** (httprexx-shaped: `__linkds` LINK + io_routine override) — all 8
  cases green on **both** batch and TSO legs, including the full transpiled
  `hello.rxp` producing correct HTML (`<h1>Hello, World!</h1>`, `<li>…</li>`).
  `parse`/`words`/`word` now run clean instead of S0C1.
- Full MVS suite green (54 tests × {batch, TSO}); host suite green (2474
  assertions). No regression — the change is behaviour-neutral for in-process
  callers (dispatch was already local there).

## Infra

`TREXXVL` is MVS-only (LINK has no host equivalent). This PR bumps the **mbt**
submodule to pick up a new `host = false` per-test flag (mvslovers/mbt#51) so
`test-host` skips it and `test-mvs` still runs it.

Closes #200
