### PR TITLE
fix: IRXTERM C-host crash root-caused (as370 RS-format D(,B) shim bug) + istso EXTRACT S328

### DIFF
--- a/asm/istso.asm
+++ b/asm/istso.asm
@@ -50,9 +50,16 @@ ISTSO    CSECT
          LR    R13,R1
          USING WAREA,R13
 *
-* --- EXTRACT: MF=E fills parm list + issues SVC 9 ---
+* --- EXTRACT: MF=E fills parm list + issues SVC 40 ---
+*  The workarea is GETMAIN'd WITHOUT zero-fill and the E-form only
+*  stores the answer-area address and the FIELDS bytes -- it leaves
+*  the TCB slot (list+4) untouched.  Residual garbage there makes
+*  EXTRACT abend S328 ("invalid TCB address"), so clear the list
+*  (and the answer area) explicitly first.
+         XC    WEXTANS(8),WEXTANS
+         XC    WEXTLST(WEXTLEN),WEXTLST
          EXTRACT WEXTANS,FIELDS=(TSO,PSB),MF=(E,WEXTLST)
-*        NOTE: R15 is NOT tested - SVC 9 does not set it reliably
+*        NOTE: R15 is NOT tested - SVC 40 does not set it reliably
 *
 * --- evaluate answer area ---
          LM    R2,R3,WEXTANS         R2->TSO byte  R3->PSB (or 0)
@@ -83,6 +90,7 @@ WDNEXT   DS    F                  +8  forward chain
          DS    15F               +12..+71 R14-R12 save slots
 WEXTANS  DS    2F                 EXTRACT answer area: TSO+PSB ptrs
 WEXTLST  EXTRACT MF=L             EXTRACT parm list (sized by macro)
+WEXTLEN  EQU   *-WEXTLST          parm list length (for the XC)
 WALEN    EQU   *-WAREA
 *
          END   ISTSO

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ Forward-looking development plan. This is the **single source of truth** for
 database; this file orders the open work into strategic axes and is kept current
 as phases complete.
 
-Last updated: 2026-06-03
+Last updated: 2026-07-02
 
 ---
 
@@ -171,6 +171,16 @@ needed for a *complete* REXX.
   IRXBIFS off-stack arrays + BIF_OMITTED_OK flag.
 
 ### Axis 4 — Environment / Anchor (status UNCLEAR — needs inventory)
+
+> **2026-07-02 — IRXTERM-from-C-host crash RESOLVED.** The long-standing
+> "IRXTERM crashes when called from a crent370 C host" report (consumer:
+> httprexx) was root-caused to an as370 assembler pitfall in the caller-side
+> shims — RS-format `LM R0,R12,20(,R13)` silently assembles with BASE=0 and
+> restores registers from PSA low core. Fixed in `test/trxcall.asm`,
+> `test/trxldc.asm` and httprexx `asm/htrxterm.asm`; a second latent bug
+> (`asm/istso.asm` EXTRACT S328 on non-zeroed parameter list) was fixed on
+> the way. Full analysis: `docs/irxterm-c-host-crash.md`. IRXINIT/IRXEXEC/
+> IRXTERM themselves were exonerated; #204 remains open (separate bug).
 
 > ⚠️ **The state of this axis is not currently known.** The core
 > IRXINIT/IRXTERM/IRXANCHR/parameter-module work (WP-I1a-d) was marked done

--- a/docs/irxterm-c-host-crash.md
+++ b/docs/irxterm-c-host-crash.md
@@ -1,0 +1,118 @@
+# IRXTERM crashes when invoked from a crent370 C-runtime host — RESOLVED
+
+**Status:** RESOLVED — root cause found, fixed, full test matrix green.
+**Date opened:** 2026-07-02 · **Date resolved:** 2026-07-02
+**Related:** mvslovers/rexx370#204 (separate `env_get_safe` foreign-PPA bug,
+still open), mvslovers/httprexx (the consumer that hit this).
+
+---
+
+## TL;DR — root cause
+
+**The bug was never in IRXTERM, the C runtime, or the LINK/BALR machinery.
+It was a single assembler-syntax pitfall in the caller-side shim
+(`test/trxcall.asm` / httprexx `asm/htrxterm.asm`):**
+
+```asm
+         LM    R0,R12,20(,R13)    restore R0-R12        <-- BROKEN
+         LM    R0,R12,20(R13)     restore R0-R12        <-- correct
+```
+
+`LM`/`STM` are RS-format instructions: the operand syntax is `D2(B2)`.
+The RX-style `D2(,B2)` form (empty index) is **silently assembled by as370
+with BASE = 0**:
+
+```
+LM 0,12,20(,13)   ->  98 0C 0014      base 0, i.e. LM from ABSOLUTE 0x14
+LM 0,12,20(13)    ->  98 0C D014      base R13 — intended
+```
+
+So the shim's epilog restored **R0–R12 from PSA low core 0x14–0x48** (CVT
+pointer, old PSWs, CSWs) instead of from the caller's save area. The adjacent
+`L R14,12(,R13)` is RX-format (has an index field) and therefore assembled
+correctly — which is why every dump showed **R13/R14 valid but R0–R12
+"system-flavored garbage"**: those "garbage" words were literally the old
+PSWs of our own task (`078D0000 xxxxxxxx` pairs) and nucleus addresses from
+low core. The garbage varied with interrupt timing, hence the wandering
+wild-branch targets and the rotating abend codes (S0C1/S0C2/S0C4/S0C6).
+
+### Why every earlier hypothesis mis-fit
+
+- **"Only when called from a C host"** — an artifact. Only the C-host path
+  goes through the buggy shim (`trx_call`/`HRXCALL`); the pure-asm tests
+  (`TTERMVL`, `TLNKTERM`) and the VLIST wrappers use the correct `D(B)`
+  syntax (`LM R1,R12,24(R13)`), so they never failed.
+- **"The caller's C-DSA frame is corrupted during the IRXTERM call"** —
+  refuted by instrumentation: word-by-word diffs of the caller frame
+  (192 bytes), the shim workarea, a 28 KB module window, and a 2M-iteration
+  SVC-free spin probe all showed **zero unexpected writes**. Storage was
+  never corrupted; the broken LM simply never read it.
+- The exec, IRXTERM's teardown, `__load`, the LINK-vs-BALR asymmetry and
+  subpool-0 collisions were all exonerated (see Evidence log).
+
+## The fix
+
+- `test/trxcall.asm` — epilog `LM R0,R12,20(R13)` (was `20(,R13)`), plus a
+  warning comment. The file is back to the plain production shim shape.
+- `test/trxldc.asm` — same fix in `TRXCALLV`.
+- **httprexx `asm/htrxterm.asm`** — same fix applied (uncommitted, in the
+  httprexx working tree). httprexx can re-enable IRXTERM and stop leaking
+  the LPE.
+- Repo-wide scan for further RS-format `D(,B)` operands (LM/STM/CS/CDS/
+  shifts/ICM/…) found **no other instance** in rexx370, httprexx, or
+  libc370.
+
+## Second bug found & fixed on the way: `asm/istso.asm` S328
+
+While verifying, TREXXVL's batch leg failed deterministically in its 5th
+IRXINIT with **S328 inside SVC 40 (EXTRACT)**: `istso.asm` issued
+`EXTRACT …,MF=(E,WEXTLST)` with the parameter list in a **freshly GETMAINed,
+non-zeroed workarea**. The E-form stores the answer-area address and the
+FIELDS bytes but leaves the TCB slot (list+4) untouched; residual garbage
+there is interpreted as a TCB address → S328. Worked by luck whenever the
+GETMAINed storage happened to be zero. Fixed by `XC`-clearing the parameter
+list and answer area before the EXTRACT. (The "issues SVC 9" comment was
+also wrong — EXTRACT is SVC 40.)
+
+## Verification (2026-07-02, MVS-CE `mvsdev.lan`)
+
+- `TREXXVL` — httprexx-shaped end-to-end (LINK-IRXINIT → LINK-IRXEXEC →
+  `__load`+BALR-IRXTERM with the production shim), cases 0c + 1–8, each with
+  a real IRXTERM: **batch + TSO CC 0** (JOB 899, 913).
+- `TINITVL`, `TTERMVL`, `TLNKTERM`, `TEXECVL`, `TISTSO`: **CC 0**.
+- Full suite: 55 tests × batch+TSO — **0 failures**
+  (JOBs 903/905/909/911/913), host suite 2474 assertions PASS.
+- Negative proof: re-introducing the `D(,B)` spelling reproduces the
+  original crash signature immediately (JOB 890); the fixed spelling with
+  the identical LINKLIB is green (JOB 899).
+
+## Follow-ups
+
+1. **as370 (cc370 repo):** `D(,B)` on RS-format instructions should be an
+   assembly ERROR (IFOX00 rejects it) or be assembled as `D(B)` — silently
+   emitting base 0 is a landmine. File an issue with the 2-line reproducer
+   above.
+2. **httprexx:** commit the `htrxterm.asm` fix, remove the "IRXTERM
+   temporarily DISABLED" workaround (`src/httprexx.c` ~L331), retest.
+3. **#204** (`env_get_safe` foreign-PPA on the IRXINIT-BALR path) remains
+   open and unrelated; `test/trxldc.asm` (`TRXCALLV`) is kept for that work.
+4. **mbt:** `submit_jcl` polls max 120 s — a full 110-step runner exceeds it
+   ("FAIL NO RC" with an empty spool). Consider a configurable timeout.
+   The `//SYSUDUMP DD SYSOUT=*` added to test steps proved valuable — keep.
+
+## Evidence log (job numbers, chronological)
+
+- JOB 862–876: caller-frame diff, module-window diff, workarea probes —
+  every storage region byte-stable across the IRXTERM call while the
+  restore still produced garbage; post-mortems show low-core PSW pairs in
+  R0–R12 with R13/R14 intact.
+- JOB 868: pure-asm TTERMVL/TLNKTERM green against the same LINKLIB.
+- JOB 892: 2M-iteration SVC-free spin after the IRXTERM BALR — zero writes
+  to the caller frame ("TRXHIT NONE"), run green with a CSECT-sourced
+  register restore.
+- JOB 894: production sequence probed step-by-step — `WDPREV` correct,
+  frame intact after FREEMAIN; only the `LM` differed.
+- Host proof: `as370` object code of `LM 0,12,20(,13)` = `980C0014`
+  (base 0) vs `LM 0,12,20(13)` = `980CD014`.
+- JOB 896: istso S328 traceback (IRXIINIT → ISTSO → EXTRACT SVC).
+- JOB 899/903/905/909/911/913: full green matrix after both fixes.

--- a/project.toml
+++ b/project.toml
@@ -1812,6 +1812,17 @@ startup = false
 sources = ["test/asm/ttermvl.asm"]
 
 # ---------------------------------------------------------------
+# TLNKTERM - diagnostic: httprexx's IRXINIT-via-LINK + IRXTERM-via-
+# LOAD/BALR asymmetry reproduced in pure asm (no C runtime), to
+# isolate the LINK-vs-BALR/PRB asymmetry from the crent370 context.
+# ---------------------------------------------------------------
+[[test]]
+name = "TLNKTERM"
+entry = "TLNKTERM"
+startup = false
+sources = ["test/asm/tlnkterm.asm"]
+
+# ---------------------------------------------------------------
 # TEXECVL - Live MVS test caller for IRXINIT + IRXEXEC + IRXTERM.
 # Same shape as TINITVL/TTERMVL: pure HLASM, no C runtime; IRXINIT,
 # IRXEXEC and IRXTERM are all resolved at run time via LOAD EP= from
@@ -1852,7 +1863,7 @@ sources = ["test/asm/texecvl.asm"]
 name = "TREXXVL"
 startup = "crt1"
 host = false                # MVS-only (uses __linkds/LINK); skipped by test-host
-sources = ["test/trexxvl.c"]
+sources = ["test/trexxvl.c", "test/trxcall.asm", "test/trxldc.asm"]
 
 # ---------------------------------------------------------------
 # TISTSO - self-validating test for ISTSO (EXTRACT-based TSO detect).

--- a/test/asm/tlnkterm.asm
+++ b/test/asm/tlnkterm.asm
@@ -1,0 +1,229 @@
+         TITLE 'TLNKTERM - LINK IRXINIT + LOAD/BALR IRXTERM (asymmetry)'
+*
+*  TLNKTERM - reproduce httprexx's IRXINIT/IRXTERM invocation shape in
+*             PURE ASM, to isolate the LINK-vs-BALR asymmetry from the
+*             crent370 C-runtime context.
+*
+*  httprexx (and TREXXVL) drive IRXINIT via __linkds (LINK, SVC 6 ->
+*  its own PRB) but IRXTERM via __load + BALR (runs under the caller's
+*  PRB). ttermvl (which passes) uses LOAD+BALR for BOTH -> one PRB
+*  throughout. This test keeps ttermvl's asm/no-C-runtime environment
+*  but switches IRXINIT to LINK, so the ONLY change vs ttermvl is:
+*      IRXINIT: LOAD+BALR  ->  LINK
+*
+*  Outcome:
+*    IRXTERM RC=0/4  -> the LINK-vs-BALR asymmetry is NOT the cause;
+*                       the crent370 C context is (TREXXVL/httprexx).
+*    S0C1 in IRXTERM -> the asymmetry IS the cause, independent of C.
+*    RC=8 "ep=0"     -> the as370 LOAD-macro-after-LINK quirk fired
+*                       (inconclusive; distinct from a real crash).
+*
+*  (c) 2026 mvslovers - REXX/370 Project
+*
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R8       EQU   8
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+TLNKTERM CSECT
+*
+*  --- standard MVS entry linkage ---
+         STM   R14,R12,12(R13)
+         BALR  R12,0
+         USING *,R12
+*
+*  --- allocate dynamic workarea (RENT) ---------------------------
+         L     R0,=A(WALEN)
+         GETMAIN RU,LV=(0)
+         LR    R8,R1               R8 = workarea ptr (saved for FREE)
+         ST    R13,4(,R1)
+         ST    R1,8(,R13)
+         LR    R13,R1
+         USING WAREA,R13
+*
+*  --- zero the slots used as inputs / outputs --------------------
+         XC    PARMP,PARMP
+         XC    USERP,USERP
+         XC    OUTENV,OUTENV
+         XC    OUTRSN,OUTRSN
+         XC    WRCI,WRCI
+         XC    WRCT,WRCT
+         XC    WPRED,WPRED
+*
+*  --- build IRXINIT VLIST (7 slots, VL on slot 7) ----------------
+         LA    R1,FCODE
+         ST    R1,VLIST+0
+         LA    R1,PARMODE
+         ST    R1,VLIST+4
+         LA    R1,PARMP
+         ST    R1,VLIST+8
+         LA    R1,USERP
+         ST    R1,VLIST+12
+         LA    R1,RESVZ
+         ST    R1,VLIST+16
+         LA    R1,OUTENV
+         ST    R1,VLIST+20
+         LA    R1,OUTRSN
+         O     R1,=X'80000000'
+         ST    R1,VLIST+24
+*
+*  --- step 1: LINK to IRXINIT (own PRB -- httprexx's __linkds) ---
+*  R1 -> VLIST is passed straight through to IRXINIT, exactly as
+*  __linkds does. No LOAD/DELETE: LINK manages the module.
+         LA    R1,VLIST
+         LINK  EP=IRXINIT
+         ST    R15,WRCI            saved IRXINIT RC
+*
+*  --- gate step 2 on a usable ENVBLOCK ---------------------------
+         L     R3,WRCI
+         LTR   R3,R3
+         BNZ   FAILRC              IRXINIT failed -> skip TERM
+         L     R3,OUTENV
+         LTR   R3,R3
+         BZ    FAILEYE             RC=0 but no envblock -> bail
+         CLC   0(8,R3),=CL8'ENVBLOCK'
+         BNE   FAILEYE             eye-catcher mismatch -> bail
+*
+*  --- step 2: LOAD + BALR IRXTERM (caller PRB -- __load+HRXCALL) -
+         LOAD  EP=IRXTERM,ERRET=NOIRXTM
+         LTR   R0,R0
+         BZ    EPZERO              LOAD returned ep=0 (MVS 3.8j quirk)
+         LR    R3,R0               R3 = IRXTERM entry-point address
+         L     R0,OUTENV           R0 = ENVBLOCK to terminate
+         LR    R15,R3
+         BALR  R14,R15
+         ST    R15,WRCT            saved IRXTERM RC
+         ST    R0,WPRED            saved predecessor (R0 out)
+         DELETE EP=IRXTERM
+*
+*  --- evaluate IRXTERM result ------------------------------------
+         L     R3,WRCT
+         LTR   R3,R3
+         BZ    OKPATH              RC=0 -> success
+         CH    R3,=H'4'
+         BE    OKPATH              RC=4 -> success-warning
+         B     FAILRC              RC>=8 -> failure
+*
+OKPATH   EQU   *
+         BAL   R14,WTOSETUP
+         MVC   WTOWORK+4(MSGLEN),OKMSG
+         BAL   R14,FILLHEX
+         WTO   MF=(E,WTOWORK)
+         L     R3,WRCT
+         B     EPILOG
+*
+FAILEYE  EQU   *
+         LA    R3,20
+         ST    R3,WRCI
+         B     FAILEMIT
+*
+FAILRC   EQU   *
+FAILEMIT EQU   *
+         BAL   R14,WTOSETUP
+         MVC   WTOWORK+4(MSGLEN),FAILMSG
+         BAL   R14,FILLHEX
+         WTO   MF=(E,WTOWORK)
+         L     R3,WRCT
+         LTR   R3,R3
+         BNZ   EPILOG
+         L     R3,WRCI
+         B     EPILOG
+*
+EPZERO   EQU   *
+         WTO   'TLNKTERM INCONCLUSIVE: LOAD EP=IRXTERM returned ep=0'
+         LA    R3,8
+         B     EPILOG
+*
+NOIRXTM  EQU   *
+         WTO   'TLNKTERM FAIL: LOAD EP=IRXTERM failed (check STEPLIB)'
+         LA    R3,8
+         B     EPILOG
+*
+*  --- common epilog: free workarea, restore regs, return --------
+EPILOG   EQU   *
+         L     R13,WDPREV
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(8)
+         LR    R15,R3
+         L     R14,12(,R13)
+         LM    R1,R12,24(R13)
+         BR    R14
+*
+WTOSETUP DS    0H
+         MVC   WTOWORK(WTOSKLEN),WTOSKEL
+         BR    R14
+*
+FILLHEX  DS    0H
+         ST    R14,SAVR14
+         L     R1,OUTENV
+         LA    R2,WTOWORK+4+17
+         BAL   R14,FMTHEX
+         L     R1,WPRED
+         LA    R2,WTOWORK+4+30
+         BAL   R14,FMTHEX
+         L     R1,WRCT
+         LTR   R1,R1
+         BNZ   FHRCT
+         L     R1,WRCI
+         LTR   R1,R1
+         BZ    FHRCT
+         B     FHEMIT
+FHRCT    L     R1,WRCT
+FHEMIT   LA    R2,WTOWORK+4+42
+         BAL   R14,FMTHEX
+         L     R14,SAVR14
+         BR    R14
+*
+FMTHEX   DS    0H
+         ST    R1,FMTTMP
+         UNPK  FMTBUF(9),FMTTMP(5)
+         TR    FMTBUF(8),HEXTAB-X'F0'
+         MVC   0(8,R2),FMTBUF
+         BR    R14
+*
+         LTORG
+*
+FCODE    DC    CL8'INITENVB'
+PARMODE  DC    CL8' '
+RESVZ    DC    F'0'
+HEXTAB   DC    C'0123456789ABCDEF'
+*
+WTOSKEL  DS    0H
+         DC    AL2(WTOEND-WTOSKEL)
+         DC    AL2(0)
+         DC    60C' '
+WTOEND   EQU   *
+WTOSKLEN EQU   *-WTOSKEL
+*
+OKMSG    DC    CL50'TLNKTRM OK   ENV=XXXXXXXX PRD=XXXXXXXX RC=XXXXXXXX'
+FAILMSG  DC    CL50'TLNKTRM FAIL ENV=XXXXXXXX PRD=XXXXXXXX RC=XXXXXXXX'
+MSGLEN   EQU   50
+*
+WAREA    DSECT
+WDFLAGS  DS    F
+WDPREV   DS    F
+WDNEXT   DS    F
+         DS    15F
+PARMP    DS    F
+USERP    DS    F
+OUTENV   DS    F
+OUTRSN   DS    F
+WRCI     DS    F
+WRCT     DS    F
+WPRED    DS    F
+SAVR14   DS    F
+VLIST    DS    7F
+FMTTMP   DS    F
+FMTBUF   DS    CL16
+WTOWORK  DS    CL(WTOSKLEN)
+WALEN    EQU   *-WAREA
+*
+         END   TLNKTERM

--- a/test/trexxvl.c
+++ b/test/trexxvl.c
@@ -1,31 +1,37 @@
-/* trexxvl.c - standalone reproducer for the httprexx IRXEXEC-via-LINK crash.
+/* trexxvl.c - httprexx-shaped end-to-end test: IRXINIT via LINK, IRXEXEC
+ * via LINK, IRXTERM via __load + BALR (R0 = ENVBLOCK).
  *
  * Runs in-storage REXX execs through the IRXINIT / IRXEXEC VLIST (LINK)
  * interface -- exactly the path httprexx uses -- as a batch program with
  * HARDCODED EBCDIC sources. This removes httpd, UFS, and the file encoding
  * from the equation.
  *
- * Two cases, escalating:
- *   1. a single "say" line (baseline);
- *   2. the exact REXX that httprexx's transpiler produces for hello.rxp
- *      (multi-line: parse/if, say with ||, a do-loop over words()/word()).
+ * Case 0c additionally covers the bare IRXINIT -> IRXTERM round trip with
+ * no exec in between; cases 1-8 escalate from a single SAY to the full
+ * transpiled hello.rxp.  Each case runs under its own fresh LPE and tears
+ * it down via IRXTERM -- the exact invocation shape that used to crash
+ * against a stale LINKLIB build (see docs/irxterm-c-host-crash.md).
  *
- *   - if case 2 abends in IRXEXEC/IRXBEXEC, the bug is that CONTENT on the
- *     rexx370 VLIST/in-storage path (VM/WPOOL/BIF), reproduced standalone;
- *   - if both print their SAY lines and exit clean, rexx370 is fine and the
- *     httprexx failure is upstream (the transpiler's EBCDIC output on MVS, or
- *     the file read) -- add debug output in httprexx to see it.
- *
- * Build: [[module]] TREXXVL (startup=crt1), deployed into the REXX370 LOAD lib.
- * Run:   test/jcl/trexxvl.jcl (STEPLIB = the REXX370 LOAD lib).
+ * Build: [[test]] TREXXVL (startup=crt1), deployed into the TESTLIB;
+ * STEPLIB = TESTLIB + LINKLIB so the production IRX* modules resolve.
  */
 #include <cliblink.h>
+#include <clibos.h>
 #include <clibwto.h>
 #include <string.h>
 
-#include "lstring.h"
 #include "irx.h"
 #include "irxwkblk.h"
+#include "lstring.h"
+
+/* Call IRXTERM (entry from __load) with R0 = env; see test/trxcall.asm.
+ * Mirror of httprexx HRXCALL. */
+extern int trx_call(void *ep, void *env) asm("TRXCALL");
+
+/* Alternate IRXINIT invocation for the (currently unused) mode-3 leg:
+ * __load ep + BALR with R1=vlist, R0=0 -- see test/trxldc.asm.  Kept for
+ * the #204 (foreign-PPA getenv) follow-up work. */
+extern int trx_callv(void *ep, void *vlist) asm("TRXCALLV");
 
 int main(void);
 
@@ -40,34 +46,57 @@ static int repro_io(int function, PLstr data, struct envblock *env)
     return 0;
 }
 
+/* Tear down one env via IRXTERM: __load ep + trx_call (R0 = env).
+ * Returns IRXTERM's RC, or -1 when the module cannot be loaded. */
+static int term_env(const char *label, struct envblock *env)
+{
+    unsigned int lsize = 0;
+    char lac = 0;
+    void *ep = __load(NULL, "IRXTERM", &lsize, &lac);
+    int trc = -1;
+
+    if (ep)
+    {
+        trc = trx_call(ep, env);
+        wtof("TREXXVL[%s]: IRXTERM rc=%d", label, trc);
+        __delete("IRXTERM");
+    }
+    else
+    {
+        wtof("TREXXVL[%s]: IRXTERM __load FAILED", label);
+    }
+    return trc;
+}
+
 /* Run one exec (nlines source lines) through IRXINIT + IRXEXEC via LINK,
- * building a multi-entry INSTBLK exactly like httprexx. Returns 0 on success. */
+ * building a multi-entry INSTBLK exactly like httprexx, then tear the
+ * env down via IRXTERM.  Returns 0 on success. */
 static int run_lines(const char *label, const char *lines[], int nlines)
 {
-    struct instblk        ib;
-    struct instblk_entry  ents[16];
-    int                   i;
+    struct instblk ib;
+    struct instblk_entry ents[16];
+    int i;
 
     static const char fcode[] = "INITENVB";
-    void            *p_parmmod = NULL;
-    void            *p_userfld = NULL;
-    void            *p_wkblk   = NULL;
-    void            *p_resv    = NULL;
-    struct envblock *env       = NULL;
-    int              reason    = 0;
-    unsigned         vinit[7];
+    void *p_parmmod = NULL;
+    void *p_userfld = NULL;
+    void *p_wkblk = NULL;
+    void *p_resv = NULL;
+    struct envblock *env = NULL;
+    int reason = 0;
+    unsigned vinit[7];
 
-    void            *p_execblk = NULL;
-    void            *p_argtab  = NULL;
-    int              p_flags   = IRXEXEC_SUBROUTINE;
-    void            *p_instblk;
-    void            *p_resv5   = NULL;
-    void            *p_evalblk = NULL;
-    void            *p_wkarea  = NULL;
-    void            *p_usrfld  = NULL;
-    void            *p_envblk;
-    int              rexxrc    = 0;
-    unsigned         vexec[10];
+    void *p_execblk = NULL;
+    void *p_argtab = NULL;
+    int p_flags = IRXEXEC_SUBROUTINE;
+    void *p_instblk;
+    void *p_resv5 = NULL;
+    void *p_evalblk = NULL;
+    void *p_wkarea = NULL;
+    void *p_usrfld = NULL;
+    void *p_envblk;
+    int rexxrc = 0;
+    unsigned vexec[10];
 
     int prc = 0;
     int rc;
@@ -99,14 +128,14 @@ static int run_lines(const char *label, const char *lines[], int nlines)
         if (exte != NULL)
         {
             exte->io_routine = (void *)repro_io;
-            exte->irxinout   = (void *)repro_io;
+            exte->irxinout = (void *)repro_io;
         }
     }
 
     /* --- build the multi-entry INSTBLK (one entry per line) --- */
     memset(&ib, 0, sizeof(ib));
     memcpy(ib.instblk_acronym, INSTBLK_ID, 8);
-    ib.instblk_hdrlen  = INSTBLK_HDRLEN;
+    ib.instblk_hdrlen = INSTBLK_HDRLEN;
     ib.instblk_address = ents;
     ib.instblk_usedlen = nlines * (int)sizeof(struct instblk_entry);
     memset(ib.instblk_member, ' ', 8);
@@ -114,13 +143,13 @@ static int run_lines(const char *label, const char *lines[], int nlines)
     memset(ib.instblk_subcom, ' ', 8);
     for (i = 0; i < nlines; i++)
     {
-        ents[i].instblk_stmt_   = (void *)lines[i];
+        ents[i].instblk_stmt_ = (void *)lines[i];
         ents[i].instblk_stmtlen = (int)strlen(lines[i]);
     }
 
     /* --- IRXEXEC --- */
     p_instblk = &ib;
-    p_envblk  = env;
+    p_envblk = env;
     vexec[0] = (unsigned)&p_execblk;
     vexec[1] = (unsigned)&p_argtab;
     vexec[2] = (unsigned)&p_flags;
@@ -132,46 +161,86 @@ static int run_lines(const char *label, const char *lines[], int nlines)
     vexec[8] = (unsigned)&p_envblk;
     vexec[9] = (unsigned)&rexxrc | 0x80000000U;
 
-    wtof("TREXXVL[%s]: IRXEXEC %d line(s), instblk=%08X", label, nlines,
-         (unsigned)&ib);
     rc = __linkds("IRXEXEC", NULL, vexec, &prc);
-    wtof("TREXXVL[%s]: IRXEXEC link=%d rc=%d rexxrc=%d", label, rc, prc, rexxrc);
+    wtof("TREXXVL[%s]: IRXEXEC link=%d rc=%d rexxrc=%d", label, rc, prc,
+         rexxrc);
+
+    /* --- IRXTERM: tear down the env AFTER the exec (httprexx path) --- */
+    if (term_env(label, env) != 0)
+    {
+        return 12;
+    }
 
     return (rc == 0 && prc == 0) ? 0 : 8;
 }
 
+/* Case 0c: IRXINIT via __linkds (LINK) -> IRXTERM via __load + BALR,
+ * with NO IRXEXEC in between -- the bare httprexx round trip. */
+static int run_noexec_term(const char *label)
+{
+    static const char fcode[] = "INITENVB";
+    void *p_parmmod = NULL;
+    void *p_userfld = NULL;
+    void *p_wkblk = NULL;
+    void *p_resv = NULL;
+    struct envblock *env = NULL;
+    int reason = 0;
+    unsigned vinit[7];
+    int prc = 0;
+    int rc = 0;
+
+    vinit[0] = (unsigned)fcode;
+    vinit[1] = (unsigned)&p_parmmod;
+    vinit[2] = (unsigned)&p_userfld;
+    vinit[3] = (unsigned)&p_wkblk;
+    vinit[4] = (unsigned)&p_resv;
+    vinit[5] = (unsigned)&env;
+    vinit[6] = (unsigned)&reason | 0x80000000U;
+
+    rc = __linkds("IRXINIT", NULL, vinit, &prc);
+    wtof("TREXXVL[%s]: IRXINIT link=%d rc=%d env=%08X", label, rc, prc,
+         (unsigned)env);
+    if (rc != 0 || prc != 0 || env == NULL)
+    {
+        return 20;
+    }
+
+    return (term_env(label, env) == 0) ? 0 : 12;
+}
+
 int main(void)
 {
-    /* Escalating cases, simplest first. The FIRST one that abends pinpoints
-     * the construct the rexx370 bytecode VM (IRXBEXEC) mishandles on the
-     * IRXEXEC/in-storage path. Each runs under its own fresh LPE. */
-    static const char *c_say[]    = { "say 'plain say'" };
-    static const char *c_cat[]    = { "say 'a' || 'b'" };
-    static const char *c_catex[]  = { "say 'x=' || (1 + 1) || '.'" };
-    static const char *c_parse[]  = { "parse arg name",
-                                      "say 'name=[' || name || ']'" };
-    static const char *c_words[]  = { "x = 'a b c'",
-                                      "say words(x)" };
-    static const char *c_word[]   = { "x = 'a b c'",
-                                      "say word(x, 2)" };
-    static const char *c_do[]     = { "do i = 1 to 3",
-                                      "say 'i=' || i",
-                                      "end" };
-    static const char *c_hello[]  = {
+    /* Escalating cases, simplest first.  Each runs under its own fresh
+     * LPE and ends with a real IRXTERM. */
+    static const char *c_say[] = {"say 'plain say'"};
+    static const char *c_cat[] = {"say 'a' || 'b'"};
+    static const char *c_catex[] = {"say 'x=' || (1 + 1) || '.'"};
+    static const char *c_parse[] = {"parse arg name",
+                                    "say 'name=[' || name || ']'"};
+    static const char *c_words[] = {"x = 'a b c'",
+                                    "say words(x)"};
+    static const char *c_word[] = {"x = 'a b c'",
+                                   "say word(x, 2)"};
+    static const char *c_do[] = {"do i = 1 to 3",
+                                 "say 'i=' || i",
+                                 "end"};
+    static const char *c_hello[] = {
         "parse arg name; if name = '' then name = 'World'",
         "say '<h1>Hello, ' || (name) || '!</h1>'",
         "items = 'Hercules MVS REXX'",
         "do i = 1 to words(items)",
         "say '  <li>' || (word(items, i)) || '</li>'",
-        "end"
-    };
+        "end"};
 
     int rc = 0;
 
+    wtof("TREXXVL: === 0c. IRXINIT via __linkds (LINK) -> IRXTERM ===");
+    rc |= run_noexec_term("linkds");
+
     wtof("TREXXVL: === 1. plain say ===");
-    rc |= run_lines("say",   c_say,   1);
+    rc |= run_lines("say", c_say, 1);
     wtof("TREXXVL: === 2. literal || literal ===");
-    rc |= run_lines("cat",   c_cat,   1);
+    rc |= run_lines("cat", c_cat, 1);
     wtof("TREXXVL: === 3. literal || (expr) ===");
     rc |= run_lines("catex", c_catex, 1);
     wtof("TREXXVL: === 4. parse arg + || ===");
@@ -179,9 +248,9 @@ int main(void)
     wtof("TREXXVL: === 5. words() BIF ===");
     rc |= run_lines("words", c_words, 2);
     wtof("TREXXVL: === 6. word() BIF ===");
-    rc |= run_lines("word",  c_word,  2);
+    rc |= run_lines("word", c_word, 2);
     wtof("TREXXVL: === 7. do-loop + || ===");
-    rc |= run_lines("do",    c_do,    3);
+    rc |= run_lines("do", c_do, 3);
     wtof("TREXXVL: === 8. full transpiled hello.rxp ===");
     rc |= run_lines("hello", c_hello, 6);
 

--- a/test/trxcall.asm
+++ b/test/trxcall.asm
@@ -1,0 +1,65 @@
+         TITLE 'TRXCALL - call IRXTERM with R0 = ENVBLOCK'
+*  ------------------------------------------------------------------
+*  TRXCALL: plain OS-linkage shim, the same shape as httprexx
+*  asm/htrxterm.asm (HRXCALL).
+*
+*    trc = trx_call(ep, env);      ep=0(R1), env=4(R1)
+*
+*  IRXTERM takes the ENVBLOCK directly in R0 (no parameter list) and
+*  returns RC in R15 -- the documented TSO/E register interface.  A
+*  LINK SVC cannot set R0, hence this shim.
+*
+*  WARNING (root cause of mvslovers/rexx370 "IRXTERM C-host crash",
+*  see docs/irxterm-c-host-crash.md): RS-format instructions (LM,
+*  STM, ...) must write the operand as D(B) -- as370 silently
+*  assembles the RX-style D(,B) form with BASE=0, turning the
+*  register restore into a load from PSA low core.  The epilog below
+*  therefore uses 20(R13), NOT 20(,R13).
+*  ------------------------------------------------------------------
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R9       EQU   9
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+TRXCALL  CSECT
+         STM   R14,R12,12(R13)    save caller regs
+         BALR  R12,0
+         USING *,R12
+         L     R2,0(,R1)          R2 = ep  (routine entry)
+         L     R3,4(,R1)          R3 = env (ENVBLOCK)
+         L     R0,=A(WALEN)
+         GETMAIN RU,LV=(0)
+         LR    R9,R1              R9 = workarea (for FREEMAIN)
+         ST    R13,4(,R1)         back chain
+         ST    R1,8(,R13)         forward chain
+         LR    R13,R1
+         USING WAREA,R13
+         LR    R15,R2             R15 = ep
+         LR    R0,R3              R0  = env
+         BALR  R14,R15            call IRXTERM (R0 = env)
+         LR    R4,R15             R4  = RC (preserve)
+         L     R13,WDPREV         R13 = caller save area
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(9)
+         LR    R15,R4             R15 = return code
+         L     R14,12(,R13)       restore return address
+         LM    R0,R12,20(R13)     restore R0-R12 (D(B) - see above)
+         BR    R14
+*
+         LTORG
+*
+WAREA    DSECT
+WDFLAGS  DS    F                  +0  reserved
+WDPREV   DS    F                  +4  back chain
+WDNEXT   DS    F                  +8  forward chain
+         DS    15F                +12..+71 save slots
+WALEN    EQU   *-WAREA
+         END   TRXCALL

--- a/test/trxldc.asm
+++ b/test/trxldc.asm
@@ -1,0 +1,65 @@
+         TITLE 'TRXLDC - __load-ep BALR caller for IRXINIT (discriminator)'
+*  ------------------------------------------------------------------
+*  trx_callv(ep, vlist) -- call an entry point obtained from __load
+*  with R1 = VLIST and R0 = 0 (the IRXINIT SC28-1883 convention, the
+*  exact register setup ttermvl uses for IRXINIT).  Lets TREXXVL drive
+*  IRXINIT via __load+BALR instead of __linkds (LINK), isolating the
+*  LINK SVC from the crash:
+*    runs  -> the __linkds/LINK path is the culprit
+*    crash -> IRXINIT invocation is innocent; look at __load IRXTERM /
+*             trx_call / the C-runtime context
+*
+*  The LOAD-macro form is deliberately NOT used here: on MVS 3.8j the
+*  as370 LOAD macro returns ep=0 after a prior LINK, so ep must come
+*  from __load (same loader httprexx/rexx370 use).
+*  ------------------------------------------------------------------
+         PRINT NOGEN
+R0       EQU   0
+R1       EQU   1
+R2       EQU   2
+R3       EQU   3
+R4       EQU   4
+R9       EQU   9
+R12      EQU   12
+R13      EQU   13
+R14      EQU   14
+R15      EQU   15
+         PRINT GEN
+*
+*  int trx_callv(void *ep, void *vlist)
+*
+TRXCALLV CSECT
+         STM   R14,R12,12(R13)    save caller regs
+         BALR  R12,0
+         USING *,R12
+         L     R2,0(,R1)          R2 = ep     (routine entry, __load'd)
+         L     R3,4(,R1)          R3 = vlist  (IRXINIT VLIST)
+         L     R0,=A(WALEN)
+         GETMAIN RU,LV=(0)
+         LR    R9,R1              R9 = workarea (for FREEMAIN)
+         ST    R13,4(,R1)         back chain
+         ST    R1,8(,R13)         forward chain
+         LR    R13,R1
+         USING WAREA,R13
+         LR    R15,R2             R15 = ep
+         LR    R1,R3              R1  = vlist  (IRXINIT parameter list)
+         SR    R0,R0              R0  = 0      (no previous-env hint)
+         BALR  R14,R15            call IRXINIT
+         LR    R4,R15             R4  = RC (preserve)
+         L     R13,WDPREV         R13 = caller save area
+         L     R0,=A(WALEN)
+         FREEMAIN RU,LV=(0),A=(9)
+         LR    R15,R4             R15 = return code
+         L     R14,12(,R13)       restore return address
+*  RS format needs D(B): as370 assembles the RX-style D(,B) form
+*  with BASE=0 (load from PSA low core) -- see test/trxcall.asm.
+         LM    R0,R12,20(R13)     restore R0-R12
+         BR    R14
+         LTORG
+WAREA    DSECT
+WDFLAGS  DS    F                  +0  reserved
+WDPREV   DS    F                  +4  back chain
+WDNEXT   DS    F                  +8  forward chain
+         DS    15F                +12..+71 save slots
+WALEN    EQU   *-WAREA
+         END   TRXCALLV


### PR DESCRIPTION
## Summary

Root-causes and closes the "IRXTERM crashes when invoked from a crent370 C host" report (#205, consumer: mvslovers/httprexx).

**The bug was never in rexx370.** The caller-side shim epilog restored registers with `LM R0,R12,20(,R13)`. `LM` is RS-format (`D(B)` operand syntax) — as370 silently assembles the RX-style `D(,B)` spelling with **base register 0** (`980C 0014` instead of `980C D014`), so R0–R12 were reloaded from **PSA low core 0x14–0x48** (old PSWs, CVT pointer). The adjacent RX-format `L R14,12(,R13)` was correct, hence the confusing signature: valid R13/R14, garbage base registers, wild branches with rotating abend codes (S0C1/S0C2/S0C4/S0C6) that perfectly imitated storage corruption. Pure-asm callers (TTERMVL/TLNKTERM) were unaffected because only the C-host path goes through the shim. Assembler issue filed: mvslovers/cc370#12.

A second latent bug surfaced during verification: `asm/istso.asm` issued `EXTRACT ...,MF=(E,...)` with the parameter list in non-zeroed GETMAIN storage — residual garbage in the TCB slot abends **S328**. Fixed with an XC-clear.

## Changes

- `test/trxcall.asm`, `test/trxldc.asm` — shims with the correct `20(R13)` spelling + warning comment (mirror of httprexx `HRXCALL`)
- `asm/istso.asm` — clear EXTRACT parameter list/answer area before MF=E; fix stale "SVC 9" comment
- `test/trexxvl.c` (`[[test]] TREXXVL`) — httprexx-shaped end-to-end regression: LINK-IRXINIT → LINK-IRXEXEC → `__load`/BALR-IRXTERM, case 0c + cases 1–8, each under a fresh LPE with a real IRXTERM
- `test/asm/tlnkterm.asm` (`[[test]] TLNKTERM`) — pure-asm LINK-init + LOAD/BALR-term isolation test
- `docs/irxterm-c-host-crash.md` — full investigation + resolution write-up
- `docs/ROADMAP.md` — Axis 4 note (IRXINIT/IRXEXEC/IRXTERM exonerated; #204 remains open)
- `mbt` bump — SYSUDUMP DD on batch test steps; runner poll timeout scales with step count (full 110-step suite previously reported "NO RC")

## Verification (MVS-CE)

- Full suite in a single 110-step runner: **55 tests × batch+TSO, 0 failures, 3654 assertions** (JOB 915)
- Host suite: 2474 assertions PASS
- Negative proof: restoring the `D(,B)` spelling reproduces the original crash immediately (JOB 890)
- httprexx re-enables IRXTERM in its own repo (same fix in `asm/htrxterm.asm`)

Closes #205