### PR TITLE
fix(bytecode): fall back to the interpreter on IRXBC_ERR_STRTOOLONG (rc=29)

### DIFF
--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -278,6 +278,26 @@ int irx_exec_dispatch(struct execblk *execblk,
     return exit_rc;
 }
 
+/* Bytecode compile-time limitations that the token-walk interpreter can
+ * still run.  Each is raised inside irx_bc_compile() (during bc_program),
+ * BEFORE any bytecode executes, so falling back re-runs the program from a
+ * clean slate with no risk of double side effects:
+ *   UNSUP          - a construct the compiler does not yet handle
+ *   STRTOOLONG     - a literal or symbol exceeds IRXBC_STR_MAX; the bytecode
+ *                    const/symbol table stores its length in a single byte,
+ *                    so 64+ byte strings cannot be represented (the
+ *                    interpreter has no such limit)
+ *   PARSE_COMPOUND - a compound-variable target in a PARSE template
+ * Execute-time errors from irx_bc_execute (OPCODE/ARITH/STACK/IO/...) are
+ * deliberately excluded: that bytecode already ran with side effects and
+ * must stay fatal rather than silently re-run under the interpreter. */
+static int bc_err_is_fallback(int rc)
+{
+    return rc == IRXBC_ERR_UNSUP ||
+           rc == IRXBC_ERR_STRTOOLONG ||
+           rc == IRXBC_ERR_PARSE_COMPOUND;
+}
+
 int irx_exec_run(const char *source, int source_len,
                  const char *args, int args_len,
                  int *rc_out, struct envblock *envblock)
@@ -353,10 +373,12 @@ int irx_exec_run(const char *source, int source_len,
 
             rc = irx_bc_compile(envblock, source, source_len, &bc,
                                 &unsup_reason, &unsup_line);
-            if (rc == IRXBC_ERR_UNSUP)
+            if (bc_err_is_fallback(rc))
             {
-                /* Unsupported construct — release bc and fall through
-                 * to the token-walk path below. */
+                /* A compile-time limitation (unsupported construct, an
+                 * over-long literal/symbol, ...) — release bc and fall
+                 * through to the token-walk path below, which has no such
+                 * limits.  No bytecode ran, so this is side-effect free. */
                 if (bc != NULL)
                 {
                     void *p = bc;

--- a/test/tstbcexe.c
+++ b/test/tstbcexe.c
@@ -37,6 +37,7 @@
 #include "irxexec.h"
 #include "irxfunc.h"
 #include "irxwkblk.h"
+#include "lstring.h"
 
 #ifndef __MVS__
 void *_simulated_ectenvbk = NULL;
@@ -61,6 +62,29 @@ static int tests_failed = 0;
             printf("  FAIL: %s\n", msg); \
         }                                \
     } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Mock I/O routine — captures the last SAY line.                    */
+/* ------------------------------------------------------------------ */
+static char g_captured[512];
+static int g_captured_len = 0;
+
+static int capture_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL && Lpstr(data) != NULL)
+    {
+        int n = (int)Llen(data);
+        if (n > (int)sizeof(g_captured) - 1)
+        {
+            n = (int)sizeof(g_captured) - 1;
+        }
+        memcpy(g_captured, Lpstr(data), (size_t)n);
+        g_captured_len = n;
+        g_captured[n] = '\0';
+    }
+    return 0;
+}
 
 /* ------------------------------------------------------------------ */
 /*  Compile source and execute via the VM directly.                   */
@@ -203,6 +227,69 @@ static void test_e2e_empty_bytecode(void)
     irxterm(env);
 }
 
+/* A string literal longer than IRXBC_STR_MAX (63) cannot be represented in
+ * the bytecode const table (1-byte length prefix), so irx_bc_compile fails
+ * with IRXBC_ERR_STRTOOLONG.  irx_exec_run must fall back to the token-walk
+ * interpreter — which has no such limit — instead of surfacing the error.
+ * Regression for the HTTPREXX .rxp failure "IRXEXEC ... rc=29 rexxrc=29",
+ * where an ordinary HTML line (>63 bytes) inside SAY aborted the exec. */
+static void test_e2e_long_literal_fallback(void)
+{
+    /* 70-byte literal (> IRXBC_STR_MAX) — a typical transpiled HTML line. */
+    static const char *src =
+        "say '<html><head><meta charset=\"utf-8\">"
+        "<title>demo.rxp</title></head>'";
+    static const char *want =
+        "<html><head><meta charset=\"utf-8\">"
+        "<title>demo.rxp</title></head>";
+
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    struct irxexte *exte;
+    unsigned before;
+    int exit_rc = -1;
+    int rc;
+
+    printf("  [e2e: >63-byte literal falls back, no rc=29]\n");
+
+    rc = irxinit(NULL, &env);
+    CHECK(rc == 0 && env != NULL, "irxinit succeeds");
+    if (rc != 0 || env == NULL)
+    {
+        return;
+    }
+
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
+    CHECK(wk != NULL, "work block is present");
+    if (wk == NULL)
+    {
+        irxterm(env);
+        return;
+    }
+
+    exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+    {
+        exte->io_routine = (void *)capture_io;
+    }
+
+    wk->wkbi_use_bytecode = 1;
+    before = wk->wkbi_bc_fallback_count;
+    g_captured_len = 0;
+    g_captured[0] = '\0';
+
+    rc = irx_exec_run(src, (int)strlen(src), NULL, 0, &exit_rc, env);
+    CHECK(rc == 0, "irx_exec_run returns 0 (not IRXBC_ERR_STRTOOLONG=29)");
+    CHECK(exit_rc == 0, "exit_rc == 0");
+    CHECK(wk->wkbi_bc_fallback_count == before + 1,
+          "bytecode fell back to the interpreter");
+    CHECK(g_captured_len == (int)strlen(want) &&
+              memcmp(g_captured, want, strlen(want)) == 0,
+          "SAY output is complete and correct");
+
+    irxterm(env);
+}
+
 /* ------------------------------------------------------------------ */
 /*  main                                                              */
 /* ------------------------------------------------------------------ */
@@ -229,6 +316,7 @@ int main(void)
     /* End-to-end tests create their own environments. */
     test_e2e_bytecode_flag();
     test_e2e_empty_bytecode();
+    test_e2e_long_literal_fallback();
 
     printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
     if (tests_failed > 0)


### PR DESCRIPTION
Fixes the HTTPREXX `rc=29` failure: an ordinary `.rxp` page aborts because a transpiled `say '<...>'` line exceeds the bytecode compiler's 63-byte string-literal limit.

## Cause

The bytecode constant/symbol table uses fixed 64-byte slots (`IRXBC_ENTRY_SIZE = 64`: 1 length byte + 63 data bytes), so `IRXBC_STR_MAX = 63`. A literal or symbol > 63 bytes makes `add_const()` / `add_sym()` return `IRXBC_ERR_STRTOOLONG` (29). `irx_exec_run` only fell back to the token-walk interpreter on `IRXBC_ERR_UNSUP`, so STRTOOLONG bubbled up as R15 = 29 and aborted the exec — although the interpreter runs the program fine.

## Change

- `bc_err_is_fallback()` helper covering the compile-time-limitation errors (`UNSUP`, `STRTOOLONG`, `PARSE_COMPOUND`); `irx_exec_run` uses it for the fallback decision.
- Execute-time errors from `irx_bc_execute` (OPCODE/ARITH/STACK/IO) stay fatal — that bytecode already ran with side effects. STRTOOLONG is raised in `bc_program()` before any bytecode runs, so the fallback is side-effect free.

## Tests

- New regression `test/tstbcexe.c::test_e2e_long_literal_fallback` — 70-byte literal → rc 0, fallback taken (`wkbi_bc_fallback_count` +1), SAY output byte-exact.
- Full host suite green (**2480/2480**). `test/tstbcln.c` still asserts the compiler *itself* returns `STRTOOLONG` at 64 bytes — the compiler contract is intentionally unchanged; only the exec-layer reaction changes.

## Verification status

Host-verified (ASCII). Control-flow-only change (encoding-independent); **verification on MVS is pending a rebuild + redeploy of the IRX\* load modules to the LINKLIB**.

Follow-up: #208 (lift the 63-byte limit so long-literal programs stay on the bytecode fast path instead of falling back).

Closes #207
