### PR TITLE
fix(init): env_get_safe — gate getenv() on a live CLIBCRT for the current TCB (#204)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -184,8 +184,9 @@ needed for a *complete* REXX.
 > S0C4 when IRXINIT is reached via LOAD+BALR from a foreign C host) is now
 > fixed: `env_get_safe()` gates `getenv()` on a CLIBCRT being registered for
 > the current TCB — a silent replay of `@@CRTGET`'s lookup — rather than a
-> bare non-NULL-PPA check. On-target repro: TREXXVL case 0d (pending
-> `make test-mvs`).
+> bare non-NULL-PPA check. Verified on MVS: TREXXVL case 0d (IRXINIT via
+> `__load`+BALR) returns rc=0 with no S0C4, and TSTFLIP (`setenv`/`getenv`
+> on a legitimate runtime) stays green.
 
 > ⚠️ **The state of this axis is not currently known.** The core
 > IRXINIT/IRXTERM/IRXANCHR/parameter-module work (WP-I1a-d) was marked done

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -180,7 +180,12 @@ needed for a *complete* REXX.
 > `test/trxldc.asm` and httprexx `asm/htrxterm.asm`; a second latent bug
 > (`asm/istso.asm` EXTRACT S328 on non-zeroed parameter list) was fixed on
 > the way. Full analysis: `docs/irxterm-c-host-crash.md`. IRXINIT/IRXEXEC/
-> IRXTERM themselves were exonerated; #204 remains open (separate bug).
+> IRXTERM themselves were exonerated. The related **#204** (`env_get_safe`
+> S0C4 when IRXINIT is reached via LOAD+BALR from a foreign C host) is now
+> fixed: `env_get_safe()` gates `getenv()` on a CLIBCRT being registered for
+> the current TCB — a silent replay of `@@CRTGET`'s lookup — rather than a
+> bare non-NULL-PPA check. On-target repro: TREXXVL case 0d (pending
+> `make test-mvs`).
 
 > ⚠️ **The state of this axis is not currently known.** The core
 > IRXINIT/IRXTERM/IRXANCHR/parameter-module work (WP-I1a-d) was marked done

--- a/docs/irxterm-c-host-crash.md
+++ b/docs/irxterm-c-host-crash.md
@@ -3,7 +3,8 @@
 **Status:** RESOLVED — root cause found, fixed, full test matrix green.
 **Date opened:** 2026-07-02 · **Date resolved:** 2026-07-02
 **Related:** mvslovers/rexx370#204 (separate `env_get_safe` foreign-PPA bug,
-still open), mvslovers/httprexx (the consumer that hit this).
+fixed on the `issue-204-foreign-ppa-getenv` branch — pending `make test-mvs`),
+mvslovers/httprexx (the consumer that hit this).
 
 ---
 
@@ -94,8 +95,11 @@ also wrong — EXTRACT is SVC 40.)
    above.
 2. **httprexx:** commit the `htrxterm.asm` fix, remove the "IRXTERM
    temporarily DISABLED" workaround (`src/httprexx.c` ~L331), retest.
-3. **#204** (`env_get_safe` foreign-PPA on the IRXINIT-BALR path) remains
-   open and unrelated; `test/trxldc.asm` (`TRXCALLV`) is kept for that work.
+3. **#204** (`env_get_safe` foreign-PPA on the IRXINIT-BALR path) is **fixed**:
+   `env_get_safe()` now gates `getenv()` on a CLIBCRT being registered for the
+   current TCB (a silent replay of `@@CRTGET`'s lookup) instead of merely
+   checking for a non-NULL PPA. `test/trxldc.asm` (`TRXCALLV`) now drives
+   TREXXVL case 0d, the on-target repro (pending `make test-mvs`).
 4. **mbt:** `submit_jcl` polls max 120 s — a full 110-step runner exceeds it
    ("FAIL NO RC" with an empty spool). Consider a configurable timeout.
    The `//SYSUDUMP DD SYSOUT=*` added to test steps proved valuable — keep.

--- a/docs/irxterm-c-host-crash.md
+++ b/docs/irxterm-c-host-crash.md
@@ -3,7 +3,7 @@
 **Status:** RESOLVED — root cause found, fixed, full test matrix green.
 **Date opened:** 2026-07-02 · **Date resolved:** 2026-07-02
 **Related:** mvslovers/rexx370#204 (separate `env_get_safe` foreign-PPA bug,
-fixed on the `issue-204-foreign-ppa-getenv` branch — pending `make test-mvs`),
+fixed on the `issue-204-foreign-ppa-getenv` branch — verified on MVS),
 mvslovers/httprexx (the consumer that hit this).
 
 ---
@@ -99,7 +99,8 @@ also wrong — EXTRACT is SVC 40.)
    `env_get_safe()` now gates `getenv()` on a CLIBCRT being registered for the
    current TCB (a silent replay of `@@CRTGET`'s lookup) instead of merely
    checking for a non-NULL PPA. `test/trxldc.asm` (`TRXCALLV`) now drives
-   TREXXVL case 0d, the on-target repro (pending `make test-mvs`).
+   TREXXVL case 0d, the on-target repro — verified on MVS (JOB00931): IRXINIT
+   via `__load`+BALR returns rc=0, no S0C4.
 4. **mbt:** `submit_jcl` polls max 120 s — a full 110-step runner exceeds it
    ("FAIL NO RC" with an empty spool). Consider a configurable timeout.
    The `//SYSUDUMP DD SYSOUT=*` added to test steps proved valuable — keep.

--- a/src/irx#init.c
+++ b/src/irx#init.c
@@ -42,8 +42,11 @@
 #include "irxwkblk.h"
 
 #ifdef __MVS__
-#include <clibos.h>  /* __load(), __delete() — crent370 */
-#include <clibppa.h> /* __PPAGET() — C-runtime presence check */
+#include <clibary.h>  /* arraycount() — walk the PPA CLIBCRT array */
+#include <clibcrt.h>  /* CLIBCRT — per-TCB C-runtime work area */
+#include <cliblock.h> /* lock()/unlock() — shared PPA read latch */
+#include <clibos.h>   /* __load(), __delete() — crent370 */
+#include <clibppa.h>  /* __PPAGET(), CLIBPPA — C-runtime presence check */
 #endif
 
 /* Lock the CON-1 §3.1 ENVBLOCK size on MVS — the IBM-reserved tail
@@ -223,19 +226,73 @@ static int env_eq_ci(const char *a, const char *b)
 /*  Shared helper: env_get_safe                                       */
 /*                                                                    */
 /*  getenv() reaches the environment through @@GRTGET -> @@CRTGET,    */
-/*  which requires an established C runtime (a CLIBCRT registered in  */
-/*  the PPA).  On the module-entry path — IRXINIT reached via BALR    */
-/*  from IRXTMPW or the VLIST wrappers, not via @@CRT0 — no CRT is    */
-/*  set up, so a plain getenv() logs a spurious                       */
-/*  "__CRTGET ... not found in PPA(00000000)" at every call.  Skip it */
-/*  when no PPA exists (the production default is correct there);     */
-/*  on the host and in @@CRT0-bootstrapped modules a PPA exists and    */
-/*  getenv() works normally.                                          */
+/*  which locate the C runtime by matching the *current TCB* against  */
+/*  the CLIBCRT array anchored in the PPA.  When no CLIBCRT matches — */
+/*  asm callers with no runtime of their own, or IRXINIT reached via  */
+/*  LOAD+BALR from a *foreign* C host whose PPA it inherits — @@CRTGET */
+/*  returns NULL and getenv() then dereferences the NULL GRT in low   */
+/*  core: an S0C4 (issue #204).  A non-NULL PPA is therefore not a    */
+/*  safe guard on its own: the PPA can be present but foreign.        */
+/*                                                                    */
+/*  crt_present_for_current_tcb() replays @@CRTGET's own lookup —     */
+/*  same PPA, same PSATOLD, same CLIBCRT-array scan — but silently    */
+/*  (no "__CRTGET ... not found" WTO) and as a bool.  getenv() runs   */
+/*  only when a CLIBCRT for the running TCB actually exists, i.e.     */
+/*  exactly when getenv() can resolve a live runtime instead of       */
+/*  faulting.  On the host (no __MVS__) getenv() is always safe.      */
 /* ================================================================== */
+#ifdef __MVS__
+/* PSATOLD lives at low-core offset 0x21C and holds the address of the
+ * currently dispatched TCB — the same word @@CRTGET keys its CLIBCRT
+ * lookup on.  This mirrors @@CRTGET's body verbatim (minus its
+ * diagnostic WTO) so the "runtime present?" verdict is equivalent by
+ * construction: same __PPAGET(), same shared read latch, same scan. */
+static int crt_present_for_current_tcb(void)
+{
+    int locked = 0;
+    unsigned *psa = 0;
+    void *tcb = (void *)psa[0x21c / 4];
+    CLIBPPA *ppa = __PPAGET();
+    CLIBCRT *crt = (CLIBCRT *)0;
+    unsigned count = 0;
+    unsigned n;
+
+    if (!ppa)
+    {
+        goto quit;
+    }
+
+    locked = lock(ppa, 1); /* 1 = read only (shared) */
+    if (locked != 0)
+    {
+        goto quit;
+    }
+
+    count = arraycount(&ppa->ppacrt);
+
+    for (n = 0; n < count; n++)
+    {
+        if (ppa->ppacrt[n]->crttcb == tcb)
+        {
+            crt = ppa->ppacrt[n];
+            break;
+        }
+    }
+
+    if (locked == 0)
+    {
+        unlock(ppa, 1);
+    }
+
+quit:
+    return crt != (CLIBCRT *)0;
+}
+#endif
+
 static const char *env_get_safe(const char *name)
 {
 #ifdef __MVS__
-    if (__PPAGET() == NULL)
+    if (!crt_present_for_current_tcb())
     {
         return NULL;
     }

--- a/test/trexxvl.c
+++ b/test/trexxvl.c
@@ -208,6 +208,55 @@ static int run_noexec_term(const char *label)
     return (term_env(label, env) == 0) ? 0 : 12;
 }
 
+/* Case 0d (#204 repro): IRXINIT via __load + BALR (R1 = VLIST, R0 = 0),
+ * then IRXTERM.  Unlike 0c (LINK -> fresh PRB -> PPA = NULL -> getenv
+ * skipped), a BALR from this live crent370 host leaves IRXINIT running
+ * against the *host's* (foreign) PPA.  env_get_safe() must recognise that
+ * no CLIBCRT is registered for the current TCB and skip getenv() rather
+ * than fault (S0C4).  MVS-only: there is no PPA/TCB on the host build. */
+static int run_balr_init_term(const char *label)
+{
+    static const char fcode[] = "INITENVB";
+    void *p_parmmod = NULL;
+    void *p_userfld = NULL;
+    void *p_wkblk = NULL;
+    void *p_resv = NULL;
+    struct envblock *env = NULL;
+    int reason = 0;
+    unsigned vinit[7];
+    unsigned int lsize = 0;
+    char lac = 0;
+    void *ep;
+    int rc;
+
+    vinit[0] = (unsigned)fcode;
+    vinit[1] = (unsigned)&p_parmmod;
+    vinit[2] = (unsigned)&p_userfld;
+    vinit[3] = (unsigned)&p_wkblk;
+    vinit[4] = (unsigned)&p_resv;
+    vinit[5] = (unsigned)&env;
+    vinit[6] = (unsigned)&reason | 0x80000000U;
+
+    ep = __load(NULL, "IRXINIT", &lsize, &lac);
+    if (ep == NULL)
+    {
+        wtof("TREXXVL[%s]: IRXINIT __load FAILED", label);
+        return 20;
+    }
+
+    rc = trx_callv(ep, vinit);
+    wtof("TREXXVL[%s]: IRXINIT balr rc=%d reason=%d env=%08X", label, rc,
+         reason, (unsigned)env);
+    __delete("IRXINIT");
+
+    if (rc != 0 || env == NULL)
+    {
+        return 20;
+    }
+
+    return (term_env(label, env) == 0) ? 0 : 12;
+}
+
 int main(void)
 {
     /* Escalating cases, simplest first.  Each runs under its own fresh
@@ -236,6 +285,9 @@ int main(void)
 
     wtof("TREXXVL: === 0c. IRXINIT via __linkds (LINK) -> IRXTERM ===");
     rc |= run_noexec_term("linkds");
+
+    wtof("TREXXVL: === 0d. IRXINIT via __load+BALR (foreign PPA #204) ===");
+    rc |= run_balr_init_term("balr");
 
     wtof("TREXXVL: === 1. plain say ===");
     rc |= run_lines("say", c_say, 1);


### PR DESCRIPTION
Fixes #204

## Problem

`env_get_safe()` in `src/irx#init.c` guarded `getenv()` with a bare non-NULL
PPA check. That only covers the "no C runtime" case (asm callers such as the
VLIST wrappers, where `__PPAGET()` is NULL). When the standalone **IRXINIT**
module is reached via **LOAD+BALR from a running crent370 C host**, it inherits
the *host's* PPA — non-NULL but **foreign** — so the guard passes.

`getenv()` then walks `@@GRTGET → @@CRTGET`, which key the C runtime on the
**current TCB (PSATOLD)**. No CLIBCRT is registered for that TCB in the
inherited PPA, so `@@CRTGET` returns NULL, `@@GRTGET` returns NULL, and
`getenv()` dereferences the NULL GRT in low core (`lock(&grt->grtenv, …)` at
offset 0x20) → **S0C4**.

## Fix

Replace the guard with `crt_present_for_current_tcb()` — a **silent replay of
`@@CRTGET`'s own lookup** (same `__PPAGET()`, same PSATOLD, same shared read
latch, same CLIBCRT-array scan), minus the diagnostic `WTO`. Because it mirrors
`@@CRTGET`'s body, its "runtime present?" verdict is equivalent by construction:
`getenv()` now runs **only when a CLIBCRT is actually registered for the running
TCB** — exactly the precondition for `getenv()` to resolve a live runtime
instead of faulting.

This closes the foreign-PPA fault while **preserving the paths where `getenv()`
legitimately works**:
- the host build (no `__MVS__`, unchanged);
- `@@CRT0`-bootstrapped modules — notably `TSTFLIP`, which exercises
  `setenv`/`getenv` on MVS and would regress if `getenv()` were simply dropped
  on the target.

## Test

Adds **TREXXVL case 0d**: drives IRXINIT via `__load` + BALR (R1=VLIST, R0=0)
through the existing `TRXCALLV` shim — the exact foreign-PPA reproduction from
the issue — then tears the env down via IRXTERM. MVS-only (there is no PPA/TCB
on the host cross-build). `test/trxldc.asm` was confirmed to use the correct
RS-format `LM R0,R12,20(R13)`, so 0d cannot masquerade as the (separate,
already-fixed) `D(,B)` shim crash.

## Verification

- **c2asm370 `-Wall -Werror`**: `make irxinit` and `make trexxvl` both compile
  and link clean. This is the authoritative gate — the entire `#ifdef __MVS__`
  block is invisible to host gcc/clangd (neither defines `__MVS__`).
- **Host suite** (`make test-host`): 50 tests / 2480 assertions pass, incl.
  `TSTFLIP` (25). No regression.
- **On MVS** (`make deploy` → `make test-mvs`, JOB00931), against the freshly
  deployed fixed IRXINIT in the LINKLIB:
  - **TREXXVL case 0d** (foreign-PPA repro, IRXINIT via `__load`+BALR) — CC 0
    in both batch and TSO; joblog shows `IRXINIT balr rc=0 reason=0 env=…` and
    `IRXTERM rc=0`. No S0C4.
  - **TSTFLIP** — CC 0 in batch and TSO; the fixed `env_get_safe()` (statically
    linked) still reads `REXX370_BYTECODE` correctly via `setenv`/`getenv` on a
    legitimate MVS runtime.

## Docs

- `docs/ROADMAP.md` (Axis 4 note) and `docs/irxterm-c-host-crash.md` updated to
  record #204 as fixed (pending MVS run) rather than open.
