### PR TITLE
fix(bytecode): fixed-table overflow falls back to the interpreter

### DIFF
--- a/include/irxbops.h
+++ b/include/irxbops.h
@@ -395,7 +395,7 @@
 /* ================================================================== */
 
 #define IRXBC_OK                 0  /* success                               */
-#define IRXBC_ERR_STOR           20 /* irxstor allocation failed             */
+#define IRXBC_ERR_STOR           20 /* irxstor allocation failed (fatal)     */
 #define IRXBC_ERR_TOKN           21 /* tokenizer returned an error           */
 #define IRXBC_ERR_UNSUP          22 /* unsupported construct                 */
 #define IRXBC_ERR_OPCODE         23 /* unknown opcode encountered by VM      */
@@ -408,5 +408,6 @@
 #define IRXBC_ERR_STRTOOLONG     29 /* literal/symbol exceeds IRXBC_STR_MAX  */
 #define IRXBC_ERR_CALL           30 /* CALL stack overflow (IRXBC_CALL_DEPTH)    */
 #define IRXBC_ERR_PARSE_COMPOUND 31 /* compound-variable target in PARSE template */
+#define IRXBC_ERR_CAPACITY       33 /* compile-time fixed-table overflow (fallback) */
 
 #endif /* IRXBOPS_H */

--- a/project.toml
+++ b/project.toml
@@ -1594,6 +1594,49 @@ sources = [
 ]
 
 # ---------------------------------------------------------------
+# TSTBCAP - issue #212: bytecode fixed-table overflow falls back.
+# A program that overflows a fixed compiler table (code/constants/
+# symbols) now returns IRXBC_ERR_CAPACITY (distinct from the fatal
+# IRXBC_ERR_STOR for real allocation failures); irx_exec_run treats
+# it as fallback-eligible and re-runs under the token-walk
+# interpreter instead of aborting.  Verifies the compile return
+# codes and the end-to-end fallback (RC=0, correct output).
+#
+# Invocation:
+#   TSO    :  CALL 'hlq.LOAD(TSTBCAP)'
+#   Batch  :  EXEC PGM=TSTBCAP
+#
+# Expected: CC=0
+# ---------------------------------------------------------------
+[[test]]
+name = "TSTBCAP"
+startup = "crt1"
+sources = [
+  "test/tstbcap.c",
+  "src/irx#init.c",
+  "src/irx#term.c",
+  "src/irx#stor.c",
+  "src/irx#anch.c",
+  "src/irx#uid.c",
+  "src/irx#msid.c",
+  "src/irx#cond.c",
+  "src/irx#bif.c",
+  "src/irx#bifs.c",
+  "src/irx#io.c",
+  "src/irx#lstr.c",
+  "src/irx#tokn.c",
+  "src/irx#vpol.c",
+  "src/irx#pars.c",
+  "src/irx#ctrl.c",
+  "src/irx#exec.c",
+  "src/irx#bcom.c",
+  "src/irx#bvm.c",
+  "src/irx#bctl.c",
+  "src/irx#arith.c",
+  "asm/istso.asm",
+]
+
+# ---------------------------------------------------------------
 # TSTBCNUM - WP-BC-NUMERIC: NUMERIC DIGITS/FUZZ/FORM statement.
 # Verifies the bytecode compiler + VM implement the NUMERIC
 # statement (OP_SET_NUMERIC) — closing the first decommission gate

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -197,8 +197,8 @@ static int emit_byte(struct bcom_ctx *ctx, unsigned char op)
 {
     if (ctx->code_len >= BCOM_MAX_CODE)
     {
-        ctx->rc = IRXBC_ERR_STOR;
-        return IRXBC_ERR_STOR;
+        ctx->rc = IRXBC_ERR_CAPACITY;
+        return IRXBC_ERR_CAPACITY;
     }
     ctx->code[ctx->code_len++] = op;
     return IRXBC_OK;
@@ -208,8 +208,8 @@ static int emit_u16(struct bcom_ctx *ctx, int idx)
 {
     if (ctx->code_len + 2 > BCOM_MAX_CODE)
     {
-        ctx->rc = IRXBC_ERR_STOR;
-        return IRXBC_ERR_STOR;
+        ctx->rc = IRXBC_ERR_CAPACITY;
+        return IRXBC_ERR_CAPACITY;
     }
     ctx->code[ctx->code_len++] = (unsigned char)(idx & 0xFF);
     ctx->code[ctx->code_len++] = (unsigned char)((idx >> 8) & 0xFF);
@@ -221,8 +221,8 @@ static int emit_i16(struct bcom_ctx *ctx, int offset)
     unsigned int v = (unsigned int)(short)(offset);
     if (ctx->code_len + 2 > BCOM_MAX_CODE)
     {
-        ctx->rc = IRXBC_ERR_STOR;
-        return IRXBC_ERR_STOR;
+        ctx->rc = IRXBC_ERR_CAPACITY;
+        return IRXBC_ERR_CAPACITY;
     }
     ctx->code[ctx->code_len++] = (unsigned char)(v & 0xFF);
     ctx->code[ctx->code_len++] = (unsigned char)((v >> 8) & 0xFF);
@@ -453,7 +453,7 @@ static int add_const(struct bcom_ctx *ctx, const char *text, int len)
     }
     if (ctx->const_count >= BCOM_MAX_CONSTS)
     {
-        ctx->rc = IRXBC_ERR_STOR;
+        ctx->rc = IRXBC_ERR_CAPACITY;
         return -1;
     }
     i = ctx->const_count++;
@@ -484,7 +484,7 @@ static int add_sym(struct bcom_ctx *ctx, const char *name)
     }
     if (ctx->sym_count >= BCOM_MAX_SYMS)
     {
-        ctx->rc = IRXBC_ERR_STOR;
+        ctx->rc = IRXBC_ERR_CAPACITY;
         return -1;
     }
     i = ctx->sym_count++;

--- a/src/irx#exec.c
+++ b/src/irx#exec.c
@@ -288,6 +288,11 @@ int irx_exec_dispatch(struct execblk *execblk,
  *                    so 64+ byte strings cannot be represented (the
  *                    interpreter has no such limit)
  *   PARSE_COMPOUND - a compound-variable target in a PARSE template
+ *   CAPACITY       - the program overflows one of the compiler's fixed
+ *                    tables (code / constants / symbols); the interpreter
+ *                    has no such limits.  This is a *capacity* limit, kept
+ *                    distinct from IRXBC_ERR_STOR (a real irxstor failure,
+ *                    which stays fatal — see irx#bcom.c).
  * Execute-time errors from irx_bc_execute (OPCODE/ARITH/STACK/IO/...) are
  * deliberately excluded: that bytecode already ran with side effects and
  * must stay fatal rather than silently re-run under the interpreter. */
@@ -295,7 +300,8 @@ static int bc_err_is_fallback(int rc)
 {
     return rc == IRXBC_ERR_UNSUP ||
            rc == IRXBC_ERR_STRTOOLONG ||
-           rc == IRXBC_ERR_PARSE_COMPOUND;
+           rc == IRXBC_ERR_PARSE_COMPOUND ||
+           rc == IRXBC_ERR_CAPACITY;
 }
 
 int irx_exec_run(const char *source, int source_len,

--- a/test/tstbcap.c
+++ b/test/tstbcap.c
@@ -1,0 +1,294 @@
+/* ------------------------------------------------------------------ */
+/*  tstbcap.c - issue #212: bytecode fixed-table overflow falls back   */
+/*                                                                    */
+/*  The bytecode compiler keeps three FIXED tables (src/irx#bcom.c):   */
+/*    BCOM_MAX_CODE 16384, BCOM_MAX_CONSTS 512, BCOM_MAX_SYMS 512.     */
+/*  A program that overflows one of them cannot be represented as      */
+/*  bytecode, but the token-walk interpreter has no such limits.  The  */
+/*  overflow is raised inside irx_bc_compile() BEFORE any bytecode     */
+/*  executes, so re-running under the interpreter is side-effect free  */
+/*  — exactly like the existing UNSUP / STRTOOLONG / PARSE_COMPOUND    */
+/*  fallback codes.                                                    */
+/*                                                                    */
+/*  This test verifies that a capacity overflow now returns the        */
+/*  dedicated IRXBC_ERR_CAPACITY code (distinct from IRXBC_ERR_STOR,   */
+/*  which stays for real irxstor failures) and that irx_exec_run       */
+/*  falls back to the interpreter and runs the program correctly       */
+/*  instead of aborting fatally:                                       */
+/*    1. compile: >512 distinct constants  -> IRXBC_ERR_CAPACITY;      */
+/*    2. compile: >512 distinct symbols    -> IRXBC_ERR_CAPACITY;      */
+/*    3. compile: a small program          -> IRXBC_OK (no false       */
+/*       positive at the boundary);                                    */
+/*    4. run:     the overflowing program falls back (fallback>0) and  */
+/*       produces the correct output with RC=0 (was fatal rc=20);      */
+/*    5. run:     the small program stays on the VM (exec>0, no        */
+/*       fallback) and produces the correct output.                    */
+/*                                                                    */
+/*  Cross-compile build (Linux/gcc):                                  */
+/*    LSTR="-I contrib/lstring370-0.1.0-dev/include"                   */
+/*    LSRC="../lstring370/src/lstr#cor.c ../lstring370/src/lstr#cvt.c  */
+/*          ../lstring370/src/lstr#fmt.c ../lstring370/src/lstr#srch.c */
+/*          ../lstring370/src/lstr#sub.c ../lstring370/src/lstr#wrd.c  */
+/*          ../lstring370/src/lstr#xlt.c"                              */
+/*    gcc -I include $LSTR -Wall -Wextra -std=gnu99 \                 */
+/*        -o /tmp/tstbcap test/tstbcap.c \                             */
+/*        src/irx#init.c  src/irx#term.c  src/irx#stor.c \            */
+/*        src/irx#anch.c  src/irx#env.c   src/irx#uid.c  \            */
+/*        src/irx#msid.c  src/irx#cond.c  src/irx#bif.c  \            */
+/*        src/irx#bifs.c  src/irx#io.c    src/irx#lstr.c \            */
+/*        src/irx#tokn.c  src/irx#vpol.c  src/irx#pars.c \            */
+/*        src/irx#ctrl.c  src/irx#exec.c  src/irx#arith.c \           */
+/*        src/irx#bcom.c  src/irx#bvm.c   src/irx#bctl.c \            */
+/*        $LSRC && /tmp/tstbcap                                       */
+/*                                                                    */
+/*  (c) 2026 mvslovers - REXX/370 Project                             */
+/* ------------------------------------------------------------------ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "irx.h"
+#include "irxbctl.h"
+#include "irxbops.h"
+#include "irxbvm.h"
+#include "irxexbl.h"
+#include "irxexec.h"
+#include "irxfunc.h"
+#include "irxwkblk.h"
+
+#ifndef __MVS__
+void *_simulated_ectenvbk = NULL;
+#endif
+
+/* Distinct-entry counts that straddle BCOM_MAX_CONSTS / BCOM_MAX_SYMS (512). */
+#define OVER_LIMIT  700 /* comfortably over the 512-entry fixed tables    */
+#define UNDER_LIMIT 100 /* comfortably under — must still compile to bc   */
+
+#define SRCBUF_SIZE 8192
+
+static int tests_run = 0;
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define CHECK(cond, msg)                 \
+    do                                   \
+    {                                    \
+        tests_run++;                     \
+        if (cond)                        \
+        {                                \
+            tests_passed++;              \
+            printf("  PASS: %s\n", msg); \
+        }                                \
+        else                             \
+        {                                \
+            tests_failed++;              \
+            printf("  FAIL: %s\n", msg); \
+        }                                \
+    } while (0)
+
+/* ------------------------------------------------------------------ */
+/*  Output capture                                                    */
+/* ------------------------------------------------------------------ */
+
+#define CAPBUF_SIZE 4096
+
+static char g_cap[CAPBUF_SIZE];
+static int g_cap_len = 0;
+
+static void cap_reset(void)
+{
+    g_cap_len = 0;
+    g_cap[0] = '\0';
+}
+
+static int capture_io(int function, PLstr data, struct envblock *envblock)
+{
+    (void)envblock;
+    if (function == RXFWRITE && data != NULL && Lpstr(data) != NULL)
+    {
+        int n = (int)Llen(data);
+        if (g_cap_len + n + 1 < CAPBUF_SIZE)
+        {
+            memcpy(g_cap + g_cap_len, Lpstr(data), (size_t)n);
+            g_cap_len += n;
+            g_cap[g_cap_len++] = '\n';
+            g_cap[g_cap_len] = '\0';
+        }
+    }
+    return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Program generators                                                */
+/* ------------------------------------------------------------------ */
+
+/* n assignments of DISTINCT string literals to one variable, then a
+ * final SAY.  Each literal 'cI' is a distinct constant, so the const
+ * table grows by one per line; the lone symbol 'v' never overflows.
+ * The final value (and the SAY output) is "c<n-1>". */
+static int gen_consts(char *buf, int cap, int n)
+{
+    int off = 0;
+    for (int i = 0; i < n; i++)
+    {
+        off += snprintf(buf + off, (size_t)(cap - off), "v='c%d'\n", i);
+    }
+    off += snprintf(buf + off, (size_t)(cap - off), "say v\n");
+    return off;
+}
+
+/* n assignments to DISTINCT variables, then a SAY of the first one.
+ * Each name aI is a distinct symbol, so the symbol table grows by one
+ * per line; the constant '1' is added once and deduped.  The SAY
+ * output is "1". */
+static int gen_syms(char *buf, int cap, int n)
+{
+    int off = 0;
+    for (int i = 0; i < n; i++)
+    {
+        off += snprintf(buf + off, (size_t)(cap - off), "a%d=1\n", i);
+    }
+    off += snprintf(buf + off, (size_t)(cap - off), "say a0\n");
+    return off;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Assertions                                                        */
+/* ------------------------------------------------------------------ */
+
+/* Direct compile: assert irx_bc_compile returns exactly expected_rc.
+ * Frees any container it produced (only the IRXBC_OK path allocates). */
+static void check_compile(struct envblock *env, const char *src, int len,
+                          int expected_rc, const char *tag)
+{
+    struct irx_bc_execblk *bc = NULL;
+    int rc = irx_bc_compile(env, src, len, &bc, NULL, NULL);
+    char label[160];
+
+    snprintf(label, sizeof(label), "compile: %s", tag);
+    CHECK(rc == expected_rc, label);
+    if (rc != expected_rc)
+    {
+        printf("    expected rc=%d, got rc=%d\n", expected_rc, rc);
+    }
+
+    if (bc != NULL)
+    {
+        void *p = bc;
+        irxstor(RXSMFRE, 0, &p, env);
+    }
+}
+
+/* Full run through irx_exec_run with the bytecode path on.  When
+ * want_fallback is set the compile must overflow and fall back to the
+ * interpreter (fallback>0) yet still finish RC=0 with correct output;
+ * otherwise the program must run on the VM (exec>0, no fallback). */
+static void check_run(struct envblock *env, const char *src, int len,
+                      const char *expected_out, int want_fallback,
+                      const char *tag)
+{
+    struct irx_wkblk_int *wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
+    int exit_rc = 0;
+    int rc;
+    int ok;
+    char label[160];
+
+    cap_reset();
+    wk->wkbi_use_bytecode = 1;
+    wk->wkbi_bc_exec_count = 0;
+    wk->wkbi_bc_fallback_count = 0;
+    rc = irx_exec_run(src, len, NULL, 0, &exit_rc, env);
+    wk->wkbi_use_bytecode = 0;
+
+    if (want_fallback)
+    {
+        ok = rc == 0 && exit_rc == 0 && wk->wkbi_bc_fallback_count > 0 &&
+             strcmp(g_cap, expected_out) == 0;
+    }
+    else
+    {
+        ok = rc == 0 && exit_rc == 0 && wk->wkbi_bc_fallback_count == 0 &&
+             wk->wkbi_bc_exec_count > 0 && strcmp(g_cap, expected_out) == 0;
+    }
+
+    snprintf(label, sizeof(label), "run: %s", tag);
+    CHECK(ok, label);
+    if (!ok)
+    {
+        printf("    rc=%d exit_rc=%d exec=%d fallback=%d\n", rc, exit_rc,
+               wk->wkbi_bc_exec_count, wk->wkbi_bc_fallback_count);
+        printf("    expected:[%s] got:[%s]\n", expected_out, g_cap);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/*  main                                                              */
+/* ------------------------------------------------------------------ */
+
+int main(void)
+{
+    struct envblock *env = NULL;
+    struct irxexte *exte;
+    static char src[SRCBUF_SIZE];
+    char expected[16];
+    int len;
+    int rc;
+
+    printf("=== issue #212: bytecode fixed-table overflow -> fallback ===\n");
+
+    rc = irxinit(NULL, &env);
+    if (rc != 0 || env == NULL)
+    {
+        fprintf(stderr, "tstbcap: irxinit failed rc=%d\n", rc);
+        return 1;
+    }
+
+    exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+    {
+        exte->io_routine = (void *)capture_io;
+    }
+
+    printf("\n[compile: fixed-table overflow -> IRXBC_ERR_CAPACITY]\n");
+
+    /* Constants table overflow (add_const). */
+    len = gen_consts(src, SRCBUF_SIZE, OVER_LIMIT);
+    check_compile(env, src, len, IRXBC_ERR_CAPACITY,
+                  "700 distinct constants -> CAPACITY");
+
+    /* Symbols table overflow (add_sym). */
+    len = gen_syms(src, SRCBUF_SIZE, OVER_LIMIT);
+    check_compile(env, src, len, IRXBC_ERR_CAPACITY,
+                  "700 distinct symbols -> CAPACITY");
+
+    /* Boundary: a small program must still compile to bytecode. */
+    len = gen_consts(src, SRCBUF_SIZE, UNDER_LIMIT);
+    check_compile(env, src, len, IRXBC_OK,
+                  "100 distinct constants -> OK (no false positive)");
+
+    printf("\n[run: overflow falls back to the interpreter, not fatal]\n");
+
+    /* The overflowing program must fall back and run to RC=0.  Before
+     * the fix this returned a fatal rc=20 from irx_exec_run. */
+    len = gen_consts(src, SRCBUF_SIZE, OVER_LIMIT);
+    snprintf(expected, sizeof(expected), "c%d\n", OVER_LIMIT - 1);
+    check_run(env, src, len, expected, 1,
+              "700-constant program falls back and runs");
+
+    /* The small program must stay on the VM (no spurious fallback). */
+    len = gen_consts(src, SRCBUF_SIZE, UNDER_LIMIT);
+    snprintf(expected, sizeof(expected), "c%d\n", UNDER_LIMIT - 1);
+    check_run(env, src, len, expected, 0,
+              "100-constant program runs on the VM");
+
+    irxterm(env);
+
+    printf("\n--- Results: %d/%d passed", tests_passed, tests_run);
+    if (tests_failed > 0)
+    {
+        printf(", %d FAILED", tests_failed);
+    }
+    printf(" ---\n");
+
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #212

## Problem

When a REXX program exceeds one of the bytecode compiler's **fixed** tables
(`BCOM_MAX_CODE` 16384, `BCOM_MAX_CONSTS` 512, `BCOM_MAX_SYMS` 512), the
compiler returned `IRXBC_ERR_STOR` (20). `bc_err_is_fallback()` did not classify
`STOR` as fallback-eligible, so `irx_exec_run` returned it **fatally** — the
program aborted instead of falling back to the token-walk interpreter, which has
no such limits.

The overflow is raised inside `irx_bc_compile()` **before any bytecode
executes**, so falling back re-runs the program from a clean slate with no double
side effects — the same property the existing `STRTOOLONG` / `UNSUP` /
`PARSE_COMPOUND` fallback codes rely on.

## Fix (issue's preferred approach)

Give the fixed-table overflow its own return code, `IRXBC_ERR_CAPACITY` (33),
distinct from `IRXBC_ERR_STOR` (kept for genuine `irxstor` allocation failures,
which stay fatal), and add it to `bc_err_is_fallback()`.

- `include/irxbops.h` — new `IRXBC_ERR_CAPACITY`; clarified `STOR` comment.
- `src/irx#bcom.c` — the 8 fixed-table overflow sites (`emit_byte`, `emit_u16`,
  `emit_i16`, `add_const`, `add_sym`) now raise `IRXBC_ERR_CAPACITY`. The two
  genuine `irxstor` failures (compile-time OOM) keep `IRXBC_ERR_STOR` and stay
  fatal, as does every execute-time `IRXBC_ERR_STOR` in the VM (`irx#bvm.c`,
  untouched).
- `src/irx#exec.c` — `IRXBC_ERR_CAPACITY` added to `bc_err_is_fallback()` with an
  explanatory comment.

**Correctness property:** every path that can emit `IRXBC_ERR_CAPACITY` flows
through `irx_bc_compile()`'s return, which is the only thing `bc_err_is_fallback()`
gates. Leaving the OOM and VM sites as `STOR` is deliberate and non-regressive —
compile-time OOM is fatal today too, and the design keeps "out of memory → fatal"
distinct from "capacity → fall back".

## Notes / scope

- A capacity fallback leaves the `REXX370_BCDEBUG` reason unset (no `BC_UNSUP`
  reason applies) — a conscious diagnostic gap, not a bug.
- `IRXBC_ERR_PATCH` (too many forward-jump patches) and `IRXBC_ERR_LOOP` (DO
  nesting too deep) are the same *class* of compile-time fixed-limit that the
  interpreter could still run, but they are **deliberately left out of scope**
  for #212, which is specifically about the code/constants/symbols tables. They
  can follow the same pattern in a separate change if warranted.

## Tests

Adds `test/tstbcap.c` (`TSTBCAP`, registered in `project.toml`):

- compile: >512 distinct constants → `IRXBC_ERR_CAPACITY`
- compile: >512 distinct symbols → `IRXBC_ERR_CAPACITY`
- compile: a small program → `IRXBC_OK` (no false positive at the boundary)
- run: the overflowing program falls back and finishes RC=0 with correct output
  (was fatal rc=20)
- run: the small program stays on the VM (exec>0, no fallback)

Full host suite green: **51 tests, 2485 assertions, 0 fail** (TSTBCAP 5/5). The
`TSTBCAP` MVS load module also cross-compiles cleanly with c2asm370/ld370.

## Unblocks

mvslovers/httprexx#4 / PR #5 — the `.rxp` literal-chunking change becomes a
strict win once table overflow falls back instead of aborting.