### PR TITLE
fix(bytecode): chunk long string literals instead of falling back (#208)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ Forward-looking development plan. This is the **single source of truth** for
 database; this file orders the open work into strategic axes and is kept current
 as phases complete.
 
-Last updated: 2026-07-02
+Last updated: 2026-07-03
 
 ---
 
@@ -128,6 +128,16 @@ Open items:
   wrong-output divergence, not a `BC_FAIL_UNSUP` fallback gate. Token-walk (the
   correct reference here) is unchanged per CON-18; equivalence proven in
   `test/tstbdq.c`.
+- ~~**#208 — long string-literal chunking**~~ — a string literal `>` IRXBC_STR_MAX
+  (63) bytes no longer forces the whole exec onto the interpreter via
+  `IRXBC_ERR_STRTOOLONG` (the #207 fallback). **Done** (2026-07-03): `bc_exp8`'s
+  `TOK_STRING` branch now splits an over-long literal into `<=63`-byte const
+  entries rejoined at run time with `OP_CONCAT` (abuttal — byte-exact), so
+  HTTPREXX `.rxp` pages (near-all long HTML `SAY` literals) stay on the bytecode
+  fast path. No format change, no `IRXBC_VERSION` bump. Long *symbols* still can't
+  be chunked and keep relying on the #207 fallback (pathological, by design); the
+  fallback itself remains the safety net. Chunk equivalence + no-fallback proven
+  in `test/tstbcln.c` and `test/tstbcexe.c`.
 - **WP-CPS-09a-FU** — SIGNAL/CALL condition-trap *activation* (the parser-only
   baseline is done via #131; the runtime trap machinery — NOVALUE hook,
   condition dispatcher, SIGL/RC/CONDITION updates, CALL ON/OFF — is open).

--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -1069,6 +1069,113 @@ static int bpse_dedouble(const char *raw, int raw_len,
     return out_len;
 }
 
+/* ------------------------------------------------------------------ */
+/*  Long string literals — compile-time chunking (issue #208)         */
+/*                                                                    */
+/*  A constant table entry stores its length in one byte, so a single */
+/*  entry holds at most IRXBC_STR_MAX (63) bytes.  Rather than reject  */
+/*  a longer literal (which forces the whole exec onto the token-walk  */
+/*  fallback — see #207), split it into <=63-byte chunks and rejoin    */
+/*  at run time with OP_CONCAT.  Concatenation is abuttal (no          */
+/*  separator), so the reconstructed value is byte-exact:              */
+/*                                                                    */
+/*      PUSH_LIT chunk0                                               */
+/*      PUSH_LIT chunk1                                               */
+/*      CONCAT              ; chunk0 || chunk1                         */
+/*      PUSH_LIT chunk2                                               */
+/*      CONCAT              ; (chunk0 || chunk1) || chunk2            */
+/*                                                                    */
+/*  A literal that fits one entry emits a bare PUSH_LIT, identical to  */
+/*  the pre-#208 path — no format change, no IRXBC_VERSION bump.  Long */
+/*  *symbols* cannot be chunked and keep relying on the #207 fallback. */
+/* ------------------------------------------------------------------ */
+
+/* Emit one chunk: PUSH_LIT <const>, plus an OP_CONCAT to fold it into
+ * the running value unless it is the first chunk.  *first is cleared
+ * after the first chunk is emitted. */
+static void emit_lit_chunk(struct bcom_ctx *ctx, const char *text, int len,
+                           int *first)
+{
+    int ci = add_const(ctx, text, len);
+    if (ci < 0)
+    {
+        return;
+    }
+    emit_byte(ctx, OP_PUSH_LIT);
+    emit_u16(ctx, ci);
+    if (!*first)
+    {
+        emit_byte(ctx, OP_CONCAT);
+    }
+    *first = 0;
+}
+
+/* Push a string constant, splitting it into <=IRXBC_STR_MAX chunks
+ * joined by OP_CONCAT when it does not fit one table entry.  len may
+ * be 0 (emits a single empty constant, matching the old path). */
+static void emit_push_str(struct bcom_ctx *ctx, const char *text, int len)
+{
+    int off = 0;
+    int first = 1;
+
+    do
+    {
+        int chunk = len - off;
+        if (chunk > IRXBC_STR_MAX)
+        {
+            chunk = IRXBC_STR_MAX;
+        }
+        emit_lit_chunk(ctx, text + off, chunk, &first);
+        if (ctx->rc != IRXBC_OK)
+        {
+            return;
+        }
+        off += chunk;
+    } while (off < len);
+}
+
+/* Push a doubled-quote string literal: de-double once (collapsing the
+ * escaped quote pairs via bpse_dedouble), then chunk exactly as
+ * emit_push_str.  De-doubling only shrinks the text, so a raw literal
+ * that already fits one entry needs no heap; a longer one de-doubles
+ * into a transient scratch buffer (sized to the raw length so it can
+ * never overflow), freed before returning. */
+static void emit_push_str_dbl(struct bcom_ctx *ctx, const char *raw,
+                              int raw_len)
+{
+    void *scratch = NULL;
+    void *p;
+    int tlen;
+
+    if (raw_len <= IRXBC_STR_MAX)
+    {
+        char tmp[IRXBC_STR_MAX + 1];
+        tlen = bpse_dedouble(raw, raw_len, tmp, IRXBC_STR_MAX);
+        /* De-doubled length <= raw_len <= IRXBC_STR_MAX, so tlen >= 0. */
+        emit_push_str(ctx, tmp, tlen);
+        return;
+    }
+
+    if (irxstor(RXSMGET, raw_len, &scratch, ctx->env) != 0)
+    {
+        ctx->rc = IRXBC_ERR_STOR;
+        return;
+    }
+    tlen = bpse_dedouble(raw, raw_len, (char *)scratch, raw_len);
+    if (tlen >= 0)
+    {
+        emit_push_str(ctx, (char *)scratch, tlen);
+    }
+    else
+    {
+        /* Unreachable: de-doubling only shrinks, so it cannot exceed
+         * raw_len.  Defensive — fall back rather than emit garbage. */
+        ctx->rc = IRXBC_ERR_STRTOOLONG;
+    }
+    p = scratch;
+    irxstor(RXSMFRE, 0, &p, ctx->env);
+}
+
 static void bc_parse_template(struct bcom_ctx *ctx)
 {
     struct bpse_item items[BPSE_MAX_ITEMS];
@@ -1886,34 +1993,27 @@ static void bc_exp8(struct bcom_ctx *ctx)
 
     if (t->tok_type == TOK_STRING)
     {
-        char tmp[IRXBC_STR_MAX + 1];
-        int ci;
-        /* Doubled quotes inside a literal escape a single quote
+        /* Literals longer than IRXBC_STR_MAX are split into <=63-byte
+         * chunks joined by OP_CONCAT so they stay on the bytecode fast
+         * path instead of forcing a token-walk fallback (issue #208).
+         *
+         * Doubled quotes inside a literal escape a single quote
          * ('p''q''r' -> p'q'r).  The tokenizer stores the body raw and
          * only flags it (TOKF_QUOTE_DBL); de-doubling is the consumer's
          * job — mirror the PARSE-template path in bc_parse_template(). */
         if (t->tok_flags & TOKF_QUOTE_DBL)
         {
-            int tlen = bpse_dedouble(t->tok_text, (int)t->tok_length, tmp,
-                                     IRXBC_STR_MAX);
-            if (tlen < 0)
-            {
-                ctx->rc = IRXBC_ERR_STRTOOLONG;
-                return;
-            }
-            ci = add_const(ctx, tmp, tlen);
+            emit_push_str_dbl(ctx, t->tok_text, (int)t->tok_length);
         }
         else
         {
-            ci = add_const(ctx, t->tok_text, (int)t->tok_length);
+            emit_push_str(ctx, t->tok_text, (int)t->tok_length);
         }
-        if (ci < 0)
+        if (ctx->rc != IRXBC_OK)
         {
             return;
         }
         ctx->pos++;
-        emit_byte(ctx, OP_PUSH_LIT);
-        emit_u16(ctx, ci);
         return;
     }
 

--- a/test/tstbcexe.c
+++ b/test/tstbcexe.c
@@ -227,15 +227,17 @@ static void test_e2e_empty_bytecode(void)
     irxterm(env);
 }
 
-/* A string literal longer than IRXBC_STR_MAX (63) cannot be represented in
- * the bytecode const table (1-byte length prefix), so irx_bc_compile fails
- * with IRXBC_ERR_STRTOOLONG.  irx_exec_run must fall back to the token-walk
- * interpreter — which has no such limit — instead of surfacing the error.
- * Regression for the HTTPREXX .rxp failure "IRXEXEC ... rc=29 rexxrc=29",
- * where an ordinary HTML line (>63 bytes) inside SAY aborted the exec. */
-static void test_e2e_long_literal_fallback(void)
+/* A string literal longer than IRXBC_STR_MAX (63) is split at compile time
+ * into <=63-byte const-table chunks rejoined with OP_CONCAT (issue #208), so
+ * it stays on the bytecode fast path and emits byte-exact output — no
+ * token-walk fallback.  Regression for the HTTPREXX .rxp performance case:
+ * an ordinary HTML line (>63 bytes) inside SAY used to force the whole exec
+ * onto the interpreter (correct, via #207, but slow); it now runs on the VM.
+ * (The #207 fallback remains as the safety net for constructs that still
+ * cannot be represented in bytecode — e.g. over-long symbols.) */
+static void test_e2e_long_literal_bytecode(void)
 {
-    /* 70-byte literal (> IRXBC_STR_MAX) — a typical transpiled HTML line. */
+    /* ~64-byte literal (> IRXBC_STR_MAX) — a typical transpiled HTML line. */
     static const char *src =
         "say '<html><head><meta charset=\"utf-8\">"
         "<title>demo.rxp</title></head>'";
@@ -246,11 +248,12 @@ static void test_e2e_long_literal_fallback(void)
     struct envblock *env = NULL;
     struct irx_wkblk_int *wk;
     struct irxexte *exte;
-    unsigned before;
+    int fb_before;
+    int ex_before;
     int exit_rc = -1;
     int rc;
 
-    printf("  [e2e: >63-byte literal falls back, no rc=29]\n");
+    printf("  [e2e: >63-byte literal stays on bytecode, byte-exact]\n");
 
     rc = irxinit(NULL, &env);
     CHECK(rc == 0 && env != NULL, "irxinit succeeds");
@@ -274,18 +277,91 @@ static void test_e2e_long_literal_fallback(void)
     }
 
     wk->wkbi_use_bytecode = 1;
-    before = wk->wkbi_bc_fallback_count;
+    fb_before = wk->wkbi_bc_fallback_count;
+    ex_before = wk->wkbi_bc_exec_count;
     g_captured_len = 0;
     g_captured[0] = '\0';
 
     rc = irx_exec_run(src, (int)strlen(src), NULL, 0, &exit_rc, env);
     CHECK(rc == 0, "irx_exec_run returns 0 (not IRXBC_ERR_STRTOOLONG=29)");
     CHECK(exit_rc == 0, "exit_rc == 0");
-    CHECK(wk->wkbi_bc_fallback_count == before + 1,
-          "bytecode fell back to the interpreter");
+    CHECK(wk->wkbi_bc_fallback_count == fb_before,
+          "no token-walk fallback (long literal stays on bytecode)");
+    CHECK(wk->wkbi_bc_exec_count == ex_before + 1,
+          "ran on the bytecode path");
     CHECK(g_captured_len == (int)strlen(want) &&
               memcmp(g_captured, want, strlen(want)) == 0,
           "SAY output is complete and correct");
+
+    irxterm(env);
+}
+
+/* A long single-quoted literal that ALSO contains doubled quotes (''):
+ * the compiler must de-double the whole string first, THEN chunk it, so
+ * a '' pair can never straddle a chunk boundary (issue #208, doubled-
+ * quote path — the heap-scratch branch of emit_push_str_dbl).  Both the
+ * raw literal and the de-doubled value exceed IRXBC_STR_MAX, so this
+ * exercises the scratch de-double AND multi-chunk emit together.  HTML
+ * apostrophes (it''s) make this a real HTTPREXX case, not a corner. */
+static void test_e2e_long_dq_literal_bytecode(void)
+{
+    /* Raw literal (between the outer quotes) is >63 bytes and holds two
+     * '' escapes; the de-doubled value ("it's ... isn't ...") is also
+     * >63 bytes, forcing multiple chunks. */
+    static const char *src =
+        "say '<p>it''s a fairly long paragraph, "
+        "isn''t it, definitely over sixty-three bytes</p>'";
+    static const char *want =
+        "<p>it's a fairly long paragraph, "
+        "isn't it, definitely over sixty-three bytes</p>";
+
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    struct irxexte *exte;
+    int fb_before;
+    int ex_before;
+    int exit_rc = -1;
+    int rc;
+
+    printf("  [e2e: long doubled-quote literal, de-double then chunk]\n");
+
+    rc = irxinit(NULL, &env);
+    CHECK(rc == 0 && env != NULL, "irxinit succeeds");
+    if (rc != 0 || env == NULL)
+    {
+        return;
+    }
+
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
+    CHECK(wk != NULL, "work block is present");
+    if (wk == NULL)
+    {
+        irxterm(env);
+        return;
+    }
+
+    exte = (struct irxexte *)env->envblock_irxexte;
+    if (exte != NULL)
+    {
+        exte->io_routine = (void *)capture_io;
+    }
+
+    wk->wkbi_use_bytecode = 1;
+    fb_before = wk->wkbi_bc_fallback_count;
+    ex_before = wk->wkbi_bc_exec_count;
+    g_captured_len = 0;
+    g_captured[0] = '\0';
+
+    rc = irx_exec_run(src, (int)strlen(src), NULL, 0, &exit_rc, env);
+    CHECK(rc == 0, "irx_exec_run returns 0");
+    CHECK(exit_rc == 0, "exit_rc == 0");
+    CHECK(wk->wkbi_bc_fallback_count == fb_before,
+          "no token-walk fallback (stays on bytecode)");
+    CHECK(wk->wkbi_bc_exec_count == ex_before + 1,
+          "ran on the bytecode path");
+    CHECK(g_captured_len == (int)strlen(want) &&
+              memcmp(g_captured, want, strlen(want)) == 0,
+          "SAY output de-doubled ('' -> ') and byte-exact");
 
     irxterm(env);
 }
@@ -316,7 +392,8 @@ int main(void)
     /* End-to-end tests create their own environments. */
     test_e2e_bytecode_flag();
     test_e2e_empty_bytecode();
-    test_e2e_long_literal_fallback();
+    test_e2e_long_literal_bytecode();
+    test_e2e_long_dq_literal_bytecode();
 
     printf("\n=== Results: %d/%d passed", tests_passed, tests_run);
     if (tests_failed > 0)

--- a/test/tstbcln.c
+++ b/test/tstbcln.c
@@ -2,7 +2,8 @@
 /*  test/host/tstbc_clean.c — WP-BC-CLEAN tests                       */
 /*                                                                    */
 /*  Covers:                                                           */
-/*    - Long-literal rejection (IRXBC_ERR_STRTOOLONG)                */
+/*    - Long-literal chunking (issue #208): >63-byte literals split   */
+/*      into <=63-byte chunks + OP_CONCAT, byte-exact, no fallback     */
 /*    - DO COUNT: zero iterations, negative count, exactly 1,        */
 /*      small count (5), variable count, nested loops                */
 /*    - Integer fast-path: literals, variable round-trips             */
@@ -126,50 +127,130 @@ static void run_both(const char *desc, const char *src,
 #define EQUIV(desc, src, expected) run_both(desc, src, expected, expected)
 
 /* ------------------------------------------------------------------ */
-/*  Long-literal rejection                                            */
+/*  Long-literal chunking (issue #208)                                */
+/*                                                                    */
+/*  A literal longer than IRXBC_STR_MAX (63) bytes is no longer       */
+/*  rejected: the compiler splits it into <=63-byte chunks joined by  */
+/*  OP_CONCAT, so long-literal programs stay on the bytecode fast     */
+/*  path.  Long *symbols* still fall back (they cannot be chunked).   */
 /* ------------------------------------------------------------------ */
 
-static void test_strtoolong(struct envblock *env)
+/* Build "SAY '<n copies of ch>'" into buf; returns its length. */
+static int build_say_lit(char *buf, int n, char ch)
 {
-    /* Construct a literal of exactly 64 bytes (one over IRXBC_STR_MAX=63) */
-    char src[128];
-    struct irx_bc_execblk *bc = NULL;
-    int rc;
+    int len = 5;
+    memcpy(buf, "SAY '", 5);
+    memset(buf + len, ch, (size_t)n);
+    len += n;
+    buf[len++] = '\'';
+    buf[len] = '\0';
+    return len;
+}
 
-    memset(src, 0, sizeof(src));
-    /* SAY 'AAAA...A' where string is 64 'A's */
-    strcpy(src, "SAY '");
-    memset(src + 5, 'A', 64);
-    src[69] = '\'';
-    src[70] = '\0';
+static void test_literal_boundaries(struct envblock *env)
+{
+    /* Lengths straddling the old 63/64 slot boundary and several chunk
+     * widths (127 = 2 full + 1, 189 = 3 full).  Each must now COMPILE
+     * (no STRTOOLONG). */
+    static const int lengths[] = {62, 63, 64, 126, 127, 189};
+    char src[256];
+    struct irx_bc_execblk *bc;
+    int rc, i, len;
+    char msg[80];
 
-    printf("  [long literal (64 bytes) rejected]\n");
-    rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
-    CHECK(rc == IRXBC_ERR_STRTOOLONG, "compile returns IRXBC_ERR_STRTOOLONG");
-    CHECK(bc == NULL, "bc is NULL on strtoolong error");
-
-    if (bc != NULL)
+    printf("  [long string literals compile (chunked)]\n");
+    for (i = 0; i < (int)(sizeof(lengths) / sizeof(lengths[0])); i++)
     {
-        void *p = bc;
-        irxstor(RXSMFRE, 0, &p, env);
+        len = build_say_lit(src, lengths[i], 'A');
+        bc = NULL;
+        rc = irx_bc_compile(env, src, len, &bc, NULL, NULL);
+        snprintf(msg, sizeof(msg), "%d-byte literal compiles OK", lengths[i]);
+        CHECK(rc == IRXBC_OK && bc != NULL, msg);
+        if (bc != NULL)
+        {
+            void *p = bc;
+            irxstor(RXSMFRE, 0, &p, env);
+        }
     }
 
-    /* A literal of exactly 63 bytes should succeed */
-    printf("  [literal at max (63 bytes) accepted]\n");
-    memset(src, 0, sizeof(src));
-    strcpy(src, "SAY '");
-    memset(src + 5, 'B', 63);
-    src[68] = '\'';
-    src[69] = '\0';
-
+    /* A symbol (variable name) longer than IRXBC_STR_MAX cannot be
+     * chunked and must still fall back via STRTOOLONG (by design). */
+    printf("  [over-long symbol still returns STRTOOLONG]\n");
+    memcpy(src, "SAY ", 4);
+    len = 4;
+    memset(src + len, 'A', 70); /* 70-char bareword variable name */
+    len += 70;
+    src[len] = '\0';
     bc = NULL;
-    rc = irx_bc_compile(env, src, (int)strlen(src), &bc, NULL, NULL);
-    CHECK(rc == IRXBC_OK, "63-byte literal compiles OK");
+    rc = irx_bc_compile(env, src, len, &bc, NULL, NULL);
+    CHECK(rc == IRXBC_ERR_STRTOOLONG, "70-byte symbol -> STRTOOLONG");
     if (bc != NULL)
     {
         void *p = bc;
         irxstor(RXSMFRE, 0, &p, env);
     }
+}
+
+/* A 127-byte literal (three chunks: 63 'A' + 63 'B' + 'C') must run
+ * byte-exact on the bytecode path WITHOUT falling back.  The exit
+ * expression is a checksum sensitive to both content and chunk order:
+ * a reversed or dropped chunk changes LENGTH or the probed bytes. */
+static void test_long_lit_bytecode(void)
+{
+    static const char *tail =
+        "'\nEXIT (LENGTH(s)=127) + (LEFT(s,1)='A')"
+        " + (SUBSTR(s,64,1)='B') + (RIGHT(s,1)='C')";
+    struct envblock *env = NULL;
+    struct irx_wkblk_int *wk;
+    char src[256];
+    int tlen = (int)strlen(tail);
+    int len, rc, exit_rc = -999;
+
+    memcpy(src, "s = '", 5);
+    len = 5;
+    memset(src + len, 'A', 63);
+    len += 63;
+    memset(src + len, 'B', 63);
+    len += 63;
+    src[len++] = 'C';
+    memcpy(src + len, tail, (size_t)tlen);
+    len += tlen;
+
+    printf("  [127-byte literal runs byte-exact on bytecode, no fallback]\n");
+    if (irxinit(NULL, &env) != 0 || env == NULL)
+    {
+        CHECK(0, "irxinit for long-literal bytecode test");
+        return;
+    }
+    wk = (struct irx_wkblk_int *)env->envblock_workblok_ext;
+    wk->wkbi_use_bytecode = 1;
+    wk->wkbi_bc_fallback_count = 0;
+    wk->wkbi_bc_exec_count = 0;
+
+    rc = irx_exec_run(src, len, NULL, 0, &exit_rc, env);
+    CHECK(rc == 0, "long-literal exec_run returns 0");
+    CHECK(exit_rc == 4, "checksum == 4 (length + 3 positional bytes)");
+    CHECK(wk->wkbi_bc_fallback_count == 0, "no token-walk fallback");
+    CHECK(wk->wkbi_bc_exec_count == 1, "ran on the bytecode path");
+
+    irxterm(env);
+}
+
+/* Cross-check bytecode vs token-walk on a 100-byte (2-chunk) literal. */
+static void test_long_lit_equiv(void)
+{
+    char src[256];
+    int len;
+
+    memcpy(src, "s = '", 5);
+    len = 5;
+    memset(src + len, 'X', 100);
+    len += 100;
+    memcpy(src + len, "'\nEXIT LENGTH(s)", 16);
+    len += 16;
+    src[len] = '\0';
+
+    run_both("long_lit_len", src, 100, 100);
 }
 
 /* ------------------------------------------------------------------ */
@@ -335,10 +416,14 @@ int main(void)
         return 1;
     }
 
-    test_strtoolong(env);
+    test_literal_boundaries(env);
 
     irxterm(env);
     env = NULL;
+
+    /* Long-literal chunking (issue #208) — own envblocks */
+    test_long_lit_bytecode();
+    test_long_lit_equiv();
 
     /* Equivalence tests — each creates its own envblocks */
     test_do_zero();


### PR DESCRIPTION
Fixes #208

## What

A string literal longer than `IRXBC_STR_MAX` (63) bytes no longer forces the
whole exec onto the token-walk interpreter via `IRXBC_ERR_STRTOOLONG` (the #207
fallback). `bc_exp8`'s `TOK_STRING` branch now splits an over-long literal into
`<=63`-byte constant-table entries and rejoins them at run time with `OP_CONCAT`
(abuttal — no separator, so **byte-exact**):

```
PUSH_LIT chunk0
PUSH_LIT chunk1
OP_CONCAT            ; chunk0 || chunk1
PUSH_LIT chunk2
OP_CONCAT            ; (chunk0 || chunk1) || chunk2
```

This is **Approach A** from the issue: reuses the existing fixed 64-byte slots
and the existing opcode — **no `IRXBC_VERSION` bump, no VM change, no
per-constant memory overhead**. Touches only the literal-emit path in
`src/irx#bcom.c`.

Doubled-quote literals (`'it''s'`) are de-doubled **first**, then chunked, so an
escaped `''` pair can never straddle a chunk boundary. The short case is
unchanged (stack buffer, single entry); the long case de-doubles into a
transient scratch buffer sized to the raw length (freed immediately).

## Why

HTTPREXX `.rxp` pages are almost entirely long HTML `say` literals, so a single
over-long literal previously disabled the bytecode fast path for the whole exec.
They now stay on it. Correctness was already handled by #207; this is the
performance follow-up.

## Scope / limits

Long **symbols** (`>63`-byte variable names) cannot be chunked and keep relying
on the #207 fallback — pathological, by design. PARSE-template literals
(`OP_TR_LIT`, single index) and numeric literals likewise stay on the fallback.
The #207 interpreter fallback remains the safety net for anything the compiler
still cannot represent (including const-table capacity overflow).

## Tests (host: 51 suites, 2504 assertions, 0 fail)

- `test/tstbcln.c` — boundary-compile checks at 62/63/64/126/127/189 bytes (all
  now compile), an over-long **symbol** still returns `STRTOOLONG`, a byte-exact
  127-byte multi-chunk execution test asserting **no fallback**
  (`wkbi_bc_fallback_count` unchanged, `wkbi_bc_exec_count+1`), and a
  bytecode/token-walk equivalence cross-check.
- `test/tstbcexe.c` — the long-literal e2e test now asserts the literal **stays
  on the bytecode path** with byte-exact captured `SAY` output; a new long
  doubled-quote case exercises the de-double-then-chunk path.
- `docs/ROADMAP.md` — closed-gate entry under the Decommission axis.