### PR TITLE
fix: honor line-continuation comma after a binary/prefix operator (#203)

### DIFF
--- a/src/irx#bcom.c
+++ b/src/irx#bcom.c
@@ -1966,8 +1966,29 @@ static int bc_compound_tails(struct bcom_ctx *ctx,
 
 static void bc_exp8(struct bcom_ctx *ctx)
 {
-    const struct irx_token *t = tok_at(ctx, 0);
+    const struct irx_token *t;
 
+    if (ctx->rc != IRXBC_OK)
+    {
+        return;
+    }
+
+    /* A continuation-comma sitting where an operand is expected is a
+     * physical-line join (SC28-1883-0 §3.2): the comma ended a line
+     * mid-expression, so its introduced blank is insignificant next to
+     * the pending operator and the operand continues on the joined
+     * line.  Skip it here and read the operand.  The between-terms case
+     * (a comma separating two COMPLETE sub-expressions) never reaches
+     * this leaf — bc_exp3 breaks on the comma and bc_expr folds it into
+     * a blank concatenation instead.  Argument boundaries are handled by
+     * bc_funcall / bc_call_stmt before they descend, so a separator comma
+     * never arrives here either (GitHub #203). */
+    while (tok_is_cont_comma(ctx, 0))
+    {
+        ctx->pos++;
+    }
+
+    t = tok_at(ctx, 0);
     if (t == NULL || ctx->rc != IRXBC_OK)
     {
         return;

--- a/src/irx#pars.c
+++ b/src/irx#pars.c
@@ -4190,9 +4190,27 @@ done:
 
 static int parse_primary(struct irx_parser *p, PLstr out)
 {
-    const struct irx_token *t = cur_tok(p);
+    const struct irx_token *t;
     int rc;
 
+    /* A continuation-comma sitting where an operand is expected is a
+     * physical-line join (SC28-1883-0 §3.2): the comma ended a line
+     * mid-expression, so its introduced blank is insignificant next to
+     * the pending operator and the operand continues on the joined
+     * line.  Skip it and read the operand.  The between-terms case (a
+     * comma separating two COMPLETE sub-expressions) never reaches this
+     * leaf — parse_concat breaks on the comma and irx_pars_eval_expr
+     * folds it into a blank concatenation instead.  Argument-separator
+     * commas are handled by parse_function_call / kw_call before they
+     * descend, so a separator comma never arrives here either
+     * (GitHub #203). */
+    while ((t = cur_tok(p)) != NULL && t->tok_type == TOK_COMMA &&
+           (t->tok_flags & TOKF_CONTINUATION) != 0)
+    {
+        advance_tok(p);
+    }
+
+    t = cur_tok(p);
     if (t == NULL || tok_ends_clause(t))
     {
         return fail(p, IRXPARS_SYNTAX);

--- a/test/trexxvl.c
+++ b/test/trexxvl.c
@@ -273,6 +273,9 @@ int main(void)
     static const char *c_do[] = {"do i = 1 to 3",
                                  "say 'i=' || i",
                                  "end"};
+    /* #203: a trailing comma continues the clause onto the next
+     * physical line; the || binds its right operand across the join. */
+    static const char *c_cont[] = {"b = 'x' || ,", "'y'", "say b"};
     static const char *c_hello[] = {
         "parse arg name; if name = '' then name = 'World'",
         "say '<h1>Hello, ' || (name) || '!</h1>'",
@@ -305,6 +308,8 @@ int main(void)
     rc |= run_lines("do", c_do, 3);
     wtof("TREXXVL: === 8. full transpiled hello.rxp ===");
     rc |= run_lines("hello", c_hello, 6);
+    wtof("TREXXVL: === 9. line continuation (trailing comma) ===");
+    rc |= run_lines("cont", c_cont, 3);
 
     wtof("TREXXVL: all cases done rc=%d", rc);
     return rc ? 8 : 0;

--- a/test/tstbcont.c
+++ b/test/tstbcont.c
@@ -333,6 +333,53 @@ static void test_arg_separator_preserved(struct envblock *env)
 }
 
 /* ------------------------------------------------------------------ */
+/*  Continuation-comma immediately after a binary operator.            */
+/*                                                                    */
+/*  When the comma follows an operator that still needs its right      */
+/*  operand (|| + - * etc.), the physical-line join drops the comma    */
+/*  and the operator binds across the line.  The introduced blank is   */
+/*  insignificant next to the operator, so `'x' || ,<nl>'y'` is a      */
+/*  direct concatenation ("xy"), not a blank concatenation ("x y").    */
+/*  GitHub mvslovers/rexx370#203.                                      */
+/* ------------------------------------------------------------------ */
+
+static void test_operator_continuation(struct envblock *env)
+{
+    printf("\n[continuation-comma after a binary operator]\n");
+
+    /* The issue #203 reproducer: || right operand on the next line. */
+    equiv(env, "b = 'x' || ,\n'y'\nsay b", "b = 'x' || ,<nl>'y'");
+    no_fallback(env, "b = 'x' || ,\n'y'\nsay b", "xy\n",
+                "|| across continuation -> 'xy' (direct concat)");
+
+    /* Arithmetic operators bind across the continuation too. */
+    equiv(env, "n = 1 +,\n2\nsay n", "n = 1 +,<nl>2");
+    no_fallback(env, "n = 1 +,\n2\nsay n", "3\n",
+                "+ across continuation -> 3");
+
+    equiv(env, "n = 6 *,\n7\nsay n", "n = 6 *,<nl>7");
+    no_fallback(env, "n = 6 *,\n7\nsay n", "42\n",
+                "* across continuation -> 42");
+
+    /* Prefix (unary) operator across the continuation. */
+    no_fallback(env, "n = -,\n5\nsay n", "-5\n",
+                "prefix - across continuation -> -5");
+
+    /* Comparison operator across the continuation. */
+    no_fallback(env, "say 1 =,\n1", "1\n",
+                "= across continuation -> 1");
+
+    /* Logical operator across the continuation. */
+    no_fallback(env, "say 1 &,\n1", "1\n",
+                "& across continuation -> 1");
+
+    /* A bare continuation line (just a comma) between operator and
+     * operand still joins correctly. */
+    no_fallback(env, "b = 'x' ||,\n,\n'y'\nsay b", "xy\n",
+                "double continuation-comma -> 'xy'");
+}
+
+/* ------------------------------------------------------------------ */
 /*  The REXXCPS line 166-167 clause shape.                            */
 /*  Output-agnostic (ran_bc): the clause contains zero-space           */
 /*  funcall+string abuttal (format(total,,1)'s)') whose output may     */
@@ -386,6 +433,7 @@ int main(void)
 
     test_say_continuation(env);
     test_other_expr_continuation(env);
+    test_operator_continuation(env);
     test_arg_separator_preserved(env);
     test_rexxcps_shape(env);
 


### PR DESCRIPTION
Fixes #203

## Problem

A trailing comma at logical end-of-line continues a REXX clause onto the next physical line (SC28-1883-0 §3.2), the comma functionally replaced by a blank. When the comma sits where an operand is still expected — immediately after a binary or prefix operator — the clause failed:

```rexx
b = 'x' || ,
'y'
say b
```

**Expected:** `b` = `xy`, exec says `xy`, RC=0.
**Actual:** the comma reached the expression leaf (`bc_exp8` / `parse_primary`), which raised UNSUP / a syntax error. The bytecode path fell back and the token-walk failed too, so IRXEXEC returned **RC=20** with no output.

The tokenizer already keeps the comma and flags it `TOKF_CONTINUATION`, and both the bytecode compiler (`bc_expr`) and the token-walk interpreter (`irx_pars_eval_expr`) folded a *trailing* continuation-comma into a blank concatenation at the top level. That covered the **between-terms** case (`say 'a',`⏎`'b'` → `"a b"`) but not the **operator→operand** case.

## Fix

Skip a continuation-comma at the operand position in both expression leaves (`bc_exp8`, `parse_primary`). The introduced blank is insignificant next to the pending operator, so the operator binds directly across the line (`'x' || 'y'` → `"xy"`).

The two positions stay distinct:
- **between-terms** never reaches the leaf — `is_value_starter` excludes `TOK_COMMA` and `bc_exp3`/`parse_concat` break on it, so the top-level blank-concat fold still runs (`"a b"`).
- **argument separators** are unaffected — `bc_funcall`, `bc_call_stmt`, `parse_function_call`, and `kw_call` all inspect `TOK_COMMA` before descending, so a separator comma never arrives at the leaf.

## Tests

- **TSTBCONT** (host, both paths): new `test_operator_continuation` — `||`, `+`, `*`, `=`, `&`, prefix `-`, and a double continuation-comma. Each asserts the bytecode path runs with **no fallback** and matches the token-walk. Full host suite green (**2514 assertions, 0 fail**).
- **TREXXVL** (MVS-only): added case 9, the `||`-across-continuation reproducer through the real IRXEXEC-via-VLIST path — guards the exact RC=20 symptom.

## Verification notes

- TREXXVL case 9 is **MVS-only** (`host = false`) and **could not be run in this session**. It compiles by construction (mirrors cases 1–8) and needs `make test-mvs` on target to confirm RC=0.
- **Known pre-existing limitation, out of scope for #203:** a *between-terms* continuation comma **inside parentheses** — `x = ('a',`⏎`'b')` — still fails on both paths, because the `LPAREN` branch calls `bc_exp0`/`parse_or` directly (not `bc_expr`/`irx_pars_eval_expr`), so the blank-concat fold never runs there. The operator case inside parens (`('a' ||,`⏎`'b')`) works via this fix. Worth a separate follow-up if the parenthesized blank-concat join is wanted.

https://claude.ai/code/session_012e4RgjsXMQPBdHnmAgaDff