### PR TITLE
perf(vpool): per-operand resolution cache for simple variables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,14 +421,18 @@ Same class of always-do as the test-registration rule (a `[[test]]` block in
 `docs/workpackages.md` holds the historical Phase 1-3 per-WP definitions and is
 **frozen/stale** — do not treat its status table as current.
 
-Current status (2026-06-03), summarized — see ROADMAP.md for detail:
+Current status (2026-08-15), summarized — see ROADMAP.md for detail:
 - Phases 1-3 (skeleton, core interpreter, arithmetic + BIFs): complete
 - REXXCPS runs end-to-end on the **bytecode VM** (the primary path); the
   token-walk interpreter is frozen (CON-18) as fallback + equivalence reference
-- Active focus: performance toward BREXX (~20.9k vs ~89.9k cps on System A,
-  factor ~4.3×) and token-walk decommission (CON-20)
-- Next performance step: a **fresh bytecode-VM profile** (the old profile is
-  stale after three optimization rounds) before choosing the next optimization
+- Active focus: performance toward BREXX and token-walk decommission (CON-20)
+- The re-profile is **done** (`docs/diag/wp-perf-profile-2.md`, 2026-06-03) —
+  do not run another one before acting on it. It ranked the variable-resolution
+  cache first; that is #218, in progress.
+- **The old System A / System B measuring machines no longer exist.** Every cps
+  figure predating 2026-08-15 (the 20.9k System A baseline, the 4.3× factor)
+  was taken on hardware that is gone and is *not* comparable to a new
+  measurement. Re-baseline on the current system before quoting a factor.
 
 ## Knowledge sources
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ Forward-looking development plan. This is the **single source of truth** for
 database; this file orders the open work into strategic axes and is kept current
 as phases complete.
 
-Last updated: 2026-07-03
+Last updated: 2026-08-15
 
 ---
 
@@ -24,27 +24,57 @@ Two execution paths exist:
 
 **Two existential goals drive everything:**
 
-1. **Approach BREXX/370 performance.** BREXX runs REXXCPS at ~89,878 cps on
-   MVS/CE (System A). We are at ~20,899 cps (System A, post OC-ARITH) =
-   **factor ~4.3× slower**, down from 6.3× at the start of the bytecode phase.
+1. **Approach BREXX/370 performance.** Across the bytecode phase the gap to
+   BREXX narrowed from 6.3× to 4.3×. Both those figures come from System A,
+   which no longer exists — see the note under Performance history. The current
+   machine has one datapoint (17,144 cps with #218) and no BREXX reference yet,
+   so **there is no defensible factor to quote right now**; re-baselining is the
+   first Axis 1 task.
 2. **Decommission the token-walk path.** Bytecode as the sole execution path.
    Requires the bytecode VM to be (a) functionally complete and (b) broadly
    correctness-verified. Tracked in CON-20.
 
-### Performance history (System A — Docker/WSL, the "work" machine)
+### Performance history — historical, on hardware that no longer exists
 
-| Milestone | cps (System A) | factor to BREXX |
+> ⚠️ **System A and System B are both gone** (2026-08-15). `mvsdev.lan` is now
+> Proxmox directly, without Docker. Every figure in the table below was taken on
+> one of the retired machines, so **none of it is comparable to a measurement
+> taken today** — including the 4.3× factor to BREXX, whose BREXX number came
+> from System A as well. Treat the table as a record of *relative* progress
+> across the bytecode phase, not as a baseline to measure against.
+
+| Milestone | cps (System A, retired) | factor to BREXX (then) |
 |---|---|---|
 | Bytecode baseline | 14,280 | 6.3× |
 | + OC-09 (BIF dispatch) | 17,274 | 5.2× |
 | + OC-ARITH (integer op fast-path) | 20,899 | 4.3× |
-| **BREXX/370 target** | **89,878** | 1.0× |
+| **BREXX/370 reference** | **89,878** | 1.0× |
 
-> **Measurement discipline:** Two MVS systems exist — System A (Docker/WSL,
-> notebook) and System B (Docker/Proxmox-VM, home). Identical code gives
-> different cps (A ≈ 1.4× B). Always compare before/after on the *same* system,
-> and never accept a cps number without a verified `[bc] exec=1 fallback=0` line.
-> Details in CON-12.
+### Current system (`mvsdev.lan`, Proxmox direct — since 2026-08-15)
+
+| Milestone | cps | note |
+|---|---|---|
+| + varcache (#218) | **17,144** | median of 2, min 16,920 / max 17,144 |
+| pre-varcache (`cb0ebdb`) | *not yet measured* | mvsMF went down before the run |
+| BREXX/370 reference | *not yet measured* | needed before quoting any factor |
+
+**#218's MVS gain is therefore still unmeasured** — the AFTER figure has nothing
+on this machine to compare against. Host wall-clock on the `tstrxcps` kernel
+showed 1.184s → 1.093s (~7.7 %, 3 runs per side), which is an iteration signal
+only, not the metric.
+
+> **Measurement discipline:** always compare before/after on the *same* system,
+> and never accept a cps number without a verified `[bc] exec=1 fallback=0`
+> line. Details in CON-12.
+>
+> **How to run it** (undocumented until now, both parts are easy to lose a run
+> to): REXXCPS self-calibrates to ~590 s, so the step needs **`TIME=1440`** —
+> the default class limit kills it with **S322** at about 1m34, after which
+> SYSTSPRT is empty and the run looks like a program fault. The `[bc]` gate line
+> needs `REXX370_BCDEBUG=1`, passed via a **`SYSENV` DD** (libc370 `@@start.c`
+> calls `loadenv("dd:SYSENV")`, falling back to `ENVIRON`). JCL lines are
+> columns 1-71 — a JOB card one character over is rejected as "no valid JOB
+> card found".
 
 ---
 
@@ -62,6 +92,15 @@ roughly halved, not gone); cluster B (variable pool) was untouched as designed
 and is **now the #1 cluster (~27 % flat self)**.
 
 Next candidates, ranked by the new profile (share ≠ lever — see the doc):
+- ~~**Variable-resolution (pointer) cache**~~ — **built** (#218, 2026-08-15).
+  First cut is simple variables with a coarse pool generation, exactly as the
+  diag recommended. The generation is bumped only by entry frees (`DROP`,
+  stem-drop), `EXPOSE` and resize — never by assignment, which is what the
+  44.8-reads/invalidation figure rests on. Compounds fall through to the
+  uncached path untouched and remain open as a separate, lower-payoff design.
+  A latent defect was fixed on the way: `vpool_drop_stem_all` freed entries
+  without bumping the generation because it splices the bucket chain itself
+  instead of going through `unlink_entry`. Original description follows.
 - **Variable-resolution (pointer) cache** (top recommendation) — cache the
   resolved vpool entry pointer at each bytecode reference *operand site*, for the
   ~88 % **simple-variable** bulk of cluster B. **Invalidation frequency now

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,9 +27,9 @@ Two execution paths exist:
 1. **Approach BREXX/370 performance.** Across the bytecode phase the gap to
    BREXX narrowed from 6.3× to 4.3×. Both those figures come from System A,
    which no longer exists — see the note under Performance history. The current
-   machine has one datapoint (17,144 cps with #218) and no BREXX reference yet,
-   so **there is no defensible factor to quote right now**; re-baselining is the
-   first Axis 1 task.
+   machine measures ~16.8-17.1k cps and has no BREXX reference yet, so **there
+   is no defensible factor to quote right now**; measuring BREXX on this system
+   is the first Axis 1 task.
 2. **Decommission the token-walk path.** Bytecode as the sole execution path.
    Requires the bytecode VM to be (a) functionally complete and (b) broadly
    correctness-verified. Tracked in CON-20.
@@ -52,16 +52,36 @@ Two execution paths exist:
 
 ### Current system (`mvsdev.lan`, Proxmox direct — since 2026-08-15)
 
-| Milestone | cps | note |
+| Milestone | cps (n=2, gate verified) | note |
 |---|---|---|
-| + varcache (#218) | **17,144** | median of 2, min 16,920 / max 17,144 |
-| pre-varcache (`cb0ebdb`) | *not yet measured* | mvsMF went down before the run |
+| pre-varcache (`cb0ebdb`) | 16,794 / 16,820 | spread 0.15 % |
+| + varcache (#218) | 16,920 / 17,144 | spread 1.32 % |
 | BREXX/370 reference | *not yet measured* | needed before quoting any factor |
 
-**#218's MVS gain is therefore still unmeasured** — the AFTER figure has nothing
-on this machine to compare against. Host wall-clock on the `tstrxcps` kernel
-showed 1.184s → 1.093s (~7.7 %, 3 runs per side), which is an iteration signal
-only, not the metric.
+**#218 measured: +0.6 % to +2.1 %** (worst case min-after vs max-before, best
+case max-after vs min-before; +1.3 % comparing means). The four runs separate
+cleanly — every AFTER run beat every BEFORE run — so the win is real and
+consistent. But the AFTER spread (1.32 %) is the same size as the effect, so
+with n=2 per side **the range is the result; the point estimate is not
+meaningful.**
+
+> **This is the important entry in this table.** The profile put the removable
+> vpool-lookup self-time at **~18.8 %** (an upper bound), host wall-clock on the
+> `tstrxcps` kernel gained **~7.7 %**, and the Hercules-multiplier heuristic
+> below would have predicted 3-5× of that on MVS. The measured result is
+> **an order of magnitude under all three**. No explanation is recorded here
+> because none has been measured — `-O1` on MVS vs `-O2` on the host is a
+> plausible contributor and nothing more. What is established: **the Hercules
+> multiplier does not generalize to the vpool lookup.** It was validated on
+> WP-PERF-03/04, OC-12 and OC-ARITH, all of which cut memory traffic in the
+> arithmetic and dispatch paths; weigh it accordingly for the next
+> memory-bound candidate, because it now has a counterexample.
+>
+> Cheapest way to close the question, if it is worth closing: instrument
+> hit/miss counters on the cache and read them off an MVS run — that
+> distinguishes "the 18.8 % upper bound was wrong" from "the cache is not
+> hitting on MVS as it did on the host". More cps runs would only tighten a
+> bound that is already known to be small.
 
 > **Measurement discipline:** always compare before/after on the *same* system,
 > and never accept a cps number without a verified `[bc] exec=1 fallback=0`
@@ -137,6 +157,14 @@ optimizations deliver 3-5× their host-measured effect on MVS (validated across
 WP-PERF-03/04, OC-12, OC-ARITH). Weight memory-bound candidates higher than
 pure-CPU ones. The host profile is an *iteration tool*; MVS cps is the target
 metric.
+
+⚠️ **The heuristic now has a counterexample.** #218 (varcache) is
+memory-access-bound by the same reasoning, gained ~7.7 % on the host, and
+delivered **+0.6 % to +2.1 %** on MVS — a *fraction* of its host effect, not a
+multiple. The three validating cases all cut memory traffic in the arithmetic
+and dispatch paths; the vpool lookup evidently does not behave the same way. Do
+not use the multiplier to justify the next candidate without saying which of
+the validated cases it resembles.
 
 ### Axis 2 — Decommission / Correctness (toward token-walk removal)
 

--- a/include/irxvpool.h
+++ b/include/irxvpool.h
@@ -84,10 +84,44 @@ struct irx_vpool
     int exposed_stem_cap;
     struct lstr_alloc *alloc; /* injected allocator   */
 
+    /* Bumped whenever a cached entry pointer could go stale: entry
+     * free (DROP / stem-drop), EXPOSE, resize. NOT bumped on the
+     * assignment update path - vpool_set_buf writes in place on the
+     * same entry object, so a cached pointer reads the new value
+     * live. See vpool_get_cached(). Wraps at 2^32; the events are
+     * rare enough (thousands per run) that this is unreachable. */
+    unsigned long generation;
+
     /* NEXT cursor. Do not mutate the pool while iterating. */
     int next_bucket;
     struct vpool_entry *next_entry;
     int next_started;
+};
+
+/* ================================================================== */
+/*  Resolution cache                                                  */
+/* ================================================================== */
+
+/* One cache slot per bytecode operand site (per symbol-table index).
+ * Caches the bucket entry a simple-variable name resolved to, so a
+ * repeat read skips hash + bucket index + bucket walk.
+ *
+ * The cached pointer is the PRE-resolve bucket entry, not the target
+ * resolve_ref() lands on: its lifetime is then tied to exactly the
+ * pool whose generation is checked here, which makes a hit no more
+ * dangling-prone than the uncached path. resolve_ref() runs on every
+ * hit - a flag test plus at most one hop.
+ *
+ * A slot is valid only while `pool` and `gen` both still match. The
+ * owner must additionally zero its slots whenever the active pool
+ * changes: vpool_destroy() + vpool_create() can return the same
+ * address, and a fresh pool starts at generation 0, so the pair could
+ * otherwise match a dead pool by coincidence. */
+struct vpool_cache_slot
+{
+    struct irx_vpool *pool;    /* pool the entry was resolved in   */
+    unsigned long gen;         /* pool->generation at resolve time */
+    struct vpool_entry *entry; /* bucket entry, before resolve_ref */
 };
 
 /* ================================================================== */
@@ -139,6 +173,24 @@ int vpool_get_buf(struct irx_vpool *pool,
                   PLstr value,
                   int32_t *type_cache_out,
                   int32_t *int_cache_out) asm("VPOOLGTB");
+
+/* As vpool_get_buf(), but consults `slot` first and fills it on a
+ * miss. Falls straight through to the uncached path - without ever
+ * touching the slot - for any name containing a dot, so compound
+ * lookups, the stem-default fallback and exposed-stem delegation
+ * keep today's behaviour exactly.
+ *
+ * That dotless restriction is what makes skipping matches_exposed_stem()
+ * on a hit correct: every caller of vpool_expose_stem() admits only
+ * names ending in '.', and name_matches_stem() compares the stem's
+ * full length including that dot, so a dotless name can never match
+ * an exposed stem. */
+int vpool_get_cached(struct irx_vpool *pool,
+                     const char *name_data, int name_len,
+                     PLstr value,
+                     int32_t *type_cache_out,
+                     int32_t *int_cache_out,
+                     struct vpool_cache_slot *slot) asm("VPOOLGTC");
 
 int vpool_set_buf(struct irx_vpool *pool,
                   const char *name_data, int name_len,

--- a/src/irx#bvm.c
+++ b/src/irx#bvm.c
@@ -216,6 +216,25 @@ bvm_resolve_bif(struct envblock *envblock, const char *sym_base,
     return bife;
 }
 
+/* Drop every cached variable resolution (WP-PERF-VARCACHE).
+ *
+ * MUST be called after every assignment to `vpool`. A slot is keyed on
+ * (pool address, generation), and neither survives a scope change:
+ * vpool_destroy() followed by vpool_create() can hand back the same
+ * address, and a fresh pool starts at generation 0 - so a slot cached
+ * at generation 0 in the dead pool would match the new one by pure
+ * coincidence and resolve to freed memory. Flushing on the switch is
+ * what closes that window; the per-slot pool/generation check alone
+ * cannot. */
+static void vcache_flush(struct vpool_cache_slot *var_cache, int n_syms)
+{
+    if (var_cache != NULL && n_syms > 0)
+    {
+        memset(var_cache, 0,
+               (size_t)n_syms * sizeof(struct vpool_cache_slot));
+    }
+}
+
 /* ================================================================== */
 /*  Lstr helpers                                                      */
 /* ================================================================== */
@@ -850,7 +869,9 @@ int irx_bc_execute(struct envblock *envblock,
     void *call_frame_mem = NULL;
     void *proxy_parser_mem = NULL;
     void *label_pc_mem = NULL;
-    void *bif_cache_mem = NULL; /* WP-BC-OC09 */
+    void *bif_cache_mem = NULL;                /* WP-BC-OC09 */
+    struct vpool_cache_slot *var_cache = NULL; /* WP-PERF-VARCACHE */
+    void *var_cache_mem = NULL;
     int32_t *const_type_cache = NULL;
     int32_t *const_int_cache = NULL;
     void *const_cache_mem = NULL;
@@ -1004,6 +1025,25 @@ int irx_bc_execute(struct envblock *envblock,
         memset(bif_cache_mem, 0,
                (size_t)n_syms * sizeof(const struct irx_bif_entry *));
         bif_cache = (const struct irx_bif_entry **)bif_cache_mem;
+    }
+
+    /* --- WP-PERF-VARCACHE: per-symbol variable resolution cache ------ */
+    /* One slot per symbol, indexed by sym_idx parallel to bif_cache.    */
+    /* OP_LOAD hands its slot to vpool_get_cached(), which skips the     */
+    /* hash + bucket walk while the slot's pool and generation still     */
+    /* match.  Simple variables only; compounds fall through untouched.  */
+    /* Must be flushed via vcache_flush() on every change of `vpool`.    */
+    if (n_syms > 0)
+    {
+        if (irxstor(RXSMGET, n_syms * (int)sizeof(struct vpool_cache_slot),
+                    &var_cache_mem, envblock) != 0)
+        {
+            vm_rc = IRXBC_ERR_STOR;
+            goto done;
+        }
+        memset(var_cache_mem, 0,
+               (size_t)n_syms * sizeof(struct vpool_cache_slot));
+        var_cache = (struct vpool_cache_slot *)var_cache_mem;
     }
 
     /* --- OC-07: pre-compute integer cache for all constants (WP-BC-06) */
@@ -1285,10 +1325,16 @@ int irx_bc_execute(struct envblock *envblock,
                     }
                     stack[sp].type_cache = 0;
                     stack[sp].int_cache = 0;
-                    vrc = vpool_get_buf(vpool, name_data, name_len,
-                                        stack[sp].str,
-                                        &stack[sp].type_cache,
-                                        &stack[sp].int_cache);
+                    vrc = var_cache != NULL
+                              ? vpool_get_cached(vpool, name_data, name_len,
+                                                 stack[sp].str,
+                                                 &stack[sp].type_cache,
+                                                 &stack[sp].int_cache,
+                                                 &var_cache[idx])
+                              : vpool_get_buf(vpool, name_data, name_len,
+                                              stack[sp].str,
+                                              &stack[sp].type_cache,
+                                              &stack[sp].int_cache);
                     if (vrc == VPOOL_NOT_FOUND)
                     {
                         /* NOVALUE trap: fire if SIGNAL ON NOVALUE is active */
@@ -2458,6 +2504,7 @@ int irx_bc_execute(struct envblock *envblock,
                             vpool_destroy(vpool);
                             vpool = cf->prev_vpool;
                             proxy_parser->vpool = vpool;
+                            vcache_flush(var_cache, n_syms);
                             /* Isolated scope: RESULT in caller's pool is
                              * untouched — matches token-walk kw_return. */
                         }
@@ -2533,6 +2580,7 @@ int irx_bc_execute(struct envblock *envblock,
                             vpool_destroy(vpool);
                             vpool = cf->prev_vpool;
                             proxy_parser->vpool = vpool;
+                            vcache_flush(var_cache, n_syms);
                         }
 
                         vrc = vpool_set_buf(vpool, "RESULT", 6,
@@ -2632,6 +2680,7 @@ int irx_bc_execute(struct envblock *envblock,
                             vpool_destroy(vpool);
                             vpool = cf->prev_vpool;
                             proxy_parser->vpool = vpool;
+                            vcache_flush(var_cache, n_syms);
                         }
                     }
                     call_sp = 0;
@@ -2726,6 +2775,7 @@ int irx_bc_execute(struct envblock *envblock,
                             vpool_destroy(vpool);
                             vpool = cf->prev_vpool;
                             proxy_parser->vpool = vpool;
+                            vcache_flush(var_cache, n_syms);
                         }
                     }
                     call_sp = 0;
@@ -3439,6 +3489,7 @@ int irx_bc_execute(struct envblock *envblock,
                     cf->has_isolated_scope = 1;
                     vpool = new_vpool;
                     proxy_parser->vpool = vpool;
+                    vcache_flush(var_cache, n_syms);
                     break;
                 }
 
@@ -3635,6 +3686,7 @@ int irx_bc_execute(struct envblock *envblock,
                     vpool_destroy(vpool);
                     vpool = cf_t->prev_vpool;
                     proxy_parser->vpool = vpool;
+                    vcache_flush(var_cache, n_syms);
                 }
             }
             call_sp = 0;
@@ -3761,6 +3813,9 @@ done:
                 {
                     vpool_destroy(vpool);
                 }
+                /* No vcache_flush() here, unlike every other vpool
+                 * assignment: this unwinds frames after the dispatch
+                 * loop has ended, so no OP_LOAD can observe a slot. */
                 vpool = cf->prev_vpool;
             }
         }
@@ -3786,6 +3841,11 @@ done:
     if (bif_cache_mem != NULL)
     {
         void *p = bif_cache_mem;
+        irxstor(RXSMFRE, 0, &p, envblock);
+    }
+    if (var_cache_mem != NULL)
+    {
+        void *p = var_cache_mem;
         irxstor(RXSMFRE, 0, &p, envblock);
     }
     if (proxy_parser_mem != NULL)

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -289,6 +289,10 @@ static int maybe_resize(struct irx_vpool *pool)
     pool->next_bucket = 0;
     pool->next_entry = NULL;
 
+    /* Entries are re-linked, not moved, so cached pointers stay
+     * valid across a resize. Bumping anyway is free insurance. */
+    pool->generation++;
+
     return VPOOL_OK;
 }
 
@@ -377,6 +381,7 @@ static void unlink_entry(struct irx_vpool *pool, int idx,
                 prev->next = cur->next;
             }
             pool->entry_count--;
+            pool->generation++; /* frees the entry - cached ptrs die */
             return;
         }
         prev = cur;
@@ -670,6 +675,7 @@ int vpool_expose_var(struct irx_vpool *pool, const PLstr name)
     child_e->flags |= VPOOL_EXPOSED_REF;
     child_e->exposed_ref = parent_e;
 
+    pool->generation++; /* resolution target moved scope */
     return link_entry(pool, child_e);
 }
 
@@ -718,6 +724,7 @@ int vpool_expose_stem(struct irx_vpool *pool, const PLstr stem_name)
         return VPOOL_NOMEM;
     }
     pool->exposed_stem_count++;
+    pool->generation++; /* stem access now delegates to the parent */
     return VPOOL_OK;
 }
 
@@ -899,6 +906,95 @@ int vpool_get_buf(struct irx_vpool *pool, const char *name_data, int name_len,
     }
 
     return VPOOL_NOT_FOUND;
+}
+
+/* Copy an entry's value + integer caches out to the caller. Shared by
+ * the cached hit path and vpool_get_cached()'s miss path. */
+static int copy_entry_out(struct irx_vpool *pool, struct vpool_entry *tgt,
+                          PLstr value, int32_t *tc_out, int32_t *ic_out)
+{
+    if (Lstrcpy(pool->alloc, value, &tgt->value) != LSTR_OK)
+    {
+        return VPOOL_NOMEM;
+    }
+    if (tc_out != NULL)
+    {
+        *tc_out = tgt->type_cache;
+    }
+    if (ic_out != NULL)
+    {
+        *ic_out = tgt->int_cache;
+    }
+    return VPOOL_OK;
+}
+
+int vpool_get_cached(struct irx_vpool *pool, const char *name_data,
+                     int name_len, PLstr value, int32_t *tc_out,
+                     int32_t *ic_out, struct vpool_cache_slot *slot)
+{
+    Lstr name;
+    int idx;
+    struct vpool_entry *e;
+    struct vpool_entry *tgt;
+
+    if (pool == NULL || name_data == NULL || value == NULL || slot == NULL)
+    {
+        return VPOOL_BADARG;
+    }
+
+    /* Compounds keep the uncached path verbatim: the stem-default
+     * fallback and exposed-stem delegation both need the full body,
+     * and a per-operand slot cannot cache a name whose tail is
+     * re-derived on every reference. */
+    for (int i = 0; i < name_len; i++)
+    {
+        if (name_data[i] == '.')
+        {
+            return vpool_get_buf(pool, name_data, name_len, value, tc_out,
+                                 ic_out);
+        }
+    }
+
+    /* Hit: skip hash + bucket index + bucket walk + exposed-stem scan.
+     * resolve_ref() still runs - the slot holds the pre-resolve entry. */
+    if (slot->pool == pool && slot->gen == pool->generation &&
+        slot->entry != NULL)
+    {
+        tgt = resolve_ref(slot->entry);
+        if (tgt != NULL && !(tgt->flags & VPOOL_UNSET))
+        {
+            return copy_entry_out(pool, tgt, value, tc_out, ic_out);
+        }
+        /* Entry went UNSET behind the cache (EXPOSE placeholder that
+         * was never assigned) - fall through and re-resolve. */
+    }
+
+    name.pstr = (unsigned char *)name_data;
+    name.len = (size_t)name_len;
+    name.maxlen = (size_t)name_len;
+    name.type = LSTRING_TY;
+
+    idx = bucket_index(pool, &name);
+    e = find_in_bucket(pool->buckets[idx], &name);
+    if (e == NULL)
+    {
+        return VPOOL_NOT_FOUND;
+    }
+
+    tgt = resolve_ref(e);
+    if (tgt == NULL || (tgt->flags & VPOOL_UNSET))
+    {
+        return VPOOL_NOT_FOUND;
+    }
+
+    /* Only positive resolutions are cached. A miss re-resolves every
+     * time, so an entry created later is picked up without needing a
+     * generation bump on the create path. */
+    slot->pool = pool;
+    slot->gen = pool->generation;
+    slot->entry = e;
+
+    return copy_entry_out(pool, tgt, value, tc_out, ic_out);
 }
 
 int vpool_set_buf(struct irx_vpool *pool, const char *name_data, int name_len,

--- a/src/irx#vpol.c
+++ b/src/irx#vpol.c
@@ -1135,6 +1135,11 @@ int vpool_drop_stem_all(struct irx_vpool *pool,
                     pool->buckets[b] = next;
                 }
                 pool->entry_count--;
+                /* This path splices the chain itself rather than going
+                 * through unlink_entry(), so it must bump the
+                 * generation on its own - an entry is being freed and
+                 * any cached pointer to it dies with it. */
+                pool->generation++;
                 vp_entry_free(pool->alloc, e);
             }
             else

--- a/test/tstvpol.c
+++ b/test/tstvpol.c
@@ -595,6 +595,146 @@ static void test_allocator_injection(void)
 }
 
 /* ------------------------------------------------------------------ */
+/*  WP-PERF-VARCACHE - resolution cache (#218)                        */
+/* ------------------------------------------------------------------ */
+
+/* Read NAME through `slot` and assert the value. Returns the rc so a
+ * caller can distinguish NOT_FOUND from a value mismatch. */
+static int cached_get(struct irx_vpool *pool, const char *name,
+                      struct vpool_cache_slot *slot, Lstr *out)
+{
+    return vpool_get_cached(pool, name, (int)strlen(name), out, NULL, NULL,
+                            slot);
+}
+
+static void test_varcache(void)
+{
+    struct lstr_alloc *a = lstr_default_alloc();
+    struct irx_vpool *pool = vpool_create(a, NULL);
+    struct vpool_cache_slot slot;
+    Lstr value;
+    Lstr out;
+
+    printf("\n-- WP-PERF-VARCACHE: resolution cache --\n");
+
+    memset(&slot, 0, sizeof(slot));
+    Lzeroinit(&value);
+    Lzeroinit(&out);
+
+    set_lstr(a, &value, "one");
+    vpool_set_buf(pool, "X", 1, &value, 0, 0);
+
+    /* Cold read fills the slot. */
+    CHECK(cached_get(pool, "X", &slot, &out) == VPOOL_OK,
+          "varcache: cold read finds X");
+    CHECK(lstr_eq_cstr(&out, "one"), "varcache: cold read returns 'one'");
+    CHECK(slot.entry != NULL && slot.pool == pool,
+          "varcache: cold read populated the slot");
+
+    /* THE core claim: an assignment must NOT invalidate a pointer
+     * cache, because vpool_set_buf updates in place on the same entry
+     * object. A hit has to observe the new value live. */
+    unsigned long gen_before = pool->generation;
+    set_lstr(a, &value, "two");
+    vpool_set_buf(pool, "X", 1, &value, 0, 0);
+    CHECK(pool->generation == gen_before,
+          "varcache: assignment does not bump the generation");
+    CHECK(cached_get(pool, "X", &slot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "two"),
+          "varcache: cached hit sees the value written in place");
+
+    /* (a) entry free - DROP must invalidate. */
+    vpool_drop_buf(pool, "X", 1);
+    CHECK(pool->generation != gen_before,
+          "varcache: DROP bumps the generation");
+    CHECK(cached_get(pool, "X", &slot, &out) == VPOOL_NOT_FOUND,
+          "varcache: dropped variable is not served from the cache");
+
+    /* A re-created variable is picked up even though nothing bumped
+     * the generation on create - misses are never cached. */
+    set_lstr(a, &value, "three");
+    vpool_set_buf(pool, "X", 1, &value, 0, 0);
+    CHECK(cached_get(pool, "X", &slot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "three"),
+          "varcache: re-created variable resolves again");
+
+    /* A slot carrying a foreign pool must never be honoured. */
+    struct irx_vpool *other = vpool_create(a, NULL);
+    set_lstr(a, &value, "other_x");
+    vpool_set_buf(other, "X", 1, &value, 0, 0);
+    CHECK(cached_get(other, "X", &slot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "other_x"),
+          "varcache: slot from another pool is re-resolved, not reused");
+
+    /* (d) resize - entries are re-linked, not moved, but the bump
+     * must still happen so a stale slot cannot outlive it. */
+    struct irx_vpool *big = vpool_create(a, NULL);
+    struct vpool_cache_slot bslot;
+    memset(&bslot, 0, sizeof(bslot));
+    set_lstr(a, &value, "keep");
+    vpool_set_buf(big, "K", 1, &value, 0, 0);
+    CHECK(cached_get(big, "K", &bslot, &out) == VPOOL_OK,
+          "varcache: K cached before resize");
+    for (int i = 0; i < 200; i++)
+    {
+        char nm[16];
+        sprintf(nm, "F%d", i);
+        set_lstr(a, &value, "filler");
+        vpool_set_buf(big, nm, (int)strlen(nm), &value, 0, 0);
+    }
+    CHECK(cached_get(big, "K", &bslot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "keep"),
+          "varcache: K still correct after the pool resized");
+
+    /* (b) scope switch - EXPOSE changes where a name resolves. */
+    struct irx_vpool *parent = vpool_create(a, NULL);
+    struct irx_vpool *child = vpool_create(a, parent);
+    struct vpool_cache_slot cslot;
+    Lstr nm_y;
+
+    memset(&cslot, 0, sizeof(cslot));
+    Lzeroinit(&nm_y);
+    set_lstr(a, &value, "parent_y");
+    vpool_set_buf(parent, "Y", 1, &value, 0, 0);
+    set_lstr(a, &value, "child_y");
+    vpool_set_buf(child, "Y", 1, &value, 0, 0);
+
+    CHECK(cached_get(child, "Y", &cslot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "child_y"),
+          "varcache: child Y cached as the child's own value");
+
+    set_lstr(a, &nm_y, "Y");
+    unsigned long cgen = child->generation;
+    vpool_expose_var(child, &nm_y);
+    CHECK(child->generation != cgen,
+          "varcache: EXPOSE bumps the child's generation");
+    CHECK(cached_get(child, "Y", &cslot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "parent_y"),
+          "varcache: after EXPOSE the cache resolves to the parent value");
+
+    /* Compounds must bypass the slot entirely - the stem-default
+     * fallback lives in the uncached path. */
+    struct vpool_cache_slot dslot;
+    memset(&dslot, 0, sizeof(dslot));
+    set_lstr(a, &value, "default");
+    vpool_set_buf(pool, "S.", 2, &value, 0, 0);
+    CHECK(cached_get(pool, "S.TAIL", &dslot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "default"),
+          "varcache: compound falls back to the stem default");
+    CHECK(dslot.entry == NULL && dslot.pool == NULL,
+          "varcache: compound lookup leaves the slot untouched");
+
+    Lfree(a, &nm_y);
+    Lfree(a, &value);
+    Lfree(a, &out);
+    vpool_destroy(child);
+    vpool_destroy(parent);
+    vpool_destroy(big);
+    vpool_destroy(other);
+    vpool_destroy(pool);
+}
+
+/* ------------------------------------------------------------------ */
 /*  Main                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -611,6 +751,7 @@ int main(void)
     test_expose_stem();
     test_iteration();
     test_allocator_injection();
+    test_varcache();
 
     printf("\n=== Results: %d/%d passed",
            tests_passed, tests_run);

--- a/test/tstvpol.c
+++ b/test/tstvpol.c
@@ -712,6 +712,28 @@ static void test_varcache(void)
               lstr_eq_cstr(&out, "parent_y"),
           "varcache: after EXPOSE the cache resolves to the parent value");
 
+    /* (a, cont.) stem-drop frees entries by splicing the bucket chain
+     * itself instead of calling unlink_entry(), so it has to bump the
+     * generation on its own. A dotless slot cannot dangle from it
+     * today - only "STEM." names are freed - but the counter's
+     * invariant is "bumped whenever an entry is freed", and the
+     * compound cache will depend on it. */
+    struct vpool_cache_slot sslot;
+    memset(&sslot, 0, sizeof(sslot));
+    set_lstr(a, &value, "elem");
+    vpool_set_buf(pool, "T.1", 3, &value, 0, 0);
+    set_lstr(a, &value, "plain");
+    vpool_set_buf(pool, "P", 1, &value, 0, 0);
+    CHECK(cached_get(pool, "P", &sslot, &out) == VPOOL_OK,
+          "varcache: P cached before the stem drop");
+    unsigned long sgen = pool->generation;
+    vpool_drop_stem_all(pool, "T.", 2);
+    CHECK(pool->generation != sgen,
+          "varcache: stem-drop bumps the generation");
+    CHECK(cached_get(pool, "P", &sslot, &out) == VPOOL_OK &&
+              lstr_eq_cstr(&out, "plain"),
+          "varcache: unrelated simple var survives the stem drop");
+
     /* Compounds must bypass the slot entirely - the stem-default
      * fallback lives in the uncached path. */
     struct vpool_cache_slot dslot;


### PR DESCRIPTION
Closes #218.

## Measured result — read this first

Baseline and varcache builds measured back to back on `mvsdev.lan`, two runs each, `[bc] exec=1 fallback=0` verified on all four:

| build | cps | spread |
|---|---|---|
| pre-varcache (`cb0ebdb`) | 16,794 / 16,820 | 0.15 % |
| + varcache (this PR) | 16,920 / 17,144 | 1.32 % |

**+0.6 % to +2.1 %.** Every AFTER run beat every BEFORE run, so the win is real and consistent — but it came in **an order of magnitude under prediction**: the profile put the removable vpool-lookup self-time at ~18.8 % (upper bound), host wall-clock on the `tstrxcps` kernel gained ~7.7 %, and the Hercules-multiplier heuristic would have predicted 3-5× *of that* on MVS. The AFTER spread is the same size as the effect, so with n=2 per side the range is the result and the point estimate is not meaningful.

No cause is claimed. `-O1` on MVS vs `-O2` on the host is a plausible contributor and nothing more; nothing isolating it was measured. What the run does establish is recorded at the heuristic in ROADMAP: **the Hercules multiplier does not generalize to the vpool lookup** — it was validated on WP-PERF-03/04, OC-12 and OC-ARITH, all of which cut memory traffic in the arithmetic and dispatch paths, and it now has a counterexample.

Cheapest way to close the open question, if it is worth closing: instrument hit/miss counters and read them off an MVS run. That distinguishes "the 18.8 % bound was wrong" from "the cache is not hitting on MVS as it did on the host". More cps runs would only tighten a bound already known to be small.

## What the cache does

Caches the bucket entry an `OP_LOAD` operand resolved to, in a slot array indexed by symbol index, parallel to the OC-09 BIF cache. A hit skips `hash_bytes` + `bucket_index` + `find_in_bucket` + the exposed-stem scan and reads the value live out of the entry.

The win rests on **assignment not invalidating it**: `vpool_set_buf` updates via `Lstrcpy` on the same entry object, so the entry address is stable across writes, and `maybe_resize` re-links entries without moving them. Writes are 90.8 % of invalidation candidates — that is what separates this from the write-invalidated variant the diag measured at 2.06 reads/invalidation. Only entry frees (`DROP`, stem-drop), `EXPOSE` and resize bump the pool generation.

## Design decisions worth reviewing

**Simple variables only.** Any name containing a dot falls straight through to `vpool_get_buf` without touching the slot, so the stem-default fallback and exposed-stem delegation keep today's behaviour. That restriction is also what makes skipping `matches_exposed_stem()` on a hit correct: every `vpool_expose_stem()` caller admits only names ending in `.`, and `name_matches_stem()` compares the stem's full length *including* that dot, so a dotless name can never match one. All four production callers were checked (`irx#bvm.c:3465/3556`, `irx#pars.c:2202/2232`).

**The slot holds the pre-resolve bucket entry**, not the `resolve_ref` target — that ties its lifetime to exactly the pool whose generation is checked, making a hit no more dangling-prone than the uncached path. `resolve_ref` runs on every hit (a flag test plus at most one hop).

**Only positive resolutions are cached**, so a variable created later is picked up without needing a generation bump on the create path — and negative caching, with its staleness hazard, never arises.

**`vcache_flush()` is called after every assignment to `vpool`.** The per-slot (pool, generation) check cannot close one window on its own: `vpool_destroy` followed by `vpool_create` can return the same address, and a fresh pool starts at generation 0, so a slot cached at generation 0 in the dead pool would match the new one by coincidence and resolve into freed memory.

## Defect found on the way

`vpool_drop_stem_all` freed entries **without bumping the generation**, because it splices the bucket chain itself instead of going through `unlink_entry`. Not reachable through this cache — it holds simple variables only, and a stem drop frees `STEM.` names exclusively — but it violates the invariant the counter documents, and the planned compound cache would have inherited it. Fixed in its own commit with a test.

## Verification

- `TSTVPOL` 66 assertions (+19), one per item of the diag's invalidation checklist: assignment does *not* invalidate, `DROP` does, stem-drop does, `EXPOSE` re-resolves to the parent, resize stays correct, a foreign-pool slot is never honoured, compounds leave the slot untouched.
- Full host suite: **2560 assertions, 0 fail**.
- MVS: deployed and measured as above; the LINKLIB currently holds this build.

## Also in this PR

ROADMAP and CLAUDE.md, per the project rule that a PR closing a named work package updates the source of truth:

- **System A and System B no longer exist.** `mvsdev.lan` is now Proxmox directly. Every cps figure on record — including the 4.3× factor to BREXX — came from retired hardware and is not comparable to anything measured today. The history table is marked as such and a table for the current system replaces it as where new numbers go.
- CLAUDE.md's status block still named "run a fresh bytecode-VM profile" as the next step. That profile has existed since 2026-06-03 and its top-ranked candidate is what this PR implements.
- **How to run REXXCPS at all**, which was nowhere in the repo and costs a ten-minute run each time it is rediscovered: `TIME=1440` (the default class limit ABENDs it **S322** at ~1m34 with an empty SYSTSPRT, which reads like a program fault), and `REXX370_BCDEBUG=1` via a **`SYSENV` DD** for the `[bc]` gate line.

https://claude.ai/code/session_01KvYdVw785GZRZ5AVg1KM7b
